### PR TITLE
Fix crash when reloading app during Chrome debugging

### DIFF
--- a/lib/realm.js
+++ b/lib/realm.js
@@ -119,12 +119,15 @@ Object.defineProperties(Realm, {
         value: Object.freeze(propTypes),
     },
     defaultPath: {
-        get: rpc.getDefaultPath,
-        set: rpc.setDefaultPath,
+        get: util.getterForProperty('defaultPath'),
+        set: util.setterForProperty('defaultPath'),
     },
     clearTestState: {
         value: rpc.clearTestState,
     },
 });
+
+// The session ID refers to the Realm constructor object in the RPC server.
+Realm[keys.id] = rpc.createSession();
 
 module.exports = Realm;

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -7,6 +7,7 @@ let DEVICE_HOST = 'localhost:8082';
 let {keys, objectTypes, propTypes} = constants;
 let typeConverters = {};
 let XMLHttpRequest = window.XMLHttpRequest;
+let sessionId;
 
 // Check if XMLHttpRequest has been overridden, and get the native one if that's the case.
 if (XMLHttpRequest.__proto__ != window.XMLHttpRequestEventTarget) {
@@ -19,8 +20,7 @@ if (XMLHttpRequest.__proto__ != window.XMLHttpRequestEventTarget) {
 module.exports = {
     registerTypeConverter,
 
-    getDefaultPath,
-    setDefaultPath,
+    createSession,
     createRealm,
     callMethod,
     getProperty,
@@ -36,12 +36,9 @@ function registerTypeConverter(type, handler) {
     typeConverters[type] = handler;
 }
 
-function getDefaultPath() {
-    return sendRequest('get_default_path');
-}
-
-function setDefaultPath(path) {
-    sendRequest('set_default_path', {path});
+function createSession() {
+    sessionId = sendRequest('create_session');
+    return sessionId;
 }
 
 function createRealm(args) {
@@ -137,7 +134,9 @@ function deserialize(realmId, info) {
 }
 
 function sendRequest(command, data) {
-    let body = JSON.stringify(data || {});
+    data = Object.assign({}, data, sessionId ? {sessionId} : null);
+
+    let body = JSON.stringify(data);
     let request = new XMLHttpRequest();
     let url = 'http://' + DEVICE_HOST + '/' + command;
 

--- a/src/RJSRealm.hpp
+++ b/src/RJSRealm.hpp
@@ -31,7 +31,5 @@ JSClassRef RJSNotificationClass();
 std::string RJSDefaultPath();
 void RJSSetDefaultPath(std::string path);
 
-JSObjectRef RealmConstructor(JSContextRef ctx, JSObjectRef constructor, size_t argumentCount, const JSValueRef arguments[], JSValueRef* jsException);
-
 std::map<std::string, realm::ObjectDefaults> &RJSDefaults(realm::Realm *realm);
 std::map<std::string, JSValueRef> &RJSPrototypes(realm::Realm *realm);


### PR DESCRIPTION
Added a session ID, that actually tracks the Realm constructor in our RPC server's JS context. This conveniently let us remove the special casing for defaultPath as well as letting us call the Realm constructor with JSObjectCallAsConstructor.

Fixes #68
