### PR TITLE
Make List objects work with Object.keys in Chrome

### DIFF
--- a/lib/lists.js
+++ b/lib/lists.js
@@ -18,11 +18,5 @@ util.createMethods(List.prototype, constants.propTypes.LIST, [
 ], true);
 
 function create(realmId, info) {
-    let meta = util.createList(List.prototype, realmId, info, true);
-    let list = Object.create(meta);
-
-    // This will make attempts at assigning to out-of-bounds indices throw an exception.
-    Object.preventExtensions(list);
-
-    return list;
+    return util.createList(List.prototype, realmId, info, true);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,14 @@ function createList(prototype, realmId, info, mutable) {
     let list = Object.create(prototype);
     let size = 0;
 
-    Object.defineProperty(list, 'length', {get: getterForProperty('length')});
+    Object.defineProperties(list, {
+        'length': {
+            get: getterForProperty('length'),
+        },
+        '-1': {
+            value: undefined,
+        },
+    });
 
     list[keys.resize] = function(length) {
         if (length == null) {
@@ -27,9 +34,9 @@ function createList(prototype, realmId, info, mutable) {
             return;
         }
 
-        if (length > size) {
-            let props = {};
+        let props = {};
 
+        if (length > size) {
             for (let i = size; i < length; i++) {
                 props[i] = {
                     get: getterForProperty(i),
@@ -38,14 +45,20 @@ function createList(prototype, realmId, info, mutable) {
                     configurable: true,
                 };
             }
-
-            Object.defineProperties(list, props);
         }
         else if (length < size) {
-            for (let i = size - 1; i >= length; i--) {
+            for (let i = size; i >= length; i--) {
                 delete list[i];
             }
         }
+
+        // Helpfully throw an exception on attempts to set to list[list.length].
+        props[length] = {
+            value: undefined,
+            configurable: true,
+        };
+
+        Object.defineProperties(list, props);
 
         size = length;
     };

--- a/tests/ArrayTests.js
+++ b/tests/ArrayTests.js
@@ -115,10 +115,14 @@ module.exports = BaseTest.extend({
         });
 
         var count = 0;
+        var keys = Object.keys(obj.arrayCol);
         for (var index in obj.arrayCol) {
-            count++;
+            TestCase.assertEqual(count++, +index);
+            TestCase.assertEqual(keys[index], index);
         }
-        TestCase.assertEqual(2, count);
+
+        TestCase.assertEqual(count, 2);
+        TestCase.assertEqual(keys.length, 2);
     },
 
     testPush: function() {


### PR DESCRIPTION
Rather than using Object.preventExtensions to throw exceptions when setting any out-of-bounds index, we must instead compromise by only throwing for the common cases, which are -1 and list.length. Having Object.keys() support is essential for List to work with React Native ListViewDataSource.

Resolves #80
