### PR TITLE
[WIP] Return unique JS objects if they have a primary key

### DIFF
--- a/src/RJSRealm.hpp
+++ b/src/RJSRealm.hpp
@@ -17,4 +17,5 @@ std::string RJSDefaultPath();
 void RJSSetDefaultPath(std::string path);
 
 std::map<std::string, realm::ObjectDefaults> &RJSDefaults(realm::Realm *realm);
+std::map<std::string, JSObjectRef> &RJSObjects(realm::Realm *realm, std::string type);
 std::map<std::string, JSValueRef> &RJSPrototypes(realm::Realm *realm);

--- a/src/RJSRealm.mm
+++ b/src/RJSRealm.mm
@@ -68,6 +68,7 @@ public:
     }
 
     std::map<std::string, ObjectDefaults> m_defaults;
+    std::map<std::string, std::map<std::string, JSObjectRef>>m_objects;
     std::map<std::string, JSValueRef> m_prototypes;
 
   private:
@@ -97,6 +98,11 @@ public:
 
 std::map<std::string, ObjectDefaults> &RJSDefaults(Realm *realm) {
     return static_cast<RJSRealmDelegate *>(realm->m_binding_context.get())->m_defaults;
+}
+
+std::map<std::string, JSObjectRef> &RJSObjects(Realm *realm, std::string type) {
+    auto &objects = static_cast<RJSRealmDelegate *>(realm->m_delegate.get())->m_objects;
+    return objects[type];
 }
 
 std::map<std::string, JSValueRef> &RJSPrototypes(Realm *realm) {

--- a/src/RJSUtil.hpp
+++ b/src/RJSUtil.hpp
@@ -30,10 +30,10 @@ inline T RJSGetInternal(JSObjectRef jsObject) {
 
 template<typename T>
 JSClassRef RJSCreateWrapperClass(const char * name, JSObjectGetPropertyCallback getter = NULL, JSObjectSetPropertyCallback setter = NULL, const JSStaticFunction *funcs = NULL,
-                                 JSObjectGetPropertyNamesCallback propertyNames = NULL) {
+                                 JSObjectGetPropertyNamesCallback propertyNames = NULL, JSObjectFinalizeCallback finalize = RJSFinalize<T>) {
     JSClassDefinition classDefinition = kJSClassDefinitionEmpty;
     classDefinition.className = name;
-    classDefinition.finalize = RJSFinalize<T>;
+    classDefinition.finalize = finalize;
     classDefinition.getProperty = getter;
     classDefinition.setProperty = setter;
     classDefinition.staticFunctions = funcs;

--- a/src/object-store/object_schema.cpp
+++ b/src/object-store/object_schema.cpp
@@ -60,6 +60,9 @@ ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(n
 }
 
 Property *ObjectSchema::property_for_name(StringData name) {
+    if (!name.size()) {
+        return nullptr;
+    }
     for (auto& prop : properties) {
         if (StringData(prop.name) == name) {
             return &prop;

--- a/tests/RealmTests.js
+++ b/tests/RealmTests.js
@@ -106,8 +106,9 @@ module.exports = BaseTest.extend({
             TestCase.assertEqual(obj0.valueCol, 'newVal0');
             TestCase.assertEqual(objects.length, 2);
 
-            realm.create('IntPrimaryObject', {primaryCol: 0}, true);
+            var newObj0 = realm.create('IntPrimaryObject', {primaryCol: 0}, true);
             TestCase.assertEqual(obj0.valueCol, 'newVal0');
+            TestCase.assertEqual(obj0, newObj0);
         });
 
         // test upsert with all type and string primary object


### PR DESCRIPTION
This implementation does not yet handle the case where the primary key is changed on an object. This would mostly resolve #19, since we can't completely resolve it without having unique object ids.