### PR TITLE
Remove uses of for-of loops in RPC modules

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -4,6 +4,9 @@
     "browser": true,
     "es6": true,
   },
+  "ecmaFeatures": {
+    "forOf": false
+  },
   "globals": {
     "global": true
   }

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -25,14 +25,14 @@ function create(realmId, info) {
     object[keys.id] = info.id;
     object[keys.type] = info.type;
 
-    for (let prop of schema.properties) {
+    schema.properties.forEach((prop) => {
         let name = prop.name;
 
         props[name] = {
             get: util.getterForProperty(name),
             set: util.setterForProperty(name),
         };
-    }
+    });
 
     Object.defineProperties(object, props);
 

--- a/lib/realm.js
+++ b/lib/realm.js
@@ -101,9 +101,7 @@ class Realm {
 
         rpc.commitTransaction(realmId);
 
-        for (let callback of this[listenersKey]) {
-            callback(this, 'change');
-        }
+        this[listenersKey].forEach((cb) => cb(this, 'change'));
     }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -28,9 +28,7 @@ function addMutationListener(realmId, callback) {
 function fireMutationListeners(realmId) {
     let listeners = mutationListeners[realmId];
     if (listeners) {
-        for (let callback of listeners) {
-            callback();
-        }
+        listeners.forEach((cb) => cb());
     }
 }
 
@@ -97,11 +95,11 @@ function createList(prototype, realmId, info, mutable) {
 function createMethods(prototype, type, methodNames, mutates) {
     let props = {};
 
-    for (let name of methodNames) {
+    methodNames.forEach((name) => {
         props[name] = {
             value: createMethod(type, name, mutates),
         };
-    }
+    });
 
     Object.defineProperties(prototype, props);
 }


### PR DESCRIPTION
The React Native packager does not transform for-of loops, and minification step uses UglifyJS, which does not yet support ES6 syntax.

Fixes #120
