### PR TITLE
Make Realm object properties enumerable

### DIFF
--- a/lib/objects.js
+++ b/lib/objects.js
@@ -19,7 +19,6 @@ function create(realmId, info) {
     let schema = info.schema;
     let constructor = (registeredConstructors[realmId] || {})[schema.name];
     let object = constructor ? Object.create(constructor.prototype) : {};
-    let props = {};
 
     object[keys.realm] = realmId;
     object[keys.id] = info.id;
@@ -28,13 +27,12 @@ function create(realmId, info) {
     schema.properties.forEach((prop) => {
         let name = prop.name;
 
-        props[name] = {
+        Object.defineProperty(object, name, {
+            enumerable: true,
             get: util.getterForProperty(name),
             set: util.setterForProperty(name),
-        };
+        });
     });
-
-    Object.defineProperties(object, props);
 
     return object;
 }

--- a/src/js_object.cpp
+++ b/src/js_object.cpp
@@ -42,8 +42,14 @@ bool ObjectSetProperty(JSContextRef ctx, JSObjectRef jsObject, JSStringRef jsPro
     return true;
 }
 
-void ObjectPropertyNames(JSContextRef ctx, JSObjectRef object, JSPropertyNameAccumulatorRef propertyNames) {
-    return;
+void ObjectPropertyNames(JSContextRef ctx, JSObjectRef jsObject, JSPropertyNameAccumulatorRef propertyNames) {
+    Object *obj = RJSGetInternal<Object *>(jsObject);
+
+    for (auto &prop : obj->object_schema.properties) {
+        JSStringRef propertyName = RJSStringForString(prop.name);
+        JSPropertyNameAccumulatorAddName(propertyNames, propertyName);
+        JSStringRelease(propertyName);
+    }
 }
 
 JSClassRef RJSObjectClass() {

--- a/tests/lib/ObjectTests.js
+++ b/tests/lib/ObjectTests.js
@@ -253,6 +253,24 @@ module.exports = BaseTest.extend({
         TestCase.assertEqual(obj.arrayCol[1].doubleCol, 1);
         TestCase.assertEqual(obj.arrayCol[2].doubleCol, 2);
     },
+    testEnumerablePropertyNames: function() {
+        var basicTypesValues = [true, 1, 1.1, 1.11, 'string', new Date(1), new ArrayBuffer()];
+        var realm = new Realm({schema: [schemas.BasicTypes]});
+        var object;
+
+        realm.write(function() {
+            object = realm.create('BasicTypesObject', basicTypesValues);
+        });
+
+        var propNames = schemas.BasicTypes.properties.map(function(prop) { return prop.name; });
+        TestCase.assertArraysEqual(Object.keys(object), propNames, 'Object.keys');
+
+        for (var key in object) {
+            TestCase.assertEqual(key, propNames.shift());
+        }
+
+        TestCase.assertEqual(propNames.length, 0);
+    },
     testDataProperties: function() {
         var realm = new Realm({schema: [schemas.DefaultValues, schemas.TestObject]});
         var object;

--- a/tests/react-test-app/index.ios.js
+++ b/tests/react-test-app/index.ios.js
@@ -35,7 +35,7 @@ function runTests() {
             }
             catch (e) {
                 console.log('- ' + testName);
-                console.warn(e);
+                console.warn(e.message);
             }
             finally {
                 if (testSuite.afterEach) {


### PR DESCRIPTION
This will make it compatible with `Object.assign` and other patterns that iterate the objects' keys. This will resolve #166
