### PR TITLE
Fix crash caused by accessing invalid ObjectSchema

### DIFF
--- a/src/object-store/list.hpp
+++ b/src/object-store/list.hpp
@@ -27,7 +27,7 @@ namespace realm {
       public:
         List(SharedRealm &r, const ObjectSchema &s, LinkViewRef l) : m_realm(r), object_schema(s), m_link_view(l) {}
 
-        const ObjectSchema &object_schema;
+        const ObjectSchema object_schema;
         SharedRealm realm() { return m_realm; }
 
         size_t size();

--- a/src/object-store/object_accessor.hpp
+++ b/src/object-store/object_accessor.hpp
@@ -27,7 +27,7 @@ namespace realm {
         template<typename ValueType, typename ContextType>
         static inline Object create(ContextType ctx, SharedRealm realm, ObjectSchema &object_schema, ValueType value, bool try_update);
 
-        const ObjectSchema &object_schema;
+        const ObjectSchema object_schema;
         SharedRealm realm() { return m_realm; }
         Row row() { return m_row; }
 


### PR DESCRIPTION
These references would eventually become invalid. The quickest fix is for them to no longer be references. The longer-term fix might be to only store the object type and dynamically retrieve the ObjectSchema only when necessary.

Fixes #181
