### PR TITLE
Fix broken iterator methods on Android

### DIFF
--- a/lib/array-methods.js
+++ b/lib/array-methods.js
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+var arrayPrototype = Array.prototype;
+
+[
+    'join',
+    'slice',
+    'forEach',
+    'every',
+    'some',
+    'find',
+    'findIndex',
+    'map',
+    'reduce',
+    'reduceRight',
+].forEach(function(methodName) {
+    var method = arrayPrototype[methodName];
+    if (method) {
+        exports[methodName] = {value: method};
+    }
+});
+
+['entries', 'keys', 'values'].forEach(function(methodName) {
+    var method = function() {
+        var self = this;
+        var index = 0;
+
+        return {
+            next: function() {
+                if (!self || index >= self.length) {
+                    self = null;
+                    return {done: true, value: undefined};
+                }
+
+                var value;
+                switch (methodName) {
+                    case 'entries':
+                        value = [index, self[index]];
+                        break;
+                    case 'keys':
+                        value = index;
+                        break;
+                    default:
+                        value = self[index];
+                }
+
+                index++;
+                return {done: false, value: value};
+            }
+        };
+    };
+
+    exports[methodName] = {value: method};
+});

--- a/lib/array-methods.js
+++ b/lib/array-methods.js
@@ -70,3 +70,8 @@ var arrayPrototype = Array.prototype;
 
     exports[methodName] = {value: method};
 });
+
+/* global Symbol */
+if (typeof Symbol != 'undefined' && Symbol.iterator) {
+    exports[Symbol.iterator] = exports.values;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+var arrayMethods = require('./array-methods');
 var realmConstructor;
 
 if (typeof Realm != 'undefined') {
@@ -29,30 +30,6 @@ if (typeof Realm != 'undefined') {
 } else {
     throw new Error('Missing Realm constructor - please ensure RealmReact framework is included!');
 }
-
-var arrayPrototype = Array.prototype;
-var arrayMethods = {};
-
-[
-    'join',
-    'slice',
-    'forEach',
-    'every',
-    'some',
-    'find',
-    'findIndex',
-    'map',
-    'reduce',
-    'reduceRight',
-    'entries',
-    'keys',
-    'values',
-].forEach(function(methodName) {
-    var method = arrayPrototype[methodName];
-    if (method) {
-        arrayMethods[methodName] = {value: method};
-    }
-});
 
 // Add the specified Array methods to the prototype of List and Results.
 Object.defineProperties(realmConstructor.List.prototype, arrayMethods);

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -567,16 +567,39 @@ module.exports = BaseTest.extend({
             TestCase.assertEqual(list.reduce(function(n, p) {return n + p.age}, 0), 33);
             TestCase.assertEqual(list.reduceRight(function(n, p) {return n + p.age}, 0), 33);
 
-            // Some of these may not be present in every environment.
-            if (list.entries) {
-                TestCase.assertEqual(list.entries().next().value[1].name, 'Ari');
-            }
-            if (list.keys) {
-                TestCase.assertEqual(list.keys().next().value, 0);
-            }
-            if (list.values) {
-                TestCase.assertEqual(list.values().next().value.name, 'Ari');
-            }
+            [
+                'entries',
+                'keys',
+                'values',
+            ].forEach(function(methodName) {
+                var iterator = list[methodName]();
+                var count = 0;
+                var result;
+
+                while ((result = iterator.next()) && !result.done) {
+                    var value = result.value;
+
+                    switch (methodName) {
+                        case 'entries':
+                            TestCase.assertEqual(value.length, 2);
+                            TestCase.assertEqual(value[0], count);
+                            TestCase.assertEqual(value[1].name, list[count].name);
+                            break;
+                        case 'keys':
+                            TestCase.assertEqual(value, count);
+                            break;
+                        default:
+                            TestCase.assertEqual(value.name, list[count].name);
+                            break;
+                    }
+
+                    count++;
+                }
+
+                TestCase.assertEqual(result.done, true);
+                TestCase.assertEqual(result.value, undefined);
+                TestCase.assertEqual(count, list.length);
+            });
         });
     },
 });

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -571,7 +571,12 @@ module.exports = BaseTest.extend({
                 'entries',
                 'keys',
                 'values',
+                typeof Symbol != 'undefined' && Symbol.iterator, // eslint-disable-line no-undef
             ].forEach(function(methodName) {
+                if (!methodName) {
+                    return;
+                }
+
                 var iterator = list[methodName]();
                 var count = 0;
                 var result;


### PR DESCRIPTION
The `ArrayIterator` implementation in the JSC version used on Android was broken, so we implement it ourselves. Also added `Symbol.iterator`, fixing #235.