### PR TITLE
Fix ARM hook into JSGlobalContextCreateInGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Support relative paths when opening realms
 
 ### Bugfixes
+* Fix for crash on Android when initializing the Realm module
 * Automatically forward port 8082 for Android
 * Fix broken iterator methods on Android
 * Don't download or unpack core libraries unnecessarily


### PR DESCRIPTION
@alazier @nhachicha I figured out the cause of the crash. Merging this would allow for us to continue to support React Native v0.20+, which I think would be good for us to do for at least one more release. I do think we should eventually drop this hack in favor of requiring v0.22, but I think it would be kinder to our existing users to wait another release to do that. Also, I think we should merge this even if we do move forward with #317 in case we ever need to revert back to using this hack if React Native stops supporting the new method to get direct access to the `JSGlobalContextRef`. It would be good to have a working version sitting in our git history.

We were loading into the program counter (`PC`), which is not good in THUMB mode, so we now instead load into R3, since it's a temp register not used by this function (it only takes two arguments). Also, when building this module in THUMB mode itself, we needed to clear the ARM instruction cache, which wasn't needed when switching from THUMB to ARM mode.