### PR TITLE
fixes #329

### DIFF
--- a/src/object-store/src/shared_realm.cpp
+++ b/src/object-store/src/shared_realm.cpp
@@ -184,7 +184,8 @@ Group *Realm::read_group()
 
 SharedRealm Realm::get_shared_realm(Config config)
 {
-    return RealmCoordinator::get_coordinator(config.path)->get_realm(std::move(config));
+    auto coordinator = RealmCoordinator::get_coordinator(config.path);
+    return coordinator->get_realm(std::move(config));
 }
 
 void Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)


### PR DESCRIPTION
We found this fix with @tgoyne 
we suspect gcc to do an optimisation on x86 causing `config.path` in  `RealmCoordinator::get_coordinator(config.path)->get_realm(std::move(config));` to be empty, causing it to retrieve the default coordinator that points to a different path.