### PR TITLE
Fix disabling of RCTDevMenu for tests on iOS 9.3

### DIFF
--- a/tests/react-test-app/ios/ReactTests/RealmReactTests.m
+++ b/tests/react-test-app/ios/ReactTests/RealmReactTests.m
@@ -34,18 +34,31 @@ extern NSMutableArray *RCTGetModuleClasses(void);
 - (void)setUp;
 @end
 
+@interface RCTDevMenuDisabler : RCTDevMenu
+@end
+
 @interface RealmReactTests : RealmJSTests
 @end
 
 @interface RealmReactChromeTests : RealmReactTests
 @end
 
+
+@implementation RCTDevMenuDisabler
+
++ (void)load {
+    // +[RCTDevMenu load] is guaranteed to have been called since it's the superclass.
+    // We remove it since it interferes with us fully controlling the executor class.
+    NSMutableArray *moduleClasses = RCTGetModuleClasses();
+    [moduleClasses removeObject:[RCTDevMenu class]];
+}
+
+@end
+
+
 @implementation RealmReactTests
 
 + (void)load {
-    NSMutableArray *moduleClasses = RCTGetModuleClasses();
-    [moduleClasses removeObject:[RCTDevMenu class]];
-
     RCTAddLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
         NSAssert(level < RCTLogLevelError, RCTFormatLog(nil, level, fileName, lineNumber, message));
     });
@@ -223,6 +236,7 @@ extern NSMutableArray *RCTGetModuleClasses(void);
 }
 
 @end
+
 
 @implementation RealmReactChromeTests
 


### PR DESCRIPTION
After upgrading to Xcode 7.3, the test bundle is being loaded before the rest of the app. We need to ensure +[RCTDevMenu load] is called before we remove it from the set of native modules.