### PR TITLE
Get correct path to adb from Android Studio

### DIFF
--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -17,7 +17,8 @@ allprojects {
 apply plugin: 'com.android.library'
 
 task forwardDebugPort(type: Exec) {
-    commandLine 'adb', 'forward', 'tcp:8082', 'tcp:8082'
+    def adb = android.getAdbExe()?.toString() ?: 'false'
+    commandLine adb, 'forward', 'tcp:8082', 'tcp:8082'
     ignoreExitValue true
     doLast {
         if (execResult.getExitValue() != 0) {


### PR DESCRIPTION
If adb really isn't found (unsure what conditions would cause that to happen), then `false` will be called which will result in that warning message being displayed instead.

Fixes #351