### PR TITLE
Remove changes_available implementation that asserts

### DIFF
--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -36,9 +36,6 @@ using RJSAccessor = realm::NativeAccessor<JSValueRef, JSContextRef>;
 
 class RJSRealmDelegate : public BindingContext {
 public:
-    virtual void changes_available() {
-        assert(0);
-    }
     virtual void did_change(std::vector<ObserverState> const& observers, std::vector<void*> const& invalidated) {
         notify("change");
     }


### PR DESCRIPTION
This gets called when a Realm changes on another thread, but is called on the correct thread on iOS. It doesn't look like it will be called on Android, so we can unofficially support iOS accessing Realms from multiple bindings for now.

Fixes #352