### PR TITLE
Update rnpm version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepublish": "scripts/prepublish.sh"
   },
   "dependencies": {
-    "rnpm": "1.5.2",
+    "rnpm": "1.6.1",
     "xcode": "0.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Users are still hitting the issue with Test in the project name as we are including the offending version of rnpm as a dependency. 

@appden