### PR TITLE
Update test and example apps to use React Native 0.24.1

### DIFF
--- a/examples/ReactExample/package.json
+++ b/examples/ReactExample/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^0.14.5",
-    "react-native": "^0.22.0",
+    "react-native": "^0.24.1",
     "realm": "file:../.."
   }
 }

--- a/examples/ReactNativeBenchmarks/package.json
+++ b/examples/ReactNativeBenchmarks/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^0.14.5",
-    "react-native": "^0.22.0",
+    "react-native": "^0.24.1",
     "react-native-sqlite-storage": "^2.1.3",
     "react-native-store": "^0.4.1",
     "realm": "file:../.."

--- a/tests/react-test-app/package.json
+++ b/tests/react-test-app/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^0.14.5",
-    "react-native": "^0.22.0",
+    "react-native": "^0.24.1",
     "react-native-fs": "^1.1.0",
     "xmlbuilder": "^4.2.1",
     "realm": "file:../..",


### PR DESCRIPTION
This might make tests run more reliably on iOS due to some internal changes, mainly "Stop the runloop from invalidate instead of dealloc" (99c7de2).