### PR TITLE
Fix error message when specifying invalid schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * When accessing an empty Results `undefined` is returned rather than throwing an exception
 * Accessing a deleted object throws a JS exception rather than crashing
 * Accessing an invalidated Results snapshot throws a JS exception rather than crashing
+* Fix for error message when specifying properties with invalid object types
 
 0.11.1 Release notes (2016-3-29)
 =============================================================

--- a/src/object-store/src/object_store.cpp
+++ b/src/object-store/src/object_store.cpp
@@ -570,7 +570,7 @@ InvalidNullabilityException::InvalidNullabilityException(std::string const& obje
 MissingObjectTypeException::MissingObjectTypeException(std::string const& object_type, Property const& property) :
     ObjectSchemaPropertyException(object_type, property)
 {
-    m_what = "Property '" + property.name + "' has an invalid type '" + property.object_type + "'.'";
+    m_what = "Property '" + property.name + "' has an invalid type '" + property.object_type + "'.";
 }
 
 MismatchedPropertiesException::MismatchedPropertiesException(std::string const& object_type, Property const& old_property, Property const& new_property) :

--- a/src/object-store/src/object_store.cpp
+++ b/src/object-store/src/object_store.cpp
@@ -169,7 +169,7 @@ void ObjectStore::verify_schema(Schema const& actual_schema, Schema& target_sche
         errors.insert(errors.end(), more_errors.begin(), more_errors.end());
     }
     if (errors.size()) {
-        throw SchemaValidationException(errors);
+        throw SchemaUpdateValidationException(errors);
     }
 }
 
@@ -522,6 +522,16 @@ DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors) :
     m_validation_errors(errors)
 {
+    m_what ="The following errors were encountered during schema validation: ";
+    for (auto const& error : errors) {
+        m_what += std::string("\n- ") + error.what();
+    }
+}
+
+
+SchemaUpdateValidationException::SchemaUpdateValidationException(std::vector<ObjectSchemaValidationException> const& errors) :
+    SchemaValidationException(errors)
+{
     m_what ="Migration is required due to the following errors: ";
     for (auto const& error : errors) {
         m_what += std::string("\n- ") + error.what();
@@ -560,7 +570,7 @@ InvalidNullabilityException::InvalidNullabilityException(std::string const& obje
 MissingObjectTypeException::MissingObjectTypeException(std::string const& object_type, Property const& property) :
     ObjectSchemaPropertyException(object_type, property)
 {
-    m_what = "Target type '" + property.object_type + "' doesn't exist for property '" + property.name + "'.";
+    m_what = "Property '" + property.name + "' has an invalid type '" + property.object_type + "'.'";
 }
 
 MismatchedPropertiesException::MismatchedPropertiesException(std::string const& object_type, Property const& old_property, Property const& new_property) :

--- a/src/object-store/src/object_store.hpp
+++ b/src/object-store/src/object_store.hpp
@@ -159,6 +159,11 @@ namespace realm {
       private:
         std::vector<ObjectSchemaValidationException> m_validation_errors;
     };
+    
+    class SchemaUpdateValidationException : public SchemaValidationException {
+      public:
+        SchemaUpdateValidationException(std::vector<ObjectSchemaValidationException> const& errors);
+    };
 
     class ObjectSchemaValidationException : public ObjectStoreException {
       public:


### PR DESCRIPTION
Closes #253 and #130 

Now when specifying an invalid schema it does not tell you that you need a migration (which was confusing and incorrect). It now correctly says that the schema is invalid. For cases where the schema changes the migration message is displayed when needed.

@appden 