### PR TITLE
Plug RealmDelegate leak and support changing constructors/defaults

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -19,11 +19,11 @@
 'use strict';
 
 import { NativeModules } from 'react-native';
-import { keys, propTypes, objectTypes } from './constants';
+import { keys, objectTypes } from './constants';
 import Collection, * as collections from './collections';
 import List, { createList } from './lists';
 import Results, { createResults } from './results';
-import RealmObject, { createObject, registerConstructors, typeForConstructor } from './objects';
+import RealmObject, * as objects from './objects';
 import * as rpc from './rpc';
 import * as util from './util';
 
@@ -31,7 +31,7 @@ const {debugHosts, debugPort} = NativeModules.Realm;
 
 rpc.registerTypeConverter(objectTypes.LIST, createList);
 rpc.registerTypeConverter(objectTypes.RESULTS, createResults);
-rpc.registerTypeConverter(objectTypes.OBJECT, createObject);
+rpc.registerTypeConverter(objectTypes.OBJECT, objects.createObject);
 rpc.registerTypeConverter(objectTypes.REALM, createRealm);
 
 function createRealm(_, info) {
@@ -59,7 +59,7 @@ function setupRealm(realm, realmId) {
 export default class Realm {
     constructor(config) {
         let schemas = typeof config == 'object' && config.schema;
-        let constructors = {};
+        let constructors = schemas ? {} : null;
 
         for (let i = 0, len = schemas ? schemas.length : 0; i < len; i++) {
             let item = schemas[i];
@@ -83,14 +83,15 @@ export default class Realm {
         }
 
         let realmId = rpc.createRealm(Array.from(arguments));
-
-        registerConstructors(realmId, constructors);
         setupRealm(this, realmId);
+
+        // This will create mappings between the id, path, and potential constructors.
+        objects.registerConstructors(realmId, this.path, constructors);
     }
 
     create(type, ...args) {
         if (typeof type == 'function') {
-            type = typeForConstructor(this[keys.realm], type);
+            type = objects.typeForConstructor(this[keys.realm], type);
         }
 
         let method = util.createMethod(objectTypes.REALM, 'create', true);
@@ -99,7 +100,7 @@ export default class Realm {
 
     objects(type, ...args) {
         if (typeof type == 'function') {
-            type = typeForConstructor(this[keys.realm], type);
+            type = objects.typeForConstructor(this[keys.realm], type);
         }
 
         let method = util.createMethod(objectTypes.REALM, 'objects');
@@ -147,6 +148,7 @@ Object.defineProperties(Realm, {
     clearTestState: {
         value: function() {
             collections.clearMutationListeners();
+            objects.clearRegisteredConstructors();
             rpc.clearTestState();
         },
     },

--- a/lib/browser/objects.js
+++ b/lib/browser/objects.js
@@ -21,7 +21,8 @@
 import { keys, objectTypes } from './constants';
 import { getterForProperty, setterForProperty, createMethods } from './util';
 
-const registeredConstructors = {};
+let registeredConstructors = {};
+let registeredRealmPaths = {};
 
 export default class RealmObject {
 }
@@ -31,9 +32,15 @@ createMethods(RealmObject.prototype, objectTypes.OBJECT, [
     'isValid',
 ]);
 
+export function clearRegisteredConstructors() {
+    registeredConstructors = {};
+    registeredRealmPaths = {};
+}
+
 export function createObject(realmId, info) {
     let schema = info.schema;
-    let constructor = (registeredConstructors[realmId] || {})[schema.name];
+    let realmPath = registeredRealmPaths[realmId];
+    let constructor = (registeredConstructors[realmPath] || {})[schema.name];
     let object = Object.create(constructor ? constructor.prototype : RealmObject.prototype);
 
     object[keys.realm] = realmId;
@@ -58,12 +65,17 @@ export function createObject(realmId, info) {
     return object;
 }
 
-export function registerConstructors(realmId, constructors) {
-    registeredConstructors[realmId] = constructors;
+export function registerConstructors(realmId, realmPath, constructors) {
+    registeredRealmPaths[realmId] = realmPath;
+
+    if (constructors) {
+        registeredConstructors[realmPath] = constructors;
+    }
 }
 
 export function typeForConstructor(realmId, constructor) {
-    let constructors = registeredConstructors[realmId];
+    let realmPath = registeredRealmPaths[realmId];
+    let constructors = registeredConstructors[realmPath];
 
     for (let name in constructors) {
         if (constructors[name] == constructor) {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -402,7 +402,7 @@ module.exports = BaseTest.extend({
     testRealmCreateWithDefaults: function() {
         var realm = new Realm({schema: [schemas.DefaultValues, schemas.TestObject]});
 
-        var writeCallback = function() {
+        var createAndTestObject = function() {
             var obj = realm.create('DefaultValuesObject', {});
             var properties = schemas.DefaultValues.properties;
 
@@ -419,11 +419,11 @@ module.exports = BaseTest.extend({
             TestCase.assertEqual(obj.arrayCol[0].doubleCol, properties.arrayCol.default[0].doubleCol);
         };
 
-        realm.write(writeCallback);
+        realm.write(createAndTestObject);
 
         // Defaults should still work when creating another Realm instance.
         realm = new Realm();
-        realm.write(writeCallback);
+        realm.write(createAndTestObject);
     },
 
     testRealmCreateWithChangingDefaults: function() {
@@ -436,17 +436,17 @@ module.exports = BaseTest.extend({
 
         var realm = new Realm({schema: [objectSchema]});
 
-        var writeCallback = function() {
+        var createAndTestObject = function() {
             var object = realm.create('IntObject', {});
             TestCase.assertEqual(object.intCol, objectSchema.properties.intCol.default);
         };
 
-        realm.write(writeCallback);
+        realm.write(createAndTestObject);
 
         objectSchema.properties.intCol.default++;
 
         realm = new Realm({schema: [objectSchema]});
-        realm.write(writeCallback);
+        realm.write(createAndTestObject);
     },
 
     testRealmCreateWithConstructor: function() {


### PR DESCRIPTION
The primary reason for support changing constructors/defaults is for hot module loading to work correctly. Also, before doing `new Realm()` would wipe out the constructors and defaults, which was not intended. We now only swap them if a new `schema` was provided. I added some tests for this behavior.