### PR TITLE
Fix ES6 class inheritance of Realm.Object with Babel

### DIFF
--- a/examples/ReactExample/components/realm.js
+++ b/examples/ReactExample/components/realm.js
@@ -20,20 +20,22 @@
 
 import Realm from 'realm';
 
-class Todo {}
+class Todo extends Realm.Object {}
 Todo.schema = {
     name: 'Todo',
     properties: {
-        done: {type: Realm.Types.BOOL, default: false},
-        text: Realm.Types.STRING,
+        done: {type: 'bool', default: false},
+        text: 'string',
     },
 };
-class TodoList {}
+
+class TodoList extends Realm.Object {}
 TodoList.schema = {
     name: 'TodoList',
     properties: {
-        name: Realm.Types.STRING,
-        items: {type: Realm.Types.LIST, objectType: 'Todo', default: []},
+        name: 'string',
+        items: {type: 'list', objectType: 'Todo'},
     },
 };
+
 export default new Realm({schema: [Todo, TodoList]});

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -237,7 +237,7 @@ inline typename T::Function Realm<T>::create_constructor(ContextType ctx) {
     FunctionType results_constructor = ObjectWrap<T, ResultsClass<T>>::create_constructor(ctx);
     FunctionType realm_object_constructor = ObjectWrap<T, RealmObjectClass<T>>::create_constructor(ctx);
 
-    PropertyAttributes attributes = PropertyAttributes(ReadOnly | DontEnum | DontDelete);
+    PropertyAttributes attributes = ReadOnly | DontEnum | DontDelete;
     Object::set_property(ctx, realm_constructor, "Collection", collection_constructor, attributes);
     Object::set_property(ctx, realm_constructor, "List", list_constructor, attributes);
     Object::set_property(ctx, realm_constructor, "Results", results_constructor, attributes);

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -35,12 +35,16 @@
 namespace realm {
 namespace js {
 
-enum PropertyAttributes {
+enum PropertyAttributes : unsigned {
     None       = 0,
     ReadOnly   = 1 << 0,
     DontEnum   = 1 << 1,
     DontDelete = 1 << 2
 };
+
+inline PropertyAttributes operator|(PropertyAttributes a, PropertyAttributes b) {
+    return PropertyAttributes(static_cast<unsigned>(a) | static_cast<unsigned>(b));
+}
 
 template<typename T>
 struct String {

--- a/src/jsc/jsc_init.cpp
+++ b/src/jsc/jsc_init.cpp
@@ -37,7 +37,7 @@ void RJSInitializeInContext(JSContextRef ctx) {
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
     JSObjectRef realm_constructor = RJSConstructorCreate(ctx);
 
-    jsc::Object::set_property(ctx, global_object, realm_string, realm_constructor, js::PropertyAttributes(js::ReadOnly | js::DontEnum | js::DontDelete));
+    jsc::Object::set_property(ctx, global_object, realm_string, realm_constructor, js::ReadOnly | js::DontEnum | js::DontDelete);
 }
 
 } // extern "C"

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -36,6 +36,9 @@ module.exports = BaseTest.extend({
         TestCase.assertThrows(function() {
             new Realm.List();
         });
+
+        TestCase.assertEqual(typeof Realm.List, 'function');
+        TestCase.assertTrue(Realm.List instanceof Function);
     },
 
     testListLength: function() {

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -435,10 +435,14 @@ module.exports = BaseTest.extend({
 
     testObjectConstructor: function() {
         var realm = new Realm({schema: [schemas.TestObject]});
+
         realm.write(function() {
             var obj = realm.create('TestObject', {doubleCol: 1});
             TestCase.assertTrue(obj instanceof Realm.Object);
         });
+
+        TestCase.assertEqual(typeof Realm.Object, 'function');
+        TestCase.assertTrue(Realm.Object instanceof Function);
     },
 
     testIsValid: function() {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -27,6 +27,9 @@ module.exports = BaseTest.extend({
     testRealmConstructor: function() {
         var realm = new Realm({schema: []});
         TestCase.assertTrue(realm instanceof Realm);
+
+        TestCase.assertEqual(typeof Realm, 'function');
+        TestCase.assertTrue(Realm instanceof Function);
     },
 
     testRealmConstructorPath: function() {

--- a/tests/js/results-tests.js
+++ b/tests/js/results-tests.js
@@ -34,6 +34,9 @@ module.exports = BaseTest.extend({
         TestCase.assertThrows(function() {
             new Realm.Results();
         });
+
+        TestCase.assertEqual(typeof Realm.Results, 'function');
+        TestCase.assertTrue(Realm.Results instanceof Function);
     },
 
     testResultsLength: function() {


### PR DESCRIPTION
From [a comment](https://github.com/realm/realm-js/pull/395#issuecomment-217060447) on #395, it was clear that we failed to test that `extends Realm.Object` would work. This makes it work and checks that it works in React Native with the example app test.