### PR TITLE
Avoid copying `Object` and `List` instances unnecessarily

### DIFF
--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -96,7 +96,7 @@ void ListClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t index,
     auto list = get_internal<T, ListClass<T>>(object);
     auto realm_object = realm::Object(list->get_realm(), list->get_object_schema(), list->get(index));
 
-    return_value.set(RealmObjectClass<T>::create_instance(ctx, realm_object));
+    return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
 }
 
 template<typename T>
@@ -132,7 +132,7 @@ void ListClass<T>::pop(ContextType ctx, ObjectType this_object, size_t argc, con
         size_t index = size - 1;
         auto realm_object = realm::Object(list->get_realm(), list->get_object_schema(), list->get(index));
 
-        return_value.set(RealmObjectClass<T>::create_instance(ctx, realm_object));
+        return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
         list->remove(index);
     }
 }
@@ -161,7 +161,7 @@ void ListClass<T>::shift(ContextType ctx, ObjectType this_object, size_t argc, c
     else {
         auto realm_object = realm::Object(list->get_realm(), list->get_object_schema(), list->get(0));
 
-        return_value.set(RealmObjectClass<T>::create_instance(ctx, realm_object));
+        return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
         list->remove(0);
     }
 }
@@ -192,7 +192,7 @@ void ListClass<T>::splice(ContextType ctx, ObjectType this_object, size_t argc, 
     for (size_t i = 0; i < remove; i++) {
         auto realm_object = realm::Object(list->get_realm(), list->get_object_schema(), list->get(index));
 
-        removed_objects.push_back(RealmObjectClass<T>::create_instance(ctx, realm_object));
+        removed_objects.push_back(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
         list->remove(index);
     }
     for (size_t i = 2; i < argc; i++) {

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -41,7 +41,7 @@ struct ListClass : ClassDefinition<T, realm::List, CollectionClass<T>> {
     using Value = js::Value<T>;
     using ReturnValue = js::ReturnValue<T>;
 
-    static ObjectType create_instance(ContextType, realm::List &);
+    static ObjectType create_instance(ContextType, realm::List);
 
     // properties
     static void get_length(ContextType, ObjectType, ReturnValue &);
@@ -81,8 +81,8 @@ struct ListClass : ClassDefinition<T, realm::List, CollectionClass<T>> {
 };
 
 template<typename T>
-typename T::Object ListClass<T>::create_instance(ContextType ctx, realm::List &list) {
-    return create_object<T, ListClass<T>>(ctx, new realm::List(list));
+typename T::Object ListClass<T>::create_instance(ContextType ctx, realm::List list) {
+    return create_object<T, ListClass<T>>(ctx, new realm::List(std::move(list)));
 }
 
 template<typename T>

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -125,7 +125,7 @@ struct NativeAccessor {
         throw std::runtime_error("object is not a Realm Object");
     }
     static ValueType from_object(ContextType ctx, realm::Object realm_object) {
-        return RealmObjectClass<T>::create_instance(ctx, realm_object);
+        return RealmObjectClass<T>::create_instance(ctx, std::move(realm_object));
     }
 
     static size_t list_size(ContextType ctx, ValueType &value) {

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -135,7 +135,7 @@ struct NativeAccessor {
         return Object::validated_get_object(ctx, Value::validated_to_object(ctx, value), (uint32_t)index);
     }
     static ValueType from_list(ContextType ctx, realm::List list) {
-        return ListClass<T>::create_instance(ctx, list);
+        return ListClass<T>::create_instance(ctx, std::move(list));
     }
 
     static Mixed to_mixed(ContextType ctx, ValueType &val) {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -491,7 +491,7 @@ void RealmClass<T>::create(ContextType ctx, ObjectType this_object, size_t argc,
     }
 
     auto realm_object = realm::Object::create<ValueType>(ctx, realm, *object_schema, object, update);
-    return_value.set(RealmObjectClass<T>::create_instance(ctx, realm_object));
+    return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
 }
 
 template<typename T>

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -40,7 +40,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::Object> {
     using Function = js::Function<T>;
     using ReturnValue = js::ReturnValue<T>;
 
-    static ObjectType create_instance(ContextType, realm::Object &);
+    static ObjectType create_instance(ContextType, realm::Object);
 
     static void get_property(ContextType, ObjectType, const String &, ReturnValue &);
     static bool set_property(ContextType, ObjectType, const String &, ValueType);
@@ -67,12 +67,12 @@ void RealmObjectClass<T>::is_valid(ContextType ctx, ObjectType this_object, size
 }
     
 template<typename T>
-typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::Object &realm_object) {
+typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::Object realm_object) {
     static String prototype_string = "prototype";
 
     auto delegate = get_delegate<T>(realm_object.realm().get());
     auto name = realm_object.get_object_schema().name;
-    auto object = create_object<T, RealmObjectClass<T>>(ctx, new realm::Object(realm_object));
+    auto object = create_object<T, RealmObjectClass<T>>(ctx, new realm::Object(std::move(realm_object)));
 
     if (!delegate || !delegate->m_constructors.count(name)) {
         return object;

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -208,7 +208,7 @@ void ResultsClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t ind
     }
 
     auto realm_object = realm::Object(results->get_realm(), results->get_object_schema(), results->get(index));
-    return_value.set(RealmObjectClass<T>::create_instance(ctx, realm_object));
+    return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
 }
 
 template<typename T>


### PR DESCRIPTION
Avoid copying `Object` and `List` instances when we can instead move them.