### PR TITLE
Add async inter-process change notification test for Node

### DIFF
--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -70,6 +70,11 @@
 		F674784A1CC81F1900F9273C /* platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F67478481CC81F1300F9273C /* platform.cpp */; };
 		F68A278C1BC2722A0063D40A /* RJSModuleLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = F68A278B1BC2722A0063D40A /* RJSModuleLoader.m */; };
 		F6BCCFE21C8380A400FE31AE /* lib in Resources */ = {isa = PBXBuildFile; fileRef = F6BCCFDF1C83809A00FE31AE /* lib */; };
+		F6E931BA1CFEAE170016AF14 /* collection_notifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B961CE6AADD00A8669F /* collection_notifications.cpp */; };
+		F6E931BB1CFEAE310016AF14 /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B991CE6AAEF00A8669F /* collection_change_builder.cpp */; };
+		F6E931BC1CFEAE340016AF14 /* collection_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B9B1CE6AAEF00A8669F /* collection_notifier.cpp */; };
+		F6E931BD1CFEAE370016AF14 /* list_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B9D1CE6AAEF00A8669F /* list_notifier.cpp */; };
+		F6E931BE1CFEAE3A0016AF14 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B9F1CE6AAEF00A8669F /* results_notifier.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -748,16 +753,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F6E931BA1CFEAE170016AF14 /* collection_notifications.cpp in Sources */,
 				F60102D31CBB966E00EC01BA /* js_realm.cpp in Sources */,
 				F60102D61CBB96B400EC01BA /* object_schema.cpp in Sources */,
 				F60102D41CBB96AB00EC01BA /* index_set.cpp in Sources */,
 				F60102DB1CBB96C600EC01BA /* parser.cpp in Sources */,
+				F6E931BB1CFEAE310016AF14 /* collection_change_builder.cpp in Sources */,
 				F60102D51CBB96AE00EC01BA /* list.cpp in Sources */,
+				F6E931BC1CFEAE340016AF14 /* collection_notifier.cpp in Sources */,
 				F60102DC1CBB96C900EC01BA /* query_builder.cpp in Sources */,
 				F60102DD1CBB96CC00EC01BA /* external_commit_helper.cpp in Sources */,
 				F63117F01CEB0D5F00ECB2DE /* weak_realm_notifier.cpp in Sources */,
 				F60102E11CBB96DD00EC01BA /* transact_log_handler.cpp in Sources */,
+				F6E931BE1CFEAE3A0016AF14 /* results_notifier.cpp in Sources */,
 				F60102D71CBB96B800EC01BA /* object_store.cpp in Sources */,
+				F6E931BD1CFEAE370016AF14 /* list_notifier.cpp in Sources */,
 				F60102DA1CBB96C300EC01BA /* shared_realm.cpp in Sources */,
 				F60102E01CBB96D900EC01BA /* realm_coordinator.cpp in Sources */,
 				F60102EA1CBCAFC300EC01BA /* node_dummy.cpp in Sources */,

--- a/src/jsc/jsc_class.hpp
+++ b/src/jsc/jsc_class.hpp
@@ -169,7 +169,7 @@ inline JSClassRef ObjectWrap<ClassType>::create_constructor_class() {
     // This must be set for `typeof constructor` to be 'function'.
     definition.callAsFunction = call;
 
-    if (s_class.constructor) {
+    if (reinterpret_cast<void*>(s_class.constructor)) {
         definition.callAsConstructor = construct;
     }
     if (!s_class.static_methods.empty()) {
@@ -226,7 +226,7 @@ inline JSValueRef ObjectWrap<ClassType>::call(JSContextRef ctx, JSObjectRef func
     }
 
     // Classes without a constructor should still be subclassable.
-    if (s_class.constructor) {
+    if (reinterpret_cast<void*>(s_class.constructor)) {
         try {
             s_class.constructor(ctx, this_object, argc, arguments);
         }
@@ -241,7 +241,7 @@ inline JSValueRef ObjectWrap<ClassType>::call(JSContextRef ctx, JSObjectRef func
 
 template<typename ClassType>
 inline JSObjectRef ObjectWrap<ClassType>::construct(JSContextRef ctx, JSObjectRef constructor, size_t argc, const JSValueRef arguments[], JSValueRef* exception) {
-    if (!s_class.constructor) {
+    if (!reinterpret_cast<void*>(s_class.constructor)) {
         *exception = jsc::Exception::value(ctx, s_class.name + " is not a constructor");
         return nullptr;
     }

--- a/src/jsc/jsc_types.hpp
+++ b/src/jsc/jsc_types.hpp
@@ -30,7 +30,6 @@ namespace jsc {
 struct Types {
     using Context = JSContextRef;
     using GlobalContext = JSGlobalContextRef;
-    using ClassDefinition = JSClassRef;
     using Value = JSValueRef;
     using Object = JSObjectRef;
     using String = JSStringRef;

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -226,7 +226,7 @@ inline void ObjectWrap<ClassType>::construct(Nan::NAN_METHOD_ARGS_TYPE info) {
     if (!info.IsConstructCall()) {
         Nan::ThrowError("Constructor must be called with new");
     }
-    if (s_class.constructor) {
+    if (reinterpret_cast<void*>(s_class.constructor)) {
         auto isolate = info.GetIsolate();
         auto arguments = get_arguments(info);
         v8::Local<v8::Object> this_object = info.This();

--- a/tests/index.js
+++ b/tests/index.js
@@ -28,6 +28,11 @@ const mockery = require('mockery');
 function runTests() {
     const Realm = require('realm');
     const RealmTests = require('./js');
+
+    RealmTests.registerTests({
+        WorkerTests: require('./js/worker-tests'),
+    });
+
     const testNames = RealmTests.getTestNames();
     let passed = true;
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -50,28 +50,27 @@ function runTests() {
         }
     };
 
-    for (let suiteName in testNames) {
-        console.log('Starting ' + suiteName);
+    return Object.keys(testNames).reduce((suitePromiseChain, suiteName) => {
+        return suitePromiseChain.then(() => {
+            console.log('Starting ' + suiteName);
 
-        for (let testName of testNames[suiteName]) {
-            RealmTests.runTest(suiteName, 'beforeEach');
-
-            try {
-                RealmTests.runTest(suiteName, testName);
-                console.log('+ ' + testName);
-            }
-            catch (e) {
-                console.warn('- ' + testName);
-                console.error(e.message, e.stack);
-                passed = false;
-            }
-            finally {
-                RealmTests.runTest(suiteName, 'afterEach');
-            }
-        }
-    }
-
-    return passed;
+            return testNames[suiteName].reduce((testPromiseChain, testName) => {
+                return testPromiseChain.then(() => {
+                    return RealmTests.runTest(suiteName, 'beforeEach');
+                }).then(() => {
+                    return RealmTests.runTest(suiteName, testName);
+                }).then(() => {
+                    console.log('+ ' + testName);
+                }, (err) => {
+                    console.warn('- ' + testName);
+                    console.warn(err.message || err);
+                    passed = false;
+                }).then(() => {
+                    return RealmTests.runTest(suiteName, 'afterEach');
+                });
+            }, Promise.resolve());
+        });
+    }, Promise.resolve()).then(() => passed);
 }
 
 if (require.main == module) {
@@ -79,7 +78,15 @@ if (require.main == module) {
     mockery.warnOnUnregistered(false);
     mockery.registerMock('realm', require('..'));
 
-    if (!runTests()) {
-        process.exit(1);
-    }
+    runTests().then(
+        (passed) => {
+            if (!passed) {
+                process.exit(1);
+            }
+        },
+        (err) => {
+            console.error(err);
+            process.exit(1);
+        }
+    );
 }

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -145,14 +145,19 @@ module.exports = {
     },
 
     testDefaultPath: function() {
+        var defaultPath = Realm.defaultPath;
         var defaultRealm = new Realm({schema: []});
         TestCase.assertEqual(defaultRealm.path, Realm.defaultPath);
 
-        var newPath = Realm.defaultPath.substring(0, Realm.defaultPath.lastIndexOf("/") + 1) + 'default2.realm';
-        Realm.defaultPath = newPath;
-        defaultRealm = new Realm({schema: []});
-        TestCase.assertEqual(defaultRealm.path, newPath, "should use updated default realm path");
-        TestCase.assertEqual(Realm.defaultPath, newPath, "defaultPath should have been updated");
+        try {
+            var newPath = Realm.defaultPath.substring(0, defaultPath.lastIndexOf('/') + 1) + 'default2.realm';
+            Realm.defaultPath = newPath;
+            defaultRealm = new Realm({schema: []});
+            TestCase.assertEqual(defaultRealm.path, newPath, "should use updated default realm path");
+            TestCase.assertEqual(Realm.defaultPath, newPath, "defaultPath should have been updated");
+        } finally {
+            Realm.defaultPath = defaultPath;
+        }
     },
 
     testRealmSchemaVersion: function() {

--- a/tests/js/worker-tests-script.js
+++ b/tests/js/worker-tests-script.js
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/* eslint-env es6, node */
+/* eslint-disable no-console */
+
+'use strict';
+
+const Realm = require('../..');
+
+const handlers = {
+    create(options) {
+        let realm = new Realm(options.config);
+
+        realm.write(() => {
+            realm.create(options.type, options.properties);
+        });
+    }
+};
+
+process.on('message', (message) => {
+    process.send(handleMessage(message));
+});
+
+function handleMessage(message) {
+    let error, result;
+
+    try {
+        let handler = handlers[message.action];
+        if (handler) {
+            result = handler(message);
+        } else {
+            throw new Error('Unknown worker action: ' + message.action);
+        }
+    } catch (e) {
+        console.warn(e);
+        error = e.message;
+    }
+
+    return {error, result};
+}

--- a/tests/js/worker-tests.js
+++ b/tests/js/worker-tests.js
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/* eslint-env es6, node */
+
+'use strict';
+
+const Realm = require('realm');
+const TestCase = require('./asserts');
+const schemas = require('./schemas');
+const Worker = require('./worker');
+
+module.exports = {
+    testChangeNotifications() {
+        return new Promise((resolve, reject) => {
+            let config = {schema: [schemas.TestObject]};
+            let realm = new Realm(config);
+            let objects = realm.objects('TestObject');
+            let worker = new Worker(__dirname + '/worker-tests-script.js');
+
+            // Test will fail if it does not receive a change event within a second.
+            let timer = setTimeout(() => {
+                reject(new Error('Timed out waiting for change notification'));
+            }, 1000);
+
+            let cleanup = () => {
+                clearTimeout(timer);
+                worker.terminate();
+            };
+
+            // Test will pass if it receives a change event and the Realm changed.
+            realm.addListener('change', () => {
+                try {
+                    TestCase.assertEqual(objects.length, 1);
+                    TestCase.assertEqual(objects[0].doubleCol, 42);
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                } finally {
+                    cleanup();
+                }
+            });
+
+            worker.onmessage = (message) => {
+                if (message.error) {
+                    cleanup();
+                    reject(message.error);
+                }
+            };
+
+            worker.postMessage({
+                action: 'create',
+                config: config,
+                type: 'TestObject',
+                properties: {
+                    doubleCol: 42,
+                }
+            });
+        });
+    }
+};

--- a/tests/js/worker.js
+++ b/tests/js/worker.js
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/* eslint-env es6, node */
+
+'use strict';
+
+class Worker {
+    constructor(script) {
+        this._process = require('child_process').fork(script);
+
+        this._process.on('message', (message) => {
+            if (this.onmessage) {
+                this.onmessage(message);
+            }
+        });
+    }
+    postMessage(message) {
+        this._process.send(message);
+    }
+    terminate() {
+        if (this._process) {
+            this._process.kill();
+            delete this._process;
+        }
+    }
+}
+
+module.exports = Worker;

--- a/tests/react-test-app/index.android.js
+++ b/tests/react-test-app/index.android.js
@@ -48,7 +48,7 @@ async function runTests() {
             itemTest.att('name', testName);
 
             try {
-                runTest(suiteName, testName);
+                await runTest(suiteName, testName);
             }
             catch (e) {
                 itemTest.ele('error', {'message': ''}, e.message);

--- a/tests/react-test-app/tests/index.js
+++ b/tests/react-test-app/tests/index.js
@@ -27,10 +27,10 @@ RealmTests.registerTests({
 });
 
 // Listen for event to run a particular test.
-NativeAppEventEmitter.addListener('realm-run-test', (test) => {
+NativeAppEventEmitter.addListener('realm-run-test', async ({suite, name}) => {
     let error;
     try {
-        RealmTests.runTest(test.suite, test.name);
+        await RealmTests.runTest(suite, name);
     } catch (e) {
         error = '' + e;
     }
@@ -50,23 +50,23 @@ export function getTestNames() {
     return RealmTests.getTestNames();
 }
 
-export function runTests() {
+export async function runTests() {
     let testNames = getTestNames();
 
     for (let suiteName in testNames) {
         console.log('Starting ' + suiteName);
 
         for (let testName of testNames[suiteName]) {
-            runTest(suiteName, testName);
+            await runTest(suiteName, testName);
         }
     }
 }
 
-export function runTest(suiteName, testName) {
-    RealmTests.runTest(suiteName, 'beforeEach');
+export async function runTest(suiteName, testName) {
+    await RealmTests.runTest(suiteName, 'beforeEach');
 
     try {
-        RealmTests.runTest(suiteName, testName);
+        await RealmTests.runTest(suiteName, testName);
         console.log('+ ' + testName);
     }
     catch (e) {
@@ -75,6 +75,6 @@ export function runTest(suiteName, testName) {
         throw e;
     }
     finally {
-        RealmTests.runTest(suiteName, 'afterEach');
+        await RealmTests.runTest(suiteName, 'afterEach');
     }
 }


### PR DESCRIPTION
This PR also lays the foundation for async tests to come to other platforms. It ensures the `ExternalCommitHelper` and `WeakRealmNotifier` are working as intended.

Resolves #461