### PR TITLE
Fix test failure in Chrome debug mode

### DIFF
--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -104,10 +104,6 @@ function serialize(realmId, value) {
 
     let id = value[idKey];
     if (id) {
-        if (value[realmKey] != realmId) {
-            throw new Error('Unable to serialize value from another Realm');
-        }
-
         return {id};
     }
 

--- a/tests/react-test-app/tests/index.js
+++ b/tests/react-test-app/tests/index.js
@@ -52,14 +52,22 @@ export function getTestNames() {
 
 export async function runTests() {
     let testNames = getTestNames();
+    let passed = true;
 
     for (let suiteName in testNames) {
         console.log('Starting ' + suiteName);
 
         for (let testName of testNames[suiteName]) {
-            await runTest(suiteName, testName);
+            try {
+                await runTest(suiteName, testName);
+            }
+            catch (e) {
+                passed = false;
+            }
         }
     }
+
+    return passed;
 }
 
 export async function runTest(suiteName, testName) {


### PR DESCRIPTION
We had a new failure in Chrome debug mode in the `testLinkTypesPropertySetters` test. This fixes that.