### PR TITLE
Add support for debugging in Visual Studio Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ npm-debug.log
 .gradle
 local.properties
 
+# Visual Studio Code
+.vscode
+tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Please use `rnpm 1.9.0` or later to link your project. Older versions are no longer supported.
 
 ### Enhancements
-* None
+* Added support for debugging in Visual Studio Code.
 
 ### Bugfixes
 * None

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -151,6 +151,35 @@ function deserializeDict(realmId, info) {
     return object;
 }
 
+function makeRequest(url, data) {
+    let statusCode;
+    let responseText;
+
+    // The global __debug__ object is provided by Visual Studio Code.
+    if (global.__debug__) {
+        let request = global.__debug__.require('sync-request');
+        let response = request('POST', url, {json: data});
+
+        statusCode = response.statusCode;
+        responseText = response.body.toString('utf-8');
+    } else {
+        let body = JSON.stringify(data);
+        let request = new XMLHttpRequest();
+
+        request.open('POST', url, false);
+        request.send(body);
+
+        statusCode = request.status;
+        responseText = request.responseText;
+    }
+
+    if (statusCode != 200) {
+        throw new Error(responseText);
+    }
+
+    return JSON.parse(responseText);
+}
+
 function sendRequest(command, data, host = sessionHost) {
     if (!host) {
         throw new Error('Must first create RPC session with a valid host');
@@ -158,18 +187,8 @@ function sendRequest(command, data, host = sessionHost) {
 
     data = Object.assign({}, data, sessionId ? {sessionId} : null);
 
-    let body = JSON.stringify(data);
-    let request = new XMLHttpRequest();
     let url = 'http://' + host + '/' + command;
-
-    request.open('POST', url, false);
-    request.send(body);
-
-    if (request.status != 200) {
-        throw new Error(request.responseText);
-    }
-
-    let response = JSON.parse(request.responseText);
+    let response = makeRequest(url, data);
 
     if (!response || response.error) {
         let error = response && response.error;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ if (typeof Realm != 'undefined') {
     // The global Realm constructor should be available on device (using JavaScriptCore).
     realmConstructor = Realm;  // eslint-disable-line no-undef
 // eslint-disable-next-line
-} else if (typeof navigator != 'undefined' && navigator.userAgent) {
+} else if (typeof window != 'undefined') {
     // The userAgent will be defined when running in a browser (such as Chrome debugging mode).
     realmConstructor = require('./browser').default; // (exported as ES6 module)
 // eslint-disable-next-line

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "bindings": "^1.2.1",
     "nan": "^2.3.3",
-    "node-gyp": "^3.3.1"
+    "node-gyp": "^3.3.1",
+    "sync-request": "^3.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
Since Code runs in Node, rather than Chrome, we need to require the `sync-request` module. The global `__debug__` object was exposed by the vscode-react-native plugin v0.1.5 for us to be able to do that.

Resolves #374