### PR TITLE
Make Results derived from List use its LinkViewRef

### DIFF
--- a/src/object-store/src/list.cpp
+++ b/src/object-store/src/list.cpp
@@ -50,6 +50,12 @@ Query List::get_query() const
     return m_link_view->get_target_table().where(m_link_view);
 }
 
+const Table* List::get_table() const
+{
+    verify_attached();
+    return &m_link_view->get_target_table();
+}
+
 size_t List::get_origin_row_index() const
 {
     verify_attached();
@@ -169,13 +175,13 @@ void List::delete_all()
     m_link_view->remove_all_target_rows();
 }
 
-Results List::sort(SortOrder order)
+Results List::sort(SortOrder order) const
 {
     verify_attached();
     return Results(m_realm, *m_object_schema, m_link_view, util::none, std::move(order));
 }
 
-Results List::filter(Query q)
+Results List::filter(Query q) const
 {
     verify_attached();
     return Results(m_realm, *m_object_schema, m_link_view, get_query().and_query(std::move(q)));

--- a/src/object-store/src/list.hpp
+++ b/src/object-store/src/list.hpp
@@ -51,6 +51,7 @@ public:
     const std::shared_ptr<Realm>& get_realm() const { return m_realm; }
     Query get_query() const;
     const ObjectSchema& get_object_schema() const { return *m_object_schema; }
+    const Table* get_table() const;
     size_t get_origin_row_index() const;
 
     bool is_valid() const;
@@ -72,8 +73,8 @@ public:
 
     void delete_all();
 
-    Results sort(SortOrder order);
-    Results filter(Query q);
+    Results sort(SortOrder order) const;
+    Results filter(Query q) const;
 
     bool operator==(List const& rgt) const noexcept;
 

--- a/src/object-store/src/results.cpp
+++ b/src/object-store/src/results.cpp
@@ -475,6 +475,12 @@ Query Results::get_query() const
     REALM_UNREACHABLE();
 }
 
+const Table* Results::get_table() const
+{
+    validate_read();
+    return m_table;
+}
+
 TableView Results::get_tableview()
 {
     validate_read();

--- a/src/object-store/src/results.hpp
+++ b/src/object-store/src/results.hpp
@@ -74,6 +74,9 @@ public:
     // Get the currently applied sort order for this Results
     SortOrder const& get_sort() const noexcept { return m_sort; }
 
+    // Get the table targeted by this Results
+    const Table* get_table() const;
+
     // Get a tableview containing the same rows as this Results
     TableView get_tableview();
 


### PR DESCRIPTION
There are some advantages for the `Results` being built from a `LinkViewRef`, and the object store very much encourages that with its `filter` and `sort` methods on List.
