### PR TITLE
Fix crash from calling objects() after close()

### DIFF
--- a/src/object-store/src/shared_realm.cpp
+++ b/src/object-store/src/shared_realm.cpp
@@ -205,6 +205,8 @@ Realm::~Realm()
 
 Group *Realm::read_group()
 {
+    verify_open();
+
     if (!m_group) {
         m_group = &const_cast<Group&>(m_shared_group->begin_read());
     }
@@ -315,6 +317,13 @@ void Realm::verify_in_write() const
 {
     if (!is_in_transaction()) {
         throw InvalidTransactionException("Cannot modify persisted objects outside of a write transaction.");
+    }
+}
+
+void Realm::verify_open() const
+{
+    if (is_closed()) {
+        throw InvalidTransactionException("Can't read a Realm that was closed.");
     }
 }
 

--- a/src/object-store/src/shared_realm.hpp
+++ b/src/object-store/src/shared_realm.hpp
@@ -133,6 +133,7 @@ namespace realm {
         thread_id_t thread_id() const { return m_thread_id; }
         void verify_thread() const;
         void verify_in_write() const;
+        void verify_open() const;
 
         bool can_deliver_notifications() const noexcept;
 
@@ -140,7 +141,7 @@ namespace realm {
         // Realm after closing it will produce undefined behavior.
         void close();
 
-        bool is_closed() { return !m_read_only_group && !m_shared_group; }
+        bool is_closed() const { return !m_read_only_group && !m_shared_group; }
 
         // returns the file format version upgraded from if an upgrade took place
         util::Optional<int> file_format_upgraded_from_version() const;

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -654,6 +654,10 @@ module.exports = {
         TestCase.assertThrows(function() {
             realm.objects(InvalidPerson);
         });
+        TestCase.assertThrows(function() {
+            realm.close();
+            realm.objects('PersonObject');
+        });
     },
 
     testRealmObjectForPrimaryKey: function() {


### PR DESCRIPTION
The `read_group()` method was called when m_shared_group is NULL. The `verify_open()` check probably should be added in more places, but calling it all over the place is probably not ideal.