### PR TITLE
Remove usage of Realm.Types in the spec and deprecate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Breaking changes
+* Deprecate `Realm.Types`. Please specify the type name as lowercase string instead.
+
+### Enhancements
+* None
+
+### Bugfixes
+* None
+
 0.14.2 Release notes (2016-7-11)
 =============================================================
 ### Breaking changes

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,18 +41,29 @@ if (typeof Realm != 'undefined') {
 Object.defineProperties(realmConstructor.Collection.prototype, arrayMethods);
 
 // TODO: Remove this now useless object.
+var types = Object.freeze({
+    'BOOL': 'bool',
+    'INT': 'int',
+    'FLOAT': 'float',
+    'DOUBLE': 'double',
+    'STRING': 'string',
+    'DATE': 'date',
+    'DATA': 'data',
+    'OBJECT': 'object',
+    'LIST': 'list',
+});
 Object.defineProperty(realmConstructor, 'Types', {
-    value: Object.freeze({
-        'BOOL': 'bool',
-        'INT': 'int',
-        'FLOAT': 'float',
-        'DOUBLE': 'double',
-        'STRING': 'string',
-        'DATE': 'date',
-        'DATA': 'data',
-        'OBJECT': 'object',
-        'LIST': 'list',
-    })
+    get: function() {
+        var stack = new Error().stack.split("\n").slice(2).join("\n");
+        var msg = '`Realm.Types` is deprecated! Please specify the type name as lowercase string instead!\n'+stack;
+        if (console.warn != undefined) {
+            console.warn(msg);
+        }
+        else {
+            console.log(msg);
+        }
+        return types;
+    }
 });
 
 module.exports = realmConstructor;

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,13 +54,18 @@ var types = Object.freeze({
 });
 Object.defineProperty(realmConstructor, 'Types', {
     get: function() {
-        var stack = new Error().stack.split("\n").slice(2).join("\n");
-        var msg = '`Realm.Types` is deprecated! Please specify the type name as lowercase string instead!\n'+stack;
-        if (console.warn != undefined) {
-            console.warn(msg);
-        }
-        else {
-            console.log(msg);
+        if (typeof console != 'undefined') {
+            /* global console */
+            /* eslint-disable no-console */
+            var stack = new Error().stack.split("\n").slice(2).join("\n");
+            var msg = '`Realm.Types` is deprecated! Please specify the type name as lowercase string instead!\n'+stack;
+            if (console.warn != undefined) {
+                console.warn(msg);
+            }
+            else {
+                console.log(msg);
+            }
+            /* eslint-enable no-console */
         }
         return types;
     }

--- a/scripts/reset-simulators.sh
+++ b/scripts/reset-simulators.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+while pgrep -q Simulator; do
+    # Kill all the current simulator processes as they may be from a
+    # different Xcode version
+    pkill Simulator 2>/dev/null || true
+    # CoreSimulatorService doesn't exit when sent SIGTERM
+    pkill -9 Simulator 2>/dev/null || true
+  done
+
+# Shut down simulators until there's no booted ones left
+# Only do one at a time because devices sometimes show up multiple times
+while xcrun simctl list | grep -q Booted; do
+  xcrun simctl list | grep Booted | sed 's/.* (\(.*\)) (Booted)/\1/' | head -n 1 | xargs xcrun simctl shutdown
+done
+
+# Clean up all available simulators
+(
+    previous_device=''
+    IFS=$'\n' # make newlines the only separator
+    for LINE in $(xcrun simctl list); do
+        if [[ $LINE =~ unavailable || $LINE =~ disconnected ]]; then
+            # skip unavailable simulators
+            continue
+        fi
+
+        if [[ $LINE =~ "--" ]]; then
+            # Reset the last seen device so we won't consider devices with the same name to be duplicates
+            # if they appear in different sections.
+            previous_device=""
+            continue
+        fi
+
+        regex='^(.*) [(]([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})[)]'
+        if [[ $LINE =~ $regex ]]; then
+            device="${BASH_REMATCH[1]}"
+            guid="${BASH_REMATCH[2]}"
+
+            # Delete the simulator if it's a duplicate of the last seen one
+            # Otherwise delete all contents and settings for it
+            if [[ $device == $previous_device ]]; then
+                xcrun simctl delete $guid
+            else
+                xcrun simctl erase $guid
+                previous_device="$device"
+            fi
+        fi
+    done
+)
+
+if [[ -a "${DEVELOPER_DIR}/Applications/iOS Simulator.app" ]]; then
+    open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
+elif [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
+    open "${DEVELOPER_DIR}/Applications/Simulator.app"
+fi
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,16 +30,6 @@ cleanup() {
   rm -f "$PACKAGER_OUT" "$LOGCAT_OUT"
 }
 
-kill_ios_simulator() {
-  while pgrep -q Simulator; do
-    # Kill all the current simulator processes as they may be from a
-    # different Xcode version
-    pkill Simulator 2>/dev/null || true
-    # CoreSimulatorService doesn't exit when sent SIGTERM
-    pkill -9 Simulator 2>/dev/null || true
-  done
-}
-
 open_chrome() {
   local dir
   for dir in "$HOME/Applications" "/Applications"; do
@@ -65,7 +55,7 @@ start_packager() {
 }
 
 xctest() {
-  kill_ios_simulator
+  ${SRCROOT}/scripts/reset-simulators.sh 
 
   local dest="$(xcrun simctl list devices | grep -v unavailable | grep -m 1 -o '[0-9A-F\-]\{36\}')"
   xcodebuild -scheme "$1" -configuration "$CONFIGURATION" -sdk iphonesimulator -destination id="$dest" build test

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -50,13 +50,13 @@ module.exports = {
             var prop = schemas.BasicTypes.properties[name];
             var type = typeof prop == 'object' ? prop.type : prop;
 
-            if (type == Realm.Types.FLOAT || type == Realm.Types.DOUBLE) {
+            if (type == 'float' || type == 'double') {
                 TestCase.assertEqualWithTolerance(object[name], basicTypesValues[name], 0.000001);
             }
-            else if (type == Realm.Types.DATA) {
+            else if (type == 'data') {
                 TestCase.assertArraysEqual(new Uint8Array(object[name]), RANDOM_DATA);
             }
-            else if (type == Realm.Types.DATE) {
+            else if (type == 'date') {
                 TestCase.assertEqual(object[name].getTime(), basicTypesValues[name].getTime());
             }
             else {
@@ -100,13 +100,13 @@ module.exports = {
 
             TestCase.assertEqual(nullObject[name], null);
 
-            if (type == Realm.Types.FLOAT || type == Realm.Types.DOUBLE) {
+            if (type == 'float' || type == 'double') {
                 TestCase.assertEqualWithTolerance(object[name], basicTypesValues[name], 0.000001);
             }
-            else if (type == Realm.Types.DATA) {
+            else if (type == 'data') {
                 TestCase.assertArraysEqual(new Uint8Array(object[name]), RANDOM_DATA);
             }
-            else if (type == Realm.Types.DATE) {
+            else if (type == 'date') {
                 TestCase.assertEqual(object[name].getTime(), basicTypesValues[name].getTime());
             }
             else {

--- a/tests/js/query-tests.js
+++ b/tests/js/query-tests.js
@@ -42,9 +42,9 @@ function convertValue(value, schema, type) {
     });
 }
 
-typeConverters[Realm.Types.DATE] = function(value) { return new Date(value); };
-typeConverters[Realm.Types.DATA] = function(value) { return new Uint8Array(value); };
-typeConverters[Realm.Types.OBJECT] = convertValue;
+typeConverters['date'] = function(value) { return new Date(value); };
+typeConverters['data'] = function(value) { return new Uint8Array(value); };
+typeConverters['object'] = convertValue;
 
 function runQuerySuite(suite) {
     var realm = new Realm({schema: suite.schema});

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -116,7 +116,7 @@ module.exports = {
         }, 'The schema should be an array of ObjectSchema objects');
 
         TestCase.assertThrows(function() {
-            new Realm({schema: [{properties: {intCol: Realm.Types.INT}}]});
+            new Realm({schema: [{properties: {intCol: 'int'}}]});
         }, 'The schema should be an array of ObjectSchema objects');
     },
 

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -23,7 +23,7 @@ var Realm = require('realm');
 exports.TestObject = {
     name: 'TestObject',
     properties: {
-        doubleCol: Realm.Types.DOUBLE,
+        doubleCol: 'double',
     }
 };
 
@@ -31,9 +31,9 @@ function PersonObject() {}
 PersonObject.schema = {
     name: 'PersonObject',
     properties: {
-        name:    Realm.Types.STRING,
-        age:     Realm.Types.DOUBLE,
-        married: {type: Realm.Types.BOOL, default: false}, 
+        name:    'string',
+        age:     'double',
+        married: {type: 'bool', default: false}, 
     }
 };
 PersonObject.prototype.description = function() {
@@ -54,26 +54,26 @@ exports.PersonList = {
 exports.BasicTypes = {
     name: 'BasicTypesObject',
     properties: {
-        boolCol:   Realm.Types.BOOL,
-        intCol:    Realm.Types.INT,
-        floatCol:  Realm.Types.FLOAT,
-        doubleCol: Realm.Types.DOUBLE,
-        stringCol: Realm.Types.STRING,
-        dateCol:   Realm.Types.DATE,
-        dataCol:   Realm.Types.DATA,
+        boolCol:   'bool',
+        intCol:    'int',
+        floatCol:  'float',
+        doubleCol: 'double',
+        stringCol: 'string',
+        dateCol:   'date',
+        dataCol:   'data',
     }
 };
 
 exports.NullableBasicTypes = {
     name: 'NullableBasicTypesObject',
     properties: {
-        boolCol:   {type: Realm.Types.BOOL,   optional: true},
-        intCol:    {type: Realm.Types.INT,    optional: true},
-        floatCol:  {type: Realm.Types.FLOAT,  optional: true},
-        doubleCol: {type: Realm.Types.DOUBLE, optional: true},
-        stringCol: {type: Realm.Types.STRING, optional: true},
-        dateCol:   {type: Realm.Types.DATE,   optional: true},
-        dataCol:   {type: Realm.Types.DATA,   optional: true},
+        boolCol:   {type: 'bool',   optional: true},
+        intCol:    {type: 'int',    optional: true},
+        floatCol:  {type: 'float',  optional: true},
+        doubleCol: {type: 'double', optional: true},
+        stringCol: {type: 'string', optional: true},
+        dateCol:   {type: 'date',   optional: true},
+        dataCol:   {type: 'data',   optional: true},
     }
 };
 
@@ -92,8 +92,8 @@ exports.LinkTypes = {
     name: 'LinkTypesObject',
     properties: {
         objectCol: 'TestObject',
-        objectCol1: {type: Realm.Types.OBJECT, objectType: 'TestObject'},
-        arrayCol:   {type: Realm.Types.LIST,   objectType: 'TestObject'},
+        objectCol1: {type: 'object', objectType: 'TestObject'},
+        arrayCol:   {type: 'list',   objectType: 'TestObject'},
     }
 };
 
@@ -101,8 +101,8 @@ exports.IntPrimary = {
     name: 'IntPrimaryObject',
     primaryKey: 'primaryCol',
     properties: {
-        primaryCol: Realm.Types.INT,
-        valueCol:   Realm.Types.STRING,
+        primaryCol: 'int',
+        valueCol:   'string',
     }
 };
 
@@ -110,8 +110,8 @@ exports.StringPrimary = {
     name: 'StringPrimaryObject',
     primaryKey: 'primaryCol',
     properties: {
-        primaryCol: Realm.Types.STRING,
-        valueCol:   Realm.Types.INT,
+        primaryCol: 'string',
+        valueCol:   'int',
     }
 };
 
@@ -119,64 +119,64 @@ exports.AllTypes = {
     name: 'AllTypesObject',
     primaryKey: 'primaryCol',
     properties: {
-        primaryCol: Realm.Types.STRING,
-        boolCol:    Realm.Types.BOOL,
-        intCol:     Realm.Types.INT,
-        floatCol:   Realm.Types.FLOAT,
-        doubleCol:  Realm.Types.DOUBLE,
-        stringCol:  Realm.Types.STRING,
-        dateCol:    Realm.Types.DATE,
-        dataCol:    Realm.Types.DATA,
+        primaryCol: 'string',
+        boolCol:    'bool',
+        intCol:     'int',
+        floatCol:   'float',
+        doubleCol:  'double',
+        stringCol:  'string',
+        dateCol:    'date',
+        dataCol:    'data',
         objectCol:  'TestObject',
-        arrayCol:   {type: Realm.Types.LIST, objectType: 'TestObject'},
+        arrayCol:   {type: 'list', objectType: 'TestObject'},
     }
 };
 
 exports.DefaultValues = {
     name: 'DefaultValuesObject',
     properties: {
-        boolCol:       {type: Realm.Types.BOOL,   default: true},
-        intCol:        {type: Realm.Types.INT,    default: -1},
-        floatCol:      {type: Realm.Types.FLOAT,  default: -1.1},
-        doubleCol:     {type: Realm.Types.DOUBLE, default: -1.11},
-        stringCol:     {type: Realm.Types.STRING, default: 'defaultString'},
-        dateCol:       {type: Realm.Types.DATE,   default: new Date(1.111)},
-        dataCol:       {type: Realm.Types.DATA,   default: new ArrayBuffer(1)},
+        boolCol:       {type: 'bool',             default: true},
+        intCol:        {type: 'int',              default: -1},
+        floatCol:      {type: 'float',            default: -1.1},
+        doubleCol:     {type: 'double',           default: -1.11},
+        stringCol:     {type: 'string',           default: 'defaultString'},
+        dateCol:       {type: 'date',             default: new Date(1.111)},
+        dataCol:       {type: 'data',             default: new ArrayBuffer(1)},
         objectCol:     {type: 'TestObject',       default: {doubleCol: 1}},
         nullObjectCol: {type: 'TestObject',       default: null},
-        arrayCol:      {type: Realm.Types.LIST, objectType: 'TestObject', default: [{doubleCol: 2}]},
+        arrayCol:      {type: 'list', objectType: 'TestObject', default: [{doubleCol: 2}]},
     }
 };
 
 exports.QueryObject = {
     name: 'QueryObject',
     properties: [
-        {name: 'bool1',   type: Realm.Types.BOOL},
-        {name: 'bool2',   type: Realm.Types.BOOL},
-        {name: 'int1',    type: Realm.Types.INT},
-        {name: 'int2',    type: Realm.Types.INT},
-        {name: 'float1',  type: Realm.Types.FLOAT},
-        {name: 'float2',  type: Realm.Types.FLOAT},
-        {name: 'double1', type: Realm.Types.DOUBLE},
-        {name: 'double2', type: Realm.Types.DOUBLE},
-        {name: 'string1', type: Realm.Types.STRING},
-        {name: 'string2', type: Realm.Types.STRING},
+        {name: 'bool1',   type: 'bool'},
+        {name: 'bool2',   type: 'bool'},
+        {name: 'int1',    type: 'int'},
+        {name: 'int2',    type: 'int'},
+        {name: 'float1',  type: 'float'},
+        {name: 'float2',  type: 'float'},
+        {name: 'double1', type: 'double'},
+        {name: 'double2', type: 'double'},
+        {name: 'string1', type: 'string'},
+        {name: 'string2', type: 'string'},
     ]
 };
 
 exports.NullQueryObject = {
     name: 'NullQueryObject',
     properties: [
-        {name: 'bool1',   type: Realm.Types.BOOL},
-        {name: 'bool2',   type: Realm.Types.BOOL},
-        {name: 'int1',    type: Realm.Types.INT},
-        {name: 'int2',    type: Realm.Types.INT},
-        {name: 'float1',  type: Realm.Types.FLOAT},
-        {name: 'float2',  type: Realm.Types.FLOAT},
-        {name: 'double1', type: Realm.Types.DOUBLE},
-        {name: 'double2', type: Realm.Types.DOUBLE},
-        {name: 'string1', type: Realm.Types.STRING},
-        {name: 'string2', type: Realm.Types.STRING},
+        {name: 'bool1',   type: 'bool'},
+        {name: 'bool2',   type: 'bool'},
+        {name: 'int1',    type: 'int'},
+        {name: 'int2',    type: 'int'},
+        {name: 'float1',  type: 'float'},
+        {name: 'float2',  type: 'float'},
+        {name: 'double1', type: 'double'},
+        {name: 'double2', type: 'double'},
+        {name: 'string1', type: 'string'},
+        {name: 'string2', type: 'string'},
     ]
 };
 


### PR DESCRIPTION
Spotted that the source code says, `Realm.Types` is useless and should be removed. I took a stab at making this possible. The way to deprecate that in the last commit might be debatable. I've also considered to make the property `configurable` and let it overwrite itself, so that it prints this warning only once.

/c @alazier @appden 