### PR TITLE
Get the path to nan relatively

### DIFF
--- a/src/node/binding.gyp
+++ b/src/node/binding.gyp
@@ -34,7 +34,7 @@
         "../object-store/src/parser",
         "../object-store/external/pegtl",
         "../../core-node/include",
-        "../../node_modules/nan"
+        "<!(node -e 'require(\"nan\")')"
       ],
       "library_dirs": [
         "$(srcdir)/../../core-node"


### PR DESCRIPTION
Under npm3 the `realm` and `nan` modules might end up as siblings so the best way to get the path to `nan` is to require it from within the `realm` module. The `nan` module prints its path so it can be captured by an external build system like in this patch.