### PR TITLE
Don't run npm install multiple times

### DIFF
--- a/examples/ReactExample/ios/ReactExample.xcodeproj/project.pbxproj
+++ b/examples/ReactExample/ios/ReactExample.xcodeproj/project.pbxproj
@@ -581,7 +581,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[ -s \"${HOME}/.nvm/nvm.sh\" ] && . \"${HOME}/.nvm/nvm.sh\"\nnpm install realm";
+			shellScript = "[ -s \"${HOME}/.nvm/nvm.sh\" ] && . \"${HOME}/.nvm/nvm.sh\"\nif [ -z \"$TEST_SCRIPT\" ]; then\n npm install realm\nfi";
 		};
 		F6C465131C48706400E79896 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,9 @@
 set -o pipefail
 set -e
 
+export TEST_SCRIPT=1
+export NPM_CONFIG_PROGRESS=false
+
 TARGET="$1"
 CONFIGURATION="${2:-"Release"}"
 DESTINATION=
@@ -58,7 +61,11 @@ xctest() {
   ${SRCROOT}/scripts/reset-simulators.sh 
 
   local dest="$(xcrun simctl list devices | grep -v unavailable | grep -m 1 -o '[0-9A-F\-]\{36\}')"
-  xcodebuild -scheme "$1" -configuration "$CONFIGURATION" -sdk iphonesimulator -destination id="$dest" build test
+  if [ -n "$XCPRETTY" ]; then
+    xcodebuild -scheme "$1" -configuration "$CONFIGURATION" -sdk iphonesimulator -destination id="$dest" test | xcpretty -c --no-utf --report junit --output build/reports/junit.xml
+  else
+    xcodebuild -scheme "$1" -configuration "$CONFIGURATION" -sdk iphonesimulator -destination id="$dest" test
+  fi
 }
 
 # Cleanup now and also cleanup when this script exits.

--- a/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
+++ b/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[ -s \"${HOME}/.nvm/nvm.sh\" ] && . \"${HOME}/.nvm/nvm.sh\" \nnpm install realm realm-tests\ncp ../../../src/object-store/tests/query.json ../node_modules/realm-tests/query-tests.json\n";
+			shellScript = "[ -s \"${HOME}/.nvm/nvm.sh\" ] && . \"${HOME}/.nvm/nvm.sh\" \nif [ -z \"$TEST_SCRIPT\" ]; then\n  npm install realm realm-tests\nfi\ncp ../../../src/object-store/tests/query.json ../node_modules/realm-tests/query-tests.json\n";
 		};
 		F6EDE5BF1C49007200B1085F /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
@fealebenpae 

Right now `npm install` is run multiple times unnecessarily when running tests. This reduces the number of runs to 1 per test.