### PR TITLE
Fix node tests

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
     },
     {
       "target_name": "object-store",
-      "dependencies": [ "realm-core", "realm-sync" ],
+      "dependencies": [ "realm-core" ],
       "type": "static_library",
       "include_dirs": [
         "src/object-store/src",
@@ -63,12 +63,6 @@
         "src/object-store/src/parser/query_builder.cpp",
         "src/object-store/src/util/format.cpp",
         "src/object-store/src/util/thread_id.cpp",
-        "src/object-store/src/sync/sync_manager.cpp",
-        "src/object-store/src/sync/sync_user.cpp",
-        "src/object-store/src/sync/sync_session.cpp",
-        "src/object-store/src/sync/impl/sync_file.cpp",
-        "src/object-store/src/sync/impl/sync_metadata.cpp",
-        "src/object-store/src/impl/apple/keychain_helper.cpp"
       ],
       "conditions": [
         ["OS=='linux'", {
@@ -80,10 +74,21 @@
           "sources": [
             "src/object-store/src/impl/apple/external_commit_helper.cpp"
           ]
+        }],
+        ["realm_enable_sync", {
+          "dependencies": [ "realm-sync" ],
+          "sources": [
+            "src/object-store/src/sync/sync_manager.cpp",
+            "src/object-store/src/sync/sync_user.cpp",
+            "src/object-store/src/sync/sync_session.cpp",
+            "src/object-store/src/sync/impl/sync_file.cpp",
+            "src/object-store/src/sync/impl/sync_metadata.cpp",
+            "src/object-store/src/impl/apple/keychain_helper.cpp"
+          ],
         }]
       ],
       "all_dependent_settings": {
-        "include_dirs": [ 
+        "include_dirs": [
           "src/object-store/src",
           "src/object-store/src/impl",
           "src/object-store/src/impl/apple",

--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -30,9 +30,9 @@ else
 fi
 
 SYNC_DIR='sync'
-SYNC_PLATFORM_TAG="cocoa-"
+SYNC_PLATFORM_TAG="node-cocoa-"
 
-SYNC_DOWNLOAD_FILE="realm-sync-$SYNC_PLATFORM_TAG$REALM_SYNC_VERSION.tar.xz"
+SYNC_DOWNLOAD_FILE="realm-sync-$SYNC_PLATFORM_TAG$REALM_SYNC_VERSION.zip"
 
 # Start current working directory at the root of the project.
 cd "$(dirname "$0")/.."
@@ -47,6 +47,8 @@ download_core() {
     local VERSION=$2
     local DOWNLOAD_FILE=$3
     local SERVER_DIR=$4
+    local UNTAR=$5
+    local UNTARRED_DIR=$6
     echo "Downloading dependency: $DIR $VERSION"
 
     local TMP_DIR="${TMPDIR:-/tmp}/$DIR"
@@ -56,7 +58,7 @@ download_core() {
     mkdir -p "$TMP_DIR"
 
     if [ ! -f "$TAR" ]; then
-	echo  "https://static.realm.io/downloads/$SERVER_DIR/$DOWNLOAD_FILE" 
+	echo  "https://static.realm.io/downloads/$SERVER_DIR/$DOWNLOAD_FILE"
         curl -f -L -s "https://static.realm.io/downloads/$SERVER_DIR/$DOWNLOAD_FILE" -o "$TMP_TAR" ||
             die "Downloading $DIR failed. Please try again once you have an Internet connection."
         mv "$TMP_TAR" "$TAR"
@@ -67,8 +69,8 @@ download_core() {
     (
         cd "$TMP_DIR"
         rm -rf "$DIR"
-        tar -xzf "$TAR"
-        mv core "$DIR-$VERSION"
+        "$UNTAR" "$TAR"
+        mv "$UNTARRED_DIR" "$DIR-$VERSION"
     )
 
     (
@@ -84,7 +86,7 @@ check_release_notes() {
 }
 
 if [ ! -e "vendor/$CORE_DIR" ]; then
-    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core
+    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core "tar -xzf" core
 elif [ -d "vendor/$CORE_DIR" -a -d ../realm-core -a ! -L "vendor/$CORE_DIR" ]; then
     # Allow newer versions than expected for local builds as testing
     # with unreleased versions is one of the reasons to use a local build
@@ -96,19 +98,19 @@ elif [ -d "vendor/$CORE_DIR" -a -d ../realm-core -a ! -L "vendor/$CORE_DIR" ]; t
 elif [ ! -L "vendor/$CORE_DIR" ]; then
     echo "vendor/$CORE_DIR is not a symlink. Deleting..."
     rm -rf "vendor/$CORE_DIR"
-    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core
+    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core "tar -xzf" core
 # With a prebuilt version we only want to check the first non-empty
 # line so that checking out an older commit will download the
 # appropriate version of core if the already-present version is too new
 elif ! grep -m 1 . "vendor/$CORE_DIR/CHANGELOG.txt" | check_release_notes; then
-    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core
+    download_core $CORE_DIR $REALM_CORE_VERSION $CORE_DOWNLOAD_FILE core "tar -xzf" core
 else
     echo "The core library seems to be up to date."
 fi
 
 
 if [ ! -e "vendor/$SYNC_DIR" ]; then
-    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync
+    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync "unzip" realm-sync-node-cocoa-$REALM_SYNC_VERSION
 elif [ -d "vendor/$SYNC_DIR" -a -d ../realm-sync -a ! -L "vendor/$SYNC_DIR" ]; then
     # Allow newer versions than expected for local builds as testing
     # with unreleased versions is one of the reasons to use a local build
@@ -120,12 +122,12 @@ elif [ -d "vendor/$SYNC_DIR" -a -d ../realm-sync -a ! -L "vendor/$SYNC_DIR" ]; t
 elif [ ! -L "vendor/$SYNC_DIR" ]; then
     echo "vendor/$SYNC_DIR is not a symlink. Deleting..."
     rm -rf "vendor/$SYNC_DIR"
-    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync
+    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync "unzip" realm-sync-node-cocoa-$REALM_SYNC_VERSION
 # With a prebuilt version we only want to check the first non-empty
 # line so that checking out an older commit will download the
 # appropriate version of core if the already-present version is too new
 elif ! grep -m 1 . "vendor/$SYNC_DIR/version.txt" | check_release_notes; then
-    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync
+    download_core $SYNC_DIR $REALM_SYNC_VERSION $SYNC_DOWNLOAD_FILE sync "unzip" realm-sync-node-cocoa-$REALM_SYNC_VERSION
 else
     echo "The sync library seems to be up to date."
 fi

--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -69,7 +69,7 @@ download_core() {
     (
         cd "$TMP_DIR"
         rm -rf "$DIR"
-        "$UNTAR" "$TAR"
+        eval "$UNTAR" "$TAR"
         mv "$UNTARRED_DIR" "$DIR-$VERSION"
     )
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -176,8 +176,7 @@ case "$TARGET" in
 "node")
   download_server
   start_server
-  bash "$SRCROOT/scripts/download-core.sh"
-  npm install --build-from-source --realm_enable_sync
+  npm install --build-from-source
 
   # Change to a temp directory.
   cd "$(mktemp -q -d -t realm.node.XXXXXX)"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -176,7 +176,7 @@ case "$TARGET" in
 "node")
   download_server
   start_server
-  npm install --build-from-source
+  npm install --build-from-source --realm_enable_sync
 
   # Change to a temp directory.
   cd "$(mktemp -q -d -t realm.node.XXXXXX)"
@@ -217,7 +217,7 @@ case "$TARGET" in
   touch "tests/sync-bundle/object-server/do_not_open_browser"
   ;;
 "object-server-integration")
-  echo -e "yes\n" | ./tests/sync-bundle/reset-server-realms.command 
+  echo -e "yes\n" | ./tests/sync-bundle/reset-server-realms.command
 
   pushd "$SRCROOT/tests"
   npm install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -176,6 +176,7 @@ case "$TARGET" in
 "node")
   download_server
   start_server
+  bash "$SRCROOT/scripts/download-core.sh"
   npm install --build-from-source --realm_enable_sync
 
   # Change to a temp directory.

--- a/src/node/gyp/realm.gyp
+++ b/src/node/gyp/realm.gyp
@@ -1,8 +1,18 @@
 {
   "variables": {
-    "use_realm_debug": "<!(echo $REALMJS_USE_DEBUG_CORE)",
-    "realm_enable_sync%": "0"
+    "use_realm_debug": "<!(echo $REALMJS_USE_DEBUG_CORE)"
   },
+  "conditions": [
+    ["OS=='mac'", {
+      "variables": {
+        "realm_enable_sync%": "1"
+      }
+    }, {
+      "variables": {
+        "realm_enable_sync%": "0"
+      }
+    }]
+  ],
   "targets": [
     {
       "target_name": "realm-core",
@@ -72,6 +82,14 @@
       },
       "target_name": "vendored-realm",
       "type": "none",
+      "actions": [
+        {
+          "action_name": "download-realm",
+           "inputs": [ ],
+           "outputs": [ "<(module_root_dir)/vendor/core-node" ],
+           "action": [ "<(module_root_dir)/scripts/download-core.sh", "node" ]
+        }
+      ],
       "conditions": [
         ["realm_enable_sync", {
           "all_dependent_settings": {
@@ -83,14 +101,7 @@
             "include_dirs": [ "<(module_root_dir)/vendor/core-node/include" ],
             "library_dirs": [ "<(module_root_dir)/vendor/core-node" ]
           },
-          "actions": [
-            {
-              "action_name": "download-realm",
-               "inputs": [ ],
-               "outputs": [ "<(module_root_dir)/vendor/core-node" ],
-               "action": [ "<(module_root_dir)/scripts/download-core.sh", "node" ]
-            }
-          ]
+
         }]
       ]
 

--- a/src/node/gyp/realm.gyp
+++ b/src/node/gyp/realm.gyp
@@ -75,8 +75,8 @@
       "conditions": [
         ["realm_enable_sync", {
           "all_dependent_settings": {
-            "include_dirs": [ "<(module_root_dir)/vendor/realm-sync/include" ],
-            "library_dirs": [ "<(module_root_dir)/vendor/realm-sync/osx" ]
+            "include_dirs": [ "<(module_root_dir)/vendor/sync/include" ],
+            "library_dirs": [ "<(module_root_dir)/vendor/sync/osx" ]
           }
         }, {
           "all_dependent_settings": {

--- a/src/node/gyp/realm.gyp
+++ b/src/node/gyp/realm.gyp
@@ -18,7 +18,7 @@
         ]
       },
       "all_dependent_settings": {
-        "defines": [ "REALM_HAVE_CONFIG", "REALM_PLATFORM_NODE=1", "REALM_ENABLE_SYNC=1" ]
+        "defines": [ "REALM_HAVE_CONFIG", "REALM_PLATFORM_NODE=1", "REALM_ENABLE_SYNC=<(realm_enable_sync)" ]
       },
       "variables": {
         "prefix": "<!(echo $REALM_CORE_PREFIX)"
@@ -93,7 +93,7 @@
           ]
         }]
       ]
-      
+
     }
   ]
 }


### PR DESCRIPTION
We still need to be able to build node without sync for linux.

This is why I kept the "--realm_enable_sync" flag. It might need to be added to a few of the other npm installs (react)

The download of the sync library could be improved, I want to change the format just like the core one.

@sorenvind @alazier 


