### PR TITLE
Improve build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,7 @@
 {
   "variables": {
-    "realm_node_build_as_library%": "0"
+    "realm_node_build_as_library%": "0",
+    "realm_download_binaries%": "1"
   },
   "includes": [
     "src/node/gyp/target_defaults.gypi",

--- a/src/node/gyp/realm.gyp
+++ b/src/node/gyp/realm.gyp
@@ -82,14 +82,6 @@
       },
       "target_name": "vendored-realm",
       "type": "none",
-      "actions": [
-        {
-          "action_name": "download-realm",
-           "inputs": [ ],
-           "outputs": [ "<(module_root_dir)/vendor/core-node" ],
-           "action": [ "<(module_root_dir)/scripts/download-core.sh", "node" ]
-        }
-      ],
       "conditions": [
         ["realm_enable_sync", {
           "all_dependent_settings": {
@@ -102,9 +94,18 @@
             "library_dirs": [ "<(module_root_dir)/vendor/core-node" ]
           },
 
+        }],
+        ["realm_download_binaries", {
+          "actions": [
+            {
+              "action_name": "download-realm",
+              "inputs": [ ],
+              "outputs": [ "<(module_root_dir)/vendor/core-node" ],
+              "action": [ "<(module_root_dir)/scripts/download-core.sh", "node", "<(realm_enable_sync)" ]
+            }
+          ]
         }]
       ]
-
     }
   ]
 }


### PR DESCRIPTION
This add the "realm_download_binaries" variable so that we can skip the download when building realm-js-private.
Also. added a parameter to download-core.sh to specify if using sync or not.

We should download core and sync, not both, as sync contains core headers and binaries. Only works for node now.

@sorenvind @alazier 