### PR TITLE
Nh/update android

### DIFF
--- a/examples/ReactExample/android/app/src/main/AndroidManifest.xml
+++ b/examples/ReactExample/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+        android:name=".MainApplication">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainActivity.java
+++ b/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainActivity.java
@@ -1,13 +1,6 @@
 package io.realm.react.example;
 
 import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
-
-import java.util.Arrays;
-import java.util.List;
-
-import io.realm.react.RealmReactPackage;
 
 public class MainActivity extends ReactActivity {
 
@@ -27,17 +20,5 @@ public class MainActivity extends ReactActivity {
     @Override
     protected boolean getUseDeveloperSupport() {
         return BuildConfig.DEBUG;
-    }
-
-    /**
-     * A list of packages used by the app. If the app uses additional views
-     * or modules besides the default ones, add more packages here.
-     */
-    @Override
-    protected List<ReactPackage> getPackages() {
-        return Arrays.<ReactPackage>asList(
-            new MainReactPackage(),
-            new RealmReactPackage()
-        );
     }
 }

--- a/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainActivity.java
+++ b/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainActivity.java
@@ -13,12 +13,4 @@ public class MainActivity extends ReactActivity {
         return "ReactExample";
     }
 
-    /**
-     * Returns whether dev mode should be enabled.
-     * This enables e.g. the dev menu.
-     */
-    @Override
-    protected boolean getUseDeveloperSupport() {
-        return BuildConfig.DEBUG;
-    }
 }

--- a/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainApplication.java
+++ b/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainApplication.java
@@ -33,7 +33,6 @@ public class MainApplication extends Application implements ReactApplication {
      * A list of packages used by the app. If the app uses additional views
      * or modules besides the default ones, add more packages here.
      */
-
     @Override
     public ReactNativeHost getReactNativeHost() {
         return mReactNativeHost;

--- a/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainApplication.java
+++ b/examples/ReactExample/android/app/src/main/java/io/realm/react/example/MainApplication.java
@@ -1,0 +1,41 @@
+package io.realm.react.example;
+
+import android.app.Application;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.shell.MainReactPackage;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.realm.react.RealmReactPackage;
+
+public class MainApplication extends Application implements ReactApplication {
+
+    private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+        @Override
+        protected boolean getUseDeveloperSupport() {
+            return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+            return Arrays.<ReactPackage>asList(
+                    new MainReactPackage(),
+                    new RealmReactPackage()
+            );
+        }
+    };
+
+    /**
+     * A list of packages used by the app. If the app uses additional views
+     * or modules besides the default ones, add more packages here.
+     */
+
+    @Override
+    public ReactNativeHost getReactNativeHost() {
+        return mReactNativeHost;
+    }
+}

--- a/examples/ReactExample/android/build.gradle
+++ b/examples/ReactExample/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/ReactExample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/ReactExample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 11 18:15:12 GMT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "get-version": "echo $npm_package_version",
     "set-version": "scripts/set-version.sh",
     "get-core-version": "scripts/download-core.sh --version",
+    "get-sync-version": "scripts/download-core.sh --versionSync",
     "jsdoc": "rm -rf docs/output && jsdoc -c docs/conf.json",
     "lint": "eslint",
     "test": "scripts/test.sh",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "jsdoc": "rm -rf docs/output && jsdoc -c docs/conf.json",
     "lint": "eslint",
     "test": "scripts/test.sh",
-    "install": "node-pre-gyp install --fallback-to-build"
+    "install": "node-pre-gyp install --fallback-to-build",
+    "prepublish": "scripts/prepublish.sh"
   },
   "dependencies": {
     "nan": "^2.3.3",

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -65,6 +65,7 @@ task downloadJSCHeaders(type: Download) {
 
 task downloadRealmCore(type: Download) {
     src "https://static.realm.io/downloads/core/realm-core-android-${project.coreVersion}.tar.gz"
+    // src "https://static.realm.io/downloads/sync/realm-sync-android-${project.coreVersion}.tar.gz"
     onlyIfNewer true
     overwrite false
     dest new File(downloadsDir, "realm-core-android-${project.coreVersion}.tar.gz")

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -33,12 +33,14 @@ import org.apache.tools.ant.filters.ReplaceTokens
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.
 
 ext.coreVersion = "npm --silent run get-core-version".execute().text.trim()
+ext.syncVersion = "npm --silent run get-sync-version".execute().text.trim()
 def currentVersion = "npm --silent run get-version".execute().text.trim()
 def downloadsDir = new File("$projectDir/downloads")
 def jscDownloadDir = new File("$projectDir/src/main/jni/jsc")
 def coreDownloadDir = new File("$projectDir/src/main/jni")
 def publishDir = new File("$projectDir/../../android/")
-
+// to build with sync run: ./gradlew assembleDebug -PbuildWithSync=true
+ext.buildSync = project.hasProperty('buildWithSync') ? project.getProperty('buildWithSync').toBoolean() : false
 
 task generateVersionClass(type: Copy) {
     from 'src/main/templates/Version.java'
@@ -64,11 +66,18 @@ task downloadJSCHeaders(type: Download) {
  }
 
 task downloadRealmCore(type: Download) {
-    src "https://static.realm.io/downloads/core/realm-core-android-${project.coreVersion}.tar.gz"
-    // src "https://static.realm.io/downloads/sync/realm-sync-android-${project.coreVersion}.tar.gz"
+    if (project.buildSync) {
+        src "https://static.realm.io/downloads/sync/realm-sync-android-${project.syncVersion}.tar.gz"
+    } else {
+        src "https://static.realm.io/downloads/core/realm-core-android-${project.coreVersion}.tar.gz"
+    }
     onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "realm-core-android-${project.coreVersion}.tar.gz")
+    overwrite true
+    if (project.buildSync) {
+        dest new File(downloadsDir, "realm-core-android-${project.syncVersion}.tar.gz")
+    } else {
+        dest new File(downloadsDir, "realm-core-android-${project.coreVersion}.tar.gz")
+    }
 }
 
 task prepareRealmCore(dependsOn: downloadRealmCore, type:Copy) {
@@ -140,6 +149,8 @@ task buildReactNdkLib(dependsOn: [downloadJSCHeaders,prepareRealmCore], type: Ex
     inputs.file('src/main/jni')
     outputs.dir("$buildDir/realm-react-ndk/all")
     commandLine getNdkBuildFullPath(),
+            '-e',
+            project.buildSync ? 'BUILD_TYPE_SYNC=1' : 'BUILD_TYPE_SYNC=0',
             'NDK_PROJECT_PATH=null',
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             'NDK_OUT=' + temporaryDir,

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -14,40 +14,45 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := librealmreact
 
-LOCAL_SRC_FILES := \
-  src/js_realm.cpp \
-  src/rpc.cpp \
-  src/jsc/jsc_init.cpp \
-  src/android/platform.cpp \
-  src/android/io_realm_react_RealmReactModule.cpp \
-  src/android/jsc_override.cpp \
-  src/object-store/src/collection_notifications.cpp \
-  src/object-store/src/index_set.cpp \
-  src/object-store/src/list.cpp \
-  src/object-store/src/object_schema.cpp \
-  src/object-store/src/object_store.cpp \
-  src/object-store/src/results.cpp \
-  src/object-store/src/schema.cpp \
-  src/object-store/src/shared_realm.cpp \
-  src/object-store/src/parser/parser.cpp \
-  src/object-store/src/parser/query_builder.cpp \
-  src/object-store/src/impl/collection_change_builder.cpp \
-  src/object-store/src/impl/collection_notifier.cpp \
-  src/object-store/src/impl/list_notifier.cpp \
-  src/object-store/src/impl/realm_coordinator.cpp \
-  src/object-store/src/impl/results_notifier.cpp \
-  src/object-store/src/impl/transact_log_handler.cpp \
-  src/object-store/src/impl/android/external_commit_helper.cpp \
-  src/object-store/src/impl/android/weak_realm_notifier.cpp \
-  src/object-store/src/util/format.cpp \
-  src/object-store/src/util/thread_id.cpp \
-  vendor/base64.cpp
+LOCAL_SRC_FILES := $(wildcard vendor/*.cpp) $(wildcard src/*.cpp) $(wildcard src/jsc/*.cpp) $(wildcard src/android/*.cpp) $(wildcard src/object-store/src/*.cpp) $(wildcard src/object-store/src/impl/*.cpp) $(wildcard src/object-store/src/parser/*.cpp) $(wildcard src/object-store/src/util/*.cpp)
+# $(info >>>>>>>> LIBS>:  [${OBJ_STORE}])
+
+# LOCAL_SRC_FILES := \
+#   src/js_realm.cpp \
+#   src/rpc.cpp \
+#   src/jsc/jsc_init.cpp \
+#   src/android/platform.cpp \
+#   src/android/io_realm_react_RealmReactModule.cpp \
+#   src/android/jsc_override.cpp \
+#   src/object-store/src/collection_notifications.cpp \
+#   src/object-store/src/index_set.cpp \
+#   src/object-store/src/list.cpp \
+#   src/object-store/src/object_schema.cpp \
+#   src/object-store/src/object_store.cpp \
+#   src/object-store/src/results.cpp \
+#   src/object-store/src/schema.cpp \
+#   src/object-store/src/shared_realm.cpp \
+#   src/object-store/src/parser/parser.cpp \
+#   src/object-store/src/parser/query_builder.cpp \
+#   src/object-store/src/impl/collection_change_builder.cpp \
+#   src/object-store/src/impl/collection_notifier.cpp \
+#   src/object-store/src/impl/list_notifier.cpp \
+#   src/object-store/src/impl/realm_coordinator.cpp \
+#   src/object-store/src/impl/results_notifier.cpp \
+#   src/object-store/src/impl/transact_log_handler.cpp \
+#   src/object-store/src/impl/android/external_commit_helper.cpp \
+#   src/object-store/src/impl/weak_realm_notifier.cpp \
+#   src/object-store/src/util/format.cpp \
+#   src/object-store/src/util/thread_id.cpp \
+#   src/object-store/src/thread_confined.hpp \
+#   vendor/base64.cpp
 
 LOCAL_C_INCLUDES := src
 LOCAL_C_INCLUDES += src/jsc
 LOCAL_C_INCLUDES += src/object-store/src
 LOCAL_C_INCLUDES += src/object-store/src/impl
 LOCAL_C_INCLUDES += src/object-store/src/parser
+# LOCAL_C_INCLUDES += src/object-store/src/sync
 LOCAL_C_INCLUDES += src/object-store/external/pegtl
 LOCAL_C_INCLUDES += vendor
 LOCAL_C_INCLUDES += $(JAVA_HOME)/include

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -1,5 +1,13 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
+include $(CLEAR_VARS)
+LOCAL_MODULE := realm-android-sync-$(TARGET_ARCH_ABI)
+LOCAL_EXPORT_C_INCLUDES := core/include
+LOCAL_SRC_FILES := core/librealm-sync-android-$(TARGET_ARCH_ABI).a
+include $(PREBUILT_STATIC_LIBRARY)
+endif
+
 include $(CLEAR_VARS)
 LOCAL_MODULE := realm-android-$(TARGET_ARCH_ABI)
 LOCAL_EXPORT_C_INCLUDES := core/include
@@ -14,53 +22,66 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := librealmreact
 
-LOCAL_SRC_FILES := $(wildcard vendor/*.cpp) $(wildcard src/*.cpp) $(wildcard src/jsc/*.cpp) $(wildcard src/android/*.cpp) $(wildcard src/object-store/src/*.cpp) $(wildcard src/object-store/src/impl/*.cpp) $(wildcard src/object-store/src/parser/*.cpp) $(wildcard src/object-store/src/util/*.cpp)
-# $(info >>>>>>>> LIBS>:  [${OBJ_STORE}])
-
-# LOCAL_SRC_FILES := \
-#   src/js_realm.cpp \
-#   src/rpc.cpp \
-#   src/jsc/jsc_init.cpp \
-#   src/android/platform.cpp \
-#   src/android/io_realm_react_RealmReactModule.cpp \
-#   src/android/jsc_override.cpp \
-#   src/object-store/src/collection_notifications.cpp \
-#   src/object-store/src/index_set.cpp \
-#   src/object-store/src/list.cpp \
-#   src/object-store/src/object_schema.cpp \
-#   src/object-store/src/object_store.cpp \
-#   src/object-store/src/results.cpp \
-#   src/object-store/src/schema.cpp \
-#   src/object-store/src/shared_realm.cpp \
-#   src/object-store/src/parser/parser.cpp \
-#   src/object-store/src/parser/query_builder.cpp \
-#   src/object-store/src/impl/collection_change_builder.cpp \
-#   src/object-store/src/impl/collection_notifier.cpp \
-#   src/object-store/src/impl/list_notifier.cpp \
-#   src/object-store/src/impl/realm_coordinator.cpp \
-#   src/object-store/src/impl/results_notifier.cpp \
-#   src/object-store/src/impl/transact_log_handler.cpp \
-#   src/object-store/src/impl/android/external_commit_helper.cpp \
-#   src/object-store/src/impl/weak_realm_notifier.cpp \
-#   src/object-store/src/util/format.cpp \
-#   src/object-store/src/util/thread_id.cpp \
-#   src/object-store/src/thread_confined.hpp \
-#   vendor/base64.cpp
+LOCAL_SRC_FILES := vendor/base64.cpp
+LOCAL_SRC_FILES += src/js_realm.cpp
+LOCAL_SRC_FILES += src/rpc.cpp
+LOCAL_SRC_FILES += src/jsc/jsc_init.cpp
+LOCAL_SRC_FILES += src/android/io_realm_react_RealmReactModule.cpp
+LOCAL_SRC_FILES += src/android/jsc_override.cpp
+LOCAL_SRC_FILES += src/android/platform.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/collection_change_builder.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/collection_notifier.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/handover.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/list_notifier.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/realm_coordinator.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/results_notifier.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/transact_log_handler.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/weak_realm_notifier.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/android/external_commit_helper.cpp
+LOCAL_SRC_FILES += src/object-store/src/parser/parser.cpp
+LOCAL_SRC_FILES += src/object-store/src/parser/query_builder.cpp
+LOCAL_SRC_FILES += src/object-store/src/util/format.cpp
+LOCAL_SRC_FILES += src/object-store/src/util/thread_id.cpp
+LOCAL_SRC_FILES += src/object-store/src/collection_notifications.cpp
+LOCAL_SRC_FILES += src/object-store/src/index_set.cpp
+LOCAL_SRC_FILES += src/object-store/src/list.cpp
+LOCAL_SRC_FILES += src/object-store/src/object_schema.cpp
+LOCAL_SRC_FILES += src/object-store/src/object_store.cpp
+LOCAL_SRC_FILES += src/object-store/src/placeholder.cpp
+LOCAL_SRC_FILES += src/object-store/src/results.cpp
+LOCAL_SRC_FILES += src/object-store/src/schema.cpp
+LOCAL_SRC_FILES += src/object-store/src/shared_realm.cpp
+LOCAL_SRC_FILES += src/object-store/src/thread_confined.cpp
+ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
+LOCAL_SRC_FILES += src/object-store/src/sync/sync_manager.cpp
+LOCAL_SRC_FILES += src/object-store/src/sync/sync_session.cpp
+LOCAL_SRC_FILES += src/object-store/src/sync/sync_user.cpp
+LOCAL_SRC_FILES += src/object-store/src/sync/impl/sync_file.cpp
+LOCAL_SRC_FILES += src/object-store/src/sync/impl/sync_metadata.cpp
+endif
 
 LOCAL_C_INCLUDES := src
 LOCAL_C_INCLUDES += src/jsc
 LOCAL_C_INCLUDES += src/object-store/src
 LOCAL_C_INCLUDES += src/object-store/src/impl
 LOCAL_C_INCLUDES += src/object-store/src/parser
-# LOCAL_C_INCLUDES += src/object-store/src/sync
 LOCAL_C_INCLUDES += src/object-store/external/pegtl
 LOCAL_C_INCLUDES += vendor
 LOCAL_C_INCLUDES += $(JAVA_HOME)/include
 LOCAL_C_INCLUDES += $(JAVA_HOME)/include/darwin
 LOCAL_C_INCLUDES += core/include
+ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
+LOCAL_C_INCLUDES += src/object-store/src/sync
+endif
 
 LOCAL_ALLOW_UNDEFINED_SYMBOLS := true
-
+ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
+LOCAL_STATIC_LIBRARIES := realm-android-sync-$(TARGET_ARCH_ABI)
+LOCAL_STATIC_LIBRARIES += realm-android-$(TARGET_ARCH_ABI)
+else
 LOCAL_STATIC_LIBRARIES := realm-android-$(TARGET_ARCH_ABI)
+endif
+
+
 LOCAL_SHARED_LIBRARIES := libjsc
 include $(BUILD_SHARED_LIBRARY)

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -5,7 +5,7 @@ APP_PLATFORM := android-9
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)first-party
+NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)
 
 APP_STL := gnustl_static
 APP_CPPFLAGS := -std=c++14
@@ -18,5 +18,8 @@ APP_CPPFLAGS += -fomit-frame-pointer
 APP_LDFLAGS := -Wl,--build-id
 APP_LDFLAGS += -llog
 APP_LDFLAGS += -landroid
+ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
+APP_LDFLAGS += -lz
+endif
 
 NDK_TOOLCHAIN_VERSION := 4.9

--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -12,6 +12,9 @@ source_root="$(dirname "$0")"
 if [ "$1" = '--version' ]; then
     echo "$REALM_CORE_VERSION"
     exit 0
+elif [ "$1" = '--versionSync' ]; then
+    echo "$REALM_SYNC_VERSION"
+    exit 0
 fi
 
 # The 'node' argument will result in realm-node build being downloaded.

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -8,5 +8,5 @@ cd "$(dirname "$0")/.."
 
 if [ -n "$REALM_BUILD_ANDROID" ]; then
   rm -rf android
-  (cd react-native/android && ./gradlew publishAndroid)
+  (cd react-native/android && ./gradlew publishAndroid -PbuildWithSync=true)
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -151,6 +151,7 @@ case "$TARGET" in
   ;;
 "react-tests-android")
   [[ $CONFIGURATION == 'Debug' ]] && exit 0
+  XCPRETTY=false
 
   pushd tests/react-test-app
 

--- a/tests/react-test-app/package.json
+++ b/tests/react-test-app/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react": "15.3.2",
     "react-native": "^0.37.0",
+    "react-native-fs": "^1.1.0",
     "realm": "file:../..",
     "realm-tests": "file:../js",
     "xmlbuilder": "^4.2.1"


### PR DESCRIPTION
* Using `dependencies.list` to figure out the Core/Sync version
* Update `ReactExample`
* Add a switch to build RN Android with Sync or just core
     - `/realm-js/react-native/android/gradlew clean publishAndroid` will build using Core as a dependency only
   -  `/realm-js/react-native/android/gradlew clean publishAndroid  -PbuildWithSync=true` will pull Core + Sync & build them as static library (note: this only compile using Sync static library it doesn't enable sync yet)

@alazier @kristiandupont 

This fixes #639