### PR TITLE
Support running realm-js in Electron renderer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,24 +22,36 @@ function node_require(module) {
     return require(module);
 }
 
-var realmConstructor;
+function isNode() {
+    return typeof process == 'object' && (('' + process) == '[object process]' || typeof jest == 'object')
+}
 
-if (typeof Realm != 'undefined') {
-    // The global Realm constructor should be available on device (using JavaScriptCore).
-    realmConstructor = Realm;  // eslint-disable-line no-undef
-// eslint-disable-next-line
-} else if (typeof window != 'undefined') {
-    // The userAgent will be defined when running in a browser (such as Chrome debugging mode).
-    realmConstructor = require('./browser').default; // (exported as ES6 module)
-// eslint-disable-next-line
-} else if (typeof process == 'object' && (('' + process) == '[object process]' || typeof jest == 'object')) {
+// function isElectronRenderer() {
+//     return isNode() && process.type === 'renderer'
+// }
+
+var realmConstructor;
+if (isNode()) {
     // If process is defined, we're running in node.
     // Prevent React Native packager from seeing this module.
     var binary = node_require('node-pre-gyp');
     var path = node_require('path');
-    var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+    var pkg = path.resolve(path.join(__dirname,'../package.json'));
+    var binding_path = binary.find(pkg);
     realmConstructor = require(binding_path).Realm;
 } else {
+    if (typeof Realm != 'undefined') {
+        // The global Realm constructor should be available on device (using JavaScriptCore).
+        realmConstructor = Realm;  // eslint-disable-line no-undef
+    // eslint-disable-next-line
+    } else if (typeof window != 'undefined') {
+        // The userAgent will be defined when running in a browser (such as Chrome debugging mode).
+        realmConstructor = require('./browser').default; // (exported as ES6 module)
+    // eslint-disable-next-line
+    }
+}
+
+if (!realmConstructor) {
     throw new Error('Missing Realm constructor - please ensure RealmReact framework is included!');
 }
 


### PR DESCRIPTION
Electron is a combination of a node and
Chromium processes. Chromium processes
can have node bindings enabled and can
therefore run most npm modules seamlessly.

The current `lib/index.js` bootstrapping
logic results in a ReferenceError on the
following statement:

    typeof Realm != 'undefined'

Thus, checking whether running under node
first allows realm-js to run inside the
Electron renderer (Chromium) process.

Attached is a screenshot of the modified example demonstrated in the [realm.io blog post](https://realm.io/news/first-object-database-realm-node-js-server/) announcing Node support. Namely, a realm database is shared between Electron's main node process and the Chromium [BrowserWindow](http://electron.atom.io/docs/api/browser-window/) process that has node integration.

![vh9gxfxuuq](https://cloud.githubusercontent.com/assets/10338/20399193/0fc7d24e-acbe-11e6-9b8f-d4910d6c901a.gif)

Electron + Realm is potentially a big win. Being able to concurrently read and write to the same database is quite powerful. Chromium, of course, has IndexedDB, but it is inaccessible to the Electron's main node process without RPC orchestration. Likewise, many Electron projects leverage node sqlite bindings or PouchDB (with LevelDB bindings). But those also face the same problem of concurrency and RPC orchestration.

This fixes #673 