### PR TITLE
Fix running ./scripts/test.sh react-tests

### DIFF
--- a/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
+++ b/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		5D03FADB1E08AECF007D53EA /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		F60690071CA235610003FB26 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F60690061CA235610003FB26 /* libc++.tbd */; };
 		F60690091CA2356F0003FB26 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F60690081CA2356F0003FB26 /* libz.tbd */; };
@@ -220,6 +221,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D03FADB1E08AECF007D53EA /* libReact.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The RealmReactTests target was failing to build because it was not linking against libReact.a