### PR TITLE
Switch to using object store's master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "src/object-store"]
 	path = src/object-store
 	url = https://github.com/realm/realm-object-store.git
-	branch = js
+	branch = master

--- a/binding.gyp
+++ b/binding.gyp
@@ -63,7 +63,6 @@
         "src/object-store/src/parser/parser.cpp",
         "src/object-store/src/parser/query_builder.cpp",
         "src/object-store/src/util/format.cpp",
-        "src/object-store/src/util/thread_id.cpp",
       ],
       "conditions": [
         ["OS=='linux'", {

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -41,7 +41,6 @@ LOCAL_SRC_FILES += src/object-store/src/impl/epoll/external_commit_helper.cpp
 LOCAL_SRC_FILES += src/object-store/src/parser/parser.cpp
 LOCAL_SRC_FILES += src/object-store/src/parser/query_builder.cpp
 LOCAL_SRC_FILES += src/object-store/src/util/format.cpp
-LOCAL_SRC_FILES += src/object-store/src/util/thread_id.cpp
 LOCAL_SRC_FILES += src/object-store/src/collection_notifications.cpp
 LOCAL_SRC_FILES += src/object-store/src/index_set.cpp
 LOCAL_SRC_FILES += src/object-store/src/list.cpp

--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		02022A671DA47BD7000F0C4F /* parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02022A611DA47B8B000F0C4F /* parser.cpp */; };
 		02022A681DA47BD7000F0C4F /* query_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02022A631DA47B8B000F0C4F /* query_builder.cpp */; };
 		02022A7C1DA47EC8000F0C4F /* format.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02022A731DA47EC8000F0C4F /* format.cpp */; };
-		02022A7D1DA47EC8000F0C4F /* thread_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02022A791DA47EC8000F0C4F /* thread_id.cpp */; };
 		02409DC21BCF11D6005F3B3E /* RealmJSCoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02409DC11BCF11D6005F3B3E /* RealmJSCoreTests.m */; };
 		02414B881CE68CA200A8669F /* dates-v5.realm in Resources */ = {isa = PBXBuildFile; fileRef = 02414B871CE68CA200A8669F /* dates-v5.realm */; };
 		02414BA51CE6ABCF00A8669F /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02414B991CE6AAEF00A8669F /* collection_change_builder.cpp */; };
@@ -97,9 +96,6 @@
 		02022A741DA47EC8000F0C4F /* format.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = format.hpp; sourceTree = "<group>"; };
 		02022A761DA47EC8000F0C4F /* event_loop_signal.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = event_loop_signal.hpp; sourceTree = "<group>"; };
 		02022A781DA47EC8000F0C4F /* event_loop_signal.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = event_loop_signal.hpp; sourceTree = "<group>"; };
-		02022A791DA47EC8000F0C4F /* thread_id.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thread_id.cpp; sourceTree = "<group>"; };
-		02022A7A1DA47EC8000F0C4F /* thread_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = thread_id.hpp; sourceTree = "<group>"; };
-		02022A7B1DA47EC8000F0C4F /* thread_local.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = thread_local.hpp; sourceTree = "<group>"; };
 		02409DC11BCF11D6005F3B3E /* RealmJSCoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RealmJSCoreTests.m; path = ios/RealmJSCoreTests.m; sourceTree = "<group>"; };
 		02414B871CE68CA200A8669F /* dates-v5.realm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "dates-v5.realm"; sourceTree = "<group>"; };
 		02414B961CE6AADD00A8669F /* collection_notifications.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = collection_notifications.cpp; path = src/collection_notifications.cpp; sourceTree = "<group>"; };
@@ -290,9 +286,6 @@
 				02022A741DA47EC8000F0C4F /* format.hpp */,
 				02022A751DA47EC8000F0C4F /* generic */,
 				02022A771DA47EC8000F0C4F /* node */,
-				02022A791DA47EC8000F0C4F /* thread_id.cpp */,
-				02022A7A1DA47EC8000F0C4F /* thread_id.hpp */,
-				02022A7B1DA47EC8000F0C4F /* thread_local.hpp */,
 			);
 			name = util;
 			path = src/util;
@@ -853,7 +846,6 @@
 				02E315D21DB80DF200555337 /* sync_file.cpp in Sources */,
 				02F59EC21C88F17D007F774C /* object_store.cpp in Sources */,
 				02022A7C1DA47EC8000F0C4F /* format.cpp in Sources */,
-				02022A7D1DA47EC8000F0C4F /* thread_id.cpp in Sources */,
 				02E315CB1DB80DDD00555337 /* sync_user.cpp in Sources */,
 				02E315D31DB80DF200555337 /* sync_metadata.cpp in Sources */,
 				02F59EC11C88F17D007F774C /* object_schema.cpp in Sources */,

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "execution_context_id.hpp"
+
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -66,6 +68,7 @@ struct Context {
     using GlobalContextType = typename T::GlobalContext;
 
     static GlobalContextType get_global_context(ContextType);
+    static AbstractExecutionContextID get_execution_context_id(ContextType);
 };
 
 template<typename T>

--- a/src/jsc/jsc_context.hpp
+++ b/src/jsc/jsc_context.hpp
@@ -28,5 +28,11 @@ inline JSGlobalContextRef jsc::Context::get_global_context(JSContextRef ctx) {
     return JSContextGetGlobalContext(ctx);
 }
 
+template<>
+inline AbstractExecutionContextID jsc::Context::get_execution_context_id(JSContextRef ctx)
+{
+    return reinterpret_cast<AbstractExecutionContextID>(get_global_context(ctx));
+}
+
 } // js
 } // realm

--- a/src/node/node_context.hpp
+++ b/src/node/node_context.hpp
@@ -27,6 +27,12 @@ template<>
 inline v8::Local<v8::Context> node::Context::get_global_context(v8::Isolate* isolate) {
     return isolate->GetCurrentContext();
 }
-    
+
+template<>
+inline AbstractExecutionContextID node::Context::get_execution_context_id(v8::Isolate* isolate)
+{
+    return reinterpret_cast<AbstractExecutionContextID>(isolate);
+}
+
 } // js
 } // realm


### PR DESCRIPTION
Object store's master branch now has the necessary changes for realm-js to use it directly.

Fixes #473 and addresses #552.
