### PR TITLE
Disable dead code elimination

### DIFF
--- a/examples/ReactExample/ios/ReactExample.xcodeproj/project.pbxproj
+++ b/examples/ReactExample/ios/ReactExample.xcodeproj/project.pbxproj
@@ -843,6 +843,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -892,6 +893,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -905,7 +905,6 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 0.15.1;
 				CXX = "$(SRCROOT)/../scripts/ccache-clang++.sh";
-				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -969,7 +968,6 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 0.15.1;
 				CXX = "$(SRCROOT)/../scripts/ccache-clang++.sh";
-				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -905,6 +905,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 0.15.1;
 				CXX = "$(SRCROOT)/../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -968,6 +969,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 0.15.1;
 				CXX = "$(SRCROOT)/../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
+++ b/tests/react-test-app/ios/ReactTests.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEAD_CODE_STRIPPING = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -767,6 +768,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -826,6 +828,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -881,6 +884,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
+				DEAD_CODE_STRIPPING = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;


### PR DESCRIPTION
This fixes the linker error that we've started seeing, probably because of xcode versioning:
```
Undefined symbols for architecture i386:
1581 	  "_RCTSetLogFunction", referenced from:
1582 	      -[RealmReactTests invokeTest] in RealmReactTests.o
1583 	  "_RCTAddLogFunction", referenced from:
1584 	      +[RealmReactTests load] in RealmReactTests.o
```