### PR TITLE
Disable caching of realm instances

### DIFF
--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -311,6 +311,7 @@ static inline void convert_outdated_datetime_columns(const SharedRealm &realm) {
 template<typename T>
 void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, size_t argc, const ValueType arguments[]) {
     realm::Realm::Config config;
+    config.cache = false;
     typename Schema<T>::ObjectDefaultsMap defaults;
     typename Schema<T>::ConstructorMap constructors;
     bool schema_updated = false;

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -445,7 +445,7 @@ module.exports = {
         realm.write(createAndTestObject);
 
         // Defaults should still work when creating another Realm instance.
-        realm = new Realm();
+        realm = new Realm({schema: [schemas.DefaultValues, schemas.TestObject]});
         realm.write(createAndTestObject);
     },
 
@@ -531,7 +531,7 @@ module.exports = {
         });
 
         // The constructor should still work when creating another Realm instance.
-        realm = new Realm();
+        realm = new Realm({schema: [CustomObject, InvalidObject]});
         TestCase.assertTrue(realm.objects('CustomObject')[0] instanceof CustomObject);
         TestCase.assertTrue(realm.objects(CustomObject).length > 0);
     },


### PR DESCRIPTION
This might be the way to resolve the initialize without schema version issue among other things.