### PR TITLE
Fix typo in test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -342,7 +342,7 @@ case "$TARGET" in
   ;;
 "test-runners")
   # Create a fake realm module that points to the source root so that test-runner tests can require('realm')
-  rm -rf "$SRCROOT/tests/test-runners/node-modules/realm"
+  rm -rf "$SRCROOT/tests/test-runners/node_modules/realm"
   mkdir -p "$SRCROOT/tests/test-runners/node_modules"
   ln -s "../../.." "$SRCROOT/tests/test-runners/node_modules/realm"
 


### PR DESCRIPTION
There was another instance of `node-modules` in test.sh.