### PR TITLE
Replace `npm run get-version` with JSON parser gradle function

### DIFF
--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -66,9 +66,17 @@ String getAppId () {
 
 apply from: 'analytics.gradle'
 
+import groovy.json.JsonSlurper
+
+def getNpmVersion() {
+    def inputFile = new File("../package.json")
+    def packageJson = new JsonSlurper().parseText(inputFile.text)
+    return packageJson["version"]
+}
+
 task send(type: SendAnalyticsTask) {
     applicationId = getAppId()
-    version = "npm --silent run get-version".execute(null, projectDir).text.trim()
+    version = getNpmVersion().trim()
 }
 
 preBuild.dependsOn send

--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -69,7 +69,7 @@ apply from: 'analytics.gradle'
 import groovy.json.JsonSlurper
 
 def getNpmVersion() {
-    def inputFile = new File("../package.json")
+    def inputFile = new File(buildscript.sourceFile.getParent() + "/../package.json")
     def packageJson = new JsonSlurper().parseText(inputFile.text)
     return packageJson["version"]
 }


### PR DESCRIPTION
**Goal:** This PR is to resolve #799 
**Expected Results**: When building a react-native app that links `realm` for Android on a Microsoft Windows platform, the gradle task of SendAnalytics should send the realm package version to realm for analytic purposes.
**Actual Result**: The command `npm run get-version --silent` appears to fail as the `node` executable isn't in the gradles PATH. (https://github.com/realm/realm-js/blob/master/react-native/android/publish_android_template#L71)

This PR resolves the issue by parsing the `package.json` directly with a JSON parser instead of using the `npm run get-version` script, bypassing the need for the npm script.

It uses a gradle function created by Andrew Jack (@AndrewJack, see https://github.com/AndrewJack/versioning-react-native-app).

This one is difficult to test, however should work across all supported platforms (Microsoft Windows, Linux and MacOS).

(CLA has been signed)