### PR TITLE
Fix loading the Realm constructor for the node-server-sdk

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -45,6 +45,7 @@ module.exports = function(realmConstructor) {
         let userMethods = require('./user-methods');
         Object.defineProperties(realmConstructor.Sync.User, getOwnPropertyDescriptors(userMethods.static));
         Object.defineProperties(realmConstructor.Sync.User.prototype, getOwnPropertyDescriptors(userMethods.instance));
+        Object.defineProperty(realmConstructor.Sync.User, '_realmConstructor', { value: realmConstructor });
 
         realmConstructor.Sync.AuthError = require('./errors').AuthError;
 

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -179,8 +179,7 @@ module.exports = {
 
             url.set('pathname', '/~/__management');
 
-            const realmConstructor = require('./index');
-            return new realmConstructor({
+            return new this.constructor._realmConstructor({
                 schema: require('./management-schema'),
                 sync: {
                     user: this,

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -66,10 +66,9 @@ module.exports = {
             TestCase.assertEqual(session.state, 'active');
 
             // give the session enough time to refresh its access token and bind itself
-            let timeout = 1500;
-            if (typeof window !== 'undefined') {
-                timeout = 2500; // need a longer timeout under React Native because remote debugging
-            }
+            // TODO: Use an event to discover when the session is bound
+            let timeout = 3000;
+
             return wait(timeout).then(() => {
                 TestCase.assertEqual(session.url, `realm://localhost:9080/${user.identity}/myrealm`);
             });

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -66,7 +66,7 @@ module.exports = {
             TestCase.assertEqual(session.state, 'active');
 
             // give the session enough time to refresh its access token and bind itself
-            let timeout = 500;
+            let timeout = 1500;
             if (typeof window !== 'undefined') {
                 timeout = 2500; // need a longer timeout under React Native because remote debugging
             }


### PR DESCRIPTION
`realmConstructor = require('./index');` would resolve to the public submodule, not to the node-server-sdk.

Thanks for the help, @fealebenpae !
