### PR TITLE
Fix VScode debugging for React Native

### DIFF
--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -179,7 +179,8 @@ function makeRequest(url, data) {
     // The global __debug__ object is provided by Visual Studio Code.
     if (global.__debug__) {
         let request = global.__debug__.require('sync-request');
-        let response = request('POST', url, {json: data});
+        let body = JSON.stringify(data);
+        let response = request('POST', url, {headers: {'Content-Type': 'text/plain'}, body: body});
 
         statusCode = response.statusCode;
         responseText = response.body.toString('utf-8');

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,8 +83,10 @@ switch(getContext()) {
         break;
 
     case 'chromedebugger':
-    case 'vscodedebugger':
         realmConstructor = require('./browser').default; // (exported as ES6 module)
+        break;
+    case 'vscodedebugger':
+        realmConstructor = require('./browser'); // (exported as ES6 module)
         break;
 }
 


### PR DESCRIPTION
With our React Native project I looked into why Realm refused to work in the VScode debugging set up using react native tools.  Despite being on the latest version I kept running into #736.  After doing some proper digging I found out that the rpc call was timing out when the handler attempted to get the text from the request because the content type was "application/json" and not "text/plain" like the chrome debugger.  This caused GCDWebserver to call GWS_DNOT_REACHED which caused the server to abort and a response to not be sent.  After setting the content type to text/plain, I ran into some issues with the constructor and removing the .default for the browser import resolved the missing constructor issue.