### PR TITLE
Fixed crash issue with VSCode debugging

### DIFF
--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -180,7 +180,7 @@ function makeRequest(url, data) {
     if (global.__debug__) {
         let request = global.__debug__.require('sync-request');
         let response = request('POST', url, {
-          body: Buffer.from(JSON.stringify(data)),
+          body: JSON.stringify(data),
           headers: {
             "Content-Type": "text/plain;charset=UTF-8"
           }

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -179,7 +179,12 @@ function makeRequest(url, data) {
     // The global __debug__ object is provided by Visual Studio Code.
     if (global.__debug__) {
         let request = global.__debug__.require('sync-request');
-        let response = request('POST', url, {json: data});
+        let response = request('POST', url, {
+          body: Buffer.from(JSON.stringify(data)),
+          headers: {
+            "Content-Type": "text/plain;charset=UTF-8"
+          }
+        });
 
         statusCode = response.statusCode;
         responseText = response.body.toString('utf-8');


### PR DESCRIPTION
Goal: This PR is to resolve #736

This PR resolves the issue by:

1. Changed the request with `body` instead of `json` and provided fixed `Content-Type=text/plain` header.
2. `sync-request` package using a outdated `then-request` with deprecated `Buffer` usage, ~~let's use `Buffer.from` as workaround~~.  [update: there has no Buffer Object in react native]
