### PR TITLE
Remove need for bash script on android builds

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -83,16 +83,8 @@ task downloadRealmCore(type: Download) {
 task prepareRealmCore(dependsOn: downloadRealmCore, type:Copy) {
     from tarTree(downloadRealmCore.dest)
     into "$coreDownloadDir/core"
-    //Fixing Core file naming 'arm-*' to 'armeabi-*'
-    doLast {
-      exec {
-        workingDir = "$coreDownloadDir/core"
-            commandLine = [
-                    "bash",
-                    "-c",
-                    "find . -name \"*-arm-*\" -exec sh -c \"echo {} | sed -e s/arm/armeabi/g | xargs mv {} \" \\;"
-            ]
-      }
+    rename { String fileName ->
+        fileName.replace("-arm-", "-armeabi-")
     }
 }
 


### PR DESCRIPTION
**Goal**: Remove the need to use a bash script (`find`, `sed` & `mv`) to rename `*-arm-*` to `*-armeabi-*` (progressing to a platform independence when building realm from source)

Currently you are using a bash script at the point untarring the realm core. It's purpose is to rename any file containing `-arm-` and replace it with `-armeabi-`, otherwise the build fails.

We can utilise gradle's rename instead.

There may be a reason you've used the bash script, but I can't spot it.