### PR TITLE
Windows android build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   "scripts": {
     "get-version": "node -p process.env.npm_package_version",
     "set-version": "scripts/set-version.sh",
-    "get-core-version": "scripts/download-core.sh --version",
-    "get-sync-version": "scripts/download-core.sh --versionSync",
+    "get-core-version": "env-cmd ./dependencies.list node -p process.env.REALM_CORE_VERSION",
+    "get-sync-version": "env-cmd ./dependencies.list node -p process.env.REALM_SYNC_VERSION",
     "lint": "eslint",
     "test": "scripts/test.sh",
     "install": "node-pre-gyp install --fallback-to-build",
@@ -63,7 +63,17 @@
     "test-runner:jest": "cd tests/test-runners/jest && npm install && npm test",
     "test-runners": "npm run test-runner:ava && npm run test-runner:mocha && npm run test-runner:jest",
     "isMac": "node -p \"if (process.platform == 'darwin') { process.exit(0); } else { process.exit(-1); }\"",
-    "testMac": "npm run isMac -s && echo this is mac || echo . "
+    "testMac": "npm run isMac -s && echo this is mac || echo . ",
+    "isWin": "node -p \"if (process.platform == 'win32') { process.exit(0); } else { process.exit(-1); }\"",
+    "prealias:win:apply" : "git config alias.apply-win-symlink-aliases \"!f() { $(scripts/git-win-symlink-aliases); }; f\"",
+    "alias:win:apply" : "git apply-win-symlink-aliases",
+    "postalias:win:apply" : "git config --unset alias.apply-win-symlink-aliases",
+    "alias:win:revert" : "git config alias.rm-symlink \"\" && git config alias.rm-symlinks \"\" && git config alias.checkout-symlinks \"\"",
+    "win-fix-symlinks" : "npm run isWin -s && npm run alias:win:apply || echo . ",
+    "win-revert-symlinks" : "npm run isWin -s && npm run alias:win:revert || echo .",
+    "prereact-tests-android": "npm run isWin -s && npm run win-fix-symlinks && git checkout-symlinks && git rm-symlinks || echo . ",
+    "react-tests-android": "node scripts/react-tests-android.js || npm run postreact-tests-android",
+    "postreact-tests-android": "git checkout-symlinks || echo . && npm run win-revert-symlinks"
   },
   "dependencies": {
     "extract-zip": "^1.6.0",
@@ -77,6 +87,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
+    "env-cmd": "^5.0.0",
     "eslint": "^3.2.2",
     "eslint-plugin-jasmine": "^2.1.0",
     "eslint-plugin-react": "^6.7.0",
@@ -84,7 +95,9 @@
     "license-checker": "^8.0.3",
     "mockery": "^2.0.0",
     "rimraf": "^2.6.1",
-    "semver": "^5.1.0"
+    "semver": "^5.1.0",
+    "shelljs": "^0.7.7",
+    "shx": "^0.2.2"
   },
   "rnpm": {
     "ios": {

--- a/package.json
+++ b/package.json
@@ -69,11 +69,11 @@
     "alias:win:apply" : "git apply-win-symlink-aliases",
     "postalias:win:apply" : "git config --unset alias.apply-win-symlink-aliases",
     "alias:win:revert" : "git config alias.rm-symlink \"\" && git config alias.rm-symlinks \"\" && git config alias.checkout-symlinks \"\"",
-    "win-fix-symlinks" : "npm run isWin -s && npm run alias:win:apply || echo . ",
-    "win-revert-symlinks" : "npm run isWin -s && npm run alias:win:revert || echo .",
-    "prereact-tests-android": "npm run isWin -s && npm run win-fix-symlinks && git checkout-symlinks && git rm-symlinks || echo . ",
+    "win-fix-symlinks" : "npm run isWin -s && npm run alias:win:apply && git checkout-symlinks && git rm-symlinks || echo . ",
+    "win-revert-symlinks" : "npm run isWin -s &&  npm run alias:win:apply && git checkout-symlinks && npm run alias:win:revert || echo .",
+    "prereact-tests-android": "npm run isWin -s && npm run win-fix-symlinks || echo . ",
     "react-tests-android": "node scripts/react-tests-android.js || npm run postreact-tests-android",
-    "postreact-tests-android": "git checkout-symlinks || echo . && npm run win-revert-symlinks"
+    "postreact-tests-android": "npm run win-revert-symlinks"
   },
   "dependencies": {
     "extract-zip": "^1.6.0",

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -31,10 +31,17 @@ import org.apache.tools.ant.filters.ReplaceTokens
 // We download various C++ open-source dependencies into downloads.
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.
+def npmExecutable = 'npm';
 
-ext.coreVersion = "npm --silent run get-core-version".execute().text.trim()
-ext.syncVersion = "npm --silent run get-sync-version".execute().text.trim()
-def currentVersion = "npm --silent run get-version".execute().text.trim()
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        npmExecutable = 'npm.cmd'
+}
+ext.coreVersion = "$npmExecutable --silent run get-core-version".execute().text.trim()
+ext.syncVersion = "$npmExecutable --silent run get-sync-version".execute().text.trim()
+println "Realm Core Version: $ext.coreVersion"
+println "Realm Sync Version: $ext.syncVersion"
+
+def currentVersion = "$npmExecutable --silent run get-version".execute().text.trim()
 def downloadsDir = new File("$projectDir/downloads")
 def jscDownloadDir = new File("$projectDir/src/main/jni/jsc")
 def coreDownloadDir = new File("$projectDir/src/main/jni")

--- a/scripts/git-win-symlink-aliases
+++ b/scripts/git-win-symlink-aliases
@@ -1,0 +1,39 @@
+#Based on http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
+git config alias.rm-symlink '!__git_rm_symlink(){
+    git checkout -- "$1"
+    link=$(echo "$1")
+    POS=$'\''/'\''
+    DOS=$'\''\\\\'\''
+    doslink=${link//$POS/$DOS}
+    dest=$(dirname "$link")/$(cat "$link")
+    dosdest=${dest//$POS/$DOS}
+    if [ -f "$dest" ]; then
+        rm -f "$link"
+        cmd //C mklink //H "$doslink" "$dosdest"
+    elif [ -d "$dest" ]; then
+        rm -f "$link"
+        cmd //C mklink //J "$doslink" "$dosdest"
+    else
+        echo "ERROR: Something went wrong when processing $1 . . ."
+        echo "       $dest may not actually exist as a valid target."
+    fi
+}; __git_rm_symlink "$1"'
+
+git config alias.rm-symlinks '!__git_rm_symlinks(){
+    for symlink in $(git ls-files -s | egrep "^120000" | cut -f2); do
+        git rm-symlink "$symlink"
+        git update-index --assume-unchanged "$symlink"
+    done
+}; __git_rm_symlinks'
+
+git config alias.checkout-symlinks '!__git_checkout_symlinks(){
+    POS=$'\''/'\''
+    DOS=$'\''\\\\'\''
+    for symlink in $(git ls-files -s | egrep "^120000" | cut -f2); do
+        git update-index --no-assume-unchanged "$symlink"
+        dossymlink=${symlink//$POS/$DOS}
+        cmd //C rmdir //Q "$dossymlink" 2>/dev/null
+        git  checkout -- "$symlink"
+        echo "Restored git symlink $symlink <<===>> $(cat $symlink)"
+    done
+}; __git_checkout_symlinks'

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -30,7 +30,7 @@ if ('REALM_BUILD_ANDROID' in process.env) {
     const gradlew = process.platform === 'win32' ? 'gradlew.bat' : 'gradlew';
     const androidPath = path.resolve(__dirname, '../react-native/android');
 
-    exec(`${androidPath}/${gradlew}`, ['publishAndroid', '-PbuildWithSync=true'], { cwd: androidPath, stdio: 'inherit' });
+    exec(`${androidPath}/${gradlew}`, ['publishAndroid'], { cwd: androidPath, stdio: 'inherit' });
 }
 
 function ini(string) {

--- a/scripts/react-tests-android.js
+++ b/scripts/react-tests-android.js
@@ -1,0 +1,48 @@
+var shell = require("shelljs");
+
+shell.set("-e");
+
+shell.pushd("./tests/react-test-app");
+
+shell.exec("npm install");
+
+if (process.platform !== "win32") { 
+    shell.env["PATH"] = "/opt/android-sdk-linux/platform-tools:$PATH"
+}
+
+if (shell.env["REALM_BUILD_ANDROID"]) {
+    shell.echo("Realm is already installed");
+} else {
+    shell.env["REALM_BUILD_ANDROID"] = 1;
+    shell.exec("npm install realm realm-tests");
+}
+
+shell.cp("../../src/object-store/tests/query.json", "node_modules/realm-tests/query-tests.json");
+
+shell.echo("Uninstalling old apk");
+shell.exec("adb uninstall io.realm.react.testapp");
+
+shell.set("+e");
+shell.echo("Reversing port for physical device");
+shell.exec("adb reverse tcp:8081 tcp:8081");
+
+shell.echo("Reversing port for Realm Object Server");
+shell.exec("adb reverse tcp:9080 tcp:9080");
+
+shell.set("-e");
+
+shell.echo("Building Release APK");
+shell.pushd("android");
+shell.exec("gradlew assembleRelease");
+
+shell.echo("Installing APK");
+shell.exec("adb install app/build/outputs/apk/app-release.apk");
+
+shell.echo("Starting the Main Activity");
+shell.exec("adb shell am start -n io.realm.react.testapp/.MainActivity");
+
+shell.popd();
+
+shell.exec("adb shell \"logcat -c && logcat | grep -m 1 __REALM_REACT_ANDROID_TESTS_COMPLETED__\"");
+
+shell.exec("adb pull /sdcard/tests.xml");

--- a/scripts/react-tests-android.js
+++ b/scripts/react-tests-android.js
@@ -14,7 +14,8 @@ if (shell.env["REALM_BUILD_ANDROID"]) {
     shell.echo("Realm is already installed");
 } else {
     shell.env["REALM_BUILD_ANDROID"] = 1;
-    shell.exec("npm install realm realm-tests");
+    shell.exec("npm install realm");
+    shell.exec("npm install realm-tests");
 }
 
 shell.cp("../../src/object-store/tests/query.json", "node_modules/realm-tests/query-tests.json");


### PR DESCRIPTION
This switches every symlink to a directory junctions on Windows on pre-build step. Junctions do not require elevated process. The problem with having junctions is that git will show there are new files at the symlink place. Thus junctions are not good to be used by post-checkout script etc. Thus here they are used only on build so the build can succeed and then junctions are reverted back to symlinks as a post-build step.

So after build finishes it reverts back the the junctions to symlinks. If the build fails the revert logic is still executed.
If build is force stopped (CTRL+C) the junction points are left behind. 
This means user need to use "npm run win-revert-symlinks" to manually revert junctions to symlinks. There is a script for manually fixing symlinks if one needs to "npm run win-fix-symlinks"

The scripts for the junction-symlink convertion are from here http://stackoverflow.com/questions/5917249/git-symlinks-in-windows 

Although seemingly complex I think this handles the situation pretty fine. I think a section in the readme describing how things work will be enough to prepare the developer.

Also currently sync tests (users-tests.js and session-tests.js) are failing since we can't start the ros on windows. Maybe a way to switch these tests off if realm-js is build and run on Windows will be ok.

Let's review and discuss this and then I can update the readme with instructions.

