### PR TITLE
Expose option to force the sync history type when opening a realm

### DIFF
--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -399,7 +399,9 @@ template<typename T>
 void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constructor, ObjectType config_object, Realm::Config& config)
 {
     ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
-    if (!Value::is_undefined(ctx, sync_config_value)) {
+    if (Value::is_boolean(ctx, sync_config_value)) {
+        config.force_sync_history = Value::to_boolean(ctx, sync_config_value);
+    } else if (!Value::is_undefined(ctx, sync_config_value)) {
         auto sync_config_object = Value::validated_to_object(ctx, sync_config_value);
 
         ObjectType sync_constructor = Object::validated_get_object(ctx, realm_constructor, std::string("Sync"));


### PR DESCRIPTION
Sometimes we need to be able to open a realm file with the sync history type without spawning a sync session. Right now it's the Object Server that needs to do so internally.