### PR TITLE
Removed superfluous process handlers

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -52,16 +52,6 @@ module.exports = function(realmConstructor) {
         if (realmConstructor.Sync.cleanup) {
             // FIXME: DOES THIS WORK ON BOTH NODE AND REACT NATIVE?
             process.on('exit', realmConstructor.Sync.cleanup);
-            process.on('SIGINT', function () {
-                realmConstructor.Sync.cleanup();
-                process.exit(2);
-            });
-            process.on('uncaughtException', function(e) {
-                realmConstructor.Sync.cleanup();
-                /* eslint-disable no-console */
-                console.log(e.stack);
-                process.exit(99);
-            });
         }
 
         setConstructorOnPrototype(realmConstructor.Sync.User);


### PR DESCRIPTION
I noticed this when developing RaaS -- loading the realm-js in node is a bit intrusive when setting up process event handlers.

The `exit` handler is always called, regardless of what you do in `SIGINT` and `uncaughtException`, so we don't need to do `Sync.cleanup()` in those.  

In the case of `SIGINT`, the code was exiting with an error status.  Catching ctrl-C (interrupt) and exiting should not be considered an error condition (or we should not be forcing this on the users of realm-js).

I think we should also leave the `uncaughtException` handler undefined, as we do not want to force stack trace outputs on our users -- they should be handling process lifecycle themselves.
