### PR TITLE
report undefined deletions on deleteAll instead of max int count indexes

### DIFF
--- a/src/js_collection.hpp
+++ b/src/js_collection.hpp
@@ -50,7 +50,7 @@ typename T::Value CollectionClass<T>::create_collection_change_set(ContextType c
     std::vector<ValueType> deletions, insertions, modifications;
     
     if (change_set.deletions.count() == std::numeric_limits<size_t>::max()) {
-        deletions.push_back(Value::from_undefined(ctx));
+        deletions.push_back(Value::from_null(ctx));
     }
     else {
         for (auto index : change_set.deletions.as_indexes()) {

--- a/src/js_collection.hpp
+++ b/src/js_collection.hpp
@@ -48,8 +48,14 @@ typename T::Value CollectionClass<T>::create_collection_change_set(ContextType c
 {
     ObjectType object = Object::create_empty(ctx);
     std::vector<ValueType> deletions, insertions, modifications;
-    for (auto index : change_set.deletions.as_indexes()) {
-        deletions.push_back(Value::from_number(ctx, index));
+    
+    if (change_set.deletions.count() == std::numeric_limits<size_t>::max()) {
+        deletions.push_back(Value::from_undefined(ctx));
+    }
+    else {
+        for (auto index : change_set.deletions.as_indexes()) {
+            deletions.push_back(Value::from_number(ctx, index));
+        }
     }
     Object::set_property(ctx, object, "deletions", Object::create_array(ctx, deletions));
     


### PR DESCRIPTION
This resolves an issue where a call to deleteAll reports max int rows deleted and js binding consumes all memory trying to report all indexes in the range of 0 to max int. 
This is a fix to a limitation of the current implementation which may be changed in the future.

It means users will receive undefined value as a single result in deletions property  in their event handler 