### PR TITLE
[React-Native] Android - buildToolsVersion to 25.0.2

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -189,7 +189,7 @@ task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hey!

I was trying to change buildToolsVersion inside my project `app/build.graddle`
But every time this require 25 >=

```
* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all dependencies for configuration ':app:_debugApk'.
   > A problem occurred configuring project ':realm'.
      > The SDK Build Tools revision (23.0.1) is too low for project ':realm'. Minimum required is 25.0.0
```

Is it possible to upd buildToolsVersion? Or If you can please give a good advice

Thank 🍻 