### PR TITLE
Return debugger context if running on node in vscode debugger

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,12 @@ function getContext() {
     // If process is an object, we're probably running in Node or Electron
     // From: http://stackoverflow.com/a/24279593/1417293
     if (typeof process === 'object' && process + '' === '[object process]') {
+        
+        // Visual Studio Code defines the global.__debug__ object.
+        if (typeof global !== 'undefined' && global.__debug__) {
+            return 'vscodedebugger';
+        }
+        
         return process.type === 'renderer' ? 'electron' : 'nodejs';
     }
 


### PR DESCRIPTION
Fixes VSCode debugging getContext. Fixes #1035 