### PR TITLE
Replace calls to sync.cleanup with sync.removealllisteners

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -78,15 +78,14 @@ module.exports = function(realmConstructor) {
 
         realmConstructor.Sync.AuthError = require('./errors').AuthError;
 
-        if (realmConstructor.Sync.cleanup) {
-            // FIXME: DOES THIS WORK ON BOTH NODE AND REACT NATIVE?
-            process.on('exit', realmConstructor.Sync.cleanup);
+        if (realmConstructor.Sync.removeAllListeners) {
+            process.on('exit', realmConstructor.Sync.removeAllListeners);
             process.on('SIGINT', function () {
-                realmConstructor.Sync.cleanup();
+                realmConstructor.Sync.removeAllListeners();
                 process.exit(2);
             });
             process.on('uncaughtException', function(e) {
-                realmConstructor.Sync.cleanup();
+                realmConstructor.Sync.removeAllListeners();
                 /* eslint-disable no-console */
                 console.log(e.stack);
                 process.exit(99);


### PR DESCRIPTION
This way, we don't need to add that method in the server sdk