### PR TITLE
Extract admin status from the refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+vNext Release notes (TBD)
+=============================================================
+### Breaking changes
+* None
+
+### Enhancements
+* None
+
+### Bug fixes
+* Fix `Realm.Sync.User.prototype.isAdmin` returning `false` for logged-in admin users. 
+
 1.8.0 Release notes (2017-6-15)
 =============================================================
 ### Breaking changes

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -24,8 +24,8 @@ import { keys, objectTypes } from './constants';
 import { createMethods } from './util';
 
 export default class User {
-    static createUser(server, identity, token, isAdmin) {
-       return createUserRPC(Array.from(arguments)); 
+    static createUser(server, identity, token, isAdminToken, isAdminUser) {
+       return createUserRPC(Array.from(arguments));
     }
 
     static get all() {

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -124,7 +124,8 @@ function _authenticate(userConstructor, server, json, callback) {
                     // TODO: validate JSON
                     const token = body.refresh_token.token;
                     const identity = body.refresh_token.token_data.identity;
-                    callback(undefined, userConstructor.createUser(server, identity, token, false));
+                    const isAdmin = body.refresh_token.token_data.is_admin;
+                    callback(undefined, userConstructor.createUser(server, identity, token, false, isAdmin));
                 }) 
             }
         })

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -117,12 +117,16 @@ void UserClass<T>::is_admin(ContextType ctx, ObjectType object, ReturnValue &ret
 
 template<typename T>
 void UserClass<T>::create_user(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    validate_argument_count(argc, 3, 4);
+    validate_argument_count(argc, 3, 5);
     SharedUser *user = new SharedUser(SyncManager::shared().get_user(
-        Value::validated_to_string(ctx, arguments[1]),
-        Value::validated_to_string(ctx, arguments[2]),
-        (std::string)Value::validated_to_string(ctx, arguments[0]),
-        Value::validated_to_boolean(ctx, arguments[3]) ? SyncUser::TokenType::Admin : SyncUser::TokenType::Normal));
+        Value::validated_to_string(ctx, arguments[1], "identity"),
+        Value::validated_to_string(ctx, arguments[2], "refreshToken"),
+        (std::string)Value::validated_to_string(ctx, arguments[0], "authServerUrl"),
+        Value::validated_to_boolean(ctx, arguments[3], "isAdminToken") ? SyncUser::TokenType::Admin : SyncUser::TokenType::Normal));
+
+    if (argc == 5) {
+        (*user)->set_is_admin(Value::validated_to_boolean(ctx, arguments[4], "isAdmin"));
+    }
     return_value.set(create_object<T, UserClass<T>>(ctx, user));
 }
 


### PR DESCRIPTION
Fixes #1063 

Doesn't have tests because we can't create admin users programmatically on the server.