### PR TITLE
Expose admin users to JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+vNext Release notes (TBD)
+=============================================================
+### Breaking changes
+* None
+
+### Enhancements
+* None
+
+### Bug fixes
+* Fix admin users not appearing in `Realm.Sync.User.all`, which broke getting an access token for them.
+
 1.8.2 Release notes (2017-6-26)
 =============================================================
 ### Breaking changes

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -55,6 +55,10 @@ function scheduleAccessTokenRefresh(user, localRealmPath, realmUrl, expirationDa
     setTimeout(() => refreshAccessToken(user, localRealmPath, realmUrl), timeout);
 }
 
+function print_error() {
+    (console.error || console.log).apply(console, arguments);
+}
+
 function refreshAccessToken(user, localRealmPath, realmUrl) {
     let parsedRealmUrl = url_parse(realmUrl);
     const url = auth_url(user.server);
@@ -88,7 +92,7 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
                         if (errorHandler) {
                             errorHandler(session, error);
                         } else {
-                            (console.error || console.log).call(console, `Unhandled session token refresh error: ${error}`);
+                            print_error('Unhandled session token refresh error', error);
                         }
                     } else if (session.state !== 'invalid') {
                         parsedRealmUrl.set('pathname', json.access_token.token_data.path);
@@ -101,6 +105,8 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
                         const tokenExpirationDate = new Date(json.access_token.token_data.expires * 1000);
                         scheduleAccessTokenRefresh(newUser, localRealmPath, realmUrl, tokenExpirationDate);
                     }
+                } else {
+                    print_error(`Unhandled session token refresh error: could not look up session at path ${localRealmPath}`);
                 }
             }
         });


### PR DESCRIPTION
The JS binding used to conflate `SyncUser::is_admin()` with the user being created by calling `Realm.Sync.User.adminToken()`, but now that we expose a user’s role on the server under `is_admin()` this supposition is no longer correct.

#1097 attempted to fix one such case, but fixing it only uncovered another: in `UserClass<T>::all_users()`.  I’ve gone through all the callsites of `SyncUser::is_admin()` to make sure they don’t assume an admin token user.