### PR TITLE
Add a new optional server parameter to User.adminUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ vNext Release notes (TBD)
 ### Enhancements
 * Add support for Linking Objects (AKA Backlinks).
 * Add support for retrieving user account information.
+* Add optional `server` parameter to `Realm.Sync.User.adminUser`
+  Specifying the server address the same way as in `Realm.Sync.User.login` allows the admin token user to use the permission realm APIs.
 
 ### Bug fixes
 * Fix regression where setting a Results or List object to a `list` property would throw.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -169,9 +169,10 @@ class User {
     /**
      * Create an admin user for the given authentication server with an existing token
      * @param {string} adminToken - existing admin token
+     * @param {string} [server] - authentication server
      * @return {User} - admin user populated with the given token and server
      */
-    static adminUser(adminToken) {}
+    static adminUser(adminToken, server) {}
 
     /**
      * A dictionary containing users that are currently logged in.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -262,7 +262,7 @@ declare namespace Realm.Sync {
         readonly isAdmin: boolean;
         readonly server: string;
         readonly token: string;
-        static adminUser(adminToken: string): User;
+        static adminUser(adminToken: string, server?: string): User;
         static login(server: string, username: string, password: string, callback: (error: any, user: User) => void): void;
         static loginWithProvider(server: string, provider: string, providerToken: string, callback: (error: any, user: User) => void): void;
         static register(server: string, username: string, password: string, callback: (error: any, user: User) => void): void;

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -152,14 +152,13 @@ module.exports = {
             return allUsers[keys[0]];
         },
 
-        adminUser(token) {
+        adminUser(token, server) {
             checkTypes(arguments, ['string']);
-            var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
                 var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
                 return v.toString(16);
             });
-            var user = this.createUser('', uuid, token, true);
-            return user;
+            return this.createUser(server || '', uuid, token, true);
         },
 
         register(server, username, password, callback) {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -21,6 +21,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <regex>
 
 #include "event_loop_dispatcher.hpp"
 #include "platform.hpp"
@@ -404,7 +405,11 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         }
 
         std::string raw_realm_url = Object::validated_get_string(ctx, sync_config_object, "url");
-
+        if (shared_user->token_type() == SyncUser::TokenType::Admin) {
+            static std::regex tilde("/~/");
+            raw_realm_url = std::regex_replace(raw_realm_url, tilde, "/__auth/");
+        }
+        
         bool client_validate_ssl = true;
         ValueType validate_ssl_temp = Object::get_property(ctx, sync_config_object, "validate_ssl");
         if (!Value::is_undefined(ctx, validate_ssl_temp)) {


### PR DESCRIPTION
This enables `User.openManagementRealm()` for admin token users.

Fixes #963 