### PR TITLE
Make it possible to assign a List or Results to a List property once more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ vNext Release notes (TBD)
 * Add support for Linking Objects (AKA Backlinks).
 
 ### Bug fixes
-* Node
+* Fix regression where setting a Results or List object to a `list` property would throw.
 
 1.8.3 Release notes (2017-6-27)
 =============================================================

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -39,6 +39,11 @@
 namespace realm {
 namespace js {
 
+template<typename>
+struct ResultsClass;
+template<typename>
+struct ListClass;
+
 enum PropertyAttributes : unsigned {
     None       = 0,
     ReadOnly   = 1 << 0,
@@ -369,7 +374,17 @@ inline bool Value<T>::is_valid_for_property(ContextType context, const ValueType
             return true;
         case PropertyType::Array:
             // FIXME: Do we need to validate the types of the contained objects?
-            return is_array(context, value);
+            if (is_array(context, value)) {
+                return true;
+            }
+
+            if (is_object(context, value)) {
+                auto object = to_object(context, value);
+                return Object<T>::template is_instance<ResultsClass<T>>(context, object)
+                    || Object<T>::template is_instance<ListClass<T>>(context, object);
+            }
+
+            return false;
 
         case PropertyType::Any:
         case PropertyType::LinkingObjects:

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -921,5 +921,16 @@ module.exports = {
                 var p1 = realm.create('PersonObject', { name: 'Ari', age: 'Ten' });
             });
         }, new Error("PersonObject.age must be of type: number"));
+    },
+
+    testValidTypesForListProperties: function() {
+        var realm = new Realm({schema: [schemas.PersonObject]});
+        realm.write(function () {
+            var p1 = realm.create('PersonObject', { name: 'Ari', age: 10 });
+            var p2 = realm.create('PersonObject', { name: 'Harold', age: 55, children: realm.objects('PersonObject').filtered('age < 15') });
+            TestCase.assertEqual(p2.children.length, 1);
+            var p3 = realm.create('PersonObject', { name: 'Wendy', age: 52, children: p2.children });
+            TestCase.assertEqual(p3.children.length, 1);
+        });
     }
 };


### PR DESCRIPTION
The change made in #1069 to improve error messages when values of incorrect types were assigned to a given property was being too narrow in the types it accepted for list properties, allowing only arrays. Lists and Results are now accepted once more.

Fixes #1114.