### PR TITLE
Fix jsdoc build

### DIFF
--- a/docs/conf.json
+++ b/docs/conf.json
@@ -3,7 +3,7 @@
     "destination": "docs/output",
     "readme": "README.md",
     "recurse": true,
-    "template": "docs/jsdoc-template/template"
+    "template": "./jsdoc-template/template"
   },
   "source": {
     "include": ["docs"],


### PR DESCRIPTION
Using a path relative to the `docs/conf.json` file seems to fix the `FATAL: Unable to load template: Cannot find module 'docs/jsdoc-template/template/publish'` issue.

See https://github.com/hlapp/jsdoc/commit/0830c6e2f9456548814e675b5037cb0aedb8cf6f.