### PR TITLE
Add `Realm.empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ vNext Release notes (TBD)
 * None
 
 ### Enhancements
-* None
+* Added `Realm.prototype.empty` which is a property that indicates whether or not the realm has any objects in it.
 
 ### Bug fixes
 * Fix crash on Node.js when a listener callback throws an error.

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -23,6 +23,14 @@
  * ```
  */
 class Realm {
+   /**
+    * Indicates if this Realm contains any objects.
+    * @type {boolean}
+    * @readonly
+    * @since 1.10.0
+    */
+    get empty() {}
+
     /**
      * The path to the file where this Realm is stored.
      * @type {string}

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -52,6 +52,7 @@ function setupRealm(realm, realmId) {
     realm[keys.type] = objectTypes.REALM;
 
     [
+        'empty',
         'path',
         'readOnly',
         'schema',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -352,6 +352,7 @@ declare namespace Realm.Sync {
 declare class Realm {
     static defaultPath: string;
 
+    readonly empty: boolean;
     readonly path: string;
     readonly readOnly: boolean;
     readonly schema: Realm.ObjectSchema[];

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -178,6 +178,7 @@ public:
     static void close(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
 
     // properties
+    static void get_empty(ContextType, ObjectType, ReturnValue &);
     static void get_path(ContextType, ObjectType, ReturnValue &);
     static void get_schema_version(ContextType, ObjectType, ReturnValue &);
     static void get_schema(ContextType, ObjectType, ReturnValue &);
@@ -225,6 +226,7 @@ public:
     };
 
     PropertyMap<T> const properties = {
+        {"empty", {wrap<get_empty>, nullptr}},
         {"path", {wrap<get_path>, nullptr}},
         {"schemaVersion", {wrap<get_schema_version>, nullptr}},
         {"schema", {wrap<get_schema>, nullptr}},
@@ -499,6 +501,13 @@ void RealmClass<T>::get_default_path(ContextType ctx, ObjectType object, ReturnV
 template<typename T>
 void RealmClass<T>::set_default_path(ContextType ctx, ObjectType object, ValueType value) {
     js::set_default_path(Value::validated_to_string(ctx, value, "defaultPath"));
+}
+
+template<typename T>
+void RealmClass<T>::get_empty(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+    SharedRealm& realm = *get_internal<T, RealmClass<T>>(object);
+    bool is_empty = ObjectStore::is_empty(realm->read_group());
+    return_value.set(is_empty);
 }
 
 template<typename T>

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -932,5 +932,16 @@ module.exports = {
             var p3 = realm.create('PersonObject', { name: 'Wendy', age: 52, children: p2.children });
             TestCase.assertEqual(p3.children.length, 1);
         });
+    },
+
+    testEmpty: function() {
+        const realm = new Realm({schema: [schemas.PersonObject]});
+        TestCase.assertTrue(realm.empty);
+
+        realm.write(() => realm.create('PersonObject', { name: 'Ari', age: 10 }));
+        TestCase.assertTrue(!realm.empty);
+
+        realm.write(() => realm.delete(realm.objects('PersonObject')));
+        TestCase.assertTrue(realm.empty);
     }
 };


### PR DESCRIPTION
## What, How & Why?

Add a new property on `Realm`'s prototype that indicates whether a realm contains any objects or not.

/cc @mbalex99 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
