### PR TITLE
Don’t invoke openAsync callback twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+vNext (TBD)
+=============================================================
+### Breaking changes
+* `Realm.openAsync` will no longer open the realm if an error has occured. Previously this resulted in the callback being invoked twice - once with an error and a second time - with the synchronously opened Realm.
+
+### Enhancements
+
+### Bug fixes
+
 1.10.0 Release notes (2017-7-12)
 =============================================================
 ### Breaking changes

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -65,13 +65,14 @@ module.exports = function(realmConstructor) {
                     if (error) {
                         callback(error);
                     }
-
-                    try {
-                        let syncedRealm = new this(config);
-                        //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
-                        setTimeout(() => { callback(null, syncedRealm); }, 1);
-                    } catch (e) {
-                        callback(e);
+                    else {
+                        try {
+                            let syncedRealm = new this(config);
+                            //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
+                            setTimeout(() => { callback(null, syncedRealm); }, 1);
+                        } catch (e) {
+                            callback(e);
+                        }
                     }
                 });
         },

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -48,13 +48,14 @@ module.exports = function(realmConstructor) {
                     if (error) {
                         reject(error);
                     }
-
-                    try {
-                        let syncedRealm = new this(config);
-                        //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
-                        setTimeout(() => { resolve(syncedRealm); }, 1);
-                    } catch (e) {
-                        reject(e);
+                    else {
+                        try {
+                            let syncedRealm = new this(config);
+                            //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
+                            setTimeout(() => { resolve(syncedRealm); }, 1);
+                        } catch (e) {
+                            reject(e);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

This fixes #1140 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 💥 `Breaking` label has been applied or is not necessary
