### PR TITLE
Make jsdoc import tutorials

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "npm install && npm run lint .",
     "license-check": "npm install && license-checker --exclude \"MIT,ISC,BSD,Apache-2.0,BSD-2-Clause,BSD-3-Clause,WTFPL,Unlicense,(MIT AND CC-BY-3.0)\" | node scripts/handle-license-check.js",
     "jsdoc:clean": "rimraf ./docs/output",
-    "jsdoc": "npm install && npm run jsdoc:clean && jsdoc -c docs/conf.json",
+    "jsdoc": "npm install && npm run jsdoc:clean && jsdoc -u docs/tutorials -p package.json -c docs/conf.json",
     "prenode-tests": "npm install --build-from-source && cd tests && npm install",
     "node-tests": "cd tests && npm run test && cd ..",
     "test-runner:ava": "cd tests/test-runners/ava && npm install && npm test",


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

This makes the documentation include tutorials. I.e. the query language support page.

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

This fixes #1118 

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
