### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/react-native/android/src/main/java/io/realm/react/RealmReactPackage.java
+++ b/react-native/android/src/main/java/io/realm/react/RealmReactPackage.java
@@ -16,11 +16,6 @@ public class RealmReactPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
## What, How & Why?
For compatting the release of RN [0.47](https://github.com/facebook/react-native/releases/tag/v0.47.0), I removed the unused `createJSModules` calls.


<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 💥 `Breaking` label has been applied or is not necessary
