### PR TITLE
Fix Object.setPrototypeOf issue on Android

### DIFF
--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -44,8 +44,15 @@ PersonObject.prototype.description = function() {
 PersonObject.prototype.toString = function() {
     return this.name;
 };
-Object.setPrototypeOf(PersonObject, Realm.Object);
-Object.setPrototypeOf(PersonObject.prototype, Realm.Object.prototype);
+
+// Object.setPrototypeOf doesn't work on JSC on Android. The code below achieves the same thing.
+//Object.setPrototypeOf(PersonObject, Realm.Object);
+//Object.setPrototypeOf(PersonObject.prototype, Realm.Object.prototype);
+
+PersonObject.__proto__ = Realm.Object.__proto__;
+PersonObject.prototype.__proto__ = Realm.Object.prototype.__proto__;
+
+
 exports.PersonObject = PersonObject;
 
 exports.PersonList = {

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -49,8 +49,8 @@ PersonObject.prototype.toString = function() {
 //Object.setPrototypeOf(PersonObject, Realm.Object);
 //Object.setPrototypeOf(PersonObject.prototype, Realm.Object.prototype);
 
-PersonObject.__proto__ = Realm.Object.__proto__;
-PersonObject.prototype.__proto__ = Realm.Object.prototype.__proto__;
+PersonObject.__proto__ = Realm.Object;
+PersonObject.prototype.__proto__ = Realm.Object.prototype;
 
 
 exports.PersonObject = PersonObject;


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

`Object.setPrototypeOf` doesn't exist in JSC on Android, causing some tests to crash.
This workaround fixes that.

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
