### PR TITLE
Modernize V8 ArrayBuffer usage

### DIFF
--- a/src/node/node_types.hpp
+++ b/src/node/node_types.hpp
@@ -30,10 +30,6 @@
 
 #include "js_types.hpp"
 
-#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 || (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
-#define REALM_V8_ARRAY_BUFFER_API 1
-#endif
-
 #define HANDLESCOPE Nan::HandleScope handle_scope;
 
 namespace realm {


### PR DESCRIPTION
Instead of manually allocating a chunk of memory and asking V8 to create an ArrayBuffer around it, have V8 create an ArrayBuffer with its own allocator and copy the data in it. (fixes #1197)

Remove an extra copy when reading data from ArrayBufferViews.

Remove TODOs for Node.js versions older than 4.
