### PR TITLE
Check if the supported version (10e) of Android NDK is installed

### DIFF
--- a/scripts/check-environment.js
+++ b/scripts/check-environment.js
@@ -54,6 +54,29 @@ exec('npm --version', (err, stdout) => {
   validateEnvPath('REALM_CORE_PREFIX');
   validateEnvPath('REALM_SYNC_PREFIX');
 
-  // TODO: Check ANDROID_NDK and SDK for Android, and XCode for iOS.
+  // Check ANDROID_NDK version
+  exec('which ndk-build', (err, stdout) => {
+    if(err) {
+      console.error("Android NDK (ndk-build) not found");
+      console.error(err.message);
+      process.exit(-1);
+    }
 
+    const ndkBuildPath = stdout.trim();
+    const ndkDirPath = path.dirname(ndkBuildPath);
+    const releaseTxtPath = path.join(ndkDirPath, "RELEASE.TXT");
+
+    exec(`grep ^r10e ${releaseTxtPath}`, (err, stdout) => {
+      if(err) {
+        // RELEASE.TXT doesn't exist or version mismatch
+        console.error("Incompatible Android NDK version found. NDK 10e is required.")
+        process.exit(-1);
+      }
+
+      successLog('Android NDK 10e found');
+    });
+  });
+
+  // TODO: Check SDK for Android, and XCode for iOS.
+  
 });


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

The check environment script now verifies that NDK 10e is installed.

Different test cases:

1) Correct NDK is installed

MacBook:realm-js ashwinp$ ./scripts/test.sh check-environment
Now using node v6.5.0 (npm v3.10.3)

> realm@1.10.3 check-environment /Users/ashwinp/projects/realm-js
> node scripts/check-environment.js

Checking setup...
 ✓ npm version is 3.10.3
 ✓ Object store submodule is checked out
 ✓ REALM_CORE_PREFIX not set, downloading binaries
 ✓ REALM_SYNC_PREFIX not set, downloading binaries
 ✓ Android NDK 10e found
MacBook:realm-js ashwinp$


2) NDK not installed

MacBook:realm-js ashwinp$ ./scripts/test.sh check-environment
Now using node v6.5.0 (npm v3.10.3)

> realm@1.10.3 check-environment /Users/ashwinp/projects/realm-js
> node scripts/check-environment.js

Checking setup...
 ✓ npm version is 3.10.3
 ✓ Object store submodule is checked out
 ✓ REALM_CORE_PREFIX not set, downloading binaries
 ✓ REALM_SYNC_PREFIX not set, downloading binaries
Android NDK (ndk-build) not found
Command failed: which ndk-build


npm ERR! Darwin 16.7.0
npm ERR! argv "/Users/ashwinp/.nvm/versions/node/v6.5.0/bin/node" "/Users/ashwinp/.nvm/versions/node/v6.5.0/bin/npm" "run" "check-environment"
npm ERR! node v6.5.0
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE
npm ERR! realm@1.10.3 check-environment: `node scripts/check-environment.js`
npm ERR! Exit status 255


3) NDK installed but not 10e

MacBook:realm-js ashwinp$ ./scripts/test.sh check-environment
Now using node v6.5.0 (npm v3.10.3)

> realm@1.10.3 check-environment /Users/ashwinp/projects/realm-js
> node scripts/check-environment.js

Checking setup...
 ✓ npm version is 3.10.3
 ✓ Object store submodule is checked out
 ✓ REALM_CORE_PREFIX not set, downloading binaries
 ✓ REALM_SYNC_PREFIX not set, downloading binaries
Incompatible Android NDK version found. NDK 10e is required.

npm ERR! Darwin 16.7.0
npm ERR! argv "/Users/ashwinp/.nvm/versions/node/v6.5.0/bin/node" "/Users/ashwinp/.nvm/versions/node/v6.5.0/bin/npm" "run" "check-environment"
npm ERR! node v6.5.0
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE
npm ERR! realm@1.10.3 check-environment: `node scripts/check-environment.js`
npm ERR! Exit status 255




<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
