### PR TITLE
Fix 'jni_md.h: No such file or directory' error when building on Ubun…

### DIFF
--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -70,6 +70,7 @@ LOCAL_C_INCLUDES += src/object-store/external/pegtl
 LOCAL_C_INCLUDES += vendor
 LOCAL_C_INCLUDES += $(JAVA_HOME)/include
 LOCAL_C_INCLUDES += $(JAVA_HOME)/include/darwin
+LOCAL_C_INCLUDES += $(JAVA_HOME)/include/linux
 LOCAL_C_INCLUDES += core/include
 ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
 LOCAL_C_INCLUDES += src/object-store/src/sync


### PR DESCRIPTION
…tu 16.04 LTS

When building Android on Ubuntu 16.04 LTS, this fixes an error for a missing header file:
In file included from ./src/android/io_realm_react_RealmReactModule.cpp:19:0:
/usr/lib/jvm/java-8-oracle/include/jni.h:45:20: fatal error: jni_md.h: No such file or directory
                   ^
compilation terminated.
make: *** [/home/ashwinp/projects/realm-js/react-native/android/build/tmp/buildReactNdkLib/local/armeabi-v7a/objs-debug/realmreact/src/android/io_realm_react_RealmReactModule.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory `/home/ashwinp/projects/realm-js/react-native/android/src/main/jni'
:buildReactNdkLib FAILED

FAILURE: Build failed with an exception.

<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
