### PR TITLE
Check that Android NDK version 10e is being used for the build

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -137,6 +137,41 @@ def findNdkBuildFullPath() {
     return null
 }
 
+def checkNdkVersion(ndkBuildFullPath) {
+    def ndkPath = new File(ndkBuildFullPath).getParent()
+    def detectedNdkVersion
+    def releaseFile = new File(ndkPath, 'RELEASE.TXT')
+    def propertyFile = new File(ndkPath, 'source.properties')
+    if (releaseFile.isFile()) {
+        detectedNdkVersion = releaseFile.text.trim().split()[0].split('-')[0]
+    } else if (propertyFile.isFile()) {
+        detectedNdkVersion = getValueFromPropertiesFile(propertyFile, 'Pkg.Revision')
+        if (detectedNdkVersion == null) {
+            throw new GradleException("Failed to obtain the NDK version information from ${ndkPath}/source.properties")
+        }
+    } else {
+        throw new GradleException("Neither ${releaseFile.getAbsolutePath()} nor ${propertyFile.getAbsolutePath()} is a file.")
+    }
+    if (detectedNdkVersion != project.ndkVersion) {
+        throw new GradleException("Your NDK version: ${detectedNdkVersion}."
+                + " Realm JNI must be compiled with the version ${project.ndkVersion} of NDK.")
+    }
+}
+
+static def getValueFromPropertiesFile(File propFile, String key) {
+    if (!propFile.isFile() || !propFile.canRead()) {
+        return null
+    }
+    def prop = new Properties()
+    def reader = propFile.newReader()
+    try {
+        prop.load(reader)
+    } finally {
+        reader.close()
+    }
+    return prop.get(key)
+}
+
 def getNdkBuildFullPath() {
     def ndkBuildFullPath = findNdkBuildFullPath()
     if (ndkBuildFullPath == null) {
@@ -153,6 +188,9 @@ def getNdkBuildFullPath() {
             "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
             null)
     }
+
+    checkNdkVersion(ndkBuildFullPath);
+
     return ndkBuildFullPath
 }
 

--- a/react-native/android/gradle.properties
+++ b/react-native/android/gradle.properties
@@ -6,3 +6,4 @@ POM_PACKAGING=aar
 POM_DESCRIPTION=Android Realm React Native module. Realm is a mobile database: a replacement for SQLite & ORMs
 DEBUG_BUILD=true
 android.useDeprecatedNdk=true
+ndkVersion=r10e


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->
Check that we're using the supported version of Android NDK, which is 10e.

Test cases:

1) Correct version of NDK installed:

MacBook:android ashwinp$ ./gradlew  publishAndroid
Realm Core Version: 2.8.6
Realm Sync Version: 1.10.5
:generateVersionClass
:downloadJSCHeaders UP-TO-DATE
:downloadRealmCore UP-TO-DATE
:prepareRealmCore UP-TO-DATE
:buildReactNdkLib UP-TO-DATE
:packageReactNdkLibs UP-TO-DATE
:publishAndroid UP-TO-DATE

BUILD SUCCESSFUL

2) NDK not installed:

FAILURE: Build failed with an exception.

 Where:
Build file '/Users/ashwinp/projects/realm-js/react-native/android/build.gradle' line: 179

 What went wrong:
ndk-build binary cannot be found, check if you've set $ANDROID_NDK environment variable correctly or if ndk.dir is setup in local.properties

 Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

3) Incorrect version of NDK installed:

FAILURE: Build failed with an exception.

 Where:
Build file '/Users/ashwinp/projects/realm-js/react-native/android/build.gradle' line: 156

 What went wrong:
A problem occurred evaluating root project 'android'.
> Your NDK version: 15.1.4119039. Realm JNI must be compiled with the version r10e of NDK.

 Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED


Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
