### PR TITLE
Allow all log levels in Realm.Sync.setLogLevel()

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -314,7 +314,7 @@ declare namespace Realm.Sync {
     function addListener(serverURL: string, adminUser: Realm.Sync.User, regex: string, name: string, changeCallback: (changeEvent: ChangeEvent) => void): void;
     function removeAllListeners(name?: string): void;
     function removeListener(regex: string, name: string, changeCallback: (changeEvent: ChangeEvent) => void): void;
-    function setLogLevel(logLevel: 'error' | 'info' | 'debug'): void;
+    function setLogLevel(logLevel: 'all' | 'trace' | 'debug' | 'detail' | 'info' | 'warn' | 'error' | 'fatal' | 'off'): void;
     function setAccessToken(accessToken: string): void;
 
     type Instruction = {


### PR DESCRIPTION
## What, How & Why?

For some reason not all the log levels are listed in the argument type for `setLogLevel()`, so it is impossible to select them in a TypeScript app. E.g. I couldn't turn the logging off in ROS tests.

The PR fixes that.

## ☑️ ToDos
* [ ] 📝 Changelog entry