### PR TITLE
Move publish testing to "test.sh all"

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -62,7 +62,7 @@ git fetch origin || die 'Failed to fetch from git origin.'
 [ -z "$(git rev-list origin/$BRANCH..HEAD)" ] || die 'Local commits are not pushed to origin.'
 
 # Double check before actually publishing.
-confirm "Are you sure you want to publish $VERSION?" || die "Aborted publishing $VERSION"
+confirm "Are you sure you want to publish $VERSION? (Did you run all tests)?" || die "Aborted publishing $VERSION"
 
 # This should fail if this tag already exists.
 git tag "v$VERSION"
@@ -78,3 +78,5 @@ REALM_BUILD_ANDROID=1 npm publish ${PRERELEASE:+--tag $PRERELEASE}
 # Only push the tag to GitHub if the publish was successful.
 echo "Pushing v$VERSION tag to GitHub..."
 git push origin "v$VERSION"
+
+echo "Done. Now, you should update the documentation!"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -61,16 +61,6 @@ VERSION_BRANCH="${RELEASE_VERSION%.*}.x"
 git fetch origin || die 'Failed to fetch from git origin.'
 [ -z "$(git rev-list origin/$BRANCH..HEAD)" ] || die 'Local commits are not pushed to origin.'
 
-# Run all tests that must pass before publishing.
-for test in eslint jsdoc license-check react-example react-tests-android react-tests; do
-  for configuration in Debug Release; do
-    echo "RUNNING TEST: $test ($configuration)"
-    echo '----------------------------------------'
-    npm test "$test" "$configuration" || die "Test Failed: $test ($configuration)"
-    echo
-  done
-done
-
 # Double check before actually publishing.
 confirm "Are you sure you want to publish $VERSION?" || die "Aborted publishing $VERSION"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -396,6 +396,17 @@ case "$TARGET" in
   npm install --build-from-source
   npm run test-runners
   ;;
+"all")
+  # Run all tests that must pass before publishing.
+  for test in eslint jsdoc license-check react-example react-tests-android react-tests; do
+    for configuration in Debug Release; do
+      echo "RUNNING TEST: $test ($configuration)"
+      echo '----------------------------------------'
+      npm test "$test" "$configuration" || die "Test Failed: $test ($configuration)"
+      echo
+    done
+  done
+  ;;
 "object-store")
   pushd src/object-store
   cmake -DCMAKE_BUILD_TYPE="$CONFIGURATION" .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -398,7 +398,7 @@ case "$TARGET" in
   ;;
 "all")
   # Run all tests that must pass before publishing.
-  for test in eslint jsdoc license-check react-example react-tests-android react-tests; do
+  for test in eslint license-check react-example react-tests-android react-tests; do
     for configuration in Debug Release; do
       echo "RUNNING TEST: $test ($configuration)"
       echo '----------------------------------------'


### PR DESCRIPTION
Instead of running tests after all git checks etc., you can now run the entire test suite with `test.sh all`. Publishing will assume this has been done.