### PR TITLE
Document solution to a gotcha when running tests for a new Realm API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,13 @@ void RealmClass<T>::crashOnStart(ContextType ctx, FunctionType, ObjectType this_
 
 Testing is important, and in `tests/js/realm-tests.js` you can add the tests you need.
 
+Note: If your new API and/or test cases are not getting picked up when running the Android or iOS tests, remove the corresponding installed package from react-test-app and try again.
+
+```
+rm -rf  tests/react-test-app/node_modules/realm
+rm -rf  tests/react-test-app/node_modules/realm-tests
+```
+
 #### Wrap the function
 
 In order to call the C++ implementation, the JavaScript engine has to know about the function. You must simply add it to the map of methods/functions. Find `MethodMap<T> const methods` declaration in `src/js_realm.hpp` and add your function to it:


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

react-test-app uses npm installed copies of 'realm' and 'realm-tests', so developers might have to manually remove the installed packages to have their new API or tests show up.

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
