### PR TITLE
Don't throw an exception every 10ms in the RPC worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None
+
+### Enhancements
+* Improve performance of the RPC worker for chrome debugging.
+
+### Bug fixes
+* None
+
 1.11.1 Release notes (2017-9-1)
 =============================================================
 ### Breaking changes
@@ -8,7 +19,6 @@
 
 ### Bug fixes
 * Fix accessToken.
-
 
 1.11.0 Release notes (2017-8-31)
 =============================================================


### PR DESCRIPTION
Cuts the time taken to run the react native tests on my machine from 198 seconds to 41 seconds. Probably has a similar impact on the react native debugger performance.

