### PR TITLE
Adding missing TypeScript declaration of setFeatureToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ X.Y.Z Release notes
 * Added `Realm.deleteFile` for deleting a Realm (#363).
 
 ### Bug fixes
-* Adding missing TypeScript declation (#1283).
+* Adding missing TypeScript declations; Permissions (#1283) and `setFeatureToken()`.
 
 1.11.1 Release notes (2017-9-1)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ X.Y.Z Release notes
 * Added `Realm.deleteFile` for deleting a Realm (#363).
 
 ### Bug fixes
-* Adding missing TypeScript declations; Permissions (#1283) and `setFeatureToken()`.
+* Adding missing TypeScript definitions; Permissions (#1283) and `setFeatureToken()`.
 
 1.11.1 Release notes (2017-9-1)
 =============================================================

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -368,7 +368,9 @@ declare namespace Realm.Sync {
     function removeListener(regex: string, name: string, changeCallback: (changeEvent: ChangeEvent) => void): void;
     function setLogLevel(logLevel: 'all' | 'trace' | 'debug' | 'detail' | 'info' | 'warn' | 'error' | 'fatal' | 'off'): void;
     function setFeatureToken(token: string): void;
-    // FIXME: remove setAccessToken after 2.0.
+    /**
+     * @deprecated, to be removed in 2.0
+     */
     function setAccessToken(accessToken: string): void;
 
     type Instruction = {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -367,6 +367,8 @@ declare namespace Realm.Sync {
     function removeAllListeners(name?: string): void;
     function removeListener(regex: string, name: string, changeCallback: (changeEvent: ChangeEvent) => void): void;
     function setLogLevel(logLevel: 'all' | 'trace' | 'debug' | 'detail' | 'info' | 'warn' | 'error' | 'fatal' | 'off'): void;
+    function setFeatureToken(token: string): void;
+    // FIXME: remove setAccessToken after 2.0.
     function setAccessToken(accessToken: string): void;
 
     type Instruction = {


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: https://github.com/realm/realm-js-private/issues/322

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
