### PR TITLE
checkTypes() must only check the shortest array

### DIFF
--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -27,8 +27,8 @@ function node_require(module) {
 
 function checkTypes(args, types) {
     args = Array.prototype.slice.call(args);
-    for (var i = 0; i < Math.min(types.length, args.length); ++i) {
-        if (typeof args[i] !== types[i]) {
+    for (var i = 0; i < types.length; ++i) {
+        if (args.length > i && typeof args[i] !== types[i]) {
             throw new TypeError('param ' + i + ' must be of type ' + types[i]);
         }
     }
@@ -154,7 +154,7 @@ const staticMethods = {
         },
 
         adminUser(token, server) {
-            checkTypes(arguments, ['string']);
+            checkTypes(arguments, ['string', 'string']);
             const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
                 var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
                 return v.toString(16);

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -27,7 +27,7 @@ function node_require(module) {
 
 function checkTypes(args, types) {
     args = Array.prototype.slice.call(args);
-    for (var i = 0; i < types.length; ++i) {
+    for (var i = 0; i < Math.min(types.length, args.length); ++i) {
         if (typeof args[i] !== types[i]) {
             throw new TypeError('param ' + i + ' must be of type ' + types[i]);
         }


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

`checkTypes()` must take optional arguments into account.

Reference to the issue(s) addressed by this PR: https://github.com/realm/realm-js-private/issues/321

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
