### PR TITLE
Adding missing instructions to TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ X.Y.Z Release notes
 * Added `Realm.deleteModel` for deleting a Realm model in a migration (#573).
 
 ### Bug fixes
-* Adding missing TypeScript definitions; Permissions (#1283) and `setFeatureToken()`.
+* Adding missing TypeScript definitions; Permissions (#1283), `setFeatureToken()`, and instructions (#1298).
 
 1.11.1 Release notes (2017-9-1)
 =============================================================

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -381,7 +381,7 @@ declare namespace Realm.Sync {
     function setAccessToken(accessToken: string): void;
 
     type Instruction = {
-        type: 'INSERT' | 'SET' | 'DELETE' | 'CLEAR' | 'LIST_SET' | 'LIST_INSERT' | 'LIST_ERASE' | 'LIST_CLEAR' | 'ADD_TYPE' | 'ADD_PROPERTIES'
+        type: 'INSERT' | 'SET' | 'DELETE' | 'CLEAR' | 'LIST_SET' | 'LIST_INSERT' | 'LIST_ERASE' | 'LIST_CLEAR' | 'ADD_TYPE' | 'ADD_PROPERTIES' | 'CHANGE_IDENTITY' | 'SWAP_IDENTITY'
         object_type: string,
         identity: string,
         values: any | undefined


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Two instructions are missing in the TypeScript definition.

Reference to the issue(s) addressed by this PR: #1298

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
