### PR TITLE
Use the objectstore keypath sorting functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+vNext (TBD)
+=============================================================
+### Breaking changes
+* None
+
+### Enhancements
+* Add support for sorting Lists and Results on values from linked objects.
+
+### Bug fixes
+* None
+
 2.0.0 Release notes (2017-9-19)
 =============================================================
 ### Breaking changes

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -248,10 +248,8 @@ void ListClass<T>::filtered(ContextType ctx, FunctionType, ObjectType this_objec
 
 template<typename T>
 void ListClass<T>::sorted(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    validate_argument_count(argc, 1, 2);
-
     auto list = get_internal<T, ListClass<T>>(this_object);
-    return_value.set(ResultsClass<T>::create_sorted(ctx, *list, argc, arguments));
+    return_value.set(ResultsClass<T>::create_instance(ctx, list->sort(ResultsClass<T>::get_keypaths(ctx, argc, arguments))));
 }
     
 template<typename T>

--- a/tests/js/results-tests.js
+++ b/tests/js/results-tests.js
@@ -206,6 +206,9 @@ module.exports = {
             });
         };
 
+        objects = objects.sorted([]);
+        TestCase.assertArraysEqual(primaries(objects), [2, 3, 1, 4, 0]);
+
         objects = objects.sorted('primaryCol');
         TestCase.assertArraysEqual(primaries(objects), [0, 1, 2, 3, 4]);
 
@@ -241,9 +244,6 @@ module.exports = {
         });
         TestCase.assertThrows(function() {
             objects.sorted([1]);
-        });
-        TestCase.assertThrows(function() {
-            objects.sorted([]);
         });
         TestCase.assertThrows(function() {
             objects.sorted('fish');


### PR DESCRIPTION
Adds support for sorting on values over links, reduces the amount of code in the binding, and is required for sorting non-object lists.

Fixes #437.