### PR TITLE
Fix race conditions in testAddListener

### DIFF
--- a/tests/js/results-tests.js
+++ b/tests/js/results-tests.js
@@ -421,6 +421,11 @@ module.exports = {
     },
 
     testAddListener: function() {
+        if (typeof navigator !== 'undefined' && /Chrome/.test(navigator.userAgent)) { // eslint-disable-line no-undef
+            // FIXME: async callbacks do not work correctly in Chrome debugging mode
+            return;
+        }
+
         const realm = new Realm({ schema: [schemas.TestObject] });
         realm.write(() => {
             realm.create('TestObject', { doubleCol: 1 });

--- a/tests/react-test-app/ios/ReactTests/RealmReactTests.m
+++ b/tests/react-test-app/ios/ReactTests/RealmReactTests.m
@@ -168,6 +168,7 @@ extern NSMutableArray *RCTGetModuleClasses(void);
 + (void)waitForCondition:(BOOL *)condition description:(NSString *)description {
     NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
     NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:30.0];
+    RCTBridge *bridge = [self currentBridge];
 
     while (!*condition) {
         if ([timeout timeIntervalSinceNow] < 0) {
@@ -180,6 +181,7 @@ extern NSMutableArray *RCTGetModuleClasses(void);
             [runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
             [runLoop runMode:NSRunLoopCommonModes beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
             [NSThread sleepForTimeInterval:0.01];  // Bad things may happen without some sleep.
+            [bridge.eventDispatcher sendAppEventWithName:@"realm-dummy" body:nil]; // Ensure RN has an event loop running
         }
     }
 }


### PR DESCRIPTION
The test was resolving the promise long before it actually finished running, leading to it not testing what it was trying to test and sometimes crashing.