### PR TITLE
Fix port conflict between RN >= 0.48 and RPC server (#1294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None
+
+### Enhancements
+* None
+
+### Bug fixes
+* Fixed port conflict between RN >= 0.48 inspector proxy and RPC server used for Chrome debugging (#1294).
+
+
 1.12.0 Release notes (2017-9-14)
 =============================================================
 ### Breaking changes

--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -22,17 +22,17 @@ apply plugin: 'com.android.library'
 
 task forwardDebugPort(type: Exec) {
     def adb = android.getAdbExe()?.toString() ?: 'false'
-    commandLine adb, 'forward', 'tcp:8082', 'tcp:8082'
+    commandLine adb, 'forward', 'tcp:8083', 'tcp:8083'
     ignoreExitValue true
     doLast {
         if (execResult.getExitValue() != 0) {
             logger.error(
                 '===========================================================================\n' +
-                'WARNING: Failed to automatically forward port 8082.\n' +
-                'In order to use Realm in Chrome debugging mode, port 8082 must be forwarded\n' +
+                'WARNING: Failed to automatically forward port 8083.\n' +
+                'In order to use Realm in Chrome debugging mode, port 8083 must be forwarded\n' +
                 'from localhost to the device or emulator being used to run the application.\n' +
                 'You may need to add the appropriate flags to the command that failed:\n' +
-                '    adb forward tcp:8082 tcp:8082\n' +
+                '    adb forward tcp:8083 tcp:8083\n' +
                 '===========================================================================\n'
             )
         }

--- a/react-native/android/src/main/java/io/realm/react/RealmReactModule.java
+++ b/react-native/android/src/main/java/io/realm/react/RealmReactModule.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import fi.iki.elonen.NanoHTTPD;
 
 class RealmReactModule extends ReactContextBaseJavaModule {
-    private static final int DEFAULT_PORT = 8082;
+    private static final int DEFAULT_PORT = 8083;
     private static boolean sentAnalytics = false;
 
     private AndroidWebServer webServer;

--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -38,7 +38,7 @@
 #import "GCDWebServerErrorResponse.h"
 #import "rpc.hpp"
 
-#define WEB_SERVER_PORT 8082
+#define WEB_SERVER_PORT 8083
 
 using namespace realm::rpc;
 #endif


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

Fixes #1294 

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
