### PR TITLE
Fixes for latest react-native / metro-bundler

### DIFF
--- a/lib/react-native.js
+++ b/lib/react-native.js
@@ -18,36 +18,12 @@
 
 'use strict';
 
-// Prevent React Native packager from seeing modules required with this
-function nodeRequire(module) {
-    return require(module);
-}
-
-/* global fetch */
-if (typeof fetch === 'undefined') global.fetch = nodeRequire('node-fetch');
-
 function getContext() {
-    // If process is an object, we're probably running in Node or Electron
-    // From: http://stackoverflow.com/a/24279593/1417293
-    if (typeof process === 'object' && process + '' === '[object process]') {
-        
-        // Visual Studio Code defines the global.__debug__ object.
-        if (typeof global !== 'undefined' && global.__debug__) {
-            return 'vscodedebugger';
-        }
-        
-        return process.type === 'renderer' ? 'electron' : 'nodejs';
-    }
-
-    // When running via Jest, the jest object is defined.
-    if (typeof jest === 'object') {
-        return 'nodejs';
-    }
 
     if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') { // eslint-disable-line no-undef
         // If the navigator.userAgent contains the string "Chrome", we're likely
         // running via the chrome debugger.
-        if (typeof navigator !== 'undefined' && 
+        if (typeof navigator !== 'undefined' &&
             /Chrome/.test(navigator.userAgent)) { // eslint-disable-line no-undef
             return 'chromedebugger';
         }
@@ -61,7 +37,7 @@ function getContext() {
         return 'reactnative';
     }
 
-    // If we're not running in React Native but we already injected the Realm class, 
+    // If we're not running in React Native but we already injected the Realm class,
     // we are probably running in a pure jscore environment
     if (typeof Realm !== 'undefined') {
         return 'jscore';
@@ -74,7 +50,7 @@ function getContext() {
 
     // Finally, if the navigator.userAgent contains the string "Chrome", we're likely
     // running via the chrome debugger, even if navigator.product isn't set to "ReactNative"
-    if (typeof navigator !== 'undefined' && 
+    if (typeof navigator !== 'undefined' &&
         /Chrome/.test(navigator.userAgent)) { // eslint-disable-line no-undef
         return 'chromedebugger';
     }
@@ -85,18 +61,6 @@ function getContext() {
 var realmConstructor;
 
 switch(getContext()) {
-    case 'nodejs':
-    case 'electron':
-        nodeRequire('./submit-analytics')('Run'); 
-
-        var binary = nodeRequire('node-pre-gyp');
-        var path = nodeRequire('path');
-        var pkg = path.resolve(path.join(__dirname,'../package.json'));
-        var binding_path = binary.find(pkg);
-
-        realmConstructor = require(binding_path).Realm;
-        break;
-    
     case 'reactnative':
     case 'jscore':
         realmConstructor = Realm;  // eslint-disable-line no-undef

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -21,10 +21,6 @@
 const AuthError = require('./errors').AuthError;
 const permissionApis = require('./permission-api');
 
-function node_require(module) {
-    return require(module);
-}
-
 function checkTypes(args, types) {
     args = Array.prototype.slice.call(args);
     for (var i = 0; i < types.length; ++i) {
@@ -35,7 +31,6 @@ function checkTypes(args, types) {
 }
 
 /* global fetch */
-const performFetch = typeof fetch === 'undefined' ? node_require('node-fetch') : fetch;
 
 const url_parse = require('url-parse');
 
@@ -74,7 +69,7 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
         }),
         headers: postHeaders
     };
-    performFetch(url, options)
+    fetch(url, options)
         // in case something lower in the HTTP stack breaks, try again in 10 seconds
         .catch(() => setTimeout(() => refreshAccessToken(user, localRealmPath, realmUrl), 10 * 1000))
         .then((response) => response.json().then((json) => { return { response, json }; }))
@@ -133,7 +128,7 @@ function _authenticate(userConstructor, server, json, callback) {
         open_timeout: 5000
     };
 
-    const promise = performFetch(url, options)
+    const promise = fetch(url, options)
         .then((response) => {
             if (response.status !== 200) {
                 return response.json().then((body) => Promise.reject(new AuthError(body)));
@@ -282,7 +277,7 @@ const instanceMethods = {
                 headers,
                 open_timeout: 5000
             };
-            return performFetch(url.href, options)
+            return fetch(url.href, options)
                 .then((response) => {
                     if (response.status !== 200) {
                         return response.json()

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "typings": "./lib/index.d.ts",
   "main": "lib/index.js",
+  "react-native": "lib/react-native.js",
   "files": [
     "android",
     "lib",


### PR DESCRIPTION
The react native packager does not support dynamic require calls (facebook/react-native#6391, facebook/metro-bundler#52). Previous versions would only fail if the dynamic require was actually called, but the latest version detects the invalid syntax during build.

This update adds a replacement entry point for react-native that does not include the node-specific code.
