### PR TITLE
Workaround for RN >= 0.49 metro-bundler check for single string liter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ X.Y.Z Release notes
 
 ### Bug fixes
 * Fixed port conflict between RN >= 0.48 inspector proxy and RPC server used for Chrome debugging (#1294).
+* Workaround for RN >= 0.49 metro-bundler check for single string literal argument to `require()` (#1342)
 
 
 1.12.0 Release notes (2017-9-14)

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,9 +18,11 @@
 
 'use strict';
 
+const require_method = require;
+
 // Prevent React Native packager from seeing modules required with this
 function nodeRequire(module) {
-    return require(module);
+    return require_method(module);
 }
 
 function getContext() {
@@ -91,7 +93,7 @@ switch(getContext()) {
         var pkg = path.resolve(path.join(__dirname,'../package.json'));
         var binding_path = binary.find(pkg);
 
-        realmConstructor = require(binding_path).Realm;
+        realmConstructor = require_method(binding_path).Realm;
         break;
     
     case 'reactnative':

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -21,8 +21,10 @@
 const AuthError = require('./errors').AuthError;
 const permissionApis = require('./permission-api');
 
+const require_method = require;
+
 function node_require(module) {
-    return require(module);
+    return require_method(module);
 }
 
 function checkTypes(args, types) {


### PR DESCRIPTION
…al argument to require() (#1342)

<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?

<!--
Describe the changes and give some hints to guide your reviewers if possible.
 -->

Reference to the issue(s) addressed by this PR: # ???

<!--
- This fixes #???
- This closes realm/realm-sync#???
 -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
