### PR TITLE
Specify a timeout when making the HTTP request to refresh access tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 * Fixed port conflict between RN >= 0.48 inspector proxy and RPC server used for Chrome debugging (#1294).
+* An issue where access tokens were not refreshed correctly has been addressed.
 
 ### Internal
 * Alignment of permission schemas.

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -76,7 +76,10 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
             provider: 'realm',
             app_id: ''
         }),
-        headers: postHeaders
+        headers: postHeaders,
+        // FIXME: This timeout appears to be necessary in order for some requests to be sent at all.
+        // See https://github.com/realm/realm-js-private/issues/338 for details.
+        timeout: 1000.0
     };
     performFetch(url, options)
         .then((response) => response.json().then((json) => { return { response, json }; }))


### PR DESCRIPTION
Without the timeout, some requests are silently never made.

Fixes realm/realm-js-private#338.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
