### PR TITLE
Update the include and library search paths used when building against a local version of core / sync

### DIFF
--- a/realm.gypi
+++ b/realm.gypi
@@ -14,11 +14,13 @@
     }],
     ["use_realm_debug", {
       "variables": {
-        "debug_library_suffix": "-dbg"
+        "debug_library_suffix": "-dbg",
+        "build_directory": "build.debug",
       }
     }, {
       "variables": {
-        "debug_library_suffix": ""
+        "debug_library_suffix": "",
+        "build_directory": "build.release",
       }
     }]
   ],
@@ -40,10 +42,10 @@
       "conditions": [
         ["prefix!=''", {
           "all_dependent_settings": {
-            "include_dirs": [ "<(prefix)/src" ],
+            "include_dirs": [ "<(prefix)/src", "<(prefix)/<(build_directory)/src" ],
           },
           "direct_dependent_settings": {
-            "library_dirs": [ "<(prefix)/src/realm" ]
+            "library_dirs": [ "<(prefix)/<(build_directory)/src/realm" ]
           }
         }, {
           "dependencies": [ "vendored-realm" ]
@@ -66,15 +68,15 @@
       },
       "conditions": [
         ["prefix!=''", {
-          "all_dependent_settings+": {
+          "all_dependent_settings": {
             "include_dirs": [ "<(prefix)/src" ],
           },
-          "direct_dependent_settings+": {
+          "direct_dependent_settings": {
             "library_dirs": [ "<(prefix)/src/realm" ]
           }
         }, {
-          "dependencies+": [ "vendored-realm" ]
-        }]
+          "dependencies": [ "vendored-realm" ]
+        }],
       ],
     },
     {


### PR DESCRIPTION
Core switched to CMake a while back, resulting in build products (generated headers, libraries) ending up in different locations than before. This looks for those files in the same locations that the sync build process expects to find them (`build.debug` for debug builds, `build.release` for release).

I'm not sure what the purpose of the `+` suffix was on some of the build settings related to the `realm-sync` target, but if I left those in place the build settings were entirely ignored. Everything appears to work correctly with those suffixes removed.