### PR TITLE
Remove node 4 and 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN dpkg --add-architecture i386 && \
       unzip \
       wget \
       zip && \
-    curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get install -y nodejs && \
     echo oracle-java6-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     add-apt-repository -y ppa:webupd8team/java && \

--- a/scripts/build-node-pre-gyp.sh
+++ b/scripts/build-node-pre-gyp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-node_versions=${@:-4.4.7 5.12.0 6.5.0 7.0.0}
+node_versions=${@:-6.5.0 7.0.0}
 
 topdir=$(cd $(dirname "$0")/..; pwd)
 
@@ -41,4 +41,3 @@ for node_version in ${node_versions}; do
     cp build/stage/node-pre-gyp/*.tar.gz ${topdir}/out/
   )
 done
-


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

After deprecating Node 4 and 5, we should use node 6 in Docker.


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
