### PR TITLE
Use the official Node image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,14 +197,6 @@ def doDockerBuild(target, postStep = null) {
   }
 }
 
-// def doDockerBuild(target, postStep = null) {
-//   return {
-//     node('docker') {
-//       doDockerInside("./scripts/docker-wrapper.sh ./scripts/test.sh", target, postStep)
-//     }
-//   }
-// }
-
 def doMacBuild(target, postStep = null) {
   return {
     node('osx_vegas') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,9 @@ def doAndroidBuild(target, postStep = null) {
 def doDockerBuild(target, postStep = null) {
   return {
     node('docker') {
+      deleteDir()
+      unstash 'source'
+
       try {
         reportStatus(target, 'PENDING', 'Build has started')
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,10 +175,32 @@ def doAndroidBuild(target, postStep = null) {
 def doDockerBuild(target, postStep = null) {
   return {
     node('docker') {
-      doDockerInside("./scripts/docker-wrapper.sh ./scripts/test.sh", target, postStep)
+      try {
+        reportStatus(target, 'PENDING', 'Build has started')
+
+        docker.image('node:6').inside('-e HOME=/tmp') {
+          sh "scripts/test.sh ${target}"
+          if(postStep) {
+            postStep.call()
+          }
+          deleteDir()
+          reportStatus(target, 'SUCCESS', 'Success!')
+        }
+      } catch(Exception e) {
+        reportStatus(target, 'FAILURE', e.toString())
+        throw e
+      }
     }
   }
 }
+
+// def doDockerBuild(target, postStep = null) {
+//   return {
+//     node('docker') {
+//       doDockerInside("./scripts/docker-wrapper.sh ./scripts/test.sh", target, postStep)
+//     }
+//   }
+// }
 
 def doMacBuild(target, postStep = null) {
   return {


### PR DESCRIPTION
The master branch is broken and:
 1) there are too many layers of abstraction and finding the root cause is tedious
 2) the Docker image currently being used for node builds includes way too much (ANDROID NDK, React Native etc), making those images very big and slow to build.

Here I propose to use the official Node image and cut a few layers of abstraction.