### PR TITLE
Add support for aggregates on arrays of primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ X.Y.Z Release notes
 
 ### Enhancements
 * Added `update` method to `Realm.Results` to support bulk updates (#808).
+* Added support for aggregate functions on `Realm.Results` and `Realm.List` of primitive types.
 
 ### Bug fixes
 * None

--- a/docs/collection.js
+++ b/docs/collection.js
@@ -263,7 +263,7 @@ class Collection {
      *
      * @param {string} [property] - For a collection of objects, the property to take the maximum of.
      * @throws {Error} If no property with the name exists or if property is not numeric/date.
-     * @returns {number} the minimum value.
+     * @returns {number} the maximum value.
      * @since 1.12.1
      */
     max(property) {}

--- a/docs/collection.js
+++ b/docs/collection.js
@@ -239,8 +239,14 @@ class Collection {
    indexOf(object) {}
 
     /**
-     * Computes the minimum value of a property.
-     * @param {string} property - The name of the property.
+     * Returns the minimum value of the values in the collection or of the
+     * given property among all the objects in the collection, or `undefined`
+     * if the collection is empty.
+     *
+     * Only supported for int, float, double and date properties. `null` values
+     * are ignored entirely by this method and will not be returned.
+     *
+     * @param {string} [property] - For a collection of objects, the property to take the minimum of.
      * @throws {Error} If no property with the name exists or if property is not numeric/date.
      * @returns {number} the minimum value.
      * @since 1.12.1
@@ -248,28 +254,44 @@ class Collection {
     min(property) {}
 
     /**
-     * Computes the maximum value of a property.
-     * @param {string} property - The name of the property.
+     * Returns the maximum value of the values in the collection or of the
+     * given property among all the objects in the collection, or `undefined`
+     * if the collection is empty.
+     *
+     * Only supported for int, float, double and date properties. `null` values
+     * are ignored entirely by this method and will not be returned.
+     *
+     * @param {string} [property] - For a collection of objects, the property to take the maximum of.
      * @throws {Error} If no property with the name exists or if property is not numeric/date.
-     * @returns {number} the maximum value.
+     * @returns {number} the minimum value.
      * @since 1.12.1
      */
     max(property) {}
 
     /**
-     * Computes the sum of a property.
-     * @param {string} property - The name of the property.
-     * @throws {Error} If no property with the name exists or if property is not numeric/date.
+     * Computes the sum of the values in the collection or of the given
+     * property among all the objects in the collection, or 0 if the collection
+     * is empty.
+     *
+     * Only supported for int, float and double properties. `null` values are
+     * ignored entirely by this method.
+     * @param {string} [property] - For a collection of objects, the property to take the sum of.
+     * @throws {Error} If no property with the name exists or if property is not numeric.
      * @returns {number} the sum.
      * @since 1.12.1
      */
     sum(property) {}
 
     /**
-     * Computes the average of a property.
-     * @param {string} property - The name of the property.
-     * @throws {Error} If no property with the name exists or if property is not numeric/date.
-     * @returns {number} the average value.
+     * Computes the average of the values in the collection or of the given
+     * property among all the objects in the collection, or `undefined` if the collection
+     * is empty.
+     *
+     * Only supported for int, float and double properties. `null` values are
+     * ignored entirely by this method and will not be factored into the average.
+     * @param {string} [property] - For a collection of objects, the property to take the average of.
+     * @throws {Error} If no property with the name exists or if property is not numeric.
+     * @returns {number} the sum.
      * @since 1.12.1
      */
     avg(property) {}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -144,33 +144,10 @@ declare namespace Realm {
          */
         isValid(): boolean;
 
-        /**
-         * Computes the minimum value.
-         * @param  {string} property
-         * @returns number
-         */
-        min(property: string): number;
-
-        /**
-         * Computes the maximum value.
-         * @param  {string} property
-         * @returns number
-         */
-        max(property: string): number;
-
-        /**
-         * Computes the sum.
-         * @param  {string} property
-         * @returns number
-         */
-        sum(property: string): number;
-
-        /**
-         * Computes the average.
-         * @param  {string} property
-         * @returns number
-         */
-        avg(property: string): number;
+        min(property?: string): number|Date|null;
+        max(property?: string): number|Date|null;
+        sum(property?: string): number|null;
+        avg(property?: string): number;
 
         /**
          * @param  {string} query

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -78,12 +78,6 @@ struct ListClass : ClassDefinition<T, realm::js::List<T>, CollectionClass<T>> {
     static void is_valid(ContextType, ObjectType, Arguments, ReturnValue &);
     static void index_of(ContextType, ObjectType, Arguments, ReturnValue &);
 
-    // aggregate functions
-    static void min(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void max(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void sum(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void avg(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-
     // observable
     static void add_listener(ContextType, ObjectType, Arguments, ReturnValue &);
     static void remove_listener(ContextType, ObjectType, Arguments, ReturnValue &);
@@ -102,10 +96,10 @@ struct ListClass : ClassDefinition<T, realm::js::List<T>, CollectionClass<T>> {
         {"sorted", wrap<sorted>},
         {"isValid", wrap<is_valid>},
         {"indexOf", wrap<index_of>},
-        {"min", wrap<min>},
-        {"max", wrap<max>},
-        {"sum", wrap<sum>},
-        {"avg", wrap<avg>},
+        {"min", wrap<compute_aggregate_on_collection<ListClass<T>, AggregateFunc::Min>>},
+        {"max", wrap<compute_aggregate_on_collection<ListClass<T>, AggregateFunc::Max>>},
+        {"sum", wrap<compute_aggregate_on_collection<ListClass<T>, AggregateFunc::Sum>>},
+        {"avg", wrap<compute_aggregate_on_collection<ListClass<T>, AggregateFunc::Avg>>},
         {"addListener", wrap<add_listener>},
         {"removeListener", wrap<remove_listener>},
         {"removeAllListeners", wrap<remove_all_listeners>},
@@ -132,26 +126,6 @@ template<typename T>
 void ListClass<T>::get_length(ContextType, ObjectType object, ReturnValue &return_value) {
     auto list = get_internal<T, ListClass<T>>(object);
     return_value.set((uint32_t)list->size());
-}
-
-template<typename T>
-void ListClass<T>::min(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ListClass<T>>(AggregateFunc::Min, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ListClass<T>::max(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ListClass<T>>(AggregateFunc::Max, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ListClass<T>::sum(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ListClass<T>>(AggregateFunc::Sum, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ListClass<T>::avg(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ListClass<T>>(AggregateFunc::Avg, ctx, this_object, argc, arguments, return_value);
 }
 
 template<typename T>

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -89,12 +89,6 @@ struct ResultsClass : ClassDefinition<T, realm::js::Results<T>, CollectionClass<
 
     static void update(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
 
-    // aggregate functions
-    static void min(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void max(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void sum(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-    static void avg(ContextType, FunctionType, ObjectType, size_t, const ValueType[], ReturnValue &);
-
     // observable
     static void add_listener(ContextType, ObjectType, Arguments, ReturnValue &);
     static void remove_listener(ContextType, ObjectType, Arguments, ReturnValue &);
@@ -112,10 +106,10 @@ struct ResultsClass : ClassDefinition<T, realm::js::Results<T>, CollectionClass<
         {"filtered", wrap<filtered>},
         {"sorted", wrap<sorted>},
         {"isValid", wrap<is_valid>},
-        {"min", wrap<min>},
-        {"max", wrap<max>},
-        {"sum", wrap<sum>},
-        {"avg", wrap<avg>},
+        {"min", wrap<compute_aggregate_on_collection<ResultsClass<T>, AggregateFunc::Min>>},
+        {"max", wrap<compute_aggregate_on_collection<ResultsClass<T>, AggregateFunc::Max>>},
+        {"sum", wrap<compute_aggregate_on_collection<ResultsClass<T>, AggregateFunc::Sum>>},
+        {"avg", wrap<compute_aggregate_on_collection<ResultsClass<T>, AggregateFunc::Avg>>},
         {"addListener", wrap<add_listener>},
         {"removeListener", wrap<remove_listener>},
         {"removeAllListeners", wrap<remove_all_listeners>},
@@ -212,26 +206,6 @@ template<typename T>
 void ResultsClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     auto results = get_internal<T, ResultsClass<T>>(object);
     return_value.set((uint32_t)results->size());
-}
-
-template<typename T>
-void ResultsClass<T>::min(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ResultsClass<T>>(AggregateFunc::Min, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ResultsClass<T>::max(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ResultsClass<T>>(AggregateFunc::Max, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ResultsClass<T>::sum(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ResultsClass<T>>(AggregateFunc::Sum, ctx, this_object, argc, arguments, return_value);
-}
-
-template<typename T>
-void ResultsClass<T>::avg(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
-    compute_aggregate_on_collection<ResultsClass<T>>(AggregateFunc::Avg, ctx, this_object, argc, arguments, return_value);
 }
 
 template<typename T>

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -139,7 +139,7 @@ struct Value {
     static ValueType from_nonnull_binary(ContextType, BinaryData);
     static ValueType from_undefined(ContextType);
     static ValueType from_timestamp(ContextType, Timestamp);
-    static ValueType from_mixed(ContextType, util::Optional<Mixed> &);
+    static ValueType from_mixed(ContextType, const util::Optional<Mixed> &);
 
     static ObjectType to_array(ContextType, const ValueType &);
     static bool to_boolean(ContextType, const ValueType &);
@@ -446,7 +446,7 @@ inline typename T::Value Value<T>::from_timestamp(typename T::Context ctx, Times
 }
 
 template<typename T>
-inline typename T::Value Value<T>::from_mixed(typename T::Context ctx, util::Optional<Mixed>& mixed) {
+inline typename T::Value Value<T>::from_mixed(typename T::Context ctx, const util::Optional<Mixed>& mixed) {
     if (!mixed) {
         return from_undefined(ctx);
     }

--- a/src/js_util.hpp
+++ b/src/js_util.hpp
@@ -83,50 +83,42 @@ static inline void validate_argument_count_at_least(size_t count, size_t expecte
     }
 }
 
-template<typename T>
-static inline void compute_aggregate_on_collection(AggregateFunc func, typename T::ContextType ctx, typename T::ObjectType this_object, size_t argc, const typename T::ValueType arguments[], typename T::ReturnValue &return_value) {
-    validate_argument_count(argc, 1);
-    std::string property_name = T::Value::validated_to_string(ctx, arguments[0]);
+template<typename T, AggregateFunc func>
+void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::ObjectType this_object,
+                                     typename T::Arguments args, typename T::ReturnValue &return_value) {
 
     auto list = get_internal<typename T::Type, T>(this_object);
 
-    const ObjectSchema& object_schema = list->get_object_schema();
-    const Property* property = object_schema.property_for_name(property_name);
-    if (!property) {
-        throw std::invalid_argument(util::format("No such property: %1", property_name));
+    size_t column = 0;
+    if (list->get_type() == realm::PropertyType::Object) {
+        const ObjectSchema& object_schema = list->get_object_schema();
+        std::string property_name = T::Value::validated_to_string(ctx, args[0]);
+        const Property* property = object_schema.property_for_name(property_name);
+        if (!property) {
+            throw std::invalid_argument(util::format("Property '%1' does not exist on object '%2'",
+                                                     property_name, object_schema.name));
+        }
+        column = property->table_column;
+    }
+    else {
+        args.validate_maximum(0);
     }
 
     util::Optional<Mixed> mixed;
     switch (func) {
-        case AggregateFunc::Min: {
-            mixed = list->min(property->table_column);
+        case AggregateFunc::Min:
+            return_value.set(list->min(column));
             break;
-        }
-        case AggregateFunc::Max: {
-            mixed = list->max(property->table_column);
+        case AggregateFunc::Max:
+            return_value.set(list->max(column));
             break;
-        }
-        case AggregateFunc::Sum: {
-            mixed = list->sum(property->table_column);
+        case AggregateFunc::Sum:
+            return_value.set(list->sum(column));
             break;
-        }
-        case AggregateFunc::Avg: {
-            util::Optional<double> avg = list->average(property->table_column);
-            if (!avg) {
-                return_value.set_undefined();
-            }
-            else {
-                return_value.set(*avg);
-            }
-            return;
-        }
-        default: {
-            REALM_ASSERT(false && "Unknown aggregate function");
-            REALM_UNREACHABLE();
-        }
+        case AggregateFunc::Avg:
+            return_value.set(list->average(column));
+            break;
     }
-
-    return_value.set(T::Value::from_mixed(ctx, mixed));
 }
 
 } // js

--- a/src/jsc/jsc_return_value.hpp
+++ b/src/jsc/jsc_return_value.hpp
@@ -53,12 +53,26 @@ class ReturnValue<jsc::Types> {
     void set(uint32_t number) {
         m_value = JSValueMakeNumber(m_context, number);
     }
+    void set(const util::Optional<realm::Mixed>& mixed) {
+        m_value = Value<jsc::Types>::from_mixed(m_context, mixed);
+    }
     void set_null() {
         m_value = JSValueMakeNull(m_context);
     }
     void set_undefined() {
         m_value = JSValueMakeUndefined(m_context);
     }
+
+    template<typename T>
+    void set(const util::Optional<T>& value) {
+        if (value) {
+            set(*value);
+        }
+        else {
+            set_undefined();
+        }
+    }
+
     operator JSValueRef() const {
         return m_value;
     }

--- a/src/node/node_return_value.hpp
+++ b/src/node/node_return_value.hpp
@@ -64,11 +64,24 @@ class ReturnValue<node::Types> {
     void set(uint32_t number) {
         m_value.Set(number);
     }
+    void set(realm::Mixed mixed) {
+        m_value.Set(Value<node::Types>::from_mixed(nullptr, mixed));
+    }
     void set_null() {
         m_value.SetNull();
     }
     void set_undefined() {
         m_value.SetUndefined();
+    }
+
+    template<typename T>
+    void set(util::Optional<T> value) {
+        if (value) {
+            set(*value);
+        }
+        else {
+            m_value.SetUndefined();
+        }
     }
 };
     


### PR DESCRIPTION
These were missing from the initial implementation due to that aggregates were implemented on `master` concurrently with the AoP work on 2.0.x.