### PR TITLE
Remove configuration handling from Realm._waitForDownload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ X.Y.Z Release notes
 * Added `update` method to `Realm.Results` to support bulk updates (#808).
 
 ### Bug fixes
-* None
+* Avoid closing then reopening a sync session when using `Realm.open` (#1391).
+* Respect custom Realm paths when using `Realm.open` (#1392 and #1393).
 
 2.0.0-rc19 Release notes (2017-10-7)
 =============================================================

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -128,6 +128,7 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'removeListener',
     'removeAllListeners',
     'close',
+    '_waitForDownload',
 ]);
 
 // Mutating methods:
@@ -188,12 +189,6 @@ Object.defineProperties(Realm, {
             objects.clearRegisteredConstructors();
             rpc.clearTestState();
         },
-    },
-    _waitForDownload: {
-        value: function(_config, sessionCallback, callback) {
-            sessionCallback();
-            callback();
-        }
     },
 });
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -31,6 +31,25 @@ function setConstructorOnPrototype(klass) {
     }
 }
 
+// Return a configuration usable by `Realm.open` when waiting for a download.
+// It must have caching disabled, and no schema or schema version specified.
+function waitForDownloadConfig(config) {
+    if (!config) {
+        return {_cache: false};
+    }
+
+    if (typeof config == 'string') {
+        return {path: config, _cache: false};
+    }
+
+    if (typeof config == 'object') {
+        return Object.assign({}, config, {schema: undefined, schemaVersion: undefined, _cache: false});
+    }
+
+    // Unknown type. Pass the config through.
+    return config;
+}
+
 module.exports = function(realmConstructor) {
     // Add the specified Array methods to the Collection prototype.
     Object.defineProperties(realmConstructor.Collection.prototype, require('./collection-methods'));
@@ -45,7 +64,8 @@ module.exports = function(realmConstructor) {
         open(config) {
             let syncSession;
             let promise = new Promise((resolve, reject) => {
-                realmConstructor._waitForDownload(config,
+                let realm = new realmConstructor(waitForDownloadConfig(config));
+                realm._waitForDownload(
                     (session) => {
                         syncSession = session;
                     },
@@ -55,7 +75,7 @@ module.exports = function(realmConstructor) {
                         }
                         else {
                             try {
-                                let syncedRealm = new this(config);
+                                let syncedRealm = new realmConstructor(config);
                                 //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
                                 setTimeout(() => { resolve(syncedRealm); }, 1);
                             } catch (e) {
@@ -80,26 +100,16 @@ module.exports = function(realmConstructor) {
             const message = "Realm.openAsync is now deprecated in favor of Realm.open. This function will be removed in future versions.";
             (console.warn || console.log).call(console, message);
 
-            realmConstructor._waitForDownload(config,
-                (syncSession) => {
-                    if (progressCallback) {
-                        syncSession.addProgressNotification('download', 'forCurrentlyOutstandingWork', progressCallback);
-                    }
-                },
-                (error) => {
-                    if (error) {
-                        setTimeout(() => { callback(error); }, 1);
-                    }
-                    else {
-                        try {
-                            let syncedRealm = new this(config);
-                            //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented
-                            setTimeout(() => { callback(null, syncedRealm); }, 1);
-                        } catch (e) {
-                            setTimeout(() => { callback(e); }, 1);
-                        }
-                    }
-                });
+            let promise = this.open(config)
+            if (progressCallback) {
+                promise.progress(progressCallback)
+            }
+
+            promise.then(realm => {
+                callback(null, realm)
+            }).catch(error => {
+                callback(error);
+            });
         },
     }));
 

--- a/lib/permission-api.js
+++ b/lib/permission-api.js
@@ -72,31 +72,11 @@ function getSpecialPurposeRealm(user, realmName, schema) {
     }
   };
 
-  const _Realm = user.constructor._realmConstructor;
-
-  return new Promise((resolve, reject) => {
-    _Realm._waitForDownload(config, (error) => {
-
-      // FIXME: I don't understand why, but removing the following setTimeout causes the subsequent
-      // setTimeout call (when resolving the promise) to hang on RN iOS.
-      // This might be related to our general makeCallback issue: #1255.
-      setTimeout(() => {}, 1);
-
-      if (error) {
-        setTimeout(() => reject(error), 1);
-      }
-      else {
-        try {
-          let syncedRealm = new _Realm(config);
-          user[specialPurposeRealmsKey][realmName] = syncedRealm;
-          //FIXME: RN hangs here. Remove when node's makeCallback alternative is implemented (#1255)
-          setTimeout(() => resolve(syncedRealm), 1);
-        } catch (e) {
-          setTimeout(() => reject(e), 1);
-        }
-      }
-    });
-  });
+  let Realm = user.constructor._realmConstructor;
+  return Realm.open(config).then(realm => {
+    user[specialPurposeRealmsKey][realmName] = realm;
+    return realm;
+  })
 }
 
 function createInManagementRealm(user, modelName, modelInitializer) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -249,89 +249,6 @@ module.exports = {
             });
     },
 
-    testProgressNotificationsForRealmOpen() {
-        if (!isNodeProccess) {
-            return Promise.resolve();
-        }
-
-        const username = uuid();
-        const realmName = uuid();
-        const expectedObjectsCount = 3;
-
-        return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
-            .then(() => {
-                return Realm.Sync.User.login('http://localhost:9080', username, 'password').then(user => {
-                    const accessTokenRefreshed = this;
-                    let successCounter = 0;
-                    let progressNotificationCalled = false;
-                    let config = {
-                        sync: {
-                            user,
-                            url: `realm://localhost:9080/~/${realmName}`,
-                            _onDownloadProgress: (transferred, total) => {
-                                progressNotificationCalled = true
-                            },
-                        },
-                        schema: [{ name: 'Dog', properties: { name: 'string' } }],
-                    };
-
-                    return Realm.open(config)
-                        .then(realm => {
-                            return realm.syncSession;
-                        }).then(session => {
-                            TestCase.assertTrue(progressNotificationCalled, "Progress notification not called for Realm.open");
-                        });
-                });
-            });
-    },
-
-    testProgressNotificationsForRealmOpenAsync() {
-        if (!isNodeProccess) {
-            return Promise.resolve();
-        }
-
-        const username = uuid();
-        const realmName = uuid();
-        const expectedObjectsCount = 3;
-
-        return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
-            .then(() => {
-                return Realm.Sync.User.login('http://localhost:9080', username, 'password').then(user => {
-                    return new Promise((resolve, reject) => {
-                        let progressNotificationCalled = false;
-                        let config = {
-                            sync: { user, url: `realm://localhost:9080/~/${realmName}`,
-                                _onDownloadProgress: (transferred, total) => {
-                                    progressNotificationCalled = true
-                                },
-                            },
-                            schema: [{ name: 'Dog', properties: { name: 'string' } }],
-                        };
-
-                        Realm.openAsync(config, (error, realm) => {
-                            try {
-                                if (error) {
-                                    reject(error);
-                                }
-
-                                setTimeout(() => {
-                                    try {
-                                        TestCase.assertTrue(progressNotificationCalled, "Progress notification not called for Realm.openAsync");
-                                        resolve();
-                                    } catch (e) {
-                                        reject(e);
-                                    }
-                                }, 50);
-                            }
-                            catch (e) {
-                                reject(e);
-                            }
-                        });
-                    });
-                });
-            });
-    },
-
     testRealmOpenAsyncNoSchema() {
         if (!isNodeProccess) {
             return Promise.resolve();
@@ -697,7 +614,7 @@ module.exports = {
             });
     },
 
-    testProgressNotificationsForRealmOpen2() {
+    testProgressNotificationsForRealmOpen() {
         if (!isNodeProccess) {
             return Promise.resolve();
         }
@@ -736,7 +653,7 @@ module.exports = {
             });
     },
 
-    testProgressNotificationsForRealmOpenAsync2() {
+    testProgressNotificationsForRealmOpenAsync() {
         if (!isNodeProccess) {
             return Promise.resolve();
         }


### PR DESCRIPTION
There's no reason for `_waitForDownload` to be responsible for constructing a new Realm instance when we can instead use the constructor for that. This eliminates the potential for different handling of the Realm configuration between `_waitForDownload` and `new Realm`, which was responsible for various issues (#1391, #1392, #1393). In turn, this requires that `_waitForDownload` become an instance method.

In addition, we update `Realm.openAsync` and `getSpecialPurposeRealm` to delegate to `Realm.open` rather than reimplementing equivalent logic themselves.

Finally, the private mechanism for registering a download progress handler as part of the sync configuration (`_onDownloadProgress`) is removed in favor of the public API (`progress()` on the promise returned by `Realm.open`).

This is an alternative approach to that taken in #1394. I think it's a better long-term solution, but it's a more invasive change and carries a little more risk.

Fixes #1391, #1392, #1393.