### PR TITLE
Check for REALM_DISABLE_ANALYTICS earlier in submit-analytics.js

### DIFF
--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -25,6 +25,11 @@
 
 'use strict';
 
+if ('REALM_DISABLE_ANALYTICS' in process.env) {
+    module.exports = function(){};
+    return;
+}
+
 const os = require('os');
 const crypto = require('crypto');
 const fs = require('fs');
@@ -69,9 +74,6 @@ function getAnonymizedMachineIdentifier() {
 }
 
 module.exports = function(eventName) {
-    if ('REALM_DISABLE_ANALYTICS' in process.env)
-        return;
-
     const identifier = getAnonymizedMachineIdentifier();
     const payload = {
         'event': eventName,


### PR DESCRIPTION
Node's `require()` is synchronous and somewhat slow, so importing the modules for submit-analytics.js ends up being about half of the runtime of `require('realm')`. With this change, when analytics is disabled, nearly all of the time spent on `require('realm')` (~100ms on my machine) is spent in node-pre-gyp-related functionality for loading the native module.
 