### PR TITLE
Link against OpenSSL when building for Electron

### DIFF
--- a/realm.gypi
+++ b/realm.gypi
@@ -2,7 +2,8 @@
   "variables": {
     "realm_download_binaries%": "1",
     "use_realm_debug%": "<!(node -p \"'REALMJS_USE_DEBUG_CORE' in process.env ? 1 : 0\")",
-    "realm_js_dir%": "<(module_root_dir)"
+    "realm_js_dir%": "<(module_root_dir)",
+    "runtime%": "node"
   },
   "conditions": [
     ["OS=='mac'", {
@@ -147,6 +148,19 @@
             "libraries": [ "-lrealm-sync<(debug_library_suffix)" ]
           }, {
             "libraries": [ "-lrealm-sync-node<(debug_library_suffix)" ]
+          }],
+          ["OS=='win' and runtime=='electron'", {
+            "libraries": [ "libeay32.lib", "ssleay32.lib" ],
+            "conditions": [
+              ["target_arch=='ia32'", {
+                "library_dirs": [ "C:\\src\\vcpkg\\installed\\x86-windows-static\\lib" ]
+              }, {
+                "library_dirs": [ "C:\\src\\vcpkg\\installed\\x64-windows-static\\lib" ]
+              }],
+            ]
+          }],
+          ["OS=='linux' and runtime=='electron'", {
+            "libraries": [ "-l:libcrypto.a", "-l:libssl.a" ]
           }]
         ]
       },

--- a/target_defaults.gypi
+++ b/target_defaults.gypi
@@ -61,5 +61,6 @@
       }
     },
     "msvs_disabled_warnings": [ 4068, 4101, 4244, 4996 ],
+	"msbuild_toolset": "v141"
   }
 }

--- a/tests/electron/runner.js
+++ b/tests/electron/runner.js
@@ -4,7 +4,10 @@ const assert = require("assert");
 const path = require("path");
 const Application = require("spectron").Application;
 
-const ELECTRON_PATH = path.join(__dirname, "node_modules", ".bin", "electron");
+let ELECTRON_PATH = path.join(__dirname, "node_modules", ".bin", "electron");
+if (process.platform === 'win32') {
+  ELECTRON_PATH += '.cmd';
+}
 const MAIN_PATH = path.join(__dirname, "app", "main.js");
 const POLL_LOG_DELAY = 500;
 


### PR DESCRIPTION
We can't rely on the Electron renderer process providing OpenSSL symbols so link against it explicitly on platforms that require it.
