### PR TITLE
Don't download + extract unnecessarily at build time

### DIFF
--- a/scripts/download-realm.js
+++ b/scripts/download-realm.js
@@ -205,24 +205,30 @@ function readManifest(target) {
     try {
         return ini.parse(fs.readFileSync(path.resolve(target, MANIFEST_FILENAME), 'utf8'));
     } catch (e) {
-        return false;
+        return null;
     }
 }
 
 function shouldSkipAcquire(target, desiredManifest, force) {
+    if (force) {
+        console.log('Skipping manifest check as --force is enabled');
+        return false;
+    }
+
     const existingManifest = readManifest(target);
 
     if (!existingManifest) {
         console.log('No manifest at the target, proceeding.');
-    } else if (!Object.keys(desiredManifest).every(key => existingManifest[key] === desiredManifest[key])) {
-        console.log('Target has is non-empty but has a different manifest, overwriting.');
-    } else if (force) {
-        console.log('Target has a matching manifest but download forced.');
-    } else {
-        console.log('Matching manifest already exists at target - nothing to do (use --force to override)');
-        return true;
+        return false;
     }
-    return false;
+
+    if (!Object.keys(desiredManifest).every(key => existingManifest[key] === desiredManifest[key])) {
+        console.log('Target directory has a differing manifest, overwriting.');
+        return false;
+    }
+
+    console.log('Matching manifest already exists at target - nothing to do (use --force to override)');
+    return true;
 }
 
 const optionDefinitions = [


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
`download-realm.js` is run every time a mobile target is built. This will often download a large archive (unless it has already been downloaded since the OS temp was last cleared), and will always re-extract the archive into the target. This causes project files to be touched and (at least) Xcode to rebuild RealmJS and its dependencies.

This PR modifies `download-realm.js` to write a manifest file into the target directory containing metadata about the contents. If a manifest is present and matches what's being requested, the directory is left untouched (unless `--force` is passed). This skips an unnecessary download/extraction/build and greatly reduces build times when working on an app.

The diff looks huge because of the refactoring required to collect all the information needed before deciding whether to empty the target directory. I've changed as little as I could get away with.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary