### PR TITLE
iOS: Add requiresMainQueueSetup (YES?)

### DIFF
--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -95,6 +95,10 @@ extern "C" JSGlobalContextRef RealmReactGetJSGlobalContextForExecutor(id executo
 
 RCT_EXPORT_MODULE(Realm)
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 + (void)initialize {
     if (self != [RealmReact class]) {
         return;


### PR DESCRIPTION
## What, How & Why?
RN 0.49 shows the following warning on startup:
> Module RealmReact requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

I'm putting this PR up for discussion as much as anything - I can't tell whether main queue setup is actually required, but since a future release will change it to a background thread, sticking with the main queue is the safer option unless anyone knows better? 

There's no use of UIKit, but are various initialisation steps that may or may not be thread safe, and I know Realm does quite a bit more magic than most native modules.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
