### PR TITLE
Fix for missing Realm constructor in js debugging mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,6 @@ function getContext() {
             return 'chromedebugger';
         }
 
-
         // Check if its in remote js debugging mode
         // https://stackoverflow.com/a/42839384/3090989
         if (typeof atob !== 'undefined') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,13 @@ function getContext() {
             return 'chromedebugger';
         }
 
+
+        // Check if its in remote js debugging mode
+        // https://stackoverflow.com/a/42839384/3090989
+        if (typeof atob !== 'undefined') {
+            return 'chromedebugger';
+        }
+
         // Otherwise, we must be in a "normal" react native situation.
         // In that case, the Realm type should have been injected by the native code.
         // If it hasn't, the user likely forgot to run link.


### PR DESCRIPTION
## What, How & Why?
When enabling js remote debugging mode the app crashed with the error ```Missing Realm constructor. Did you run "react-native link realm" ?```. This PR aims to fix this problem via detecting js remote debugging mode and returning it from ```getContext()```

This closes #1407.