### PR TITLE
Update React Native Android buildToolsVersion to 26.0.2

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -254,7 +254,7 @@ task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16

--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -41,7 +41,7 @@ task forwardDebugPort(type: Exec) {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

In #992 buildToolsVersion was updated to 25.0.2,
but for build as below, buildToolsVersion in `publish_android_template` should also be updated.

>cd react-native/android
>./gradlew publishAndroid
>
>https://github.com/realm/realm-js#building-realm

And I update to the latest buildtools version: 26.0.2
