### PR TITLE
Enable object Ids on RN Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ X.Y.Z Release notes
 * None.
 
 ### Bug fixes
-* Enabled object Ids on RN Android (#1480).
+* Fixed a compilation error related to object IDs for React Native on Android (#1480).
 
 ### Internal
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enchancements
+* None.
+
+### Bug fixes
+* Enabled object Ids on RN Android (#1480).
+
+### Internal
+* None.
+
+
 2.0.5 Release notes (2017-11-9)
 =============================================================
 ### Breaking changes

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1013,8 +1013,7 @@ inline sync::ObjectID object_id_from_string(std::string const& string)
         !std::all_of(low_string.begin(), low_string.end(), isxdigit)) {
         throw std::invalid_argument("Invalid object ID.");
     }
-
-    return sync::ObjectID(std::stoull(high_string, nullptr, 16), std::stoull(low_string, nullptr, 16));
+    return sync::ObjectID(strtoull(high_string.c_str(), nullptr, 16), strtoull(low_string.c_str(), nullptr, 16));
 }
 
 } // unnamed namespace


### PR DESCRIPTION
Using C function instead of C++ function since Android NDK r10e doesn't support `std::stoull()`. It is an oversight by me when I reviewed #1460.

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #1480.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
