### PR TITLE
Update tests to not use deprecated APIs

### DIFF
--- a/tests/js/admin-user-helper.js
+++ b/tests/js/admin-user-helper.js
@@ -3,27 +3,20 @@ function node_require(module) {
     return require(module);
 }
 
-var Realm = node_require('realm');
+const Realm = node_require('realm');
 
 const adminName = "realm-admin"
 const password = '';
 
 exports.createAdminUser = function () {
-    return new Promise((resolve, reject) => {
-        Realm.Sync.User.login('http://localhost:9080', adminName, password, (error, user) => {
-            if (error) {
-                reject(error);
-                return;
-            }
-            
-            if (!user.isAdmin) {
-                reject(adminName + " user is not an admin user on this server");
-            }
+    return Realm.Sync.User.login('http://localhost:9080', adminName, password).then((user) => {
+        if (!user.isAdmin) {
+            throw new Error(`${adminName} user is not an admin user on this server`);
+        }
 
-            resolve({
-                username: adminName,
-                password
-            });
-        });
+        return {
+            username: adminName,
+            password
+        };
     });
 }

--- a/tests/js/download-api-helper.js
+++ b/tests/js/download-api-helper.js
@@ -7,7 +7,7 @@ const username = process.argv[2];
 const realmName = process.argv[3];
 const realmModule = process.argv[4];
 
-var Realm = require(realmModule);
+const Realm = require(realmModule);
 
 function createObjects(user) {
     const config = {
@@ -18,7 +18,7 @@ function createObjects(user) {
         schema: [{ name: 'Dog', properties: { name: 'string' } }]
     };
 
-    var realm = new Realm(config);
+    const realm = new Realm(config);
 
     realm.write(() => {
         for (let i = 1; i <= 3; i++) {
@@ -27,24 +27,29 @@ function createObjects(user) {
     });
 
     console.log("Dogs count " + realm.objects('Dog').length);
-    setTimeout(() => process.exit(0), 3000);
+
+    let session = realm.syncSession;
+    return new Promise((resolve, reject) => {
+        let callback = (transferred, total) => {
+            if (transferred === total) {
+                session.removeProgressNotification(callback);
+                resolve(realm);
+            }
+        }
+        session.addProgressNotification('upload', 'forCurrentlyOutstandingWork', callback);
+    });
 }
 
-Realm.Sync.User.register('http://localhost:9080', username, 'password', (error, registeredUser) => {
-    if (error) {
-        const registrationError = JSON.stringify(error);
-        Realm.Sync.User.login('http://localhost:9080', username, 'password', (err, loggedUser) => {
-            if (err) {
-                const loginError = JSON.stringify(err);
-                console.error("download-api-helper failed:\n User.register() error:\n" + err + "\n" + registrationError + "\n User.login() error:\n" + loginError);
-                process.exit(-2);
-            }
-            else {
-                createObjects(loggedUser);
-            }
-        });
-    }
-    else {
-        createObjects(registeredUser);
-    }
-});
+let registrationError;
+Realm.Sync.User.register('http://localhost:9080', username, 'password')
+  .catch((error) => {
+      registrationError = JSON.stringify(error);
+      return Realm.Sync.User.login('http://localhost:9080', username, 'password')
+    })
+    .catch((error) => {
+        const loginError = JSON.stringify(err);
+        console.error(`download-api-helper failed:\n User.register() error:\n${registrationError}\n User.login() error:\n${registrationError}`);
+        process.exit(-2);
+    })
+    .then((user) => createObjects(user))
+    .then(() => process.exit(0));

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -44,37 +44,10 @@ if (isNodeProccess) {
     path = node_require("path");
 }
 
-
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
         var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
         return v.toString(16);
-    });
-}
-
-function promisifiedRegister(server, username, password) {
-    return new Promise((resolve, reject) => {
-        Realm.Sync.User.register(server, username, password, (error, user) => {
-            if (error) {
-                console.log(`promisifiedRegister ${error}`);
-                reject(error);
-            } else {
-                resolve(user);
-            }
-        });
-    });
-}
-
-function promisifiedLogin(server, username, password) {
-    return new Promise((resolve, reject) => {
-        Realm.Sync.User.login(server, username, password, (error, user) => {
-            if (error) {
-                console.log(`promisifiedLogin ${error}`);
-                reject(error);
-            } else {
-                resolve(user);
-            }
-        });
     });
 }
 
@@ -120,9 +93,8 @@ module.exports = {
     },
 
     testProperties() {
-        return promisifiedRegister('http://localhost:9080', uuid(), 'password').then(user => {
+        return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then(user => {
             return new Promise((resolve, reject) => {
-
                 const accessTokenRefreshed = this;
                 let successCounter = 0;
                 function checkSuccess() {
@@ -162,43 +134,43 @@ module.exports = {
 
     testRealmOpen() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
         const realmName = uuid();
         const expectedObjectsCount = 3;
 
+        let user, config;
         return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
-            .then(() => {
-                return promisifiedLogin('http://localhost:9080', username, 'password').then(user => {
-                    const accessTokenRefreshed = this;
-                    let successCounter = 0;
+            .then(() => Realm.Sync.User.login('http://localhost:9080', username, 'password'))
+            .then(u => {
+                user = u;
+                const accessTokenRefreshed = this;
+                let successCounter = 0;
 
-                    let config = {
-                        sync: { user, url: `realm://localhost:9080/~/${realmName}` },
-                        schema: [{ name: 'Dog', properties: { name: 'string' } }],
-                    };
+                config = {
+                    sync: { user, url: `realm://localhost:9080/~/${realmName}` },
+                    schema: [{ name: 'Dog', properties: { name: 'string' } }],
+                };
 
-                    return Realm.open(config)
-                        .then(realm => {
-                            let actualObjectsCount = realm.objects('Dog').length;
-                            TestCase.assertEqual(actualObjectsCount, expectedObjectsCount, "Synced realm does not contain the expected objects count");
-                            return realm.syncSession;
-                        }).then(session => {
-                            TestCase.assertInstanceOf(session, Realm.Sync.Session);
-                            TestCase.assertEqual(session.user.identity, user.identity);
-                            TestCase.assertEqual(session.config.url, config.sync.url);
-                            TestCase.assertEqual(session.config.user.identity, config.sync.user.identity);
-                            TestCase.assertEqual(session.state, 'active');
-                        });
-                });
+                return Realm.open(config)
+            }).then(realm => {
+                let actualObjectsCount = realm.objects('Dog').length;
+                TestCase.assertEqual(actualObjectsCount, expectedObjectsCount, "Synced realm does not contain the expected objects count");
+
+                const session = realm.syncSession;
+                TestCase.assertInstanceOf(session, Realm.Sync.Session);
+                TestCase.assertEqual(session.user.identity, user.identity);
+                TestCase.assertEqual(session.config.url, config.sync.url);
+                TestCase.assertEqual(session.config.user.identity, config.sync.user.identity);
+                TestCase.assertEqual(session.state, 'active');
             });
     },
 
     testRealmOpenAsync() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -206,44 +178,42 @@ module.exports = {
         const expectedObjectsCount = 3;
 
         return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
-            .then(() => {
-                return Realm.Sync.User.login('http://localhost:9080', username, 'password').then(user => {
-                    return new Promise((resolve, reject) => {
-                        const accessTokenRefreshed = this;
-                        let successCounter = 0;
+            .then(() => Realm.Sync.User.login('http://localhost:9080', username, 'password'))
+            .then(user => {
+                const accessTokenRefreshed = this;
+                let successCounter = 0;
 
-                        let config = {
-                            sync: { user, url: `realm://localhost:9080/~/${realmName}` },
-                            schema: [{ name: 'Dog', properties: { name: 'string' } }],
-                        };
+                let config = {
+                    sync: { user, url: `realm://localhost:9080/~/${realmName}` },
+                    schema: [{ name: 'Dog', properties: { name: 'string' } }],
+                };
+                return new Promise((resolve, reject) => {
+                    Realm.openAsync(config, (error, realm) => {
+                        try {
+                            if (error) {
+                                reject(error);
+                            }
 
-                        Realm.openAsync(config, (error, realm) => {
-                            try {
-                                if (error) {
-                                    reject(error);
+                            let actualObjectsCount = realm.objects('Dog').length;
+                            TestCase.assertEqual(actualObjectsCount, expectedObjectsCount, "Synced realm does not contain the expected objects count");
+
+                            setTimeout(() => {
+                                try {
+                                    const session = realm.syncSession;
+                                    TestCase.assertInstanceOf(session, Realm.Sync.Session);
+                                    TestCase.assertEqual(session.user.identity, user.identity);
+                                    TestCase.assertEqual(session.config.url, config.sync.url);
+                                    TestCase.assertEqual(session.config.user.identity, config.sync.user.identity);
+                                    TestCase.assertEqual(session.state, 'active');
+                                    resolve();
+                                } catch (e) {
+                                    reject(e);
                                 }
-
-                                let actualObjectsCount = realm.objects('Dog').length;
-                                TestCase.assertEqual(actualObjectsCount, expectedObjectsCount, "Synced realm does not contain the expected objects count");
-
-                                setTimeout(() => {
-                                    try {
-                                        const session = realm.syncSession;
-                                        TestCase.assertInstanceOf(session, Realm.Sync.Session);
-                                        TestCase.assertEqual(session.user.identity, user.identity);
-                                        TestCase.assertEqual(session.config.url, config.sync.url);
-                                        TestCase.assertEqual(session.config.user.identity, config.sync.user.identity);
-                                        TestCase.assertEqual(session.state, 'active');
-                                        resolve();
-                                    } catch (e) {
-                                        reject(e);
-                                    }
-                                }, 50);
-                            }
-                            catch (e) {
-                                reject(e);
-                            }
-                        });
+                            }, 50);
+                        }
+                        catch (e) {
+                            reject(e);
+                        }
                     });
                 });
             });
@@ -251,7 +221,7 @@ module.exports = {
 
     testRealmOpenAsyncNoSchema() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -397,8 +367,8 @@ module.exports = {
             Realm.copyBundledRealmFiles();
         }
 
-        return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then(user => {
-            return new Promise((resolve, _reject) => {
+        return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password')
+            .then(user => {
                 const config = {
                     path: realm,
                     sync: {
@@ -407,30 +377,26 @@ module.exports = {
                         url: 'realm://localhost:9080/~/sync-v1'
                     }
                 };
+                return Realm.open(config)
+            })
+            .then(realm => { throw new Error("Should fail with IncompatibleSyncedRealmError") })
+            .catch(e => {
+                if (e.name == "IncompatibleSyncedRealmError") {
+                    const backupRealm = new Realm(e.configuration);
+                    TestCase.assertEqual(backupRealm.objects('Dog').length, 3);
+                    return;
+                }
 
-                Realm.open(config)
-                    .then(realm =>
-                        _reject("Should fail with IncompatibleSyncedRealmError"))
-                    .catch(e => {
-                        if (e.name == "IncompatibleSyncedRealmError") {
-                            const backupRealm = new Realm(e.configuration);
-                            TestCase.assertEqual(backupRealm.objects('Dog').length, 3);
-                            resolve();
-                            return;
-                        }
+                function printObject(o) {
+                    var out = '';
+                    for (var p in o) {
+                      out += p + ': ' + o[p] + '\n';
+                    }
+                    return out;
+                  }
 
-                        function printObject(o) {
-                            var out = '';
-                            for (var p in o) {
-                              out += p + ': ' + o[p] + '\n';
-                            }
-                            return out;
-                          }
-
-                        _reject("Failed with unexpected error " + printObject(e));
-                    });
+                throw new Error("Failed with unexpected error " + printObject(e));
             });
-        });
     },
 
     testIncompatibleSyncedRealmOpenAsync() {
@@ -514,42 +480,36 @@ module.exports = {
 
     testProgressNotificationsForRealmConstructor() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
         const realmName = uuid();
 
         return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
-            .then(() => {
-                return Realm.Sync.User.login('http://localhost:9080', username, 'password').then(user => {
-                    return new Promise((resolve, reject) => {
-                        let config = {
-                            sync: {
-                                user,
-                                url: `realm://localhost:9080/~/${realmName}`
-                            },
-                            schema: [{ name: 'Dog', properties: { name: 'string' } }],
-                        };
+            .then(() => Realm.Sync.User.login('http://localhost:9080', username, 'password'))
+            .then(user => {
+                let config = {
+                    sync: {
+                        user,
+                        url: `realm://localhost:9080/~/${realmName}`
+                    },
+                    schema: [{ name: 'Dog', properties: { name: 'string' } }],
+                };
 
-                        let realm = new Realm(config);
-                        const progressCallback = (transferred, total) => {
-                            resolve();
-                        };
-
-                        realm.syncSession.addProgressNotification('download', 'reportIndefinitely', progressCallback);
-
-                        setTimeout(function() {
-                            reject("Progress Notifications API failed to call progress callback for Realm constructor");
-                        }, 5000);
-                    });
+                const realm = new Realm(config);
+                return new Promise((resolve, reject) => {
+                    realm.syncSession.addProgressNotification('download', 'reportIndefinitely', resolve);
+                    setTimeout(function() {
+                        reject("Progress Notifications API failed to call progress callback for Realm constructor");
+                    }, 5000);
                 });
             });
     },
 
     testProgressNotificationsUnregisterForRealmConstructor() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -616,7 +576,7 @@ module.exports = {
 
     testProgressNotificationsForRealmOpen() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -655,7 +615,7 @@ module.exports = {
 
     testProgressNotificationsForRealmOpenAsync() {
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -700,7 +660,7 @@ module.exports = {
     testPartialSync() {
         // FIXME: try to enable for React Native
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         const username = uuid();
@@ -733,7 +693,7 @@ module.exports = {
     testClientReset() {
         // FIXME: try to enable for React Native
         if (!isNodeProccess) {
-            return Promise.resolve();
+            return;
         }
 
         return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then(user => {


### PR DESCRIPTION
Switch to the newer promise-based APIs rather than the callback versions. The only deprecation warnings I now get when running the tests locally are for the `openAsync()` tests (which it would make no sense to switch).