### PR TITLE
Expose disable_sync_to_disk() via an env variable

### DIFF
--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -35,7 +35,7 @@ std::string default_path() {
         s_default_path = realm::default_realm_file_directory() +
 #if defined(WIN32) && WIN32
             '\\'
-#else       
+#else
             '/'
 #endif
             + "default.realm";
@@ -105,6 +105,6 @@ std::string TypeErrorException::type_string(Property const& prop)
     return ret;
 }
 
-    
+
 } // js
 } // realm

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -44,6 +44,8 @@
 #include "platform.hpp"
 #include "results.hpp"
 
+#include <realm/disable_sync_to_disk.hpp>
+
 namespace realm {
 namespace js {
 
@@ -342,6 +344,10 @@ inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx) {
     FunctionType sync_constructor = SyncClass<T>::create_constructor(ctx);
     Object::set_property(ctx, realm_constructor, "Sync", sync_constructor, attributes);
 #endif
+
+    if (getenv("REALM_DISABLE_SYNC_TO_DISK")) {
+        realm::disable_sync_to_disk();
+    }
 
     Object::set_global(ctx, "Realm", realm_constructor);
     return realm_constructor;


### PR DESCRIPTION
This makes core not actually flush data to disk when durability is not needed, such as when running tests. Doesn't help much for realm-js since the bulk of the time in them is spent waiting for things to time out, but it cuts the run time of the ROS tests in half.