### PR TITLE
Use the sync label as the multiplex identifier

### DIFF
--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -92,32 +92,39 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
             // We do this because in React Native Remote Debugging
             // `Realm.clearTestState()` will have invalidated the user object
             let newUser = user.constructor.all[user.identity];
-            if (newUser) {
-                let session = newUser._sessionForOnDiskPath(localRealmPath);
-                if (session) {
-                    const errorHandler = session.config.error;
-                    if (response.status != 200) {
-                        let error = new AuthError(json);
-                        if (errorHandler) {
-                            errorHandler(session, error);
-                        } else {
-                            print_error('Unhandled session token refresh error', error);
-                        }
-                    } else if (session.state !== 'invalid') {
-                        parsedRealmUrl.set('pathname', json.access_token.token_data.path);
-                        session._refreshAccessToken(json.access_token.token, parsedRealmUrl.href);
-
-                        if (errorHandler && errorHandler._notifyOnAccessTokenRefreshed) {
-                            errorHandler(session, errorHandler._notifyOnAccessTokenRefreshed)
-                        }
-
-                        const tokenExpirationDate = new Date(json.access_token.token_data.expires * 1000);
-                        scheduleAccessTokenRefresh(newUser, localRealmPath, realmUrl, tokenExpirationDate);
-                    }
-                } else {
-                    print_error(`Unhandled session token refresh error: could not look up session at path ${localRealmPath}`);
-                }
+            if (!newUser) {
+                return;
             }
+            let session = newUser._sessionForOnDiskPath(localRealmPath);
+            if (!session) {
+                print_error(`Unhandled session token refresh error: could not look up session at path ${localRealmPath}`);
+            }
+
+            const errorHandler = session.config.error;
+            if (response.status != 200) {
+                let error = new AuthError(json);
+                if (errorHandler) {
+                    errorHandler(session, error);
+                } else {
+                    print_error('Unhandled session token refresh error', error);
+                }
+                return;
+            }
+            if (session.state === 'invalid') {
+                return;
+            }
+
+            const tokenData = json.access_token.token_data;
+
+            parsedRealmUrl.set('pathname', tokenData.path);
+            session._refreshAccessToken(json.access_token.token, parsedRealmUrl.href, tokenData.sync_label);
+
+            if (errorHandler && errorHandler._notifyOnAccessTokenRefreshed) {
+                errorHandler(session, errorHandler._notifyOnAccessTokenRefreshed)
+            }
+
+            const tokenExpirationDate = new Date(tokenData.expires * 1000);
+            scheduleAccessTokenRefresh(newUser, localRealmPath, realmUrl, tokenExpirationDate);
         })
         .catch((e) => {
             print_error(e);
@@ -129,10 +136,10 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
 /**
  * The base authentication method. It fires a JSON POST to the server parameter plus the auth url
  * For example, if the server parameter is `http://myapp.com`, this url will post to `http://myapp.com/auth`
- * @param {object} userConstructor 
- * @param {string} server the http or https server url 
+ * @param {object} userConstructor
+ * @param {string} server the http or https server url
  * @param {object} json the json to post to the auth endpoint
- * @param {Function} callback an optional callback with an error and user parameter 
+ * @param {Function} callback an optional callback with an error and user parameter
  * @returns {Promise} only returns a promise if the callback parameter was omitted
  */
 function _authenticate(userConstructor, server, json, callback) {
@@ -161,8 +168,8 @@ function _authenticate(userConstructor, server, json, callback) {
         });
 
     if (callback) {
-        promise.then(user => { 
-            callback(null, user); 
+        promise.then(user => {
+            callback(null, user);
         })
         .catch(err => {
              callback(err);
@@ -197,12 +204,12 @@ const staticMethods = {
                 user_info: { password: password, register: true },
                 data: username
             };
-           
+
             if (callback) {
                 const message = "register(..., callback) is now deprecated in favor of register(): Promise<User>. This function argument will be removed in future versions.";
                 (console.warn || console.log).call(console, message);
             }
-           
+
             return _authenticate(this, server, json, callback);
         },
 
@@ -213,7 +220,7 @@ const staticMethods = {
                 user_info: { password: password },
                 data: username
             };
-            
+
             if (callback) {
                 const message = "login(..., callback) is now deprecated in favor of login(): Promise<User>. This function argument will be removed in future versions.";
                 (console.warn || console.log).call(console, message);
@@ -224,7 +231,7 @@ const staticMethods = {
 
         registerWithProvider(server, options, callback) {
 
-            // Compatibility with previous signature: 
+            // Compatibility with previous signature:
             // registerWithProvider(server, provider, providerToken, callback)
             if (arguments.length === 4) {
                 checkTypes(arguments, ['string', 'string', 'string', 'function']);
@@ -250,7 +257,7 @@ const staticMethods = {
                 const message = "registerWithProvider(..., callback) is now deprecated in favor of registerWithProvider(): Promise<User>. This function argument will be removed in future versions.";
                 (console.warn || console.log).call(console, message);
             }
-            
+
             return _authenticate(this, server, json, callback);
         },
 

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -230,7 +230,7 @@ public:
 
         std::string name = "Error";
         auto error_object = Object<T>::create_empty(m_ctx);
-        
+
         if (error.is_client_reset_requested()) {
             auto config_object = Object<T>::create_empty(m_ctx);
             Object<T>::set_property(m_ctx, config_object, "path", Value<T>::from_string(m_ctx, error.user_info[SyncError::c_recovery_file_path_key]));
@@ -432,9 +432,12 @@ void SessionClass<T>::simulate_error(ContextType ctx, FunctionType, ObjectType t
 
 template<typename T>
 void SessionClass<T>::refresh_access_token(ContextType ctx, FunctionType, ObjectType this_object, size_t argc, const ValueType arguments[], ReturnValue &) {
-    validate_argument_count(argc, 2);
+    validate_argument_count(argc, 3);
 
     if (auto session = get_internal<T, SessionClass<T>>(this_object)->lock()) {
+        std::string sync_label = Value::validated_to_string(ctx, arguments[2], "syncLabel");
+        session->set_multiplex_identifier(std::move(sync_label));
+
         std::string access_token = Value::validated_to_string(ctx, arguments[0], "accessToken");
         std::string realm_url = Value::validated_to_string(ctx, arguments[1], "realmUrl");
         session->refresh_access_token(std::move(access_token), std::move(realm_url));


### PR DESCRIPTION
This makes is so that when session multiplexing is enabled a unique connection is used for each backend shard, giving some measure of load balancing with multiplexing enabled.

No public docs/changelog for this since it's only relevant to a currently undocumented feature in combination with EE.