### PR TITLE
Update Readme.md to include debugging disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ npm install --build-from-source=realm
 
         - Check [node-gyp](https://github.com/nodejs/node-gyp) manual for custom installation procedure for Windows
 
+## Issues with debugging
+Some users have reported the Chrome debugging being too slow to use after integrating Realm into their react-native project. This is due to the blocking nature of the RPC calls made through the Realm library and is an ongoing issue. If your team or project relies on debugging then please consider an alternative database library. See https://github.com/realm/realm-js/issues/491 for more information.
 
 ## Running the tests
 


### PR DESCRIPTION
## What, How & Why?
Some users on #491 have now reported investing hours of dev time to integrate Realm before having to remove it altogether due to the debugger being too slow for their team or project to use. We need to provide an honest disclaimer to developers until this issue is fixed as Realm is breaking a core, built-in piece of React Native functionality.