### PR TITLE
Making JSON library compile on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enchancements
+* Reenable Realm for RN Android (#1506).
+
+### Bug fixes
+* None.
+
+### Internal
+* None.
+
 2.0.8 Release notes (2017-11-17)
 =============================================================
 ### Breaking changes


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Due to an upgrade to a 3rd party JSON library, RN Android support was disabled in Realm JS 2.0.8. The library is patched to compile with Android NDK r10e.

This closes #1506.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~
 
*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~

## Failing tests
* `testAddListener` in `ResultsTests`
