### PR TITLE
localeconv() doesn't exist on Android API < 21.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enchancements
+* None
+
+### Bug fixes
+* Fixed a bug in 3rd party JSON parser: `localeconv()` does not exist on Android API < 21 and should not be called.
+
+### Internal
+* None.
+
 2.0.11 Release notes (2017-11-23)
 =============================================================
 ### Breaking changes

--- a/vendor/json.hpp
+++ b/vendor/json.hpp
@@ -8333,15 +8333,15 @@ class basic_json
             // check if buffer was large enough
             assert(static_cast<size_t>(written_bytes) < m_buf.size());
 
+            #if defined(ANDROID)
+            // Android NDK doesn't have access to locale info yet; API < 21 doesn't have localeconv()
+            const char thousands_sep  = ',';
+            const char decimal_point  = '.';
+            #else
             // read information from locale
             const auto loc = localeconv();
             assert(loc != nullptr);
             
-            #if defined(ANDROID)
-            // Android NDK doesn't have access to locale info yet
-            const char thousands_sep  = ',';
-            const char decimal_point  = '.';
-            #else
             const char thousands_sep = !loc->thousands_sep ? '\0'
                                        : loc->thousands_sep[0];
 
@@ -11176,11 +11176,11 @@ basic_json_parser_74:
                 // since dealing with strtod family of functions, we're
                 // getting the decimal point char from the C locale facilities
                 // instead of C++'s numpunct facet of the current std::locale
-                const auto loc = localeconv();
-                assert(loc != nullptr);
                 #if defined(ANDROID)
                 const char decimal_point_char = '.';
                 #else
+                const auto loc = localeconv();
+                assert(loc != nullptr);
                 const char decimal_point_char = (loc->decimal_point == nullptr) ? '.' : loc->decimal_point[0];
                 #endif
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

`localeconv()` doesn't exist on Android API < 21. And we hard-code the separations anyway.

Closes #1522 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
