### PR TITLE
Enable force sync history option for TypeScript (Realm-Studio)

### DIFF
--- a/docs/realm.js
+++ b/docs/realm.js
@@ -304,7 +304,7 @@ Realm.defaultPath;
  *   If omitted, the schema will be read from the existing Realm file.
  * @property {number} [schemaVersion] - **Required** (and must be incremented) after
  *   changing the `schema`.
- * @property {Object} [sync] - Sync configuration parameters with the following
+ * @property {Object|true} [sync] - Sync configuration parameters with the following
  *   child properties:
  *   - `user` - A `User` object obtained by calling `Realm.Sync.User.login`
  *   - `url` - A `string` which contains a valid Realm Sync url
@@ -350,6 +350,8 @@ Realm.defaultPath;
  *        Partial synchronisation only synchronizes those objects that match the query specified in contrast
  *        to the normal mode of operation that synchronises all objects in a remote Realm.
  *        **Partial synchronization is a tech preview. Its APIs are subject to change.**
+ * 
+ * If set to `true`, this configuration will help open a sync Realm locally/offline without any syncing capabilities.
  */
 
 /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,7 +83,7 @@ declare namespace Realm {
         inMemory?: boolean;
         schema?: ObjectClass[] | ObjectSchema[];
         schemaVersion?: number;
-        sync?: Realm.Sync.SyncConfiguration;
+        sync?: Realm.Sync.SyncConfiguration | boolean;
         deleteRealmIfMigrationNeeded?: boolean;
     }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,7 +83,7 @@ declare namespace Realm {
         inMemory?: boolean;
         schema?: ObjectClass[] | ObjectSchema[];
         schemaVersion?: number;
-        sync?: Realm.Sync.SyncConfiguration | boolean;
+        sync?: Realm.Sync.SyncConfiguration | true;
         deleteRealmIfMigrationNeeded?: boolean;
     }
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint": "^3.2.2",
     "eslint-plugin-jasmine": "^2.1.0",
     "eslint-plugin-react": "^6.7.0",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "^3.5.5",
     "license-checker": "^8.0.3",
     "mockery": "^2.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION

- The ability to force a sync history to open a sync Realm file was added in https://github.com/realm/realm-js/pull/966/files however, it's not currently possible to set the value of `sync` to `true` when used in typescript. This is needed to fix https://github.com/realm/realm-studio/issues/392

Note: instead of updating the type to 
```
sync?: Realm.Sync.SyncConfiguration | boolean;
```
I've deliberately chosen to set it to `true` only since passing `sync:false` is redundant (since this property is optional and you can completely omit it)  

- Also fixed a side issue with `jsdoc` task not working with node 8 see https://realmio.slack.com/archives/C04R271HS/p1512409645000423?thread_ts=1512408576.000186&cid=C04R271HS