### PR TITLE
update JSDOC to work with Node 8 (avoid EISDIR error)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm",
-  "version": "2.0.0-rc11",
+  "version": "2.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -270,9 +270,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "boom": {
@@ -1537,18 +1537,18 @@
       "optional": true
     },
     "jsdoc": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.4.tgz",
-      "integrity": "sha1-zu73xLrEM1yxD/QeOg9Yk5pTRCg=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "catharsis": "0.8.9",
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.7",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -2497,9 +2497,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "mime-db": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint": "^3.2.2",
     "eslint-plugin-jasmine": "^2.1.0",
     "eslint-plugin-react": "^6.7.0",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "^3.5.5",
     "license-checker": "^8.0.3",
     "mockery": "^2.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Currently, `jsdoc` task doesn't work with Node 8 causing the task to fail with 

```
Error: EISDIR: illegal operation on a directory, copyfile '/Users/Nabil/Dev/realm/realm-js/docs/jsdoc-template/template/static/fonts/OpenSans-Bold-webfont.eot' -> 'docs/output/realm/2.0.12/fonts'
    at Object.fs.copyFileSync (fs.js:1919:11)
    at /Users/Nabil/Dev/realm/realm-js/docs/jsdoc-template/template/publish.js:454:12
    at Array.forEach (<anonymous>)
    at Object.exports.publish (/Users/Nabil/Dev/realm/realm-js/docs/jsdoc-template/template/publish.js:451:17)
    at Object.module.exports.cli.generateDocs (/Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/cli.js:448:35)
    at Object.module.exports.cli.processParseResults (/Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/cli.js:399:20)
    at module.exports.cli.main (/Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/cli.js:240:14)
    at Object.module.exports.cli.runCommand (/Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/cli.js:189:5)
    at /Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/jsdoc.js:105:9
    at Object.<anonymous> (/Users/Nabil/Dev/realm/realm-js/node_modules/jsdoc/jsdoc.js:106:3)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10)
```

This PR should fix the issue