### PR TITLE
Adding property Realm.isClosed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* Added property `Realm.isClosed` which indicates if a Realm instance is closed or not.
+
+### Bug fixes
+* None.
+
+### Internal
+* None.
+
 2.0.13 Release notes (2017-12-8)
 =============================================================
 ### Breaking changes

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -73,7 +73,7 @@ class Realm {
     get isInTransaction() {}
 
     /**
-     * Indicated is this Realm is closed.
+     * Indicates if this Realm has been closed.
      * @type {boolean}
      * @readonly
      * @since 2.1.0

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -73,6 +73,14 @@ class Realm {
     get isInTransaction() {}
 
     /**
+     * Indicated is this Realm is closed.
+     * @type {boolean}
+     * @readonly
+     * @since 2.1.0
+     */
+     get isClosed() {}
+
+    /**
      * Gets the sync session if this is a synced Realm
      * @type {Session}
      */

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -60,6 +60,7 @@ function setupRealm(realm, realmId) {
         'schemaVersion',
         'syncSession',
         'isInTransaction',
+        'isClosed',
         'subscribeToObjects',
     ].forEach((name) => {
         Object.defineProperty(realm, name, {get: util.getterForProperty(name)});

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -458,6 +458,7 @@ declare class Realm {
     readonly schema: Realm.ObjectSchema[];
     readonly schemaVersion: number;
     readonly isInTransaction: boolean;
+    readonly isClosed: boolean;
 
     readonly syncSession: Realm.Sync.Session | null;
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -198,6 +198,7 @@ public:
     static void get_in_memory(ContextType, ObjectType, ReturnValue &);
     static void get_read_only(ContextType, ObjectType, ReturnValue &);
     static void get_is_in_transaction(ContextType, ObjectType, ReturnValue &);
+    static void get_is_closed(ContextType, ObjectType, ReturnValue &);
 #if REALM_ENABLE_SYNC
     static void get_sync_session(ContextType, ObjectType, ReturnValue &);
 #endif
@@ -259,6 +260,7 @@ public:
         {"inMemory", {wrap<get_in_memory>, nullptr}},
         {"readOnly", {wrap<get_read_only>, nullptr}},
         {"isInTransaction", {wrap<get_is_in_transaction>, nullptr}},
+        {"isClosed", {wrap<get_is_closed>, nullptr}},
 #if REALM_ENABLE_SYNC
         {"syncSession", {wrap<get_sync_session>, nullptr}},
 #endif
@@ -694,6 +696,11 @@ void RealmClass<T>::get_is_in_transaction(ContextType ctx, ObjectType object, Re
     return_value.set(get_internal<T, RealmClass<T>>(object)->get()->is_in_transaction());
 }
 
+template<typename T>
+void RealmClass<T>::get_is_closed(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+    return_value.set(get_internal<T, RealmClass<T>>(object)->get()->is_closed());
+}
+
 #if REALM_ENABLE_SYNC
 template<typename T>
 void RealmClass<T>::get_sync_session(ContextType ctx, ObjectType object, ReturnValue &return_value) {
@@ -738,7 +745,7 @@ void RealmClass<T>::wait_for_download_completion(ContextType ctx, ObjectType thi
 
                 ValueType callback_arguments[1];
                 callback_arguments[0] = object;
-                
+
                 Function<T>::callback(protected_ctx, protected_callback, typename T::Object(), 1, callback_arguments);
             }
 

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -57,6 +57,13 @@ module.exports = {
         TestCase.assertEqual(realm2.path, defaultDir + testPath2);
     },
 
+    testRealmIsClosed: function() {
+        const realm = new Realm({schema: []});
+        TestCase.assertFalse(realm.isClosed);
+        realm.close();
+        TestCase.assertTrue(realm.isClosed);
+    },
+
     testRealmConstructorSchemaVersion: function() {
         const defaultRealm = new Realm({schema: []});
         TestCase.assertEqual(defaultRealm.schemaVersion, 0);


### PR DESCRIPTION
## What, How & Why?

Sometimes it is useful to check if a Realm instance is closed or not. The readonly property `Realm.isClosed` is added.

`isClosed` has been chosen as it adhere to the naming in our other SDKs:

* https://realm.io/docs/dotnet/2.1.0/api/reference/Realms.Realm.html#Realms_Realm_IsClosed
* https://realm.io/docs/java/4.3.1/api/io/realm/Realm.html#isClosed--
* Realm Cocoa (Swift and Objective-C) can auto-close instances


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
