### PR TITLE
Increase the token refresh timeout to 10 sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ X.Y.Z Release notes
 
 ### Bug fixes
 * Fix a bug where `Realm.open` could unexpectedly raise a "Realm at path ... already opened with different schema version" error.
+* Increased request timeout for token refresh requests to 10 seconds. This
+  should help with failing token refreshes on a loaded server.
 
 ### Internal
 * None

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -81,7 +81,7 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
         headers: postHeaders,
         // FIXME: This timeout appears to be necessary in order for some requests to be sent at all.
         // See https://github.com/realm/realm-js-private/issues/338 for details.
-        timeout: 1000.0
+        timeout: 10000.0
     };
     performFetch(url, options)
         .then((response) => response.json().then((json) => { return { response, json }; }))


### PR DESCRIPTION
## What, How & Why?

This PR increases the timeout for token refresh requests to 10 sec. This should help with perpetually failing token refresh due to server load.

Probably fixes these:
- realm/realm-object-server-private#687
- realm/realm-object-server-private#797
- realm/realm-object-server-private#790
- realm/realm-object-server-private#698

## ☑️ ToDos
* [x] 📝 Changelog entry