### PR TITLE
Explicitly send register: false during login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ X.Y.Z Release notes
   should help with failing token refreshes on a loaded server.
 
 ### Internal
-* None.
+* Explicitly send `register: false` when logging in with `Realm.Sync.User.login` to avoid creating the user if they don't exist.
 
 2.1.1 Release notes (2017-12-15)
 =============================================================

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -225,7 +225,7 @@ const staticMethods = {
             checkTypes(arguments, ['string', 'string', 'string', 'function']);
             const json = {
                 provider: 'password',
-                user_info: { password: password },
+                user_info: { password: password, register: false },
                 data: username
             };
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This fixes a bug that will be introduced with next version of ROS where not sending a value for `register` will be interpreted as `createOrUpdate`.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
  