### PR TITLE
Support opening Realms with an admin token without a working ROS directory service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* None.
+
+### Bug fixes
+* [Object Server] Fixed a bug preventing opening Realms with an admin token without a working ROS directory service (#1615).
+
+### Internal
+* None.
+
 2.2.0 Release notes (2018-1-12)
 =============================================================
 ### Breaking changes
@@ -12,9 +26,7 @@
 ### Bug fixes
 * Fix a bug where `Realm.open` could unexpectedly raise a "Realm at path ... already opened with different schema version" error.
 * `subscribeToObjects` was added as a property for Chrome debugging (#1608).
-* Increased request timeout for token refresh requests to 10 seconds. This
-  should help with failing token refreshes on a loaded server (#1586).
-* Increased request timeout for token refresh requests to 10 seconds. This should help with failing token refreshes on a loaded server.
+* Increased request timeout for token refresh requests to 10 seconds. This should help with failing token refreshes on a loaded server (#1586).
 
 ### Internal
 * Updated to Realm Sync 2.2.9.

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -92,7 +92,21 @@ function refreshAdminToken(user, localRealmPath, realmUrl) {
     let parsedRealmUrl = url_parse(realmUrl);
     const url = append_url(user.server, 'realms/files/' + encodeURIComponent(parsedRealmUrl.pathname));
     performFetch(url, {method: 'GET', timeout: 10000.0, headers: {Authorization: user.token}})
-    .then((response) => response.json().then((json) => { return { response, json }; }))
+    .then((response) => {
+        // There may not be a Realm Directory Service running on the server
+        // we're talking to. If we're talking directly to the sync service
+        // we'll get a 404, and if we're running inside ROS we'll get a 503 if
+        // the directory service hasn't started yet (perhaps because we got
+        // called due to the directory service itself opening some Realms).
+        //
+        // In both of these cases we can just pretend we got a valid response.
+        if (response.status === 404 || response.status === 503) {
+            return {response: {status: 200}, json: {path: parsedRealmUrl.pathname, syncLabel: '_direct'}};
+        }
+        else {
+            return response.json().then((json) => { return { response, json }; });
+        }
+    })
     .then((responseAndJson) => {
         const response = responseAndJson.response;
         const json = responseAndJson.json;


### PR DESCRIPTION
Sort of awkward, but that's the joy of circular dependencies? Fixes https://github.com/realm/realm-js-private/issues/397.