### PR TITLE
Adding _getExitingUser to Chrome debugger support library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* None.
+
+### Bug fixes
+* [Object Server] Added `_getExitingUser` to the Chrome debugging support library.
+
+### Internal
+* None.
+
 2.2.3 Release notes (2018-1-17)
 =============================================================
 ### Breaking changes

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -77,6 +77,12 @@ export function _adminUser(args) {
     return deserialize(undefined, result);
 }
 
+export function _getExistingUser(args) {
+    args = args.map((arg) => serialize(null, arg));
+    const result = sendRequest('_getExistingUser', { arguments: args });
+    return deserialize(undefined, result);
+}
+
 export function callMethod(realmId, id, name, args) {
     if (args) {
         args = args.map((arg) => serialize(realmId, arg));

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-import { createUser as createUserRPC, _adminUser as _adminUserRPC, getAllUsers as getAllUsersRPC } from './rpc';
+import { createUser as createUserRPC, _adminUser as _adminUserRPC, getAllUsers as getAllUsersRPC, _getExistingUser as _getExistingUserRPC } from './rpc';
 import { keys, objectTypes } from './constants';
 import { createMethods } from './util';
 
@@ -35,6 +35,10 @@ export default class User {
     static get all() {
         return getAllUsersRPC();
     }
+
+    static _getExistinguser() {
+        return _getExistingUserRPC();
+    }
 }
 
 createMethods(User.prototype, objectTypes.USER, [
@@ -45,9 +49,9 @@ createMethods(User.prototype, objectTypes.USER, [
 export function createUser(realmId, info) {
     const userProxy = Object.create(User.prototype);
 
-    // FIXME: This is currently necessary because util/createMethod expects 
+    // FIXME: This is currently necessary because util/createMethod expects
     // the realm id to be present on any object that is used over rpc
-    userProxy[keys.realm] = "(User object)";    
+    userProxy[keys.realm] = "(User object)";
 
     userProxy[keys.id] = info.id;
     userProxy[keys.type] = objectTypes.USER;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -253,7 +253,7 @@ RPCServer::RPCServer() {
         JSObjectRef user_object = (JSObjectRef)jsc::Function::call(m_context, create_user_method, arg_count, arg_values);
         return (json){{"result", serialize_json_value(user_object)}};
     };
-    m_requests["/_getExistingUser" = [this](const json dict) {
+    m_requests["/_getExistingUser"] = [this](const json dict) {
         JSObjectRef realm_constructor = m_session_id ? JSObjectRef(m_objects[m_session_id]) : NULL;
         if (!realm_constructor) {
             throw std::runtime_error("Realm constructor not found!");

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -163,7 +163,7 @@ void RPCWorker::stop() {
 #if __APPLE__
         m_thread.join();
         m_loop = nullptr;
-#endif 
+#endif
     }
 }
 
@@ -237,21 +237,43 @@ RPCServer::RPCServer() {
         if (!realm_constructor) {
             throw std::runtime_error("Realm constructor not found!");
         }
-        
+
         JSObjectRef sync_constructor = (JSObjectRef)jsc::Object::get_property(m_context, realm_constructor, "Sync");
         JSObjectRef user_constructor = (JSObjectRef)jsc::Object::get_property(m_context, sync_constructor, "User");
         JSObjectRef create_user_method = (JSObjectRef)jsc::Object::get_property(m_context, user_constructor, "_adminUser");
-        
+
         json::array_t args = dict["arguments"];
         size_t arg_count = args.size();
         JSValueRef arg_values[arg_count];
-        
+
         for (size_t i = 0; i < arg_count; i++) {
             arg_values[i] = deserialize_json_value(args[i]);
         }
 
         JSObjectRef user_object = (JSObjectRef)jsc::Function::call(m_context, create_user_method, arg_count, arg_values);
         return (json){{"result", serialize_json_value(user_object)}};
+    };
+    m_requests["/_getExistingUser" = [this](const json dict) {
+        JSObjectRef realm_constructor = m_session_id ? JSObjectRef(m_objects[m_session_id]) : NULL;
+        if (!realm_constructor) {
+            throw std::runtime_error("Realm constructor not found!");
+        }
+
+        JSObjectRef sync_constructor = (JSObjectRef)jsc::Object::get_property(m_context, realm_constructor, "Sync");
+        JSObjectRef user_constructor = (JSObjectRef)jsc::Object::get_property(m_context, sync_constructor, "User");
+        JSObjectRef create_user_method = (JSObjectRef)jsc::Object::get_property(m_context, user_constructor, "_getExistingUser");
+
+        json::array_t args = dict["arguments"];
+        size_t arg_count = args.size();
+        JSValueRef arg_values[arg_count];
+
+        for (size_t i = 0; i < arg_count; i++) {
+            arg_values[i] = deserialize_json_value(args[i]);
+        }
+
+        JSObjectRef user_object = (JSObjectRef)jsc::Function::call(m_context, create_user_method, arg_count, arg_values);
+        return (json){{"result", serialize_json_value(user_object)}};
+
     };
     m_requests["/call_method"] = [this](const json dict) {
         JSObjectRef object = m_objects[dict["id"].get<RPCObjectID>()];


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #1625

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* [x] Chrome debug API is updated if API is available on React Native
