### PR TITLE
Fixing a typo in _getExistingUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* None.
+
+### Bug fixes
+* [Object Server] Fixed a typing error leading to `_getExistingUser` wasn't defined in the Chrome debugging support library (#1625).
+
+### Internal
+* None.
+
 2.2.4 Release notes (2018-1-18)
 =============================================================
 ### Breaking changes

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -36,7 +36,7 @@ export default class User {
         return getAllUsersRPC();
     }
 
-    static _getExistinguser() {
+    static _getExistingUser() {
         return _getExistingUserRPC();
     }
 }

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -196,9 +196,9 @@ module.exports = {
   testAuthenticateJWT() {
     let token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhdXN0aW5femhlbmciLCJpc0FkbWluIjp0cnVlLCJpYXQiOjE1MTI2OTI3NDl9.klca-3wYLe5mGdVk7N7dE9YRIlB1el1Dv6BxZNAKMsJ3Ms4vBTweu4-65kVJftiMrYhmSGY6QtTzqQ-xlLH4XzPd3jYIXlPQ45lxO7PW7EkJNs9m83VdcsJmHRHQ3PRP8V_mx0f2Ks4ga3xZ9IycAQB4q5NXLei_HJk8tRRJccZ6qB5nnAoD48Qu8JOEfhO596Mdoi-QCbH51iJZjgXo4gSRZ4KKK8jU0S6twLj_lf9jehENTqHDdtsRHdyCnICcPcz4AjFrNHEvUrsPkGxXSZ2BCGgDcvsSTVgGNV7rWU4IjH4FaDssenumi50R1QcZh8kiO35s9H6MngQsEm-zApRgd0V9_L3A6Ys47_crmKbunYRsATfMNBn2fKm5tS6RXvM2RN2G_Y9AkGgh2boY42CRy7HOcHby2vQ8IoQ-fZfE5xn_YYktNlKeNiCv3_-i86lANFbmB3tcdScrbjsgO6Tfg3u71VmJ_ZW1_vyMi5vCTEysLXfHG-OA85c3o8-25vcfuX5gIpbU-nMLgPagyn5w7Uazd27uhFfwepP9OMc8jz2JTlQICInLCUdESu8aG5d1F_IPUA5NU_ryPmebqUmyaRVDS8cGChxp0gZDNSiIvaggw8N2JCDGvk-s_PSG2pFGq0f4veYyWGBTHD_iX4a0UrhB471QZplRpMwvu7o'
     return Realm.Sync.User.authenticate('http://localhost:9080', 'jwt', { token: token })
-      .then((user) => { 
+      .then((user) => {
         TestCase.assertEqual(user.identity, 'austin_zheng')
-        Promise.resolve() 
+        Promise.resolve()
       })
       .catch((e) => { Promise.reject(e) } )
   },
@@ -250,6 +250,18 @@ module.exports = {
 
       user1.logout();
       TestCase.assertUndefined(Realm.Sync.User.current);
+    });
+  },
+
+  testGetExistingUser() {
+    let userid = uuid();
+    return Realm.Sync.User.register('http://localhost:9080', userid, 'password').then((user) => {
+      let identity = user.identity;
+      let user1 = Realm.Sync.User._getExistingUser('http://localhost:9080', identity);
+      assertIsSameUser(user1, user);
+      user.logout();
+      let user2 = Realm.Sync.User._getExistingUser('http://localhost:9080', identity);
+      TestCase.assertUndefined(user2);
     });
   },
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Due to a typing error, `_getExistingUser` wasn't defined in the Chrome debugging support library (`lib/browser`).

This closes #1625.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* [x] Chrome debug API is updated if API is available on React Native
