### PR TITLE
Reorder Electron OpenSSL dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ X.Y.Z Release notes
 
 ### Bug fixes
 * [Object Server] Fixed a typing error leading to `_getExistingUser` wasn't defined in the Chrome debugging support library (#1625).
+* [Electron] Fixed a `dlopen` error related to OpenSSL that prevented using realm-js on Linux (#1636).
 
 ### Internal
 * None.

--- a/binding.gyp
+++ b/binding.gyp
@@ -44,6 +44,11 @@
       ],
       "include_dirs": [
         "src"
+      ],
+      "conditions": [
+        ["runtime=='electron'", {
+          "dependencies": [ "OpenSSL" ]
+        }]
       ]
     },
     {

--- a/realm.gypi
+++ b/realm.gypi
@@ -190,9 +190,6 @@
           }
         }, {
           "dependencies": [ "vendored-realm" ]
-        }],
-        ["runtime=='electron'", {
-          "dependencies": [ "OpenSSL" ]
         }]
       ]
     },
@@ -226,9 +223,6 @@
           }
         }, {
           "dependencies": [ "vendored-realm" ]
-        }],
-        ["runtime=='electron'", {
-          "dependencies": [ "OpenSSL" ]
         }]
       ],
     },


### PR DESCRIPTION
## What, How & Why?
When we changed `direct_dependent_settings` to `link_settings` in #1536 that changed the order of linker flags. Because GNU ld on Linux is sensitive to the order of linker flags, this caused the `libssl.a` symbols needed by `librealm-sync-node.a` to remain undefined.

This patch attempts to cause gyp to generate linker flags in the right order of dependencies.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests (https://github.com/realm/realm-js-private/pull/402)
* [x] 📝 ~Public documentation PR created or is not necessary~
* [x] 💥 ~`Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] ~typescript definitions file is updated~
* [x] ~jsdoc files updated~
* [x] ~Chrome debug API is updated if API is available on React Native~