### PR TITLE
Add Schema Name to Error Message with Primary Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Enhancements
 * [Object Server] Wait for pending notifications to complete when removing a sync listener (#1648).
+* Add schema name to missing primary key error message
 
 ### Bug fixes
 * [Object Server] Fixed a bug causing use-after-free crashes in Global Notifier (realm-js-private #405).

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -247,7 +247,7 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
         object_schema.primary_key = Value::validated_to_string(ctx, primary_value);
         Property *property = object_schema.primary_key_property();
         if (!property) {
-            throw std::runtime_error("Schema with name '" + object_schema.name + "' is missing primary key property '" + object_schema.primary_key + "'");
+            throw std::runtime_error("Schema named '" + object_schema.name + "' specifies primary key of '" + object_schema.primary_key + "' but does not declare a property of that name.");
         }
         property->is_primary = true;
     }

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -247,7 +247,7 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
         object_schema.primary_key = Value::validated_to_string(ctx, primary_value);
         Property *property = object_schema.primary_key_property();
         if (!property) {
-            throw std::runtime_error("Schema '" + object_schema.name + "' is missing primary key property '" + object_schema.primary_key + "'");
+            throw std::runtime_error("Schema with name '" + object_schema.name + "' is missing primary key property '" + object_schema.primary_key + "'");
         }
         property->is_primary = true;
     }

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -247,7 +247,7 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
         object_schema.primary_key = Value::validated_to_string(ctx, primary_value);
         Property *property = object_schema.primary_key_property();
         if (!property) {
-            throw std::runtime_error("Missing primary key property '" + object_schema.primary_key + "'");
+            throw std::runtime_error("Schema '" + object_schema.name + "' is missing primary key property '" + object_schema.primary_key + "'");
         }
         property->is_primary = true;
     }


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

Adds "Schema with name" and object schema name in error message.

This closes #1654 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

