### PR TITLE
TypeScript: change Realm.Object interface to class

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,9 +114,7 @@ declare namespace Realm {
         linkingObjects<T>(objectType: string, property: string): Results<T>;
     }
 
-    const Object: {
-        readonly prototype: Object;
-    }
+    class Object: { }
 
     /**
      * SortDescriptor


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->



When extending Realm.Object, typescript compile shows error.

```
// Person.ts
import Realm from 'realm'

class Person extends Realm.Object {
}
```

``` 
// tsc output
Type '{ readonly prototype: Object; }' is not a constructor function type.

class Person extends Realm.Object {
                                   ~~~~~~~~~~~~
```

To fix this, I have changed `lib/index.d.ts`.

--

I don't know how to use `Realm.Object` except `extends Realm.Object`,
if there are any other use cases, the code should be modified.

env
* TypeScript: 2.7.1
* React Native: 0.52.0
* realm-js: 2.1.1

