### PR TITLE
Fixing objectForPrimaryKey return type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -545,9 +545,9 @@ declare class Realm {
     /**
      * @param  {string|Realm.ObjectSchema|Function} type
      * @param  {number|string} key
-     * @returns T
+     * @returns {T | undefined}
      */
-    objectForPrimaryKey<T>(type: string | Realm.ObjectSchema | Function, key: number | string): T | null;
+    objectForPrimaryKey<T>(type: string | Realm.ObjectSchema | Function, key: number | string): T | undefined;
 
     /**
      * @param  {string|Realm.ObjectType|Function} type


### PR DESCRIPTION
## What, How & Why?
According to https://github.com/realm/realm-js/blob/master/docs/realm.js#L171 and runtime behaviour it returns `undefined` not `null` if the object doesn't exist.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
