### PR TITLE
Don't include the downloaded files in package

### DIFF
--- a/vendor/.npmignore
+++ b/vendor/.npmignore
@@ -12,3 +12,5 @@ GCDWebServer/iOS
 GCDWebServer/Mac
 GCDWebServer/Tests
 GCDWebServer/tvOS
+
+realm-*


### PR DESCRIPTION
I have observed that we often get errors when we publish. Excluding the locally downloaded files might help.