### PR TITLE
Stop worker being redefined and breaking Jest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,9 @@ require('./extensions')(realmConstructor);
 if (realmConstructor.Sync) {
     if (getContext() === 'nodejs') {
       nodeRequire('./notifier')(realmConstructor);
-      Object.defineProperty(realmConstructor, 'Worker', {value: nodeRequire('./worker')});
+      if (!realmConstructor.Worker) {
+          Object.defineProperty(realmConstructor, 'Worker', {value: nodeRequire('./worker')});
+      }
     }
 }
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
I was experiencing a bug whereby I am:
- Running Jest tests for a class that uses Realm
- When I make a file change, I get an error message `Cannot redefine property: Worker` and have to restart the test watcher

Fix: I wrapped it in an if-statement. I don't know what `realmConstructor.Sync` or `realmConstructor.Worker` is, so I don't know if this breaks something yet 🤓 

This addresses #1635, and _for me_ it fixes the problem

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary