### PR TITLE
Adding optional user as argument to Realm.automaticSyncConfiguration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* Added an optional user as argument to `Realm.automaticSyncConfiguration` (#1708).
+
+### Bug fixes
+* None.
+
+### Internal
+* None.
+
 2.3.0 Release notes (2018-3-13)
 =============================================================
 ### Breaking changes

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -120,13 +120,14 @@ class Realm {
     static openAsync(config, callback, progressCallback) {}
 
     /**
-     * Return a configuration for a default synced Realm. The server URL for the current user will be used as base for
-     * the URL for the synced Realm.
+     * Return a configuration for a default synced Realm. The server URL for the user will be used as base for
+     * the URL for the synced Realm. If no user is supplied, the current user will be used.
+     * @param {Realm.Sync.User} - an optional sync user
      * @throws {Error} if zero or multiple users are logged in
      * @returns {Realm~Configuration} - a configuration matching a default synced Realm.
      * @since 2.3.0
      */
-    static automaticSyncConfiguration() {}
+    static automaticSyncConfiguration(user) {}
 
     /**
      * Closes this Realm so it may be re-opened with a newer schema version.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -153,24 +153,34 @@ module.exports = function(realmConstructor) {
 
         // A configuration for a default Realm
         realmConstructor.automaticSyncConfiguration = function() {
-            let users = this.Sync.User.all;
-            let identities = Object.keys(users);
-            if (identities.length === 1) {
-                let user = users[identities[0]];
-                let url = new URL(user.server);
-                let secure = (url.protocol === 'https:')?'s':'';
-                let port = (url.port === undefined)?'9080':url.port
-                let realmUrl = `realm${secure}://${url.hostname}:${port}/~/default`;
+            let user;
 
-                let config = {
-                    sync: {
-                        user,
-                        url: realmUrl
-                    }
-                };
-                return config;
+            if (arguments.length === 0) {
+                let users = this.Sync.User.all;
+                let identities = Object.keys(users);
+                if (identities.length === 1) {
+                    user = users[identities[0]];
+                } else {
+                    new Error(`One and only one user should be logged in but found ${users.length} users.`);
+                }
+            } else if (arguments.length === 1) {
+                user = arguments[0];
+            } else {
+                new Error(`Zero or one argument expected.`);
             }
-            new Error(`One and only one user should be logged in but found ${users.length} users.`);
+
+            let url = new URL(user.server);
+            let secure = (url.protocol === 'https:')?'s':'';
+            let port = (url.port === undefined)?'9080':url.port
+            let realmUrl = `realm${secure}://${url.hostname}:${port}/~/default`;
+
+            let config = {
+                sync: {
+                    user,
+                    url: realmUrl
+                }
+            };
+            return config;
         }
 
         if (realmConstructor.Sync._setFeatureToken) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -568,8 +568,9 @@ declare class Realm {
 
     /**
      * Return a configuration for a default Realm.
+     * @param {Realm.Sync.User} optional user.
      */
-    static automaticSyncConfiguration(): string;
+    static automaticSyncConfiguration(user?: Realm.Sync.User): string;
 
     /**
      * Delete the Realm file for the given configuration.

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -193,6 +193,50 @@ module.exports = {
             });
     },
 
+    testDefaultRealmFromUser() {
+        if (!isNodeProccess) {
+            return;
+        }
+
+        const username = uuid();
+        const realmName = 'default';
+        const expectedObjectsCount = 3;
+
+        let user;
+        return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
+            .then(() => Realm.Sync.User.login('http://localhost:9080', username, 'password'))
+            .then(u => {
+                user = u;
+                return Realm.open(Realm.automaticSyncConfiguration(user));
+            })
+            .then(realm => {
+                let actualObjectsCount = realm.objects('Dog').length;
+                TestCase.assertEqual(actualObjectsCount, expectedObjectsCount, "Synced realm does not contain the expected objects count");
+
+                const session = realm.syncSession;
+                TestCase.assertInstanceOf(session, Realm.Sync.Session);
+                TestCase.assertEqual(session.user.identity, user.identity);
+                TestCase.assertEqual(session.state, 'active');
+            });
+    },
+
+    testDefaultRealmInvalidArguments() {
+        if (!isNodeProccess) {
+            return;
+        }
+
+        const username = uuid();
+        const realmName = 'default';
+        const expectedObjectsCount = 3;
+
+        let user;
+        return runOutOfProcess(__dirname + '/download-api-helper.js', username, realmName, REALM_MODULE_PATH)
+            .then(() => Realm.Sync.User.login('http://localhost:9080', username, 'password'))
+            .then(u => {
+                TestCase.assertThrows(() => Realm.automaticSyncConfiguration('foo', 'bar')); // too many arguments
+            })
+    },
+
     testRealmOpenWithExistingLocalRealm() {
         if (!isNodeProccess) {
             return;


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #1708

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
