### PR TITLE
Throttle HTTP requests made to the auth server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ X.Y.Z Release notes
 * Added an optional user as argument to `Realm.automaticSyncConfiguration` (#1708).
 
 ### Bug fixes
-* None.
+* [Sync] Avoid hammering the ROS authentication service when large numbers of Realms are opened at once.
 
 ### Internal
 * None.

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -36,8 +36,43 @@ function checkTypes(args, types) {
     }
 }
 
-/* global fetch */
-const performFetch = typeof fetch === 'undefined' ? node_require('node-fetch') : fetch;
+// Perform a HTTP request, enqueuing it if too many requests are already in
+// progress to avoid hammering the server.
+const performFetch = (function() {
+    const doFetch = typeof fetch === 'undefined' ? node_require('node-fetch') : fetch;
+    const queue = [];
+    let count = 0;
+    const maxCount = 5;
+    const next = () => {
+        if (count >= maxCount) {
+            return;
+        }
+        const req = queue.shift();
+        if (!req) {
+            return;
+        }
+        const [url, options, resolve, reject] = req;
+        ++count;
+        // node doesn't support Promise.prototype.finally until 10
+        doFetch(url, options)
+            .then(response => {
+                --count;
+                next();
+                resolve(response);
+            })
+            .catch(error => {
+                --count;
+                next();
+                reject(error);
+            });
+    };
+    return (url, options) => {
+        return new Promise((resolve, reject) => {
+            queue.push([url, options, resolve, reject]);
+            next();
+        });
+    };
+})();
 
 const url_parse = require('url-parse');
 


### PR DESCRIPTION
Making thousands of HTTP requests simultaneously inevitably results in some failing or the server being overwhelmed, so limit how many can be made at once (currently to the arbitrary cap of 5) and enqueue any further requests.

*Should* fix https://github.com/realm/realm-object-server-private/issues/957, and I've verified that it does fix another customer's similar issue.