### PR TITLE
Stop Permissions being redefined and breaking Jest

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -257,10 +257,12 @@ module.exports = function(realmConstructor) {
                 permissions: '__Permission[]'
             }
         });
-        Object.defineProperty(realmConstructor, 'Permissions', {
-            value: permissionsSchema,
-            configurable: false
-        });
+        if (!realmConstructor.Permissions) {
+            Object.defineProperty(realmConstructor, 'Permissions', {
+                value: permissionsSchema,
+                configurable: false
+            });
+        }
     }
 
     // TODO: Remove this now useless object.


### PR DESCRIPTION
Fixes a related problem in exactly the same way as https://github.com/realm/realm-js/pull/1695 .

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This fixes a problem similar to https://github.com/realm/realm-js/issues/1635 that I was having with a different property.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary