### PR TITLE
Avoid leaking realms when an error occurs within an event handler

### DIFF
--- a/lib/notification-worker.js
+++ b/lib/notification-worker.js
@@ -43,7 +43,14 @@ process.on('message', (m) => {
             if (impl.onchange) {
                 const change = Realm.Sync._deserializeChangeSet(m.change);
                 if (!change.isEmpty) {
-                    impl.onchange(change);
+                    try {
+                        impl.onchange(change);
+                    }
+                    catch (e) {
+                        change.close();
+                        process.send({change: m.change});
+                        throw e;
+                    }
                 }
                 change.close();
             }

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -65,11 +65,24 @@ class FunctionListener {
             changes.release();
             return;
         }
-        const promise = Promise.resolve(this.fn(changes));
+
+        let promise;
+        try {
+            promise = Promise.resolve(this.fn(changes));
+        }
+        catch (e) {
+            changes.release();
+            throw e;
+        }
+
         this.pending.push(promise);
-        promise.then(() => {
+        const release = () => {
             changes.release();
             this.pending.splice(this.pending.indexOf(promise), 1);
+        };
+        promise.then(release).catch(e => {
+            release();
+            throw e;
         });
     }
 };


### PR DESCRIPTION
Previously returning a rejecting promise from an event handler would result in silently never receiving events for that Realm again. This makes it close the Realm and rethrow the error instead so that things will either crash or continue somewhat sensibly.