### PR TITLE
Stringify fetch body in logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* None.
+
+### Bug fixes
+* Fixed logout error due to fetch body not being stringified (#1731).
+
+### Internal
+* None.
+
 2.3.4 Release notes (2018-4-12)
 =============================================================
 ### Compatibility

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -391,9 +391,9 @@ const instanceMethods = {
         const headers = {
             Authorization: this.token
         };
-        const body = {
+        const body = JSON.stringify({
             token: this.token
-        };
+        });
         const options = {
             method: 'POST',
             headers,


### PR DESCRIPTION
In React Native, calling `user.logout()` throws an `Unsupported BodyInit type.` error. The body should be stringified here like it is elsewhere throughout this file.

I noticed there are already [logout tests](https://github.com/realm/realm-js/blob/master/tests/js/user-tests.js#L70); I didn't try to run them, but I assume they're passing because they're using a different `fetch` dependency?