### PR TITLE
Fix named linking object queries across classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+X.Y.Z Release notes
+=============================================================
+### Breaking changes
+* None.
+
+### Enhancements
+* None.
+
+### Bug fixes
+* Fix named LinkingObject queries across different classes (#1734).
+
+### Internal
+* None.
+
 2.3.3 Release notes (2018-3-23)
 =============================================================
 ### Compatibility

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -162,7 +162,6 @@ inline void alias_backlinks(parser::KeyPathMapping &mapping, const realm::Shared
                 const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
                 const TableRef target_table = ObjectStore::table_for_object_type(realm->read_group(), target_object_schema->name);
                 std::string native_name = "@links." + std::string(target_table->get_name()) + "." + property.link_origin_property_name;
-                std::cout << table->get_name() << " mapping: " << property.name << " to " << native_name << std::endl;
                 mapping.add_mapping(table, property.name, native_name);
             }
         }

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -159,8 +159,10 @@ inline void alias_backlinks(parser::KeyPathMapping &mapping, const realm::Shared
         for (const Property &property : it->computed_properties) {
             if (property.type == realm::PropertyType::LinkingObjects) {
                 auto target_object_schema = schema.find(property.object_type);
-                const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), target_object_schema->name);
-                std::string native_name = "@links." + std::string(table->get_name()) + "." + property.link_origin_property_name;
+                const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
+                const TableRef target_table = ObjectStore::table_for_object_type(realm->read_group(), target_object_schema->name);
+                std::string native_name = "@links." + std::string(target_table->get_name()) + "." + property.link_origin_property_name;
+                std::cout << table->get_name() << " mapping: " << property.name << " to " << native_name << std::endl;
                 mapping.add_mapping(table, property.name, native_name);
             }
         }

--- a/tests/js/linkingobjects-tests.js
+++ b/tests/js/linkingobjects-tests.js
@@ -103,6 +103,32 @@ module.exports = {
         TestCase.assertEqual(people.filtered('25 IN parents.age').length, 1);
     },
 
+    testNamedLinkingObjectsAcrossClasses: function() {
+        let realm = new Realm({schema: [schemas.Language, schemas.Country]});
+        realm.write(() => {
+            let english = realm.create('Language', {name: 'English'});
+            let french = realm.create('Language', {name: 'French'});
+            let danish = realm.create('Language', {name: 'Danish'});
+            let canada = realm.create('Country', {name: 'Canada', languages: [english, french]});
+            let denmark = realm.create('Country', {name: 'Denmark', languages: [danish, english]});
+            let france = realm.create('Country', {name: 'France', languages: [french, english]});
+        });
+        let languages = realm.objects('Language');
+        let spokenInThreeCountries = languages.filtered('spokenIn.@count == 3');
+        TestCase.assertEqual(spokenInThreeCountries.length, 1);
+        TestCase.assertEqual(spokenInThreeCountries[0].name, 'English');
+        let spokenInTwoCountries = languages.filtered('spokenIn.@count == 2');
+        TestCase.assertEqual(spokenInTwoCountries.length, 1);
+        TestCase.assertEqual(spokenInTwoCountries[0].name, 'French')
+        let spokenInOneCountry = languages.filtered('spokenIn.@count == 1');
+        TestCase.assertEqual(spokenInOneCountry.length, 1);
+        TestCase.assertEqual(spokenInOneCountry[0].name, 'Danish')
+        let languagesSpokenInCanada = languages.filtered('spokenIn.name ==[c] "canada"');
+        TestCase.assertEqual(languagesSpokenInCanada.length, 2);
+        TestCase.assertEqual(languagesSpokenInCanada[0].name, 'English');
+        TestCase.assertEqual(languagesSpokenInCanada[1].name, 'French');
+    },
+
     testMethod: function() {
         var realm = new Realm({schema: [schemas.PersonObject]});
 

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -307,3 +307,20 @@ exports.MultiListObject = {
         'list2':      'string[]'
     }
 };
+
+exports.Language = {
+    name: 'Language',
+    properties: {
+        name: 'string',
+        spokenIn: {type: 'linkingObjects', objectType: 'Country', property: 'languages'}
+    }
+};
+
+exports.Country = {
+    name: 'Country',
+    properties: {
+        name: 'string',
+        languages: 'Language[]',
+    }
+};
+


### PR DESCRIPTION
This fixes named LinkingObject queries not working between different classes.

Related to #1660 and reported in https://github.com/realm/realm-js-private/issues/429