### PR TITLE
Don't hang forever when the React tests fail to start

### DIFF
--- a/lib/notification-worker.js
+++ b/lib/notification-worker.js
@@ -25,7 +25,7 @@ function nodeRequire(module) {
     return require_method(module);
 }
 
-const Realm = require('.');
+const Realm = nodeRequire('.');
 
 let impl;
 process.on('message', (m) => {

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -85,7 +85,7 @@ class FunctionListener {
             throw e;
         });
     }
-};
+}
 
 class OutOfProcListener {
     constructor(regex, regexStr, worker) {
@@ -120,7 +120,7 @@ class OutOfProcListener {
         }
         this.worker.onchange(changes);
     }
-};
+}
 
 class Listener {
     constructor(Sync, server, user) {
@@ -231,7 +231,7 @@ class Listener {
         }
         this.initPromises = [];
     }
-};
+}
 
 let listener;
 function addListener(server, user, regex, event, callback) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,6 +123,6 @@ class Worker {
         const message = this._workQueue.shift();
         worker.send(message);
     }
-};
+}
 
 module.exports = Worker;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -171,7 +171,7 @@ setup_ios_simulator() {
   delete_ios_simulator >/dev/null 2>&1
 
   #parse devices
-  IOS_RUNTIME=$(xcrun simctl list runtimes |  grep -m1 -o 'com.apple.CoreSimulator.SimRuntime.iOS.*' | sed 's/[()]//g')
+  IOS_RUNTIME=$(xcrun simctl list runtimes | grep -v unavailable | grep -m1 -o 'com.apple.CoreSimulator.SimRuntime.iOS.*' | sed 's/[()]//g')
   echo using iOS Runtime ${IOS_RUNTIME} to create new simulator ${SIM_DEVICE_NAME}
 
   #create new test simulator

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -751,7 +751,7 @@ module.exports = {
                 const realm = new Realm(config1);
                 TestCase.assertFalse(realm.isClosed);
                 realm.close();
-        };
+        }
 
         function __partialIsNotAllowed() {
             let config2 = {
@@ -762,7 +762,7 @@ module.exports = {
                 }
             };
             TestCase.assertThrows(() => new Realm(config2));
-        };
+        }
 
         function shouldFail() {
             let config = {
@@ -780,11 +780,11 @@ module.exports = {
             TestCase.assertEqual(realm.objects('Dog').length, 0);
             TestCase.assertThrows(function () { var subscription = realm.objects('Dog').filtered("name == 'Lassy 1'").subscribe(); } );
             realm.close();
-        };
+        }
 
         function defaultRealmInvalidArguments() {
             TestCase.assertThrows(() => Realm.automaticSyncConfiguration('foo', 'bar')); // too many arguments
-        };
+        }
 
 
         return runOutOfProcess(__dirname + '/partial-sync-api-helper.js', username, REALM_MODULE_PATH)


### PR DESCRIPTION
This doesn't actually fix the tests not working, but does at least make it so that it doesn't sit there with simctl using 100% CPU until someone manually kills the job.