### PR TITLE
Track Realms seen in the notifier by id rather than path

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -45,11 +45,11 @@ class FunctionListener {
         return this.regexStr === regex && this.event === event && this.fn === fn;
     }
 
-    onavailable(path) {
+    onavailable(path, id) {
         if (this.regex.test(path)) {
-            if (this.event === 'available' && !this.seen[path]) {
+            if (this.event === 'available' && !this.seen[id]) {
                 this.fn(path);
-                this.seen[path] = true;
+                this.seen[id] = true;
             }
             return this.event === 'change';
         }
@@ -103,11 +103,11 @@ class OutOfProcListener {
         return this.regexStr === regex && this.worker === worker;
     }
 
-    onavailable(path) {
+    onavailable(path, id) {
         if (this.regex.test(path)) {
-            if (!this.seen[path]) {
+            if (!this.seen[id]) {
                 this.worker.onavailable(path);
-                this.seen[path] = true;
+                this.seen[id] = true;
             }
             return true;
         }
@@ -161,10 +161,11 @@ class Listener {
         changes.release();
     }
 
-    available(virtualPath) {
+    available(virtualPath, id) {
         let watch = false;
+        id = id || virtualPath;
         for (const callback of this.callbacks) {
-            if (callback.onavailable(virtualPath)) {
+            if (callback.onavailable(virtualPath, id)) {
                 watch = true;
             }
         }


### PR DESCRIPTION
If a Realm is deleted and then a new one is created at the same path it needs to be treated as a new Realm.

Required for https://github.com/realm/realm-js-private/pull/443 and should have no impact outside of that.