### PR TITLE
Add Object.linkingObjectCount()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+X.Y.Z Release notes ()
+=============================================================
+### Compatibility
+* Sync protocol: 24
+* Server-side history format: 4
+* File format: 7
+* Realm Object Server: 3.0.0 or later
+
+### Breaking changes
+* None.
+
+### Enhancements
+* Added `Object.linkingObjectsCount()` method, that returns total count of incoming links.
+
+### Bug fixes
+* None
+
+### Internal
+* None.
+
 2.5.0 Release notes (2018-5-14)
 =============================================================
 ### Compatibility

--- a/docs/object.js
+++ b/docs/object.js
@@ -52,5 +52,5 @@ class Object {
      * @returns {number} number of links to this object.
      * @since 2.6.0
      */
-    linkingObjectsCount(objectType, property) {}
+    linkingObjectsCount() {}
 }

--- a/docs/object.js
+++ b/docs/object.js
@@ -46,4 +46,11 @@ class Object {
      * @since 1.9.0
      */
     linkingObjects(objectType, property) {}
+
+    /**
+     * Returns the total count of incoming links to this object
+     * @returns {number} number of links to this object.
+     * @since 2.6.0
+     */
+    linkingObjectsCount(objectType, property) {}
 }

--- a/lib/browser/objects.js
+++ b/lib/browser/objects.js
@@ -32,6 +32,7 @@ createMethods(RealmObject.prototype, objectTypes.OBJECT, [
     'isValid',
     'objectSchema',
     'linkingObjects',
+    'linkingObjectsCount',
     '_objectId',
     '_isSameObject',
 ]);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -112,6 +112,11 @@ declare namespace Realm {
          * @returns Results<T>
          */
         linkingObjects<T>(objectType: string, property: string): Results<T>;
+
+        /**
+         * @returns number
+         */
+        linkingObjectsCount(): number;
     }
 
     const Object: {

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -53,6 +53,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::Object> {
     static void is_valid(ContextType, FunctionType, ObjectType, size_t, const ValueType [], ReturnValue &);
     static void get_object_schema(ContextType, FunctionType, ObjectType, size_t, const ValueType [], ReturnValue &);
     static void linking_objects(ContextType, FunctionType, ObjectType, size_t, const ValueType [], ReturnValue &);
+    static void linking_objects_count(ContextType, FunctionType, ObjectType, size_t, const ValueType [], ReturnValue &);
     static void get_object_id(ContextType, ObjectType, Arguments, ReturnValue &);
     static void is_same_object(ContextType, ObjectType, Arguments, ReturnValue &);
 
@@ -68,6 +69,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::Object> {
         {"isValid", wrap<is_valid>},
         {"objectSchema", wrap<get_object_schema>},
         {"linkingObjects", wrap<linking_objects>},
+        {"linkingObjectsCount", wrap<linking_objects_count>},
         {"_objectId", wrap<get_object_id>},
         {"_isSameObject", wrap<is_same_object>},
     };
@@ -200,6 +202,15 @@ void RealmObjectClass<T>::is_same_object(ContextType ctx, ObjectType object, Arg
     return_value.set(self->row().get_table() == other->row().get_table()
                      && self->row().get_index() == other->row().get_index());
 }
+    
+template<typename T>
+void RealmObjectClass<T>::linking_objects_count(ContextType ctx, FunctionType, ObjectType object, size_t argc, const ValueType arguments[], ReturnValue &return_value) {
+    auto realm_object = get_internal<T, RealmObjectClass<T>>(object);
+    const Row& row = realm_object->row();
+    
+    return_value.set((uint32_t)row.get_backlink_count());
+}
+    
 } // js
 } // realm
 

--- a/tests/js/linkingobjects-tests.js
+++ b/tests/js/linkingobjects-tests.js
@@ -195,4 +195,29 @@ module.exports = {
             TestCase.assertEqual(oliviersParents.length, 0);
         });
     },
+
+    testLinkingObjectsCount: function() {
+        var realm = new Realm({schema: [schemas.PersonObject]});
+
+        var john;
+        realm.write(function () {
+            john = realm.create('PersonObject', { name: 'John', age: 50 });
+        });
+
+        TestCase.assertEqual(john.linkingObjectsCount(), 0);
+        
+        var olivier;
+        realm.write(function() {
+            olivier = realm.create('PersonObject', {name: 'Olivier', age: 0});
+            realm.create('PersonObject', {name: 'Christine', age: 25, children: [olivier]});
+        });
+        
+        TestCase.assertEqual(olivier.linkingObjectsCount(), 1);
+        
+        realm.write(function() {
+            john.children.push(olivier);
+        });
+
+        TestCase.assertEqual(olivier.linkingObjectsCount(), 2);
+    }
 };


### PR DESCRIPTION


## What, How & Why?

This adds `Object.linkingObjectCount()` method to get the total number of incoming links to an object.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native