### PR TITLE
Fix Realm.open() with no config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (xxxx-xx-xx)
+=============================================================
+### Compatibility
+
+### Breaking changes
+* None.
+
+### Enhancements
+* None
+
+### Bug fixes
+* Fix `Realm.open()` to work without passing a config.
+
+### Internal
+
+
 2.6.0 Release notes (2018-5-16)
 =============================================================
 ### Compatibility

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -105,7 +105,7 @@ class Realm {
     /**
      * Open a Realm asynchronously with a promise. If the Realm is synced, it will be fully
      * synchronized before it is available.
-     * @param {Realm~Configuration} config
+     * @param {Realm~Configuration} config - if no config is defined, it will open the default realm
      * @returns {ProgressPromise} - a promise that will be resolved with the Realm instance when it's available.
      */
     static open(config) {}

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -64,6 +64,9 @@ module.exports = function(realmConstructor) {
     //Add async open API
     Object.defineProperties(realmConstructor, getOwnPropertyDescriptors({
         open(config) {
+            // If no config is defined, we should just open the default realm
+            if (config === undefined) { config = {}; }
+
             // For local Realms we open the Realm and return it in a resolved Promise.
             if (!("sync" in config)) {
                 let promise = Promise.resolve(new realmConstructor(config));

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -222,6 +222,21 @@ module.exports = {
         });
     },
 
+    testRealmOpenNoConfig: function() {
+        let realm = new Realm({schema: [schemas.TestObject], schemaVersion: 1});
+        realm.write(() => {
+            realm.create('TestObject', [1])
+        });
+        realm.close();
+
+        return Realm.open().then(realm => {
+            const objects = realm.objects('TestObject');
+            TestCase.assertEqual(objects.length, 1);
+            TestCase.assertEqual(objects[0].doubleCol, 1.0);
+            realm.close();
+        });
+    },
+
     testDefaultPath: function() {
         const defaultPath = Realm.defaultPath;
         let defaultRealm = new Realm({schema: []});


### PR DESCRIPTION
## What, How & Why?

Using `Realm.open()` without a config gave an incompressible error message. It should just open the default Realm (similar to `new Realm()`).

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary