### PR TITLE
Expose both newModifications and oldModifications on change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Enhancements
-* Add the `oldModifications` and `newModifications` properties to the listener change objects, which report the indices that changed in the collection both before and after the changes being notified for.
+* Add the `oldModifications` and `newModifications` properties to the listener change objects, which report the indices that changed in the collection both before and after the changes being notified for. The `modifications` property is kept as an alias for `oldModifications` but might be removed in a future version.
 
 ### Bug fixes
 * [Sync] Fixed a bug which crash query-based Realms. A bug in gcc's optimizer will generate code which in some case will lead to a memory violation and eventually a segmentation fault.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Add the `oldModifications` and `newModifications` properties to the listener change objects, which report the indices that changed in the collection both before and after the changes being notified for.
 
 ### Bug fixes
 * [Sync] Fixed a bug which crash query-based Realms. A bug in gcc's optimizer will generate code which in some case will lead to a memory violation and eventually a segmentation fault.

--- a/docs/collection.js
+++ b/docs/collection.js
@@ -427,9 +427,12 @@ class Collection {
      * @param {function(collection, changes)} callback - A function to be called when changes occur.
      *   The callback function is called with two arguments:
      *   - `collection`: the collection instance that changed,
-     *   - `changes`: a dictionary with keys `insertions`, `modifications` and `deletions`,
-     *      each containing a list of indices that were inserted, updated or deleted respectively. If
-     *      partial sync is enabled, an additional key `partial_sync` is added.
+     *   - `changes`: a dictionary with keys `insertions`, `newModifications`, `oldModifications`
+     *      and `deletions`, each containing a list of indices in the collection that were
+     *      inserted, updated or deleted respectively. `deletions` and `oldModifications` are
+     *      indices into the collection before the change happened, while `insertions` and
+     *      `newModifications` are indices into the new version of the collection. If partial sync
+     *      is enabled, an additional key `partial_sync` is added.
      *   - `changes.partial_sync`: `error` indicates if an error has occurred, `old_state` is the previous
      *      state, and `new_state` is the current state.
      * @throws {Error} If `callback` is not a function.

--- a/docs/collection.js
+++ b/docs/collection.js
@@ -431,21 +431,15 @@ class Collection {
      *      and `deletions`, each containing a list of indices in the collection that were
      *      inserted, updated or deleted respectively. `deletions` and `oldModifications` are
      *      indices into the collection before the change happened, while `insertions` and
-     *      `newModifications` are indices into the new version of the collection. If partial sync
-     *      is enabled, an additional key `partial_sync` is added.
-     *   - `changes.partial_sync`: `error` indicates if an error has occurred, `old_state` is the previous
-     *      state, and `new_state` is the current state.
+     *      `newModifications` are indices into the new version of the collection.
      * @throws {Error} If `callback` is not a function.
      * @example
      * wines.addListener((collection, changes) => {
      *  // collection === wines
-     *  if (changes.partial_sync.new_state == Realm.Sync.SubscriptionState.Initialized) {
-     *     console.log('Our subset is ready');
-     *     console.log(`${changes.insertions.length} insertions`);
-     *     console.log(`${changes.modifications.length} modifications`);
-     *     console.log(`${changes.deletions.length} deletions`);
-     *     console.log(`new size of collection: ${collection.length}`);
-     *   }
+     *  console.log(`${changes.insertions.length} insertions`);
+     *  console.log(`${changes.modifications.length} modifications`);
+     *  console.log(`${changes.deletions.length} deletions`);
+     *  console.log(`new size of collection: ${collection.length}`);
      * });
      */
     addListener(callback) {}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -140,6 +140,8 @@ declare namespace Realm {
         insertions: number[];
         deletions: number[];
         modifications: number[];
+        newModifications: number[];
+        oldModifications: number[];
     }
 
     type CollectionChangeCallback<T> = (collection: Collection<T>, change: CollectionChangeSet) => void;

--- a/tests/js/results-tests.js
+++ b/tests/js/results-tests.js
@@ -452,10 +452,16 @@ module.exports = {
             if (first) {
                 TestCase.assertEqual(testObjects.length, 3);
                 TestCase.assertEqual(changes.insertions.length, 0);
+                TestCase.assertEqual(changes.modifications.length, 0);
+                TestCase.assertEqual(changes.newModifications.length, 0);
+                TestCase.assertEqual(changes.oldModifications.length, 0);
             }
             else {
                 TestCase.assertEqual(testObjects.length, 4);
                 TestCase.assertEqual(changes.insertions.length, 1);
+                TestCase.assertEqual(changes.modifications.length, 1);
+                TestCase.assertEqual(changes.newModifications.length, 1);
+                TestCase.assertEqual(changes.oldModifications.length, 1);
             }
             first = false;
             resolve();
@@ -464,6 +470,7 @@ module.exports = {
         return new Promise((r, _reject) => {
             resolve = r;
             realm.write(() => {
+                realm.objects('TestObject')[0].doubleCol = 5;
                 realm.create('TestObject', { doubleCol: 1 });
             });
         });


### PR DESCRIPTION
I added this to the 2.8.0 changelog section as that appears to have not been released yet.