### PR TITLE
Fix building against realm-sync checkout

### DIFF
--- a/realm.gypi
+++ b/realm.gypi
@@ -212,10 +212,10 @@
       "conditions": [
         ["prefix!=''", {
           "all_dependent_settings": {
-            "include_dirs": [ "<(prefix)/src" ],
+            "include_dirs": [ "<(prefix)/src", "<(prefix)/<(build_directory)/src" ],
           },
-          "direct_dependent_settings": {
-            "library_dirs": [ "<(prefix)/src/realm" ]
+          "link_settings": {
+            "library_dirs": [ "<(prefix)/<(build_directory)/src/realm" ]
           }
         }, {
           "dependencies": [ "vendored-realm" ]


### PR DESCRIPTION
## What, How & Why?
When Sync switched to building with CMake the folder paths changed slightly. Luckily, we already know the structure from Core and can use the same one.

## ☑️ ToDos
This is purely an internal change that pertains to building the repo from source. It doesn't affect the npm package at all.