### PR TITLE
Compute realm size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+X.Y.Z Release notes
+=============================================================
+### Compatibility
+* Sync protocol: 24
+* Server-side history format: 4
+* File format: 7
+* Realm Object Server: 3.0.0 or later
+
+### Breaking changes
+* None.
+
+### Enhancements
+* Added a method named `computeSize` on the Realm object that computes the aggregated size of all objects and their history.
+
+### Bug fixes
+* None.
+
+### Internals
+* None.
+
+
 2.10.0 Release notes (2018-6-19)
 =============================================================
 ### Compatibility
@@ -167,7 +188,7 @@
 The feature known as Partial synchronization has been renamed to Query-based synchronization and is now the default mode for synchronized Realms. This has impacted a number of APIs. See below for the details.
 
 ### Deprecated
-* [Sync] `Realm.Configuration.SyncConfiguration.partial` has been deprecated in favor of `Realm.Configuration.SyncConfiguration.fullSynchronization`. 
+* [Sync] `Realm.Configuration.SyncConfiguration.partial` has been deprecated in favor of `Realm.Configuration.SyncConfiguration.fullSynchronization`.
 * [Sync] `Realm.automaticSyncConfiguration()` has been deprecated in favor of `Realm.Sync.User.createConfiguration()`.
 
 ### Breaking changes

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -286,6 +286,14 @@ class Realm {
     compact() {}
 
     /**
+     * Computes the aggregated size of all objects and their history in the Realm.
+     *
+     * Note that this will traverse the Realm and might be expensive for large Realms.
+     * @returns {number} the computed size in bytes.
+     */
+    computeSize() {}
+
+    /**
      * Writes a compacted copy of the Realm to the given path.
      *
      * The destination file cannot already exist.
@@ -456,4 +464,3 @@ class Realm {
  *   any object of this type from inside the same Realm, and will always be _optional_
  *   (meaning it may also be assigned `null` or `undefined`).
  */
-

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -130,6 +130,7 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'removeListener',
     'removeAllListeners',
     'close',
+    'computeSize',
     '_waitForDownload',
     '_objectForObjectId',
 ]);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -318,7 +318,7 @@ declare namespace Realm.Sync {
         static requestPasswordReset(server: string, email: string): Promise<void>;
 
         static completePasswordReset(server:string, reset_token:string, new_password:string): Promise<void>;
-        
+
         static requestEmailConfirmation(server:string, email:string): Promise<void>;
 
         static confirmEmail(server:string, confirmation_token:string): Promise<void>;
@@ -731,6 +731,14 @@ declare class Realm {
      * @returns boolean
      */
     compact(): boolean;
+
+    /**
+     * Computes the aggregated size of all objects and their history in the Realm.
+     *
+     * Note that this will traverse the Realm and might be expensive for large Realms.
+     * @returns {number} the computed size in bytes.
+     */
+    computeSize(): number;
 
     /**
      * Write a copy to destination path

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -237,6 +237,7 @@ public:
     static void delete_model(ContextType, ObjectType, Arguments, ReturnValue &);
     static void object_for_object_id(ContextType, ObjectType, Arguments, ReturnValue&);
     static void privileges(ContextType, ObjectType, Arguments, ReturnValue&);
+    static void compute_size(ContextType, ObjectType, Arguments, ReturnValue&);
 
     // properties
     static void get_empty(ContextType, ObjectType, ReturnValue &);
@@ -295,6 +296,7 @@ public:
         {"writeCopyTo", wrap<writeCopyTo>},
         {"deleteModel", wrap<delete_model>},
         {"privileges", wrap<privileges>},
+        {"computeSize", wrap<compute_size>},
         {"_objectForObjectId", wrap<object_for_object_id>},
  #if REALM_ENABLE_SYNC
         {"_waitForDownload", wrap<wait_for_download_completion>},
@@ -1174,6 +1176,15 @@ void RealmClass<T>::privileges(ContextType ctx, ObjectType this_object, Argument
     Object::set_property(ctx, object, "subscribe", Value::from_boolean(ctx, has_privilege(p, Privilege::Query)));
     Object::set_property(ctx, object, "setPermissions", Value::from_boolean(ctx, has_privilege(p, Privilege::SetPermissions)));
     return_value.set(object);
+}
+
+template<typename T>
+void RealmClass<T>::compute_size(ContextType ctx, ObjectType this_object, Arguments args, ReturnValue &return_value) {
+    args.validate_maximum(0);
+
+    SharedRealm realm = *get_internal<T, RealmClass<T>>(this_object);
+    auto size = realm->read_group().compute_aggregated_byte_size();
+    return_value.set(Value::from_number(ctx, size));
 }
 
 } // js

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1183,8 +1183,7 @@ void RealmClass<T>::compute_size(ContextType ctx, ObjectType this_object, Argume
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(this_object);
-    auto size = realm->read_group().compute_aggregated_byte_size();
-    return_value.set(Value::from_number(ctx, size));
+    return_value.set(Value::from_number(ctx, realm->compute_size()));
 }
 
 } // js

--- a/tests/js/compute-size-tests.js
+++ b/tests/js/compute-size-tests.js
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const Realm = require('realm');
+const TestCase = require('./asserts');
+const schemas = require('./schemas');
+
+module.exports = {
+    testComputeSizeExistsAndIncreases: function() {
+        const realm = new Realm({schema: [
+          { name: 'Something', properties: { numbers: 'int[]' } }
+        ]});
+
+        TestCase.assertEqual(typeof realm.computeSize, 'function');
+
+        const sizeInitially = realm.computeSize();
+        TestCase.assertEqual(typeof sizeInitially, 'number');
+        TestCase.assertTrue(sizeInitially > 0);
+
+        // Compact the Realm first
+        realm.compact();
+
+        const sizeCompacted = realm.computeSize();
+        TestCase.assertEqual(typeof sizeCompacted, 'number');
+        TestCase.assertTrue(sizeCompacted <= sizeInitially);
+        TestCase.assertTrue(sizeCompacted > 0);
+
+        // Add an object
+        realm.write(() => {
+          realm.create('Something', {});
+        });
+
+        const sizeAfter = realm.computeSize();
+        TestCase.assertEqual(typeof sizeAfter, 'number');
+        TestCase.assertTrue(sizeAfter > sizeCompacted);
+    },
+};

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -50,6 +50,7 @@ var TESTS = {
     EncryptionTests: require('./encryption-tests'),
     ObjectIDTests: require('./object-id-tests'),
     // Garbagecollectiontests: require('./garbage-collection'),
+    ComputeSizeTests: require('./compute-size-tests'),
 };
 
 // If sync is enabled, run the sync tests


### PR DESCRIPTION
## What, How & Why?

This adds a `computeSize` method on the Realm object.

This closes #1881.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
