### PR TITLE
Improve performance of `realm.create()` when running in node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ X.Y.Z Release notes
 ### Enhancements
 * Improved performance of creating objects with string primary keys.
 * Improved memory management to allow larger transactions.
+* Improved performance of `realm.create()` when running in node.
 
 ### Bug fixes
 * Fixed a bug which caused RN Android to fail loading (#1904).

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -68,10 +68,10 @@ public:
 
     OptionalValue value_for_property(ValueType dict, std::string const& prop_name, size_t prop_index) {
         ObjectType object = Value::validated_to_object(m_ctx, dict);
-        if (!Object::has_property(m_ctx, object, prop_name)) {
+        ValueType value = Object::get_property(m_ctx, object, prop_name);
+        if (Value::is_undefined(m_ctx, value)) {
             return util::none;
         }
-        ValueType value = Object::get_property(m_ctx, object, prop_name);
         const auto& prop = m_object_schema->persisted_properties[prop_index];
         if (!Value::is_valid_for_property(m_ctx, value, prop)) {
             throw TypeErrorException(*this, m_object_schema->name, prop, value);

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -210,6 +210,9 @@ struct Object {
     static ValueType get_prototype(ContextType, const ObjectType &);
     static void set_prototype(ContextType, const ObjectType &, const ValueType &);
 
+    static ValueType get_property(ContextType, const ObjectType &, StringData);
+    static ValueType get_property(ContextType c, const ObjectType &o, const char *s) { return get_property(c, o, StringData(s)); }
+    static ValueType get_property(ContextType c, const ObjectType &o, const std::string &s) { return get_property(c, o, StringData(s)); }
     static ValueType get_property(ContextType, const ObjectType &, const String<T> &);
     static ValueType get_property(ContextType, const ObjectType &, uint32_t);
     static void set_property(ContextType, const ObjectType &, const String<T> &, const ValueType &, PropertyAttributes attributes = None);

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -210,8 +210,6 @@ struct Object {
     static ValueType get_prototype(ContextType, const ObjectType &);
     static void set_prototype(ContextType, const ObjectType &, const ValueType &);
 
-    static bool has_property(ContextType, const ObjectType &, const String<T> &);
-    static bool has_property(ContextType, const ObjectType &, uint32_t);
     static ValueType get_property(ContextType, const ObjectType &, const String<T> &);
     static ValueType get_property(ContextType, const ObjectType &, uint32_t);
     static void set_property(ContextType, const ObjectType &, const String<T> &, const ValueType &, PropertyAttributes attributes = None);
@@ -223,10 +221,11 @@ struct Object {
 
     template<typename P>
     static ValueType validated_get_property(ContextType ctx, const ObjectType &object, const P &property, const char *message = nullptr) {
-        if (!has_property(ctx, object, property)) {
+        auto value = get_property(ctx, object, property);
+        if (Value<T>::is_undefined(ctx, value)) {
             throw std::out_of_range(message ? message : "Object missing expected property: " + util::to_string(property));
         }
-        return get_property(ctx, object, property);
+        return value;
     }
 
     static uint32_t validated_get_length(ContextType ctx, const ObjectType &object) {

--- a/src/jsc/jsc_object.hpp
+++ b/src/jsc/jsc_object.hpp
@@ -24,16 +24,6 @@ namespace realm {
 namespace js {
 
 template<>
-inline bool jsc::Object::has_property(JSContextRef ctx, const JSObjectRef &object, const jsc::String &key) {
-    return JSObjectHasProperty(ctx, object, key);
-}
-
-template<>
-inline bool jsc::Object::has_property(JSContextRef ctx, const JSObjectRef &object, uint32_t index) {
-    return JSObjectHasProperty(ctx, object, jsc::String(util::to_string(index)));
-}
-
-template<>
 inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, const jsc::String &key) {
     JSValueRef exception = nullptr;
     JSValueRef value = JSObjectGetProperty(ctx, object, key, &exception);

--- a/src/jsc/jsc_object.hpp
+++ b/src/jsc/jsc_object.hpp
@@ -24,11 +24,6 @@ namespace realm {
 namespace js {
 
 template<>
-inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, StringData key) {
-    return get_property(ctx, object, jsc::String(key));
-}
-
-template<>
 inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, const jsc::String &key) {
     JSValueRef exception = nullptr;
     JSValueRef value = JSObjectGetProperty(ctx, object, key, &exception);
@@ -36,6 +31,11 @@ inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef 
         throw jsc::Exception(ctx, exception);
     }
     return value;
+}
+
+template<>
+inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, StringData key) {
+    return get_property(ctx, object, jsc::String(key));
 }
 
 template<>

--- a/src/jsc/jsc_object.hpp
+++ b/src/jsc/jsc_object.hpp
@@ -24,6 +24,11 @@ namespace realm {
 namespace js {
 
 template<>
+inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, StringData key) {
+    return get_property(ctx, object, jsc::String(key));
+}
+
+template<>
 inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, const jsc::String &key) {
     JSValueRef exception = nullptr;
     JSValueRef value = JSObjectGetProperty(ctx, object, key, &exception);

--- a/src/node/node_object.hpp
+++ b/src/node/node_object.hpp
@@ -24,16 +24,6 @@ namespace realm {
 namespace js {
 
 template<>
-inline bool node::Object::has_property(v8::Isolate* isolate, const v8::Local<v8::Object> &object, const node::String &key) {
-    return Nan::Has(object, key).FromMaybe(false);
-}
-
-template<>
-inline bool node::Object::has_property(v8::Isolate* isolate, const v8::Local<v8::Object> &object, uint32_t index) {
-    return Nan::Has(object, index).FromMaybe(false);
-}
-
-template<>
 inline v8::Local<v8::Value> node::Object::get_property(v8::Isolate* isolate, const v8::Local<v8::Object> &object, const node::String &key) {
     Nan::TryCatch trycatch;
     auto value = Nan::Get(object, v8::Local<v8::String>(key));

--- a/src/node/node_string.hpp
+++ b/src/node/node_string.hpp
@@ -30,16 +30,35 @@ class String<node::Types> {
   public:
     String(const char* s) : m_str(s) {}
     String(const std::string &s) : m_str(s) {}
-    String(const v8::Local<v8::String> &s) : m_str(*Nan::Utf8String(s)) {}
+    String(const v8::Local<v8::String> &s);
     String(v8::Local<v8::String> &&s) : String(s) {}
 
-    operator std::string() const {
+    operator std::string() const& {
         return m_str;
+    }
+    operator std::string() && {
+        return std::move(m_str);
     }
     operator v8::Local<v8::String>() const {
         return Nan::New(m_str).ToLocalChecked();
     }
 };
+
+inline String<node::Types>::String(const v8::Local<v8::String> &s) {
+    if (s.IsEmpty() || s->Length() == 0) {
+        return;
+    }
+    if (s->IsOneByte()) {
+        m_str.resize(s->Length());
+    }
+    else {
+        // Length is in UCS-2 code units, which can take up to 3 bytes each to encode
+        m_str.resize(3 * s->Length());
+    }
+    const int flags = v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+    auto length = s->WriteUtf8(&m_str[0], m_str.size(), 0, flags);
+    m_str.resize(length);
+}
 
 } // js
 } // realm

--- a/src/node/node_string.hpp
+++ b/src/node/node_string.hpp
@@ -48,16 +48,9 @@ inline String<node::Types>::String(const v8::Local<v8::String> &s) {
     if (s.IsEmpty() || s->Length() == 0) {
         return;
     }
-    if (s->IsOneByte()) {
-        m_str.resize(s->Length());
-    }
-    else {
-        // Length is in UCS-2 code units, which can take up to 3 bytes each to encode
-        m_str.resize(3 * s->Length());
-    }
+    m_str.resize(s->Utf8Length());
     const int flags = v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-    auto length = s->WriteUtf8(&m_str[0], m_str.size(), 0, flags);
-    m_str.resize(length);
+    s->WriteUtf8(&m_str[0], m_str.size(), 0, flags);
 }
 
 } // js

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -425,7 +425,7 @@ module.exports = {
 
             realm.create('AllPrimaryTypesObject', {primaryCol: '0', objectCol: undefined}, true);
             realm.create('AllPrimaryTypesObject', {primaryCol: '1', objectCol: null}, true);
-            TestCase.assertEqual(obj0.objectCol, null);
+            TestCase.assertEqual(obj0.objectCol.doubleCol, 0);
             TestCase.assertEqual(obj1.objectCol, null);
 
             // test with string primaries


### PR DESCRIPTION
In total these changes cut the runtime of it by ~25% on the test case I've been measuring.