### PR TITLE
When forcing sync on a local Realm, use an additive schema

### DIFF
--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -785,6 +785,9 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
     ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
     if (Value::is_boolean(ctx, sync_config_value)) {
         config.force_sync_history = Value::to_boolean(ctx, sync_config_value);
+        if (config.force_sync_history) {
+            config.schema_mode = SchemaMode::Additive;
+        }
     } else if (!Value::is_undefined(ctx, sync_config_value)) {
         auto sync_config_object = Value::validated_to_object(ctx, sync_config_value);
 


### PR DESCRIPTION
Since this is the expected mode when opening a sync Realm. An alternative would be to expose the schema mode to allow users to set this manually.