### PR TITLE
Adding getters to debugging support of Realm.Sync.User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ X.Y.Z Release notes
 ### Internals
 * Upgraded to Realm Core v5.6.3.
 * Upgraded to Realm Sync v3.5.8.
+* Added properties of `Realm.Sync.User` to debugger support.
 
 
 2.10.0 Release notes (2018-6-19)

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -21,7 +21,7 @@
 
 import { createUser as createUserRPC, _adminUser as _adminUserRPC, getAllUsers as getAllUsersRPC, _getExistingUser as _getExistingUserRPC } from './rpc';
 import { keys, objectTypes } from './constants';
-import { createMethods } from './util';
+import { getterForProperty, createMethods } from './util';
 
 export default class User {
     static createUser(server, identity, token, isAdminToken, isAdminUser) {
@@ -39,7 +39,13 @@ export default class User {
     static _getExistingUser(server, identity) {
         return _getExistingUserRPC(Array.from(arguments));
     }
-}
+};
+
+Object.defineProperties(User.prototype, {
+    token: { get: getterForProperty('token') },
+    server: { get: getterForProperty('server') },
+    identity: { get: getterForProperty('identity') },
+});
 
 createMethods(User.prototype, objectTypes.USER, [
     '_logout',


### PR DESCRIPTION
## What, How & Why?

In #1860 we see a call to `/auth/revoke` which fails due to a missing token. Since it happens only during debugging, it could indicate that the debugger cannot access the user object's properties.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* [x] Chrome debug API is updated if API is available on React Native
