### PR TITLE
Expose custom HTTP headers in sync configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ X.Y.Z Release notes
 ### Enhancements
 * Added a method `Realm.computeSize()` that computes the aggregated size of all objects and their history (#1881).
 * Improved performance for devices which can support large address spaces.
+* [Sync] Exposed custom HTTP headers in `Realm.Configuration` (#1897).
 
 ### Bug fixes
 * None.
@@ -20,7 +21,7 @@ X.Y.Z Release notes
 * Upgraded to Realm Core v5.6.3.
 * Upgraded to Realm Sync v3.5.8.
 * Added properties of `Realm.Sync.User` to debugger support.
-* Fixed class names in API documentation.
+* Fixed class names in API documentation (wrong names were introduced in v2.6.0).
 
 
 2.10.0 Release notes (2018-6-19)

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -43,6 +43,7 @@
  *    synchronization mode. The default is query-based mode which only synchronizes objects that have been subscribed to.
  *    A fully synchronized Realm will synchronize the entire Realm in the background, irrespectively of the data being
  *    used or not.
+ * @property {Object} [custom_http_header] - A map (string, string) of custom HTTP headers.
  */
 
 /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -427,7 +427,7 @@ declare namespace Realm.Sync {
         partial?: boolean;
         fullSynchronization?: boolean;
         _disableQueryBasedSyncUrlChecks?:boolean;
-        custom_http_headers?: any;
+        custom_http_headers?: { [header: string]: string };
     }
 
     type ProgressNotificationCallback = (transferred: number, transferable: number) => void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -427,6 +427,7 @@ declare namespace Realm.Sync {
         partial?: boolean;
         fullSynchronization?: boolean;
         _disableQueryBasedSyncUrlChecks?:boolean;
+        custom_http_headers?: any;
     }
 
     type ProgressNotificationCallback = (transferred: number, transferable: number) => void;

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -90,6 +90,36 @@ module.exports = {
         TestCase.assertNull(realm.syncSession);
     },
 
+    testCustomHTTPHeaders() {
+        if (!isNodeProccess) {
+            return;
+        }
+
+        const username = uuid();
+        const realmName = uuid();
+
+        return Realm.Sync.User.register('http://localhost:9080', username, 'password').then(user => {
+            let config = {
+                sync: { 
+                    user, 
+                    url: `realm://localhost:9080/~/${realmName}`, 
+                    fullSynchronization: true,
+                    custom_http_headers: {
+                        'X-Foo': 'Bar'
+                    }
+                },
+                schema: [{ name: 'Dog', properties: { name: 'string' } }],
+            };
+            return Realm.open(config).then(realm => {
+                return new Promise((resolve, reject) => {
+                    TestCase.assertDefined(realm.syncSession.config.custom_http_headers);
+                    TestCase.assertEqual(realm.syncSession.config.custom_http_headers['X-Foo'], 'Bar');
+                    resolve();
+                });
+            });
+        });
+    },
+
     testProperties() {
         return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then(user => {
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What, How & Why?
Realm Object Store provides an API to specify custom HTTP headers when communicating with the sync server.

This closes #1897 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
