### PR TITLE
Add object._setLink()

### DIFF
--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -181,7 +181,10 @@ void RealmObjectClass<T>::set_link(ContextType ctx, ObjectType object, Arguments
                                            accessor.template unbox<int64_t>(args[1]));
     }
 
-    if (row_ndx != realm::not_found) {
+    if (row_ndx == realm::not_found) {
+        realm_object->row().set_null(prop->table_column);
+    }
+    else {
         realm_object->row().set_link(prop->table_column, row_ndx);
     }
 }

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -473,5 +473,87 @@ module.exports = {
         TestCase.assertTrue(new Date('2017-12-07T20:16:03.837Z').toISOString() === objects[0].dateCol.toISOString())
 
         realm.close()
+    },
+
+    testSetLink: function() {
+        const schema = [
+            {
+                name: 'PrimaryInt',
+                primaryKey: 'pk',
+                properties: {
+                    pk: 'int',
+                    value: 'int'
+                }
+            },
+            {
+                name: 'PrimaryOptionalInt',
+                primaryKey: 'pk',
+                properties: {
+                    pk: 'int?',
+                    value: 'int'
+                }
+            },
+            {
+                name: 'PrimaryString',
+                primaryKey: 'pk',
+                properties: {
+                    pk: 'string?',
+                    value: 'int'
+                }
+            },
+            {
+                name: 'Links',
+                properties: {
+                    intLink: 'PrimaryInt',
+                    optIntLink: 'PrimaryOptionalInt',
+                    stringLink: 'PrimaryString'
+                }
+            }
+        ];
+
+        const realm = new Realm({schema: schema});
+        realm.write(function() {
+            realm.create('PrimaryInt', {pk: 1, value: 2})
+            realm.create('PrimaryInt', {pk: 2, value: 4})
+            realm.create('PrimaryOptionalInt', {pk: 1, value: 2})
+            realm.create('PrimaryOptionalInt', {pk: 2, value: 4})
+            realm.create('PrimaryOptionalInt', {pk: null, value: 6})
+            realm.create('PrimaryString', {pk: 'a', value: 2})
+            realm.create('PrimaryString', {pk: 'b', value: 4})
+            realm.create('PrimaryString', {pk: null, value: 6})
+
+            const obj = realm.create('Links', {});
+
+            obj._setLink('intLink', 3);
+            TestCase.assertEqual(obj.intLink, null);
+            obj._setLink('intLink', 1);
+            TestCase.assertEqual(obj.intLink.value, 2);
+            obj._setLink('intLink', 2);
+            TestCase.assertEqual(obj.intLink.value, 4);
+            obj._setLink('intLink', 3);
+            TestCase.assertEqual(obj.intLink.value, 4);
+
+            obj._setLink('optIntLink', 3);
+            TestCase.assertEqual(obj.optIntLink, null);
+            obj._setLink('optIntLink', 1);
+            TestCase.assertEqual(obj.optIntLink.value, 2);
+            obj._setLink('optIntLink', 2);
+            TestCase.assertEqual(obj.optIntLink.value, 4);
+            obj._setLink('optIntLink', null);
+            TestCase.assertEqual(obj.optIntLink.value, 6);
+            obj._setLink('optIntLink', 3);
+            TestCase.assertEqual(obj.optIntLink.value, 6);
+
+            obj._setLink('stringLink', 'c');
+            TestCase.assertEqual(obj.stringLink, null);
+            obj._setLink('stringLink', 'a');
+            TestCase.assertEqual(obj.stringLink.value, 2);
+            obj._setLink('stringLink', 'b');
+            TestCase.assertEqual(obj.stringLink.value, 4);
+            obj._setLink('stringLink', null);
+            TestCase.assertEqual(obj.stringLink.value, 6);
+            obj._setLink('stringLink', 'c');
+            TestCase.assertEqual(obj.stringLink.value, 6);
+        });
     }
 };

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -531,7 +531,7 @@ module.exports = {
             obj._setLink('intLink', 2);
             TestCase.assertEqual(obj.intLink.value, 4);
             obj._setLink('intLink', 3);
-            TestCase.assertEqual(obj.intLink.value, 4);
+            TestCase.assertEqual(obj.intLink, null);
 
             obj._setLink('optIntLink', 3);
             TestCase.assertEqual(obj.optIntLink, null);
@@ -542,7 +542,7 @@ module.exports = {
             obj._setLink('optIntLink', null);
             TestCase.assertEqual(obj.optIntLink.value, 6);
             obj._setLink('optIntLink', 3);
-            TestCase.assertEqual(obj.optIntLink.value, 6);
+            TestCase.assertEqual(obj.optIntLink, null);
 
             obj._setLink('stringLink', 'c');
             TestCase.assertEqual(obj.stringLink, null);
@@ -553,7 +553,7 @@ module.exports = {
             obj._setLink('stringLink', null);
             TestCase.assertEqual(obj.stringLink.value, 6);
             obj._setLink('stringLink', 'c');
-            TestCase.assertEqual(obj.stringLink.value, 6);
+            TestCase.assertEqual(obj.stringLink, null);
         });
     }
 };


### PR DESCRIPTION
`object._setLink('prop', pk)` is semantically equivalent to `object.prop = realm.objectForPrimaryKey('ClassName', pk);` but roughly twice as fast due to a lot fewer intermediate steps and temporary objects. This gives a 10-20% overall speedup to the second pass of the data loader.

I tried making this just happen for normal property assignments rather than a separate function (i.e. `obj.prop = pk`) but it made the whole property validation and conversion pipeline a lot more complicated, and while it's behavior that seems useful in more cases than just the data loader it might be too weird to be worth it.