### PR TITLE
Update build.gradle

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -259,12 +259,12 @@ task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "26.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 
     sourceSets.main {


### PR DESCRIPTION
## What, How & Why?

This closes #1914 by using the root projects values for `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion` and `targetSdkVersion` - it requires that the project that compiles this project exports these values in their `build.gradle` like:

```
ext {
    buildToolsVersion = "26.0.3"
    minSdkVersion = 16
    compileSdkVersion = 26
    targetSdkVersion = 26
    supportLibVersion = "26.1.0"
}
```

NOTE: While this fixes the issue, we might need some changes to the docs to ensure people are setting the above variables in their configurations - or alternatively publish Realm JS as an AAR (https://developer.android.com/studio/projects/android-library) to prevent Realm JS from making assumptions on the build-time environment.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
