### PR TITLE
Change order of Connection notification parameters

### DIFF
--- a/docs/sync.js
+++ b/docs/sync.js
@@ -597,8 +597,12 @@ class Session {
     removeProgressNotification(progressCallback) {}
 
     /**
+     * Registers a connection notification on the session object. This will be notified about changes to the
+     * underlying connection to the Realm Object Server.
      *
-     * @param connectionCallback
+     * @param {callback(newState, oldState)} callback - called with the following arguments:
+     *   - `newState` - the new state of the connection
+     *   - `oldState` - the state the connection transitioned from.
      */
     addConnectionNotification(connectionCallback) {}
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -440,7 +440,7 @@ declare namespace Realm.Sync {
     type ProgressDirection = 'download' | 'upload';
     type ProgressMode = 'reportIndefinitely' | 'forCurrentlyOutstandingWork';
 
-    type ConnectionNotificationCallback = (oldState: ConnectionState, newState: ConnectionState) => void;
+    type ConnectionNotificationCallback = (newState: ConnectionState, oldState: ConnectionState) => void;
 
     /**
     * Session

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -597,7 +597,7 @@ void SessionClass<T>::add_connection_notification(ContextType ctx, FunctionType,
 
         std::function<ConnectionHandler> connectionFunc;
 
-        EventLoopDispatcher<ConnectionHandler> connection_handler([=](SyncSession::ConnectionState new_state, SyncSession::ConnectionState old_state) {
+        EventLoopDispatcher<ConnectionHandler> connection_handler([=](SyncSession::ConnectionState old_state, SyncSession::ConnectionState new_state) {
             HANDLESCOPE
             ValueType callback_arguments[2];
             callback_arguments[0] = Value::from_string(protected_ctx, get_connection_state_value(new_state));

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -214,7 +214,7 @@ public:
     std::string const name = "Session";
     using ProgressHandler = void(uint64_t transferred_bytes, uint64_t transferrable_bytes);
     using StateHandler = void(SyncSession::PublicState old_state, SyncSession::PublicState new_state);
-    using ConnectionHandler = void(SyncSession::ConnectionState old_state, SyncSession::ConnectionState new_state);
+    using ConnectionHandler = void(SyncSession::ConnectionState new_state, SyncSession::ConnectionState old_state);
 
     static FunctionType create_constructor(ContextType);
 
@@ -597,11 +597,11 @@ void SessionClass<T>::add_connection_notification(ContextType ctx, FunctionType,
 
         std::function<ConnectionHandler> connectionFunc;
 
-        EventLoopDispatcher<ConnectionHandler> connection_handler([=](SyncSession::ConnectionState old_state, SyncSession::ConnectionState new_state) {
+        EventLoopDispatcher<ConnectionHandler> connection_handler([=](SyncSession::ConnectionState new_state, SyncSession::ConnectionState old_state) {
             HANDLESCOPE
             ValueType callback_arguments[2];
-            callback_arguments[0] = Value::from_string(protected_ctx, get_connection_state_value(old_state));
-            callback_arguments[1] = Value::from_string(protected_ctx, get_connection_state_value(new_state));
+            callback_arguments[0] = Value::from_string(protected_ctx, get_connection_state_value(new_state));
+            callback_arguments[1] = Value::from_string(protected_ctx, get_connection_state_value(old_state));
             Function<T>::callback(protected_ctx, protected_callback, typename T::Object(), 2, callback_arguments);
         });
 

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -945,7 +945,7 @@ module.exports = {
                 };
                 
                 Realm.open(config).then(realm => {
-                    realm.syncSession.addConnectionNotification((oldState, newState) => {
+                    realm.syncSession.addConnectionNotification((newState, oldState) => {
                         if (oldState === Realm.Sync.ConnectionState.Connected && newState === Realm.Sync.ConnectionState.Disconnected) {
                             resolve('Done');
                         }
@@ -972,10 +972,10 @@ module.exports = {
                 };
                 
                 Realm.open(config).then(realm => {
-                    let callback1 = (oldState, newState) => {
+                    let callback1 = () => {
                         reject("Should not be called");
                     };
-                    let callback2 = (oldState, newState) => {
+                    let callback2 = (newState, oldState) => {
                         if (oldState === Realm.Sync.ConnectionState.Connected && newState === Realm.Sync.ConnectionState.Disconnected) {
                             resolve('Done');
                         }
@@ -1009,7 +1009,7 @@ module.exports = {
                     let session = realm.syncSession;
                     TestCase.assertEqual(session.connectionState, Realm.Sync.ConnectionState.Disconnected);
                     TestCase.assertFalse(session.isConnected());
-                    session.addConnectionNotification((oldState, newState) => {
+                    session.addConnectionNotification((newState, oldState) => {
                         switch (newState) {
                             case Realm.Sync.ConnectionState.Disconnected:
                                 TestCase.assertEqual(session.connectionState, Realm.Sync.ConnectionState.Disconnected);


### PR DESCRIPTION
After input from @kraenhansen, this PR changes the order of callback parameters from `(oldState, newState)` to `(newState, oldState)`. This better supports the common case where you are just interested in the new state and ignore the other parameters.

No changelog update as the functionality has not been released yet.