### PR TITLE
Improve handling of parallel CI jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug fixes
 * React Native for Android now supports the Android Gradle Plugin 3.0 (#1742).
 * [Sync] Fixed distinct queries with query-based sync (broken since v2.11.0).
+* Support parallel run of muliple iOS builds with React Native on the same CI machine.
 
 ### Internals
 * Updated to Object Store commit: 97fd03819f398b3c81c8b007feaca8636629050b


### PR DESCRIPTION
## What, How & Why?

1. Sometimes, it is necessary to run multiple parallel CI jobs on the same physical machine w/o any virtualization or containerization (a good example of that is building an iOS app). To work properly in that environment, realm should download a temp file to it's own unique temp folder to avoid clashes (that are actually fail with `symlink` syscall failing with `EEXISTS`).

2. To avoid an ever-growing temp folder, a new environment variable was introduced, that you can set to be inside a job's folder. That way, CI will be responsible for cleaning up after itself and keeping only the necessary amount of files.

Theoretically, all of that can be solved by overriding `TMP` env
variable but in practice in many-many environments it breaks the other
part of toolchain (even Xcode builds themselves sometimes).

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry