### PR TITLE
Using a GC'ed context will cause a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug fixes
 * React Native for Android now supports the Android Gradle Plugin 3.0 (#1742).
+* [Sync] Fixed a crash in subscription listeners (#1926).
 
 ### Internals
 * Updated to Object Store commit: 97fd03819f398b3c81c8b007feaca8636629050b

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -37,6 +37,7 @@
 #include <jni.h>
 #include "./android/io_realm_react_RealmReactModule.h"
 #include "./android/jni_utils.hpp"
+#include <android/log.h>
 
 extern jclass ssl_helper_class;
 #endif
@@ -763,7 +764,7 @@ void SubscriptionClass<T>::add_listener(ContextType ctx, ObjectType this_object,
 
         ValueType arguments[2];
         arguments[0] = static_cast<ObjectType>(protected_this),
-        arguments[1] = Value::from_number(ctx, static_cast<double>(subscription->state()));
+        arguments[1] = Value::from_number(protected_ctx, static_cast<double>(subscription->state()));
         Function::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
     });
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #1926 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
