### PR TITLE
Update devtoolset from 3 to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-2.15.0 Release notes (YYYY-MM-DD)
+X.Y.Z Release notes (YYYY-MM-DD)
 =============================================================
 ### Compatibility
 * Sync protocol: 24
@@ -26,6 +26,7 @@
 * Updated to Object Store commit: 97fd03819f398b3c81c8b007feaca8636629050b
 * Updated external packages with help from `npm audit`.
 * Upgraded to Realm Sync v3.8.11.
+* Upgraded to devtoolset-6 on Centos for Linux builds.
  
 
 2.14.2 Release notes (2018-8-8)

--- a/packaging/node-pre-gyp/base-image/Dockerfile
+++ b/packaging/node-pre-gyp/base-image/Dockerfile
@@ -20,9 +20,9 @@ RUN touch /var/lib/rpm/* \
         which \
         chrpath \
         openssl-devel \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
-        devtoolset-3-binutils \
+        devtoolset-6-gcc \
+        devtoolset-6-gcc-c++ \
+        devtoolset-6-binutils \
         libconfig-devel \
         jq \
     && yum remove -y g++ gcc \

--- a/packaging/node-pre-gyp/build-image/inside/docker-entrypoint.sh
+++ b/packaging/node-pre-gyp/build-image/inside/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-scl enable devtoolset-3 -- "$@"
+scl enable devtoolset-6 -- "$@"


### PR DESCRIPTION
Centos6 removed the packages for devtoolsets 3, 4 and 5
devtoolset-6 still uses glibc 2.12 and ships with gcc 6.3