### PR TITLE
Fix type definitions for authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Server and open synchronized Realms (#1276).
 
 ### Bug fixes
 * Removed a false negative warning when using `User.createConfiguration`.
+* Fix the type definition for `User.authenticate`.
 
 ### Internal
 * Realm Core v5.7.2.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -321,6 +321,7 @@ declare namespace Realm.Sync {
          */
         static registerWithProvider(server: string, options: { provider: string, providerToken: string, userInfo: any }, callback: (error: Error | null, user: User | null) => void): void;
         static registerWithProvider(server: string, options: { provider: string, providerToken: string, userInfo: any }): Promise<Realm.Sync.User>;
+        static authenticate(server: string, provider: string, options: any): Promise<Realm.Sync.User>;
 
         static requestPasswordReset(server: string, email: string): Promise<void>;
 
@@ -333,7 +334,6 @@ declare namespace Realm.Sync {
         static deserialize(serialized: SerializedUser): Realm.Sync.User;
 
         createConfiguration(config?: Realm.PartialConfiguration): Realm.Configuration
-        authenticate(server: string, provider: string, options: any): Promise<Realm.Sync.User>;
         serialize(): SerializedUser;
         logout(): void;
         openManagementRealm(): Realm;


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
