### PR TITLE
Add param type to addConnectionNotification/removeConnectionNotification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Server and open synchronized Realms (#1276).
 ### Bug fixes
 * Removed a false negative warning when using `User.createConfiguration`.
 * Fixed the type definition for `User.authenticate`.
+* Fixed the type definitions for `Session.addConnectionNotification` and `Session.removeConnectionNotification`
 
 ### Internal
 * Realm Core v5.7.2.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -466,8 +466,8 @@ declare namespace Realm.Sync {
         addProgressNotification(direction: ProgressDirection, mode: ProgressMode, progressCallback: ProgressNotificationCallback): void;
         removeProgressNotification(progressCallback: ProgressNotificationCallback): void;
 
-        addConnectionNotification(callback): void;
-        removeConnectionNotification(callback): void;
+        addConnectionNotification(callback: ConnectionNotificationCallback): void;
+        removeConnectionNotification(callback: ConnectionNotificationCallback): void;
 
         isConnected(): boolean;
     }


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
This PR adds the `ConnectionNotificationCallback` type to the `callback` parameter of both `Session#addConnectionNotification` and `Session#removeConnectionNotification`.

Since the `ConnectionNotificationCallback` type alias was present but unused, I suspect this has been an oversight when adding those methods to the typings.

Without an explicit type, the `callback` parameter is implicitly inferred as `any`, causing a TypeScript build to fail if `--strict=true`

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
