### PR TITLE
Fixed the type definition for Realm.Permissions.User

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -578,7 +578,7 @@ declare namespace Realm.Permissions {
 
     class User {
         static schema: ObjectSchema;
-        identity: string;
+        id: string;
     }
 
     class Role {


### PR DESCRIPTION
The `identity` field was wrong, it should have been `id` instead because that is the name of the field in Realm studio

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
The `identity` field was wrong, it should have been `id` instead

This closes #2012 

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
