### PR TITLE
Fix memory corruption in `writeCopyTo`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Server and open synchronized Realms (#1276).
 * Fixed the type definition for `User.authenticate`.
 * Added `Realm.Sync.Subscription.removeAllListeners()` to the `Subscription` proxy class used when debugging a React Native app (#479).
 * Fixed the type definitions for `Session.addConnectionNotification` and `Session.removeConnectionNotification`
+* Fixed a memory corruption in `writeCopyTo`
 
 ### Internal
 * Realm Core v5.7.2.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1098,18 +1098,24 @@ void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Argumen
     }
 
     std::string path = Value::validated_to_string(ctx, pathValue);
-    BinaryData key;
-    if (args.count == 2) {
-        ValueType key_value = args[1];
-        if (!Value::is_binary(ctx, key_value)) {
-            throw std::runtime_error("Encryption key for 'writeCopyTo' must be a Binary.");
-        }
 
-        auto key_data = Value::validated_to_binary(ctx, key_value);
-        key = { static_cast<const char *>(key_data.data()), key_data.size() };
+    if (args.count == 1) {
+        BinaryData empty_encryption_key;
+        realm->write_copy(path, empty_encryption_key);
+
+        return;
     }
 
-    realm->write_copy(path, key);
+    // enryption key is specified
+    ValueType encryption_key_arg = args[1];
+
+    if (!Value::is_binary(ctx, encryption_key_arg)) {
+        throw std::runtime_error("Encryption key for 'writeCopyTo' must be a Binary.");
+    }
+
+    auto encryption_key = Value::validated_to_binary(ctx, encryption_key_arg);
+
+    realm->write_copy(path, encryption_key.get());
 }
 
 template<typename T>

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1286,11 +1286,9 @@ module.exports = {
         TestCase.assertEqual(managedObj.objectCol.doubleCol, 1);
         TestCase.assertEqual(managedObj.nullObjectCol, null);
         TestCase.assertEqual(managedObj.arrayCol[0].doubleCol, 2);
-    }
+    },
 
 
-    // FIXME: reanble test
-    /*
     testWriteCopyTo: function() {
         const realm = new Realm({schema: [schemas.IntPrimary, schemas.AllTypes, schemas.TestObject, schemas.LinkToAllTypes]});
 
@@ -1307,7 +1305,11 @@ module.exports = {
             realm.writeCopyTo(34);
         }, "Argument to 'writeCopyTo' must be a String.");
 
-        const copyName = "testWriteCopy.realm";
+        // make sure that copies are in the same directory as the original file
+        // that is important for running tests on mobile devices,
+        // so we don't have issues with permissisons
+        const copyName = realm.path + ".copy.realm";
+
         realm.writeCopyTo(copyName);
 
         const copyConfig = { path: copyName };
@@ -1316,10 +1318,11 @@ module.exports = {
         realmCopy.close();
 
         TestCase.assertThrowsContaining(() => {
-            realm.writeCopyTo("testWriteCopyWithInvalidKey.realm", "hello");
+            realm.writeCopyTo(realm.path + ".copy-invalid-key.realm", "hello");
         }, "Encryption key for 'writeCopyTo' must be a Binary.");
 
-        const encryptedCopyName = "testWriteEncryptedCopy.realm";
+        const encryptedCopyName = realm.path + ".copy-encrypted.realm";
+
         var encryptionKey = new Int8Array(64);
         for(let i=0; i < 64; i++) {
             encryptionKey[i] = 1;
@@ -1332,5 +1335,5 @@ module.exports = {
         encryptedRealmCopy.close();
 
         realm.close();
-    }*/
+    }
 };


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
We found an issue that it isn't possible to open a realm database if it was created as a copy using `writeCopyTo` and providing an encryption key.
The error looked like that:
```
1) RealmTests : testWriteCopyTo
   Error: Unable to open a realm at path '/Users/mandrigin/golang/src/github.com/realm/realm-js/tests/default.realm.copy.realm': Invalid mnemonic. top_ref[0]: 528EB59E00000001, top_ref[1]: E008049A66C646D4, mnemonic: D1 77 E4 5C, fmt[0]: 64, fmt[1]: 63, flags: F4.
       at Error (native)
```

After investigation, we noticed a memory corruption in the key, when it was sent to `write_copy`.
```
writeCopyTo / key data is: 
[0]=31 [1]=31 [2]=31 [3]=31 [4]=31 [5]=31 [6]=31 [7]=31 [8]=31 [9]=31 [10]=31 [11]=31 [12]=31 [13]=31 [14]=31 [15]=31 [16]=31 [17]=31 [18]=31 [19]=31 [20]=31 [21]=31 [22]=31 [23]=31 [24]=31 [25]=31 [26]=31 [27]=31 [28]=31 [29]=31 [30]=31 [31]=31 [32]=31 [33]=31 [34]=31 [35]=31 [36]=31 [37]=31 [38]=31 [39]=31 [40]=31 [41]=31 [42]=31 [43]=31 [44]=31 [45]=31 [46]=31 [47]=31 [48]=31 [49]=31 [50]=31 [51]=31 [52]=31 [53]=31 [54]=31 [55]=31 [56]=31 [57]=31 [58]=31 [59]=31 [60]=31 [61]=31 [62]=31 [63]=31

ERROR: Connection[1]: Failed to connect to endpoint '::1:9080': Connection refused
write_copy / key data is: [0]=ffffffad [1]=ffffffbe [2]=ffffffab [3]=fffffff9 [4]=68 [5]=6a [6]=ffffffdd [7]=ffffffba [8]=ffffff80 [9]=ffffff82 [10]=07 [11]=00 [12]=00 [13]=60 [14]=00 [15]=00 [16]=31 [17]=31 [18]=31 [19]=31 [20]=31 [21]=31 [22]=31 [23]=31 [24]=31 [25]=31 [26]=31 [27]=31 [28]=31 [29]=31 [30]=31 [31]=31 [32]=31 [33]=31 [34]=31 [35]=31 [36]=31 [37]=31 [38]=31 [39]=31 [40]=31 [41]=31 [42]=31 [43]=31 [44]=31 [45]=31 [46]=31 [47]=31 [48]=31 [49]=31 [50]=31 [51]=31 [52]=31 [53]=31 [54]=31 [55]=31 [56]=31 [57]=31 [58]=31 [59]=31 [60]=31 [61]=31 [62]=31 [63]=31
```

**Gotcha**: this was only reproducible on iOS 10+ and Android, tests on macos always passed. Probably iOS 8 and 9 and macos have more relaxed memory optimizations.

After a closer look, it seems like this code was responsible for that (my comments):
```cpp
    BinaryData key;
    
    if (args.count == 2) {
        ValueType key_value = args[1];
        if (!Value::is_binary(ctx, key_value)) {
            throw std::runtime_error("Encryption key for 'writeCopyTo' must be a Binary.");
        }
        auto key_data = Value::validated_to_binary(ctx, key_value); // we create a local variable here
        key = { static_cast<const char *>(key_data.data()), key_data.size() }; // it's a pointer to the `key_data`
     } // here, `key_data` is freed and it's memory is up for grabs

     realm->write_copy(path, key); // key.data() points to a unused memory that can be overriden
}
```

I restructured the code a little bit and this bug doesn't appear anymore.

#### Steps to verify the problem
0) Override `tests/js/realm-tests.js` with the version from this PR (required to work well on a mobile device).
1) Tweak `scripts/test.sh` to run on a modern iOS (I hardcoded `IOS_RUNTIME='com.apple.CoreSimulator.SimRuntime.iOS-11-0'` locally)
2) Remove and update dependencies of the react-test-app:
`pushd tests/react-test-app && rm -rf node_modules && npm install && popd`
3) `scripts/test.sh react-tests`

**Expected**: `testWriteCopyTo` fails with something like `Invalid mnemonic. top_ref[0]: 528EB59E00000001, top_ref[1]: E008049A66C646D4, mnemonic: D1 77 E4 5C, fmt[0]: 64, fmt[1]: 63, flags: F4.`


#### Steps to verify the solution
1) Tweak `scripts/test.sh` to run on a modern iOS (I hardcoded `IOS_RUNTIME='com.apple.CoreSimulator.SimRuntime.iOS-11-0'` locally)
2) Remove and update dependencies of the react-test-app:
`pushd tests/react-test-app && rm -rf node_modules && npm install && popd`
3) `scripts/test.sh react-tests`

**Expected**:`testWriteCopyTo` should pass successfully.


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 🚦 Tests