### PR TITLE
Fix typescript definitions for privileges() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ X.Y.Z Release notes
 
 ### Bug fixes
 * Fixed the type definition for `Realm.Permissions.User`. Thanks to @apperside! ([#2012](https://github.com/realm/realm-js/issues/2012), since v2.3.0-beta.2)
+* Fixed the type definition for `Realm.getPrivileges()`, `Realm.getPrivileges(className)` and `Realm.getPrivileges(object)`. ([#2030](https://github.com/realm/realm-js/pull/2030), since v2.2.14)
 
 ### Compatibility
 * Realm Object Server: 3.0.0 or later
@@ -36,7 +37,6 @@ X.Y.Z Release notes
 * Added support for `LIMIT` in queries to restrict the size of the results set. This is in particular useful for query-based synced Realms. An example of the syntax is `age >= 20 LIMIT(2)`. ([#2008](https://github.com/realm/realm-js/pull/2008))
 
 ### Bug fixes
-* Type definition for `Realm.getPrivileges()`, `Realm.getPrivileges(className)` and `Realm.getPrivileges(object)` ([#2030](https://github.com/realm/realm-js/pull/2030)). Introduced in v2.2.14.
 * Fixed the type definition for `User.authenticate()`. ([#2000](https://github.com/realm/realm-js/pull/2000), since v2.2.0)
 * Added `Realm.Sync.Subscription.removeAllListeners()` to the `Subscription` proxy class used when debugging a React Native app. ([#474](https://github.com/realm/realm-js-private/issues/474), since v2.3.2)
 * Fixed a memory corruption in `writeCopyTo()` when using encryption. This could be experienced as: `Error: Unable to open a realm at path ...`. Thanks to @mandrigin! ([#1748](https://github.com/realm/realm-js/issues/1748), since v2.3.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ X.Y.Z Release notes
 * Added support for `LIMIT` in queries to restrict the size of the results set. This is in particular useful for query-based synced Realms. An example of the syntax is `age >= 20 LIMIT(2)`. ([#2008](https://github.com/realm/realm-js/pull/2008))
 
 ### Bug fixes
-* Type definition for `Realm.getPrivileges()`, `Realm.getPrivileges(className)` and `Realm.getPrivileges(object)` ([#XXXX](TODO)).
+* Type definition for `Realm.getPrivileges()`, `Realm.getPrivileges(className)` and `Realm.getPrivileges(object)` ([#2030](https://github.com/realm/realm-js/pull/2030)). Introduced in v2.2.14.
 * Fixed the type definition for `User.authenticate()`. ([#2000](https://github.com/realm/realm-js/pull/2000), since v2.2.0)
 * Added `Realm.Sync.Subscription.removeAllListeners()` to the `Subscription` proxy class used when debugging a React Native app. ([#474](https://github.com/realm/realm-js-private/issues/474), since v2.3.2)
 * Fixed a memory corruption in `writeCopyTo()` when using encryption. This could be experienced as: `Error: Unable to open a realm at path ...`. Thanks to @mandrigin! ([#1748](https://github.com/realm/realm-js/issues/1748), since v2.3.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 X.Y.Z Release notes
 =============================================================
+
 ### Bug fixes
 * Fixed the type definition for `Realm.Permissions.User`. Thanks to @apperside! ([#2012](https://github.com/realm/realm-js/issues/2012), since v2.3.0-beta.2)
 
@@ -35,6 +36,7 @@ X.Y.Z Release notes
 * Added support for `LIMIT` in queries to restrict the size of the results set. This is in particular useful for query-based synced Realms. An example of the syntax is `age >= 20 LIMIT(2)`. ([#2008](https://github.com/realm/realm-js/pull/2008))
 
 ### Bug fixes
+* Type definition for `Realm.getPrivileges()`, `Realm.getPrivileges(className)` and `Realm.getPrivileges(object)` ([#XXXX](TODO)).
 * Fixed the type definition for `User.authenticate()`. ([#2000](https://github.com/realm/realm-js/pull/2000), since v2.2.0)
 * Added `Realm.Sync.Subscription.removeAllListeners()` to the `Subscription` proxy class used when debugging a React Native app. ([#474](https://github.com/realm/realm-js-private/issues/474), since v2.3.2)
 * Fixed a memory corruption in `writeCopyTo()` when using encryption. This could be experienced as: `Error: Unable to open a realm at path ...`. Thanks to @mandrigin! ([#1748](https://github.com/realm/realm-js/issues/1748), since v2.3.4)

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -153,7 +153,7 @@ class Realm {
     close() {}
 
     /**
-     * Returns the granted privilges.
+     * Returns the granted privileges.
      *
      * This combines all privileges granted on the Realm/Class/Object by all Roles which
      * the current User is a member of into the final privileges which will
@@ -166,10 +166,11 @@ class Realm {
      *
      * Non-synchronized Realms always have permission to perform all operations.
      *
-     * @param {(Realm~ObjectType|Realm.Object)} arg - the object type or the object to compute priviliges from
-     * @returns {Object} as the computed priviliges as properties
+     * @param {(Realm~ObjectType|Realm.Object|[arg])} arg - the object type or the object to compute privileges from. If no
+     *   argument is given, the privileges for the Realm is returned.
+     * @returns {Object} as the computed privileges as properties
      * @since 2.3.0
-     * @see {Realm.Permissions} for details of priviliges and roles.
+     * @see {Realm.Permissions} for details of privileges and roles.
      */
     privileges(arg) {}
 

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -166,7 +166,7 @@ class Realm {
      *
      * Non-synchronized Realms always have permission to perform all operations.
      *
-     * @param {(Realm~ObjectType|Realm.Object|[arg])} arg - the object type or the object to compute privileges from. If no
+     * @param {(Realm~ObjectType|Realm.Object)} arg - the object type or the object to compute privileges from. If no
      *   argument is given, the privileges for the Realm is returned.
      * @returns {Object} as the computed privileges as properties
      * @since 2.3.0

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -580,13 +580,13 @@ declare namespace Realm.Permissions {
         static schema: ObjectSchema;
 
         identity: string;
+        canCreate: boolean;
         canRead: boolean;
         canUpdate: boolean;
         canDelete: boolean;
-        canSetPermissions: boolean;
         canQuery: boolean;
-        canCreate: boolean;
         canModifySchema: boolean;
+        canSetPermissions: boolean;
     }
 
     class User {
@@ -609,6 +609,29 @@ declare namespace Realm.Permissions {
     class Realm {
         static schema: ObjectSchema;
         permissions: Permission[];
+    }
+
+    class RealmPrivileges {
+        canRead: boolean;
+        canUpdate: boolean;
+        canModifySchema: boolean;
+        canSetPermissions: boolean;
+    }
+
+    class ClassPrivileges {
+        canCreate: boolean
+        canRead: boolean;
+        canUpdate: boolean;
+        canQuery: boolean;
+        canModifySchema: boolean;
+        canSetPermissions: boolean;
+    }
+
+    class ObjectPrivileges {
+        canRead: boolean;
+        canUpdate: boolean;
+        canDelete: boolean;
+        canSetPermissions: boolean;
     }
 }
 
@@ -778,9 +801,9 @@ declare class Realm {
      */
     writeCopyTo(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): void;
 
-    privileges() : Realm.Permissions.Realm;
-    privileges(objectType: string | Realm.ObjectSchema | Function) : Realm.Permissions.Class;
-    privileges(obj: Realm.Object) : Realm.Permissions.Class;
+    privileges() : Realm.Permissions.RealmPrivileges;
+    privileges(objectType: string | Realm.ObjectSchema | Function) : Realm.Permissions.ClassPrivileges;
+    privileges(obj: Realm.Object) : Realm.Permissions.ObjectPrivileges;
 }
 
 declare module 'realm' {


### PR DESCRIPTION
Even though you can access all properties in the `RealmPrivileges/ClassPrivileges/ObjectPrivileges` classes, I only exposed those with actual meaning in the definitions. This is in line with what Swift/Java does.


