### PR TITLE
Logging in using an admin token should be synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ x.x.x Release notes (yyyy-MM-dd)
 * None
 
 ### Fixes
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fixed a bug where logging in using an admin token returned a promise. The correct behavior is to be synchronious. (related to [#2037](https://github.com/realm/realm-js/issues/2037), since v2.16.1)
 
 ### Compatibility
 * File format: ver. 7 (upgrades automatically from previous formats)
 * Realm Object Server: 3.11.0 or later.
 * APIs are backwards compatible with all previous release of realm in the 2.x.y series.
- 
+
  ### Internal
 * None
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Compatibility
 * File format: ver. 7 (upgrades automatically from previous formats)
-* Realm Object Server: 3.11.0 or later.
+* Realm Object Server: 3.0.0 or later.
 * APIs are backwards compatible with all previous release of realm in the 2.x.y series.
 
  ### Internal
@@ -24,7 +24,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Compatibility
 * File format: ver. 7 (upgrades automatically from previous formats)
-* Realm Object Server: 3.11.0 or later.
+* Realm Object Server: 3.0.0 or later.
 * APIs are backwards compatible with all previous release of realm in the 2.x.y series.
 
  ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None
 
 ### Fixes
-* Fixed a bug where logging in using an admin token returned a promise. The correct behavior is to be synchronious. (related to [#2037](https://github.com/realm/realm-js/issues/2037), since v2.16.1)
+* Fixed a bug where logging in using an admin token returned a promise. The correct behavior is to be synchronous. (related to [#2037](https://github.com/realm/realm-js/issues/2037), since v2.16.1)
 
 ### Compatibility
 * File format: ver. 7 (upgrades automatically from previous formats)

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -382,7 +382,7 @@ const staticMethods = {
         checkTypes(arguments, ['string', 'object']);
         if (credentials.identityProvider === 'adminToken') {
             let u = this._adminUser(server, credentials.token);
-            return Promise.resolve(u);
+            return u;
         }
 
         return _authenticate(this, server, credentials);

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -29,7 +29,7 @@ function node_require(module) {
     return require_method(module);
 }
 
- let fs;
+let fs;
 if (isNodeProcess) {
   fs = node_require('fs');
 }
@@ -206,12 +206,8 @@ module.exports = {
     let token = obj['ADMIN_TOKEN'];
 
     let credentials = Realm.Sync.Credentials.adminToken(token);
-    return Realm.Sync.User.login('http://localhost:9080', credentials)
-      .then((user) => {
-        TestCase.assertTrue(user.isAdmin);
-        Promise.resolve();
-      })
-      .catch((e) => { Promise.reject(e) } );
+    let user = Realm.Sync.User.login('http://localhost:9080', credentials);
+    TestCase.assertTrue(user.isAdmin);
   },
 
   testAll() {


### PR DESCRIPTION
By mistake, #2038 let logging in an admin user to be asynchronous. This PR corrects this.