### PR TITLE
Handle sync config in Realm.deleteFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ x.x.x Release notes (yyyy-MM-dd)
   
 ### Fixes
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Allow `Realm.deleteFile` to be used with a sync configuration. Previously, only local Realms could be deleted with this API
+and the `sync` property on the configuration would be ignored. ([#2045](https://github.com/realm/realm-js/pull/2045), since v1.0.0)
 
 ### Compatibility
 * File format: ver. 7 (upgrades automatically from previous formats)
 * Realm Object Server: 3.11.0 or later.
 * APIs are backwards compatible with all previous release of realm in the 2.x.y series.
- 
+
  ### Internal
 * None
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm",
-  "version": "2.15.3",
+  "version": "2.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -701,17 +701,20 @@ void RealmClass<T>::delete_file(ContextType ctx, ObjectType this_object, Argumen
 
     static const String path_string = "path";
     ValueType path_value = Object::get_property(ctx, config_object, path_string);
-    ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
     if (!Value::is_undefined(ctx, path_value)) {
         config.path = Value::validated_to_string(ctx, path_value, "path");
     }
-    #if REALM_ENABLE_SYNC
-    else if (!Value::is_undefined(ctx, sync_config_value)) {
-        SyncClass<T>::populate_sync_config(ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")), config_object, config);
-    }
-    #endif
-    else if (config.path.empty()) {
-        config.path = js::default_path();
+    else {
+        #if REALM_ENABLE_SYNC
+        ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
+        if (!Value::is_undefined(ctx, sync_config_value)) {
+            SyncClass<T>::populate_sync_config(ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")), config_object, config);
+        }
+        #endif
+
+        if (config.path.empty()) {
+            config.path = js::default_path();
+        }
     }
 
     config.path = normalize_realm_path(config.path);

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -517,13 +517,6 @@ void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, size_t 
                 schema_updated = true;
             }
 
-            objectsSchema.insert(objectsSchema.end(), std::make_move_iterator(config.schema->begin()),
-                                                      std::make_move_iterator(config.schema->end()));
-
-            config.schema.emplace(realm::Schema(objectsSchema));
-        }
-#endif
-
             static const String schema_version_string = "schemaVersion";
             ValueType version_value = Object::get_property(ctx, object, schema_version_string);
             if (!Value::is_undefined(ctx, version_value)) {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -18,6 +18,13 @@
 
 'use strict';
 
+const require_method = require;
+
+// Prevent React Native packager from seeing modules required with this
+function nodeRequire(module) {
+    return require_method(module);
+}
+
 const Realm = require('realm');
 const TestCase = require('./asserts');
 const schemas = require('./schemas');
@@ -28,7 +35,7 @@ if (isNodeProcess && process.platform === 'win32') {
     pathSeparator = '\\';
 }
 
-const fs = isNodeProcess ? require('fs-extra') : require('react-native-fs');
+const fs = isNodeProcess ? nodeRequire('fs-extra') : require('react-native-fs');
 
 module.exports = {
     testRealmConstructor: function() {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -23,9 +23,12 @@ const TestCase = require('./asserts');
 const schemas = require('./schemas');
 
 let pathSeparator = '/';
-if (typeof process === 'object' && process.platform === 'win32') {
+const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';
+if (isNodeProcess && process.platform === 'win32') {
     pathSeparator = '\\';
 }
+
+const fs = isNodeProcess ? require('fs-extra') : require('react-native-fs');
 
 module.exports = {
     testRealmConstructor: function() {
@@ -1078,6 +1081,36 @@ module.exports = {
         const realm2 = new Realm(config);
         TestCase.assertEqual(realm2.objects('TestObject').length, 0);
         realm.close();
+    },
+
+    testRealmDeleteFileSyncConfig: function() {
+        if (!global.enableSyncTests) {
+            return;
+        }
+
+        return Realm.Sync.User
+            .login('http://localhost:9080', Realm.Sync.Credentials.anonymous())
+            .then(user => {
+                const config = {
+                    schema: [schemas.TestObject],
+                    sync: {user, url: 'realm://localhost:9080/~/test', fullSynchronization: true },
+                };
+
+                const realm = new Realm(config);
+                const path = realm.path;
+                realm.close();
+
+                return fs.exists(path)
+                    .then(pathExistBeforeDelete => {
+                        TestCase.assertTrue(pathExistBeforeDelete);
+                        Realm.deleteFile(config);
+
+                        return fs.exists(path)
+                    })
+                    .then(pathExistAfterDelete => {
+                        TestCase.assertFalse(pathExistAfterDelete);
+                    });
+            });
     },
 
     testRealmDeleteRealmIfMigrationNeededVersionChanged: function() {


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
This allows us to delete Realm files by passing in a sync config.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] ~📝 Public documentation PR created or is not necessary~
* [ ] ~💥 `Breaking` label has been applied or is not necessary~
