### PR TITLE
Expose customQueryBasedSyncIdentifier in the sync config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Added `SyncConfig.customQueryBasedSyncIdentifier` to allow customizing the identifier appended to the realm path
+when opening a query based Realm. This identifier is used to distinguish between query based Realms opened on
+different devices and by default Realm builds it as a combination of a user's id and a random string, allowing the
+same user to subscribe to different queries on different devices. In very rare cases, you may want to share query
+based Realms between devices and specifying the `customQueryBasedSyncIdentifier` allows you to do that.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -43,7 +43,10 @@
  *    synchronization mode. The default is query-based mode which only synchronizes objects that have been subscribed to.
  *    A fully synchronized Realm will synchronize the entire Realm in the background, irrespectively of the data being
  *    used or not.
- * @property {Object} [custom_http_header] - A map (string, string) of custom HTTP headers.
+ * @property {Object} [custom_http_headers] - A map (string, string) of custom HTTP headers.
+ * @property {string} [customQueryBasedSyncIdentifier] - A custom identifier to append to the Realm url rather than the default
+ *    identifier which is comprised of the user id and a random string. It allows you to reuse query based Realms across
+ *    different devices.
  */
 
 /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -448,6 +448,7 @@ declare namespace Realm.Sync {
         fullSynchronization?: boolean;
         _disableQueryBasedSyncUrlChecks?:boolean;
         custom_http_headers?: { [header: string]: string };
+        customQueryBasedSyncIdentifier?: string;
     }
 
     enum ConnectionState {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -990,6 +990,11 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         config.sync_config->error_handler = std::move(error_handler);
         config.sync_config->is_partial = is_partial;
 
+        ValueType custom_partial_sync_identifier_value = Object::get_property(ctx, sync_config_object, "customQueryBasedSyncIdentifier");
+        if (!Value::is_undefined(ctx, custom_partial_sync_identifier_value)) {
+            config.sync_config->custom_partial_sync_identifier = std::string(Value::validated_to_string(ctx, custom_partial_sync_identifier_value, "customQueryBasedSyncIdentifier"));
+        }
+
         // Custom HTTP headers
         ValueType sync_custom_http_headers_value = Object::get_property(ctx, sync_config_object, "custom_http_headers");
         if (!Value::is_undefined(ctx, sync_custom_http_headers_value)) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -759,7 +759,6 @@ module.exports = {
             });
     },
 
-
     // All tests releated to partial sync is assemble in one big test.
     // Since it is the same instance of ROS running, it is virtually impossible
     // to reset the state between the tests.
@@ -776,19 +775,19 @@ module.exports = {
         const expectedObjectsCount = 3;
 
         function __partialIsAllowed() {
-                // test: __partial is allowed
-                let config1 = {
-                    sync: {
-                        user: user,
-                        url: `realm://localhost:9080/default/__partial/`,
-                        _disableQueryBasedSyncUrlChecks: true,
-                        fullSynchronization: false,
-                    },
-                    schema: [ { name: 'Dog', properties: { name: 'string' } } ]
-                };
-                const realm = new Realm(config1);
-                TestCase.assertFalse(realm.isClosed);
-                realm.close();
+            // test: __partial is allowed
+            let config1 = {
+                sync: {
+                    user: user,
+                    url: `realm://localhost:9080/default/__partial/`,
+                    _disableQueryBasedSyncUrlChecks: true,
+                    fullSynchronization: false,
+                },
+                schema: [ { name: 'Dog', properties: { name: 'string' } } ]
+            };
+            const realm = new Realm(config1);
+            TestCase.assertFalse(realm.isClosed);
+            realm.close();
         }
 
         function __partialIsNotAllowed() {
@@ -800,6 +799,35 @@ module.exports = {
                 }
             };
             TestCase.assertThrows(() => new Realm(config2));
+        }
+
+        function customPartialSyncIdentifier() {
+            const customRealm = new Realm({
+                schema: [ { name: 'Dog', properties: { name: 'string' } } ],
+                sync: {
+                    user,
+                    url: 'realm://localhost:9080/default',
+                    fullSynchronization: false,
+                    customQueryBasedSyncIdentifier: "foo/bar",
+                }
+            });
+
+            // Ensure that the custom partial sync identifier was picked up and appended to the url
+            TestCase.assertTrue(customRealm.path.endsWith(encodeURIComponent("default/__partial/foo/bar")));
+            customRealm.close();
+
+            const basicRealm = new Realm({
+                schema: [ { name: 'Dog', properties: { name: 'string' } } ],
+                sync: {
+                    user,
+                    url: 'realm://localhost:9080/default',
+                    fullSynchronization: false,
+                }
+            });
+
+            // Sanity check - when there's no custom identifier, it should not end in /foo/bar
+            TestCase.assertFalse(basicRealm.path.endsWith(encodeURIComponent("default/__partial/foo/bar")));
+            customRealm.close();
         }
 
         function shouldFail() {
@@ -834,6 +862,7 @@ module.exports = {
                     __partialIsNotAllowed();
                     shouldFail();
                     defaultRealmInvalidArguments();
+                    customPartialSyncIdentifier();
 
                     return new Promise((resolve, reject) => {
                         let config = Realm.Sync.User.current.createConfiguration();
@@ -901,7 +930,6 @@ module.exports = {
                 });
             });
     },
-
 
     testClientReset() {
         // FIXME: try to enable for React Native

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -827,7 +827,7 @@ module.exports = {
 
             // Sanity check - when there's no custom identifier, it should not end in /foo/bar
             TestCase.assertFalse(basicRealm.path.endsWith(encodeURIComponent("default/__partial/foo/bar")));
-            customRealm.close();
+            basicRealm.close();
         }
 
         function shouldFail() {


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
This is needed by the GraphQL service to prevent creating multiple query based Realms.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
