### PR TITLE
Restore support for opening query-based sync Realms with a dynamic schema

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -425,41 +425,18 @@ module.exports = function(realmConstructor) {
                 }
             }
         }));
+
+        Object.defineProperties(realmConstructor, getOwnPropertyDescriptors({
+            _extendQueryBasedSchema(schema) {
+                addSchemaIfNeeded(schema, realmConstructor.Permissions.Class);
+                addSchemaIfNeeded(schema, realmConstructor.Permissions.Permission);
+                addSchemaIfNeeded(schema, realmConstructor.Permissions.Realm);
+                addSchemaIfNeeded(schema, realmConstructor.Permissions.Role);
+                addSchemaIfNeeded(schema, realmConstructor.Permissions.User);
+                addSchemaIfNeeded(schema, realmConstructor.Subscription.ResultSets);
+            },
+        }));
     }
-
-    // Realm instance methods that are always available
-    Object.defineProperties(realmConstructor.prototype, getOwnPropertyDescriptors({
-
-        /**
-         * Extra internal constructor callback called by the C++ side.
-         * Used to work around the fact that we cannot override the original constructor,
-         * but still need to modify any input config.
-         */
-        _constructor(config) {
-            // Even though this runs code only available for Sync it requires some serious misconfiguration
-            // for this to happen
-            if (config && config.sync) {
-                if (!Realm.Sync) {
-                    throw new Error("Realm is not compiled with Sync, but the configuration contains sync features.");
-                }
-                // Only inject schemas on query-based Realms
-                if (config.sync.partial === true || config.sync.fullSynchronization === false) {
-                    if (!config.schema) {
-                        config['schema'] = [];
-                    }
-
-                    addSchemaIfNeeded(config.schema, realmConstructor.Permissions.Class);
-                    addSchemaIfNeeded(config.schema, realmConstructor.Permissions.Permission);
-                    addSchemaIfNeeded(config.schema, realmConstructor.Permissions.Realm);
-                    addSchemaIfNeeded(config.schema, realmConstructor.Permissions.Role);
-                    addSchemaIfNeeded(config.schema, realmConstructor.Permissions.User);
-                    addSchemaIfNeeded(config.schema, realmConstructor.Subscription.ResultSets);
-                }
-            }
-            return config;
-        },
-    }));
-
 
     // TODO: Remove this now useless object.
     var types = Object.freeze({

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -33,25 +33,6 @@ function setConstructorOnPrototype(klass) {
     }
 }
 
-// Return a configuration usable by `Realm.open` when waiting for a download.
-// It must have caching disabled, and no schema or schema version specified.
-function waitForDownloadConfig(config) {
-    if (!config) {
-        return {_cache: false};
-    }
-
-    if (typeof config == 'string') {
-        return {path: config, _cache: false};
-    }
-
-    if (typeof config == 'object') {
-        return Object.assign({}, config, {schema: undefined, schemaVersion: undefined, _cache: false});
-    }
-
-    // Unknown type. Pass the config through.
-    return config;
-}
-
 /**
  * Finds the permissions associated with a given Role or create them as needed.
  *
@@ -118,23 +99,14 @@ module.exports = function(realmConstructor) {
 
             let syncSession;
             let promise = new Promise((resolve, reject) => {
-                let realm = new realmConstructor(waitForDownloadConfig(config));
-                realm._waitForDownload(
-                    (session) => { syncSession = session; },
-                    (error) => {
-                        realm.close();
-                        if (error) {
-                            setTimeout(() => { reject(error); }, 1);
-                        }
-                        else {
-                            try {
-                                let syncedRealm = new realmConstructor(config);
-                                setTimeout(() => { resolve(syncedRealm); }, 1);
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    });
+                syncSession = realmConstructor._asyncOpen(config, (realm, error) => {
+                    if (error) {
+                        setTimeout(() => { reject(error); }, 1);
+                    }
+                    else {
+                        setTimeout(() => { resolve(realm); }, 1);
+                    }
+                });
             });
 
             promise.progress = (callback) => {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -376,6 +376,11 @@ public:
             }
         }
 
+        // Beginning a read transaction may reread the schema, invalidating the
+        // pointer that we're returning. Avoid this by ensuring that we're in a
+        // read transaction before we search the schema.
+        realm->read_group();
+
         auto &schema = realm->schema();
         auto object_schema = schema.find(object_type);
 

--- a/tests/js/permission-tests.js
+++ b/tests/js/permission-tests.js
@@ -274,46 +274,44 @@ module.exports = {
     },
 
     testAddPermissionSchemaForQueryBasedRealmOnly() {
-        return new Promise((resolve, reject) => {
-            Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then((user) => {
-                let config = {
-                    sync: {
-                        user: user,
-                        url: `realm://NO_SERVER/foo`,
-                        fullSynchronization: false,
-                    }
-                };
+        return Realm.Sync.User.register('http://localhost:9080', uuid(), 'password').then((user) => {
+            let config = {
+                schema: [],
+                sync: {
+                    user: user,
+                    url: `realm://NO_SERVER/foo`,
+                    fullSynchronization: false,
+                }
+            };
 
-                let realm = new Realm(config);
-                TestCase.assertTrue(realm.empty);
+            let realm = new Realm(config);
+            TestCase.assertTrue(realm.empty);
 
-                TestCase.assertEqual(realm.schema.length, 5 + 1); // 5 = see below, 1 = __ResultSets
-                TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Class').length, 1);
-                TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Permission').length, 1);
-                TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Realm').length, 1);
-                TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Role').length, 1);
-                TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__User').length, 1);
+            TestCase.assertEqual(realm.schema.length, 5 + 1); // 5 = see below, 1 = __ResultSets
+            TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Class').length, 1);
+            TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Permission').length, 1);
+            TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Realm').length, 1);
+            TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__Role').length, 1);
+            TestCase.assertEqual(realm.schema.filter(schema => schema.name === '__User').length, 1);
 
-                realm.close();
-                Realm.deleteFile(config);
+            realm.close();
+            Realm.deleteFile(config);
 
-                // Full sync shouldn't include the permission schema
-                config = {
-                    sync: {
-                        user: user,
-                        url: `realm://NO_SERVER/foo`,
-                        fullSynchronization: true
-                    }
-                };
-                realm = new Realm(config);
-                TestCase.assertTrue(realm.empty);
-                TestCase.assertEqual(realm.schema.length, 0);
+            // Full sync shouldn't include the permission schema
+            config = {
+                schema: [],
+                sync: {
+                    user: user,
+                    url: `realm://NO_SERVER/foo`,
+                    fullSynchronization: true
+                }
+            };
+            realm = new Realm(config);
+            TestCase.assertTrue(realm.empty);
+            TestCase.assertEqual(realm.schema.length, 0);
 
-                realm.close();
-                Realm.deleteFile(config);
-
-                resolve();
-            }).catch(error => reject(error));
+            realm.close();
+            Realm.deleteFile(config);
         });
     },
 

--- a/tests/js/permission-tests.js
+++ b/tests/js/permission-tests.js
@@ -118,14 +118,12 @@ const getPartialRealm = () => {
                 }
             });
             return Realm.open(config); // Creates the Realm on the server
-        }).then(realm => {
-            return waitForUpload(realm);
-        }).then(realm => {
-            return waitForDownload(realm);
-        });
+        })
+        .then(waitForUpload)
+        .then(waitForDownload)
 };
 
-const assertFullAccess= function(permission) {
+const assertFullAccess = function(permission) {
     TestCase.assertTrue(permission.canCreate);
     TestCase.assertTrue(permission.canRead);
     TestCase.assertTrue(permission.canUpdate);
@@ -353,23 +351,22 @@ module.exports = {
                             realm.close();
                             Realm.deleteFile(config);
                             // connecting with an empty schema should be possible, permission is added implicitly
-                            Realm.open(user.createConfiguration()).then((realm) => {
-                                return waitForUpload(realm);
-                            }).then((realm) => {
-                                return waitForDownload(realm);
-                            }).then((realm) => {
-                                let permissions = realm.objects(Realm.Permissions.Permission).filtered(`role.name = '__User:${user.identity}'`);
-                                TestCase.assertEqual(permissions.length, 1);
-                                TestCase.assertTrue(permissions[0].canRead);
-                                TestCase.assertTrue(permissions[0].canQuery);
-                                TestCase.assertTrue(permissions[0].canUpdate);
-                                TestCase.assertFalse(permissions[0].canDelete);
-                                TestCase.assertFalse(permissions[0].canSetPermissions);
-                                TestCase.assertFalse(permissions[0].canCreate);
-                                TestCase.assertFalse(permissions[0].canModifySchema);
-                                realm.close();
-                                resolve();
-                            });
+                            return Realm.open(user.createConfiguration());
+                        })
+                        .then(waitForUpload)
+                        .then(waitForDownload)
+                        .then((realm) => {
+                            let permissions = realm.objects(Realm.Permissions.Permission).filtered(`role.name = '__User:${user.identity}'`);
+                            TestCase.assertEqual(permissions.length, 1);
+                            TestCase.assertTrue(permissions[0].canRead);
+                            TestCase.assertTrue(permissions[0].canQuery);
+                            TestCase.assertTrue(permissions[0].canUpdate);
+                            TestCase.assertFalse(permissions[0].canDelete);
+                            TestCase.assertFalse(permissions[0].canSetPermissions);
+                            TestCase.assertFalse(permissions[0].canCreate);
+                            TestCase.assertFalse(permissions[0].canModifySchema);
+                            realm.close();
+                            resolve();
                         });
                     }
                 });
@@ -379,127 +376,106 @@ module.exports = {
 
     testFindOrCreate_realmPermissions() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let realmPermissions = realm.permissions();
-                TestCase.assertEqual(2, realm.objects('__Role').length); // [ "everyone", "__User:<xxx>" ]
-                realm.write(() => {
-                    let permissions = realmPermissions.findOrCreate("foo");
-                    TestCase.assertEqual("foo", permissions.role.name);
-                    TestCase.assertEqual(0, permissions.role.members.length);
-                    TestCase.assertFalse(permissions.canCreate);
-                    TestCase.assertFalse(permissions.canRead);
-                    TestCase.assertFalse(permissions.canUpdate);
-                    TestCase.assertFalse(permissions.canDelete);
-                    TestCase.assertFalse(permissions.canQuery);
-                    TestCase.assertFalse(permissions.canModifySchema);
-                    TestCase.assertFalse(permissions.canSetPermissions);
-                    TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:<xxx>", "foo" ]
-                });
-                resolve();
+            let realmPermissions = realm.permissions();
+            TestCase.assertEqual(2, realm.objects('__Role').length); // [ "everyone", "__User:<xxx>" ]
+            realm.write(() => {
+                let permissions = realmPermissions.findOrCreate("foo");
+                TestCase.assertEqual("foo", permissions.role.name);
+                TestCase.assertEqual(0, permissions.role.members.length);
+                TestCase.assertFalse(permissions.canCreate);
+                TestCase.assertFalse(permissions.canRead);
+                TestCase.assertFalse(permissions.canUpdate);
+                TestCase.assertFalse(permissions.canDelete);
+                TestCase.assertFalse(permissions.canQuery);
+                TestCase.assertFalse(permissions.canModifySchema);
+                TestCase.assertFalse(permissions.canSetPermissions);
+                TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:<xxx>", "foo" ]
             });
         });
     },
 
     testFindOrCreate_existingRole() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                realm.write(() => {
-                    realm.create('__Role', {'name':'foo'});
-                });
-                TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
+            realm.write(() => {
+                realm.create('__Role', {'name':'foo'});
+            });
+            TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
 
-                let realmPermissions = realm.permissions();
-                realm.write(() => {
-                    let permissions = realmPermissions.findOrCreate("foo");
-                    TestCase.assertEqual("foo", permissions.role.name);
-                    TestCase.assertFalse(permissions.canCreate);
-                    TestCase.assertFalse(permissions.canRead);
-                    TestCase.assertFalse(permissions.canUpdate);
-                    TestCase.assertFalse(permissions.canDelete);
-                    TestCase.assertFalse(permissions.canQuery);
-                    TestCase.assertFalse(permissions.canModifySchema);
-                    TestCase.assertFalse(permissions.canSetPermissions);
-                    TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
-                });
-                resolve();
+            let realmPermissions = realm.permissions();
+            realm.write(() => {
+                let permissions = realmPermissions.findOrCreate("foo");
+                TestCase.assertEqual("foo", permissions.role.name);
+                TestCase.assertFalse(permissions.canCreate);
+                TestCase.assertFalse(permissions.canRead);
+                TestCase.assertFalse(permissions.canUpdate);
+                TestCase.assertFalse(permissions.canDelete);
+                TestCase.assertFalse(permissions.canQuery);
+                TestCase.assertFalse(permissions.canModifySchema);
+                TestCase.assertFalse(permissions.canSetPermissions);
+                TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
             });
         });
     },
 
     testFindOrCreate_classPermissions() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let classPermissions = realm.permissions('__Class');
-                TestCase.assertEqual(2, realm.objects('__Role').length); // [ "everyone", "__User:xxx" ]
-                realm.write(() => {
-                    let permissions = classPermissions.findOrCreate("foo");
-                    TestCase.assertEqual("foo", permissions.role.name);
-                    TestCase.assertEqual(0, permissions.role.members.length);
-                    TestCase.assertFalse(permissions.canCreate);
-                    TestCase.assertFalse(permissions.canRead);
-                    TestCase.assertFalse(permissions.canUpdate);
-                    TestCase.assertFalse(permissions.canDelete);
-                    TestCase.assertFalse(permissions.canQuery);
-                    TestCase.assertFalse(permissions.canModifySchema);
-                    TestCase.assertFalse(permissions.canSetPermissions);
-                    TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
-                });
-                resolve();
+            let classPermissions = realm.permissions('__Class');
+            TestCase.assertEqual(2, realm.objects('__Role').length); // [ "everyone", "__User:xxx" ]
+            realm.write(() => {
+                let permissions = classPermissions.findOrCreate("foo");
+                TestCase.assertEqual("foo", permissions.role.name);
+                TestCase.assertEqual(0, permissions.role.members.length);
+                TestCase.assertFalse(permissions.canCreate);
+                TestCase.assertFalse(permissions.canRead);
+                TestCase.assertFalse(permissions.canUpdate);
+                TestCase.assertFalse(permissions.canDelete);
+                TestCase.assertFalse(permissions.canQuery);
+                TestCase.assertFalse(permissions.canModifySchema);
+                TestCase.assertFalse(permissions.canSetPermissions);
+                TestCase.assertEqual(3, realm.objects('__Role').length); // [ "everyone", "__User:xxx", "foo" ]
             });
         });
     },
 
     testFindOrCreate_throwsOutsideWrite() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let realmPermissions = realm.permissions();
-                TestCase.assertThrows(() => realmPermissions.findOrCreate("foo"));
-                let classPermissions = realm.permissions('__Class');
-                TestCase.assertThrows(() => classPermissions.findOrCreate("foo"));
-                resolve();
-            });
+            let realmPermissions = realm.permissions();
+            TestCase.assertThrows(() => realmPermissions.findOrCreate("foo"));
+            let classPermissions = realm.permissions('__Class');
+            TestCase.assertThrows(() => classPermissions.findOrCreate("foo"));
         });
     },
 
     testPermissions_Realm: function() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let permissions = realm.permissions();
-                TestCase.assertEqual(1, permissions.permissions.length);
-                let perm = permissions.permissions[0];
-                TestCase.assertEqual("everyone", perm.role.name);
-                assertFullAccess(perm);
-                resolve();
-            });
+            let permissions = realm.permissions();
+            TestCase.assertEqual(1, permissions.permissions.length);
+            let perm = permissions.permissions[0];
+            TestCase.assertEqual("everyone", perm.role.name);
+            assertFullAccess(perm);
         });
     },
 
     testPermissions_Class: function() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let permissions = realm.permissions('__Class');
-                TestCase.assertEqual('__Class', permissions.name)
-                TestCase.assertEqual(1, permissions.permissions.length);
-                let perm = permissions.permissions[0];
-                TestCase.assertEqual("everyone", perm.role.name);
-                TestCase.assertTrue(perm.canCreate);
-                TestCase.assertTrue(perm.canRead);
-                TestCase.assertTrue(perm.canUpdate);
-                TestCase.assertFalse(perm.canDelete);
-                TestCase.assertTrue(perm.canQuery);
-                TestCase.assertFalse(perm.canModifySchema);
-                TestCase.assertTrue(perm.canSetPermissions);
-                resolve();
-            });
+            let permissions = realm.permissions('__Class');
+            TestCase.assertEqual('__Class', permissions.name)
+            TestCase.assertEqual(1, permissions.permissions.length);
+            let perm = permissions.permissions[0];
+            TestCase.assertEqual("everyone", perm.role.name);
+            TestCase.assertTrue(perm.canCreate);
+            TestCase.assertTrue(perm.canRead);
+            TestCase.assertTrue(perm.canUpdate);
+            TestCase.assertFalse(perm.canDelete);
+            TestCase.assertTrue(perm.canQuery);
+            TestCase.assertFalse(perm.canModifySchema);
+            TestCase.assertTrue(perm.canSetPermissions);
         });
     },
 
     testPermissions_Class_InvalidClassArgument: function() {
         return getPartialRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                TestCase.assertThrows(() => realm.permissions('foo'));
-                resolve();
-            });
+            TestCase.assertThrows(() => realm.permissions('foo'));
         });
     },
 


### PR DESCRIPTION
Mostly just a proof of concept and needs some further work and tests. The basic idea here is to only add the permissions types to the schema if there is one (rather than forcing it to be in non-dynamic mode), and then call `update_schema()` on the temporary download Realm to solve the actual problem hit in #1976.