### PR TITLE
Use regex instead of simple substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed an incorrect property named returned from `Realm.subscriptions()`. (since v2.19.0-rc.2)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -27,6 +27,8 @@ let getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors || function(obj
     }, {});
 };
 
+const subscriptionObjectNameRegex = /^(class_)?(.*?)(_matches)?$/gm;
+
 function setConstructorOnPrototype(klass) {
     if (klass.prototype.constructor !== klass) {
         Object.defineProperty(klass.prototype, 'constructor', { value: klass, configurable: true, writable: true });
@@ -393,7 +395,7 @@ module.exports = function(realmConstructor) {
                     let matches_property = subscription['matches_property'];
                     let sub = {
                         name: subscription['name'],
-                        objectType: matches_property.substr(0, matches_property.length-8), // remove _matches
+                        objectType: matches_property.replace(subscriptionObjectNameRegex, '$2'),
                         query: subscription['query'],
                     }
                     listOfSubscriptions.push(sub);


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This fixes an issue with incorrect object types returned for permission subscriptions.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
