### PR TITLE
Added support for the `n` node version manager

### DIFF
--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -860,7 +860,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ -d \"$HOME/.asdf/shims\" ]]; then\n  export PATH=$HOME/.asdf/shims:$PATH\nfi\n\n[ -z \"$NVM_DIR\" ] && export NVM_DIR=\"$HOME/.nvm\"\n\nif [[ -s \"$HOME/.nvm/nvm.sh\" ]]; then\n  . \"$HOME/.nvm/nvm.sh\"\nelif [[ -x \"$(command -v brew)\" && -s \"$(brew --prefix nvm)/nvm.sh\" ]]; then\n  . \"$(brew --prefix nvm)/nvm.sh\"\nfi\n \nif [[ \"$(command -v nvm)\" ]]; then\n nvm install 7.10.0\nfi\n \n node ../scripts/download-realm.js ios --sync";
+			shellScript = "if [[ -d \"$HOME/.asdf/shims\" ]]; then\n  export PATH=$HOME/.asdf/shims:$PATH\nfi\n\nif [[ -d \"$HOME/.n\" ]]; then\n  export N_PREFIX=\"$HOME/.n\"; [[ :$PATH: == *\":$N_PREFIX/bin:\"* ]] || PATH+=\":$N_PREFIX/bin\"\nfi\n\nif [[ \"$(command -v n)\" ]]; then\n n 7.10.0\nelse\n  [ -z \"$NVM_DIR\" ] && export NVM_DIR=\"$HOME/.nvm\"\n\n  if [[ -s \"$HOME/.nvm/nvm.sh\" ]]; then\n    . \"$HOME/.nvm/nvm.sh\"\n  elif [[ -x \"$(command -v brew)\" && -s \"$(brew --prefix nvm)/nvm.sh\" ]]; then\n    . \"$(brew --prefix nvm)/nvm.sh\"\n  fi\n \n  if [[ \"$(command -v nvm)\" ]]; then\n    nvm install 7.10.0\n  else\n    echo \"RealmJS requires a node package manager (n or nvm).\"\n    exit 1\n  fi\nfi\n \nnode ../scripts/download-realm.js ios --sync\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Currently Realm expects to use nvm. However, (n)[https://github.com/tj/n} is a valid alternative. This change adds support for users using the `n` version manager.

Expanded script content:

```sh
if [[ -d "$HOME/.asdf/shims" ]]; then
  export PATH=$HOME/.asdf/shims:$PATH
fi

if [[ -d "$HOME/.n" ]]; then
  export N_PREFIX="$HOME/.n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"
fi

if [[ "$(command -v n)" ]]; then
 n 7.10.0
else
  [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"

  if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
    . "$HOME/.nvm/nvm.sh"
  elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
    . "$(brew --prefix nvm)/nvm.sh"
  fi
 
  if [[ "$(command -v nvm)" ]]; then
    nvm install 7.10.0
  else
    echo "RealmJS requires a node package manager (n or nvm)."
    exit 1
  fi
fi
 
node ../scripts/download-realm.js ios --sync
```

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
