### PR TITLE
Update README to include Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Realm](https://github.com/realm/realm-js/raw/master/logo.png)
 
 Realm is a mobile database that runs directly inside phones, tablets or wearables.
-This project hosts the JavaScript versions of [Realm](https://realm.io/). Currently we only support React Native (both iOS & Android) and Node.js (on MacOS and Linux) but we are considering adding support for Cordova/PhoneGap/Ionic as well.
+This project hosts the JavaScript versions of [Realm](https://realm.io/). Currently we only support React Native (both iOS & Android) and Node.js up to v9.11.2 (on MacOS and Linux) but we are considering adding support for Cordova/PhoneGap/Ionic as well.
 
 ## Features
 


### PR DESCRIPTION
This closes #2081

Realm doesn't support Node v10+. This adds a blip to the README to note this. I couldn't find a public repo for the docs website--I feel like this would be better for the [Getting Started](https://realm.io/docs/javascript/latest/#getting-started) guide but I'm not sure if the docs are open source.