### PR TITLE
Throw a meaningful error when refreshing a token for an invalid Realm path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fixed an incorrect property names returned from `Realm.subscriptions()`. (since v2.19.0-rc.2)
+* Fixed an incorrect property name returned from `Realm.subscriptions()`. (since v2.19.0-rc.2)
 * Fixed opening query-based Realms with a dynamic schema. Previously the schema would always contain only the types present when the Realm was first added and not any types added later. (since v2.3.0)
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* A more meaningful exception will be thrown when trying to refresh the access token for a Realm with an invalid url. Previously, trying to connect to a Realm with a url that lacks the path component (e.g. `realm://foo.com`) would result in errors like `Cannot read property ‘token_data’ of undefined`. Instead, now we'll print out the Realm url and provide a more meaningful exception message. ([#ROS-1310](https://github.com/realm/realm-object-server-private/issues/1310), since v1.0.2)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
@@ -21,7 +21,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fixed an incorrect property named returned from `Realm.subscriptions()`. (since v2.19.0-rc.2)
+* Fixed an incorrect property names returned from `Realm.subscriptions()`. (since v2.19.0-rc.2)
 * Fixed opening query-based Realms with a dynamic schema. Previously the schema would always contain only the types present when the Realm was first added and not any types added later. (since v2.3.0)
 
 ### Compatibility

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -201,7 +201,12 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
         throw new Error("Server for user must be specified");
     }
 
-    let parsedRealmUrl = url_parse(realmUrl);
+    const parsedRealmUrl = url_parse(realmUrl);
+    const path = parsedRealmUrl.pathname;
+    if (!path) {
+        throw new Error(`Unexpected Realm path inferred from url '${realmUrl}'. The path section of the url should be a non-empty string.`);
+    }
+
     if (user.isAdminToken) {
         return refreshAdminToken(user, localRealmPath, realmUrl);
     }
@@ -211,7 +216,7 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
         method: 'POST',
         body: JSON.stringify({
             data: user.token,
-            path: parsedRealmUrl.pathname,
+            path,
             provider: 'realm',
             app_id: ''
         }),

--- a/tests/js/encryption-tests.js
+++ b/tests/js/encryption-tests.js
@@ -81,7 +81,7 @@ module.exports = {
                 encryptionKey: new Int8Array(64),
                 sync: {
                     user: adminUser,
-                    url: 'realm://localhost:9080'
+                    url: 'realm://localhost:9080/~/encryptedRealm'
                 }
             });
             adminUser.logout(); // FIXME: clearTestState() doesn't clean up enough and Realm.Sync.User.current might not work


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

Fixes https://github.com/realm/realm-object-server-private/issues/1310.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
