### PR TITLE
Fix Typescript definition for Permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ x.x.x Release notes (yyyy-MM-dd)
  ### Internal
 * None.
 
+2.19.1 Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* The Typescript definition for `Realm.Permissions.Permission` did not have the correct `role` property defined. Since 2.3.0.
+
+### Compatibility
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous release of realm in the 2.x.y series.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+
+ ### Internal
+* None.
+
 2.19.0 Release notes (2018-11-8)
 =============================================================
 This release contains all changes from v2.19.0-rc.1 to v2.19.0-rc.5.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -585,7 +585,7 @@ declare namespace Realm.Permissions {
     class Permission {
         static schema: ObjectSchema;
 
-        identity: string;
+        role: Role;
         canCreate: boolean;
         canRead: boolean;
         canUpdate: boolean;


### PR DESCRIPTION
The `role` property was not correct in the `Permission` Typescript definition leading to compile errors of the form: `error TS2339: Property 'role' does not exist on type 'Permission'.`