### PR TITLE
Give the app a chance to disable analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Removed calls to `new Buffer()` as this is deprecated with Node 10. ([#2107](https://github.com/realm/realm-js/issues/2107), since 2.19.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.
@@ -13,7 +13,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 
  ### Internal
-* None.
+* Introduce 100 ms delay before submitting analytics so that an app may disable it after importing Realm. ([#2108](https://github.com/realm/realm-js/pull/2108))
+* Distinguish between node.js and electron in the `BindingType` field when submitting analytics. ([#2108](https://github.com/realm/realm-js/pull/2108))
 
 2.19.0 Release notes (2018-11-8)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
  ### Internal
 * Introduce 100 ms delay before submitting analytics so that an app may disable it after importing Realm. ([#2108](https://github.com/realm/realm-js/pull/2108))
 * Distinguish between node.js and electron in the `BindingType` field when submitting analytics. ([#2108](https://github.com/realm/realm-js/pull/2108))
+* Add a package to compute the Windows analytics identifier rather than returning `null` which likely accounts for the disproportionally large number of unique Windows users. ([#2108](https://github.com/realm/realm-js/pull/2108))
 
 2.19.0 Release notes (2018-11-8)
 =============================================================

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,12 +35,12 @@ function getContext() {
             return 'vscodedebugger';
         }
 
-        return process.type === 'renderer' ? 'electron' : 'nodejs';
+        return process.type === 'renderer' ? 'electron' : 'node.js';
     }
 
     // When running via Jest, the jest object is defined.
     if (typeof jest === 'object') {
-        return 'nodejs';
+        return 'node.js';
     }
 
     if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') { // eslint-disable-line no-undef
@@ -89,10 +89,11 @@ function getContext() {
 
 var realmConstructor;
 
-switch(getContext()) {
-    case 'nodejs':
+const context = getContext();
+switch(context) {
+    case 'node.js':
     case 'electron':
-        nodeRequire('./submit-analytics')('Run');
+        nodeRequire('./submit-analytics')('Run', context);
 
         var binary = nodeRequire('node-pre-gyp');
         var path = nodeRequire('path');
@@ -120,7 +121,7 @@ if (!realmConstructor) {
 require('./extensions')(realmConstructor);
 
 if (realmConstructor.Sync) {
-    if (getContext() === 'nodejs') {
+    if (context === 'node.js') {
       nodeRequire('./notifier')(realmConstructor);
       if (!realmConstructor.Worker) {
           Object.defineProperty(realmConstructor, 'Worker', {value: nodeRequire('./worker')});

--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -34,7 +34,14 @@ if (isAnalyticsDisabled()) {
 } else {
     const os = require('os');
     const request = require('request');
-    const { machineIdSync } = require("node-machine-id");
+    const crypto = require('crypto');
+    const { machineId } = require("node-machine-id");
+
+    function sha256(data) {
+        let hash = crypto.createHash('sha256');
+        hash.update(data);
+        return hash.digest('hex');
+    }
 
     module.exports = function(eventName, context) {
         // Submit analytics after some time - we do this to give the application a chance to disable analytics.
@@ -43,25 +50,32 @@ if (isAnalyticsDisabled()) {
                 return;
             }
 
-            const identifier = machineIdSync();
-            const payload = {
-                'event': eventName,
-                'properties': {
-                    'token': 'aab85907a13e1ff44a95be539d9942a9',
-                    'distinct_id': identifier,
-                    'Anonymized Machine Identifier': identifier,
-                    'Anonymized Application ID': sha256(__dirname),
-                    'Binding': context || 'node.js',
-                    'Version': require('../package.json').version,
-                    'Language': 'javascript',
-                    'OS Type': os.platform(),
-                    'OS Version': os.release(),
-                    'Node.js versions': process.versions
-                }
-            };
+            machineId()
+                .catch() // Ignore errors
+                .then((identifier) => {
+                    if (!identifier) {
+                        identifier = sha256('unknown');
+                    }
 
-            request(`https://api.mixpanel.com/track/?data=${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64')}&ip=1`,
-            () => { /* Analytics failed. Do nothing. */ });
+                    const payload = {
+                        'event': eventName,
+                        'properties': {
+                            'token': 'aab85907a13e1ff44a95be539d9942a9',
+                            'distinct_id': identifier,
+                            'Anonymized Machine Identifier': identifier,
+                            'Anonymized Application ID': sha256(__dirname),
+                            'Binding': context || 'node.js',
+                            'Version': require('../package.json').version,
+                            'Language': 'javascript',
+                            'OS Type': os.platform(),
+                            'OS Version': os.release(),
+                            'Node.js versions': process.versions
+                        }
+                    };
+
+                    request(`https://api.mixpanel.com/track/?data=${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64')}&ip=1`,
+                    () => { /* Analytics failed. Do nothing. */ });
+                });
         }, 100);
     }
 

--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -33,56 +33,8 @@ if (isAnalyticsDisabled()) {
     module.exports = function(){};
 } else {
     const os = require('os');
-    const crypto = require('crypto');
-    const fs = require('fs');
     const request = require('request');
-
-    function sha256(data) {
-        let hash = crypto.createHash('sha256');
-        hash.update(data);
-        return hash.digest('hex');
-    }
-
-    function getDarwinIdentifier() {
-        const interfaces = os.networkInterfaces();
-        const iface = interfaces["en0"] || interfaces["en1"];
-        if (!iface) {
-            return Buffer.from('unknown', 'utf8');
-        }
-
-        const mac = iface[0].mac.replace(/:/g, '');
-        return Buffer.from(mac, 'hex');
-    }
-
-    function getLinuxIdentifier() {
-        if (fs.existsSync('/var/lib/dbus/machine-id')) {
-            return fs.readFileSync('/var/lib/dbus/machine-id');
-        }
-
-        if (fs.existsSync('/etc/machine-id')) {
-            return fs.readFileSync('/etc/machine-id');
-        }
-
-        return Buffer.from('unknown', 'utf8');
-    }
-
-    function getWindowsIdentifier() {
-        // TODO: implement this
-        return Buffer.from('unknown', 'utf8');
-    }
-
-    function getAnonymizedMachineIdentifier() {
-        switch (os.platform()) {
-            case 'darwin':
-                return sha256(getDarwinIdentifier());
-            case 'linux':
-                return sha256(getLinuxIdentifier());
-            case 'windows':
-                return sha256(getWindowsIdentifier());
-            default:
-                return null;
-        }
-    }
+    const { machineIdSync } = require("node-machine-id");
 
     module.exports = function(eventName, context) {
         // Submit analytics after some time - we do this to give the application a chance to disable analytics.
@@ -91,7 +43,7 @@ if (isAnalyticsDisabled()) {
                 return;
             }
 
-            const identifier = getAnonymizedMachineIdentifier();
+            const identifier = machineIdSync();
             const payload = {
                 'event': eventName,
                 'properties': {

--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -66,12 +66,19 @@ if (isAnalyticsDisabled()) {
         return Buffer.from('unknown', 'utf8');
     }
 
+    function getWindowsIdentifier() {
+        // TODO: implement this
+        return Buffer.from('unknown', 'utf8');
+    }
+
     function getAnonymizedMachineIdentifier() {
         switch (os.platform()) {
             case 'darwin':
                 return sha256(getDarwinIdentifier());
             case 'linux':
                 return sha256(getLinuxIdentifier());
+            case 'windows':
+                return sha256(getWindowsIdentifier());
             default:
                 return null;
         }
@@ -86,19 +93,19 @@ if (isAnalyticsDisabled()) {
 
             const identifier = getAnonymizedMachineIdentifier();
             const payload = {
-            'event': eventName,
-            'properties': {
-                'token': 'aab85907a13e1ff44a95be539d9942a9',
-                'distinct_id': identifier,
-                'Anonymized Machine Identifier': identifier,
-                'Anonymized Application ID': sha256(__dirname),
-                'Binding': context || 'node.js',
-                'Version': require('../package.json').version,
-                'Language': 'javascript',
-                'OS Type': os.platform(),
-                'OS Version': os.release(),
-                'Node.js versions': process.versions
-            }
+                'event': eventName,
+                'properties': {
+                    'token': 'aab85907a13e1ff44a95be539d9942a9',
+                    'distinct_id': identifier,
+                    'Anonymized Machine Identifier': identifier,
+                    'Anonymized Application ID': sha256(__dirname),
+                    'Binding': context || 'node.js',
+                    'Version': require('../package.json').version,
+                    'Language': 'javascript',
+                    'OS Type': os.platform(),
+                    'OS Version': os.release(),
+                    'Node.js versions': process.versions
+                }
             };
 
             request(`https://api.mixpanel.com/track/?data=${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64')}&ip=1`,

--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -10,7 +10,7 @@
 // application path & anonymized machine identifier is the only way for us to
 // count actual usage of the other metrics accurately. If we don’t have a way to
 // deduplicate the info reported, it will be useless, as a single developer
-// `npm install`-ing the same app 10 times would report 10 times more than another 
+// `npm install`-ing the same app 10 times would report 10 times more than another
 // developer that only installs once, making the data all but useless.
 // No one likes sharing data unless it’s necessary, we get it, and we’ve
 // debated adding this for a long long time. If you truly, absolutely
@@ -20,12 +20,16 @@
 // Currently the following information is reported:
 // - What version of Realm is being installed.
 // - The OS platform and version which is being used.
-// - Node.js, v8, libuv, OpenSSL version numbers. 
+// - Node.js, v8, libuv, OpenSSL version numbers.
 // - An anonymous machine identifier and hashed application path to aggregate the other information on.
 
 'use strict';
 
-if ('REALM_DISABLE_ANALYTICS' in process.env) {
+function isAnalyticsDisabled() {
+    return 'REALM_DISABLE_ANALYTICS' in process.env;
+}
+
+if (isAnalyticsDisabled()) {
     module.exports = function(){};
 } else {
     const os = require('os');
@@ -43,54 +47,63 @@ if ('REALM_DISABLE_ANALYTICS' in process.env) {
         const interfaces = os.networkInterfaces();
         const iface = interfaces["en0"] || interfaces["en1"];
         if (!iface) {
-        return Buffer.from('unknown', 'utf8');
+            return Buffer.from('unknown', 'utf8');
         }
 
         const mac = iface[0].mac.replace(/:/g, '');
-        return new Buffer(mac, 'hex');
+        return Buffer.from(mac, 'hex');
     }
 
     function getLinuxIdentifier() {
         if (fs.existsSync('/var/lib/dbus/machine-id')) {
-        return fs.readFileSync('/var/lib/dbus/machine-id');
-        } else if (fs.existsSync('/etc/machine-id')) {
-        return fs.readFileSync('/etc/machine-id');
-        } else {
-        return Buffer.from('unknown', 'utf8');
+            return fs.readFileSync('/var/lib/dbus/machine-id');
         }
+
+        if (fs.existsSync('/etc/machine-id')) {
+            return fs.readFileSync('/etc/machine-id');
+        }
+
+        return Buffer.from('unknown', 'utf8');
     }
 
     function getAnonymizedMachineIdentifier() {
         switch (os.platform()) {
-        case 'darwin':
-            return sha256(getDarwinIdentifier());
-        case 'linux':
-            return sha256(getLinuxIdentifier());
-        default:
-            return null;
+            case 'darwin':
+                return sha256(getDarwinIdentifier());
+            case 'linux':
+                return sha256(getLinuxIdentifier());
+            default:
+                return null;
         }
     }
 
-    module.exports = function(eventName) {
-        const identifier = getAnonymizedMachineIdentifier();
-        const payload = {
-        'event': eventName,
-        'properties': {
-            'token': 'aab85907a13e1ff44a95be539d9942a9',
-            'distinct_id': identifier,
-            'Anonymized Machine Identifier': identifier,
-            'Anonymized Application ID': sha256(__dirname),
-            'Binding': 'node.js',
-            'Version': require('../package.json').version,
-            'Language': 'javascript',
-            'OS Type': os.platform(),
-            'OS Version': os.release(),
-            'Node.js versions': process.versions
-        }
-        };
+    module.exports = function(eventName, context) {
+        // Submit analytics after some time - we do this to give the application a chance to disable analytics.
+        setTimeout(() => {
+            if (isAnalyticsDisabled()) {
+                return;
+            }
 
-        request(`https://api.mixpanel.com/track/?data=${new Buffer(JSON.stringify(payload), 'utf8').toString('base64')}&ip=1`, 
-        () => { /* Analytics failed. Do nothing. */ });
+            const identifier = getAnonymizedMachineIdentifier();
+            const payload = {
+            'event': eventName,
+            'properties': {
+                'token': 'aab85907a13e1ff44a95be539d9942a9',
+                'distinct_id': identifier,
+                'Anonymized Machine Identifier': identifier,
+                'Anonymized Application ID': sha256(__dirname),
+                'Binding': context || 'node.js',
+                'Version': require('../package.json').version,
+                'Language': 'javascript',
+                'OS Type': os.platform(),
+                'OS Version': os.release(),
+                'Node.js versions': process.versions
+            }
+            };
+
+            request(`https://api.mixpanel.com/track/?data=${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64')}&ip=1`,
+            () => { /* Analytics failed. Do nothing. */ });
+        }, 100);
     }
 
     if (require.main === module) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,7 +2325,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -2697,7 +2697,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,6 +2052,11 @@
         "is-stream": "^1.0.1"
       }
     },
+    "node-machine-id": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.10.tgz",
+      "integrity": "sha512-6SVxo3Ic2Qc09z1rCJh3No7ubizPLszImsMQnZZWfzeOC6SYU4orN214++c3ikB8uaP/A6dwSlO88A3ohI5oNA=="
+    },
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "ini": "^1.3.4",
     "nan": "^2.10.0",
     "node-fetch": "^1.6.3",
+    "node-machine-id": "^1.1.10",
     "node-pre-gyp": "^0.11.0",
     "progress": "^2.0.0",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

1. Introduce 100 ms delay before submitting analytics - this is helpful to handle a case where setting the environment variable in code happens after realm is imported.
2. Add a `context` argument to distinguish between node.js and electron.
3. Removes `new Buffer` calls which are deprecated in node 10.

Fixes https://github.com/realm/realm-js/issues/2107.
## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry