### PR TITLE
Realm._constructor() has been replaced by Realm._asyncOpen()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* Removed calls to `new Buffer()` as this is deprecated with Node 10. ([#2107](https://github.com/realm/realm-js/issues/2107), since 2.19.0)
+* Removed calls to `new Buffer()` as this is deprecated with Node 10. ([#2107](https://github.com/realm/realm-js/issues/2107), since v2.19.0)
+* Removes call to `Realm._constructor()` in the React Native debugging support library (https://github.com/realm/realm-js/issues/491#issuecomment-438688937, since v2.19.0-rc.4)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -77,7 +77,6 @@ function getObjectType(realm, type) {
 
 export default class Realm {
     constructor(config) {
-        config = this._constructor(config);
         let schemas = typeof config == 'object' && config.schema;
         let constructors = schemas ? {} : null;
 
@@ -133,6 +132,7 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'close',
     '_waitForDownload',
     '_objectForObjectId',
+    '_asyncOpen'
 ]);
 
 // Mutating methods:


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Reported in https://github.com/realm/realm-js/issues/491#issuecomment-438688937

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* [x] Chrome debug API is updated if API is available on React Native
