### PR TITLE
Add  lower bound when refreshing tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-mm-dd)
 * None.
 
 ### Fixed
-* Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds have been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since 1.0.2)
+* Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds has been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since v1.0.2)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-mm-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds have been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since 1.0.2)
+
+### Compatibility
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous release of realm in the 2.x.y series.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+
+ ### Internal
+* None.
+
 2.19.1 Release notes (2018-11-15)
 =============================================================
 ### Enhancements

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -26,8 +26,9 @@ const require_method = require;
 const URL = require('url-parse');
 
 const refreshTimers = {};
-const retryInterval = 5 * 1000;
-const refreshBuffer = 20 * 1000;
+const retryInterval = 5 * 1000; // Amount of time between retrying authentication requests, if the first request failed.
+const refreshBuffer = 20 * 1000; // A "safe" amount of time before a token expires that allow us to refresh it.
+const refreshLowerBound = 10 * 1000; // Lower bound for refreshing tokens.
 
 function node_require(module) {
     return require_method(module);
@@ -119,7 +120,7 @@ function scheduleAccessTokenRefresh(user, localRealmPath, realmUrl, expirationDa
     // We assume that access tokens have ~ the same expiration time, so if someone already
     // scheduled a refresh, it's likely to complete before the one we would have scheduled
     if (!userTimers[localRealmPath]) {
-        const timeout = expirationDate - Date.now() - refreshBuffer;
+        const timeout = Math.max(expirationDate - Date.now() - refreshBuffer, refreshLowerBound);
         userTimers[localRealmPath] = setTimeout(() => {
             delete userTimers[localRealmPath];
             refreshAccessToken(user, localRealmPath, realmUrl);


### PR DESCRIPTION
Fixes #2115 

This introduces a somewhat arbitrary lower bound for refreshing tokens. It is mostly selected to be low enough so you never hit it in practical use cases, and high enough so it doesn't completely spam the server log if you configure the server in a way that would cause immediate refreshes.

Potentially a safer way is to enforce a lower bound on the server side since this is where the TTL is defined. but since there is no contract for this with the server, having it here also makes sense.

In the worst case where the server sets a TTL below 10 seconds, then you will experience "gaps" in the synchronization.