### PR TITLE
Don't refresh tokens for sessions that have been closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
-
-### Compatibility
-* Realm Object Server: 3.11.0 or later.
-* APIs are backwards compatible with all previous release of realm in the 2.x.y series.
-* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
-
- ### Internal
-* None.
-
-x.x.x Release notes (yyyy-MM-dd)
-=============================================================
-### Enhancements
-* None.
-
-### Fixed
 * Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds has been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since v1.0.2)
+* Prevent automatic token refreshes for Realms that have been closed. Previously, these could have resulted in obscure `Unhandled session token refresh error` messages in the logs that were benign. ([#2119](https://github.com/realm/realm-js/pull/2119))
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -135,7 +135,6 @@ function print_error() {
 function validateRefresh(user, localRealmPath, response, json) {
     let session = user._sessionForOnDiskPath(localRealmPath);
     if (!session) {
-        print_error(`Unhandled session token refresh error: could not look up session for user ${user.identity} at path ${localRealmPath}`);
         return;
     }
 
@@ -198,6 +197,13 @@ function refreshAdminToken(user, localRealmPath, realmUrl) {
 }
 
 function refreshAccessToken(user, localRealmPath, realmUrl) {
+    if (!user._sessionForOnDiskPath(localRealmPath)) {
+        // We're trying to refresh the token for a session that's closed. This could happen, for example,
+        // when the server is not reachable and we periodically try to refresh the token, but the user has
+        // already closed the Realm file.
+        return;
+    }
+
     if (!user.server) {
         throw new Error("Server for user must be specified");
     }
@@ -259,7 +265,7 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
         })
         .catch((e) => {
             print_error(e);
-            // in case something lower in the HTTP stack breaks, try again in 10 seconds
+            // in case something lower in the HTTP stack breaks, try again in `retryInterval` seconds
             setTimeout(() => refreshAccessToken(user, localRealmPath, realmUrl), retryInterval);
         })
 }


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

This prevents annoying messages about unhandled session errors that the user can do nothing about.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
