### PR TITLE
Check the correct name when adding permissions object schemas to the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds has been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since v1.0.2)
 * Prevent automatic token refreshes for Realms that have been closed. Previously, these could have resulted in obscure `Unhandled session token refresh error` messages in the logs that were benign. ([#2119](https://github.com/realm/realm-js/pull/2119))
+* Check the correct name when automatically adding the permission object schemas to the schema for query-based sync realms so that defining types with the same name works correctly. ([#2121](https://github.com/realm/realm-js/pull/2121), since 2.15.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -64,16 +64,10 @@ function findOrCreatePermissionForRole(realmObject, permissions, roleName) {
  * Adds the schema object if one isn't already defined
  */
 function addSchemaIfNeeded(schemaList, schemaObj) {
-    for (var i = 0; i < schemaList.length; i++) {
-        const obj = schemaList[i];
-        if (obj === undefined) {
-            continue;
-        }
-        if (schemaObj.name === obj.name || (obj.schema !== undefined && (schemaObj.name === obj.schema.name))) {
-            return;
-        }
+    const name = schemaObj.schema.name;
+    if (schemaList.find((obj) => obj && (obj.name === name || (obj.schema && obj.schema.name === name))) === undefined) {
+        schemaList.push(schemaObj);
     }
-    schemaList.push(schemaObj);
 }
 
 module.exports = function(realmConstructor) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1021,6 +1021,31 @@ module.exports = {
         });
     },
 
+    testRoleClassWithPartialSyncCanCoexistWithPermissionsClass() {
+        if (!isNodeProccess) {
+            return;
+        }
+
+        const username = uuid();
+        const credentials = Realm.Sync.Credentials.nickname(username);
+        return Realm.Sync.User.login('http://localhost:9080', credentials).then(user => {
+            let config = {
+                schema: [{name: 'Role', properties: {name: 'string'}}],
+                sync: {
+                    user: user,
+                    url: 'realm://localhost:9080/~/roleClass',
+                    fullSynchronization: false,
+                    error: (session, error) => console.log(error)
+                }
+            };
+            return Realm.open(config);
+        }).then(realm => {
+            // verify that these don't throw
+            realm.objects('Role');
+            realm.objects('__Role');
+        });
+    },
+
     testClientReset() {
         // FIXME: try to enable for React Native
         if (!isNodeProccess) {


### PR DESCRIPTION
The `name` property of the schema object is the name of the class (i.e. `Role` for the role object) rather than the schema name (i.e. `__Role`). This happened to work if only the predefined schema objects were used and no user-defined classes had the non-underscore-prefixed names, but broke otherwise.

Fixes #2120.