### PR TITLE
Add support for uploading. and downloading changes easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Adds support for setting a custom User-Agent string using `Realm.Sync.setUserAgent(...)`. This string will be sent to the server when creating a connection. ([#XXX]())
-* Adds support for uploading and downloading changes using `Realm.Sync.Session.uploadAllLocalChanges(timeout)` and `Realm.Sync.Session.downloadAllRemoteChanges(timeout)`. ([#XXXX]()) 
+* Adds support for setting a custom User-Agent string using `Realm.Sync.setUserAgent(...)`. This string will be sent to the server when creating a connection. ([#2102](https://github.com/realm/realm-js/issues/2102))
+* Adds support for uploading and downloading changes using `Realm.Sync.Session.uploadAllLocalChanges(timeout)` and `Realm.Sync.Session.downloadAllRemoteChanges(timeout)`. ([#2122](https://github.com/realm/realm-js/issues/2122)) 
 
 ### Fixed
 * Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds has been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since v1.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Adds support for setting a custom User-Agent string using `Realm.Sync.setUserAgent(...)`. This string will be sent to the server when creating a connection. ([#XXX]())
+* Adds support for uploading and downloading changes using `Realm.Sync.Session.uploadAllLocalChanges(timeout)` and `Realm.Sync.Session.downloadAllRemoteChanges(timeout)`. ([#XXXX]()) 
 
 ### Fixed
 * Tokens are refreshed ahead of time. If the lifetime of the token is lower than the threshold for refreshing it will cause the client to continously refresh, spamming the server with refresh requests. A lower bound of 10 seconds has been introduced. ([#2115](https://github.com/realm/realm-js/issues/2115), since v1.0.2)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,6 +203,7 @@ def doDockerBuild(target, postStep = null) {
 def doMacBuild(target, postStep = null) {
   return {
     node('osx_vegas') {
+      env.DEVELOPER_DIR = "/Applications/Xcode-9.4.app/Contents/Developer"
       doInside("./scripts/test.sh", target, postStep)
     }
   }

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -766,19 +766,19 @@ class Session {
 
     /**
      * This method returns a promise that does not resolve successfully until all known local changes have been uploaded
-     * to the server or the specified timeout is hit in which case it be rejected. If the method times out, the upload
+     * to the server or the specified timeout is hit in which case it will be rejected. If the method times out, the upload
      * will still continue in the background.
      *
      * This method cannot be called before the Realm has been opened.
      *
-     * @param timeout maximum amount of time to wait in milliseconds before the promise will be rejected. If no timeout
+     * @param timeout maximum amount of time to wait in milliseconds before the promise is rejected. If no timeout
      * is specified the method will wait forever.
      */
     uploadAllLocalChanges(timeoutMs) {}
 
     /**
-     * This method returns a promise that does not resolve sucessfully until all known remote changes have been
-     * downloaded and applied to the Realm or the specified timeout is hit in which it will be rejected. If the method
+     * This method returns a promise that does not resolve successfully until all known remote changes have been
+     * downloaded and applied to the Realm or the specified timeout is hit in which case it will be rejected. If the method
      * times out, the download will still continue in the background.
      *
      * This method cannot be called before the Realm has been opened.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -764,6 +764,29 @@ class Session {
      */
     pause() {}
 
+    /**
+     * This method returns a promise that does not resolve successfully until all known local changes have been uploaded
+     * to the server or the specified timeout is hit in which case it be rejected. If the method times out, the upload
+     * will still continue in the background.
+     *
+     * This method cannot be called before the Realm has been opened.
+     *
+     * @param timeout maximum amount of time to wait in milliseconds before the promise will be rejected. If no timeout
+     * is specified the method will wait forever.
+     */
+    uploadAllLocalChanges(timeoutMs) {}
+
+    /**
+     * This method returns a promise that does not resolve sucessfully until all known remote changes have been
+     * downloaded and applied to the Realm or the specified timeout is hit in which it will be rejected. If the method
+     * times out, the download will still continue in the background.
+     *
+     * This method cannot be called before the Realm has been opened.
+     *
+     * @param timeout maximum amount of time to wait in milliseconds before the promise will be rejected. If no timeout
+     * is specified the method will wait forever.
+     */
+    downloadAllServerChanges(timeoutMs) {}
 }
 
 /**

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -272,7 +272,7 @@ module.exports = function(realmConstructor) {
             waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
         };
 
-        realmConstructor.Sync.prototype.downloadAllLocalChanges = function(timeout) {
+        realmConstructor.Sync.Session.prototype.downloadAllLocalChanges = function(timeout) {
             waitForCompletion(this, this._waitForDownloadCompletion, timeout, `Downloading changes did not complete ${timeout} ms.`);
         };
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -269,11 +269,11 @@ module.exports = function(realmConstructor) {
         }
 
         realmConstructor.Sync.Session.prototype.uploadAllLocalChanges = function(timeout) {
-            waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
+            return waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
         };
 
         realmConstructor.Sync.Session.prototype.downloadAllServerChanges = function(timeout) {
-            waitForCompletion(this, this._waitForDownloadCompletion, timeout, `Downloading changes did not complete ${timeout} ms.`);
+            return waitForCompletion(this, this._waitForDownloadCompletion, timeout, `Downloading changes did not complete ${timeout} ms.`);
         };
 
         // Keep these value in sync with subscription_state.hpp

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -78,7 +78,7 @@ function addSchemaIfNeeded(schemaList, schemaObj) {
 
 function waitForCompletion(session, fn, timeout, timeoutErrorMessage) {
     const waiter = new Promise((resolve, reject) => {
-        fn((error) => {
+        fn.call(session, (error) => {
             if (error === undefined) {
                 setTimeout(() => { resolve(); }, 1); // FIXME Check if thread is up to date?
             } else {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -268,7 +268,7 @@ module.exports = function(realmConstructor) {
             }
         }
 
-        realmConstructor.Sync.prototype.uploadAllLocalChanges = function(timeout) {
+        realmConstructor.Sync.Session.prototype.uploadAllLocalChanges = function(timeout) {
             waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
         };
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -76,6 +76,30 @@ function addSchemaIfNeeded(schemaList, schemaObj) {
     schemaList.push(schemaObj);
 }
 
+function waitForCompletion(session, fn, timeout, timeoutErrorMessage) {
+    const waiter = new Promise((resolve, reject) => {
+        fn((error) => {
+            if (error === undefined) {
+                setTimeout(() => { resolve(); }, 1); // FIXME Check if thread is up to date?
+            } else {
+                setTimeout(() => { reject(error); }, 1);
+            }
+        });
+    });
+    if (timeout === undefined) {
+        return waiter;
+    } else {
+        return Promise.race([
+            waiter,
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    reject(timeoutErrorMessage);
+                }, timeout)
+            })
+        ]);
+    }
+}
+
 module.exports = function(realmConstructor) {
     // Add the specified Array methods to the Collection prototype.
     Object.defineProperties(realmConstructor.Collection.prototype, require('./collection-methods'));
@@ -243,6 +267,14 @@ module.exports = function(realmConstructor) {
                 console.log('Realm.Sync.setFeatureToken() is deprecated and you can remove any calls to it.');
             }
         }
+
+        realmConstructor.Sync.prototype.uploadAllLocalChanges = function(timeout) {
+            waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
+        };
+
+        realmConstructor.Sync.prototype.downloadAllLocalChanges = function(timeout) {
+            waitForCompletion(this, this._waitForDownloadCompletion, timeout, `Downloading changes did not complete ${timeout} ms.`);
+        };
 
         // Keep these value in sync with subscription_state.hpp
         realmConstructor.Sync.SubscriptionState = {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -272,7 +272,7 @@ module.exports = function(realmConstructor) {
             waitForCompletion(this, this._waitForUploadCompletion, timeout, `Uploading changes did not complete in ${timeout} ms.`);
         };
 
-        realmConstructor.Sync.Session.prototype.downloadAllLocalChanges = function(timeout) {
+        realmConstructor.Sync.Session.prototype.downloadAllServerChanges = function(timeout) {
             waitForCompletion(this, this._waitForDownloadCompletion, timeout, `Downloading changes did not complete ${timeout} ms.`);
         };
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -80,7 +80,7 @@ function waitForCompletion(session, fn, timeout, timeoutErrorMessage) {
     const waiter = new Promise((resolve, reject) => {
         fn.call(session, (error) => {
             if (error === undefined) {
-                setTimeout(() => { resolve(); }, 1); // FIXME Check if thread is up to date?
+                setTimeout(() => { resolve(); }, 1);
             } else {
                 setTimeout(() => { reject(error); }, 1);
             }
@@ -88,16 +88,15 @@ function waitForCompletion(session, fn, timeout, timeoutErrorMessage) {
     });
     if (timeout === undefined) {
         return waiter;
-    } else {
-        return Promise.race([
-            waiter,
-            new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    reject(timeoutErrorMessage);
-                }, timeout)
-            })
-        ]);
     }
+    return Promise.race([
+        waiter,
+        new Promise((resolve, reject) => {
+            setTimeout(() => {
+                reject(timeoutErrorMessage);
+            }, timeout)
+        })
+    ]);
 }
 
 module.exports = function(realmConstructor) {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -80,9 +80,9 @@ function waitForCompletion(session, fn, timeout, timeoutErrorMessage) {
     const waiter = new Promise((resolve, reject) => {
         fn.call(session, (error) => {
             if (error === undefined) {
-                setTimeout(() => { resolve(); }, 1);
+                setTimeout(() => resolve(), 1);
             } else {
-                setTimeout(() => { reject(error); }, 1);
+                setTimeout(() => reject(error), 1);
             }
         });
     });

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -491,7 +491,7 @@ declare namespace Realm.Sync {
         pause(): void;
 
         downloadAllServerChanges(timeoutMs?: number): Promise<void>;
-        uploadAllLocalChanges(): Promise<void>;
+        uploadAllLocalChanges(timeoutMs?: number): Promise<void>;
     }
 
     type SubscriptionNotificationCallback = (subscription: Subscription, state: number) => void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -489,6 +489,9 @@ declare namespace Realm.Sync {
 
         resume(): void;
         pause(): void;
+
+        downloadAllServerChanges(): Promise<void>;
+        uploadAllLocalChanges(): Promise<void>;
     }
 
     type SubscriptionNotificationCallback = (subscription: Subscription, state: number) => void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -490,7 +490,7 @@ declare namespace Realm.Sync {
         resume(): void;
         pause(): void;
 
-        downloadAllServerChanges(): Promise<void>;
+        downloadAllServerChanges(timeoutMs?: number): Promise<void>;
         uploadAllLocalChanges(): Promise<void>;
     }
 

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -696,7 +696,6 @@ void SessionClass<T>::wait_for_completion(Direction direction, ContextType ctx, 
         Protected<ObjectType> protected_this(ctx, this_object);
         Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
 
-        std::function<DownloadUploadCompletionHandler> completion_func;
         EventLoopDispatcher<DownloadUploadCompletionHandler> completion_handler([=](std::error_code error) {
             HANDLESCOPE
             ValueType callback_arguments[1];
@@ -711,14 +710,13 @@ void SessionClass<T>::wait_for_completion(Direction direction, ContextType ctx, 
             Function<T>::callback(protected_ctx, protected_callback, typename T::Object(), 1, callback_arguments);
         });
 
-        completion_func = std::move(completion_handler);
         bool callback_registered;
         switch(direction) {
             case Upload:
-                callback_registered = session->wait_for_upload_completion(std::move(completion_func));
+                callback_registered = session->wait_for_upload_completion(std::move(completion_handler));
                 break;
             case Download:
-                callback_registered = session->wait_for_download_completion(std::move(completion_func));
+                callback_registered = session->wait_for_download_completion(std::move(completion_handler));
                 break;
         }
         if (!callback_registered) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1287,42 +1287,38 @@ module.exports = {
         }
 
         return new Promise((resolve, reject) => {
-            try {
-                let admin1 = await Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin1", true));
-                resolve();
-            } catch (e) {
-                reject(e);
-            }
-        };
-        //         .then((admin1) => {
-        //             const admin1Config = admin1.createConfiguration({
-        //                 sync:  {
-        //                     url: REALM_URL,
-        //                     fullSynchronization: true
-        //                 }
-        //             });
-        //             Realm.open(admin1Config).then((admin1Realm) => {
-        //                 admin1Realm.write(() => { admin1Realm.create('CompletionHandlerObject', { 'name': 'foo'}); });
-        //                 admin1Realm.syncSession.uploadAllLocalChanges().then(() => {
-        //                     admin1Realm.close();
-        //                     Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin2", true))
-        //                         .then((admin2) => {
-        //                             const admin2Config = admin2.createConfiguration({
-        //                                 sync:  {
-        //                                     url: REALM_URL,
-        //                                     fullSynchronization: true
-        //                                 }
-        //                             });
-        //                             Realm.open(admin2Config).then(admin2Realm => {
-        //                                 admin2Realm.syncSession.downloadAllServerChanges().then(() => {
-        //
-        //                                 }).catch(e => { reject(e); });
-        //                             });
-        //                         }).catch(e => { reject(e); });
-        //                 }).catch(e => { reject(e); });;
-        //             }).catch(e => { reject(e); });
-        //         }).catch(e => { reject(e); });
-        // });
+            Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin1", true))
+                .then((admin1) => {
+                    const admin1Config = admin1.createConfiguration({
+                        sync:  {
+                            url: REALM_URL,
+                            fullSynchronization: true
+                        }
+                    });
+                    Realm.open(admin1Config).then((admin1Realm) => {
+                        admin1Realm.write(() => { admin1Realm.create('CompletionHandlerObject', { 'name': 'foo'}); });
+                        admin1Realm.syncSession.uploadAllLocalChanges().then(() => {
+                            admin1Realm.close();
+                            Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin2", true))
+                                .then((admin2) => {
+                                    const admin2Config = admin2.createConfiguration({
+                                        sync:  {
+                                            url: REALM_URL,
+                                            fullSynchronization: true
+                                        }
+                                    });
+                                    Realm.open(admin2Config).then(admin2Realm => {
+                                        admin2Realm.syncSession.downloadAllServerChanges().then(() => {
+                                            TestCase.assertEqual(1,  admin2Realm.objects('CompletionHandlerObject').length);
+                                            admin2Realm.close();
+                                            resolve();
+                                        }).catch(e => { reject(e); });
+                                    });
+                                }).catch(e => { reject(e); });
+                        }).catch(e => { reject(e); });;
+                    }).catch(e => { reject(e); });
+                }).catch(e => { reject(e); });
+        });
     },
 
     testDownloadAllLocalChanges() {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1271,4 +1271,61 @@ module.exports = {
             })
         })
     },
+
+    testUploadAllLocalChanges() {
+        if(!isNodeProccess) {
+            return;
+        }
+
+        const AUTH_URL = 'http://localhost:9080';
+        const REALM_URL = 'realm://localhost:9080/completion_realm';
+        const schema = {
+            'name': 'CompletionHandlerObject',
+            properties: {
+                'name': { type: 'string'}
+            }
+        }
+
+        return new Promise((resolve, reject) => {
+            try {
+                let admin1 = await Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin1", true));
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        };
+        //         .then((admin1) => {
+        //             const admin1Config = admin1.createConfiguration({
+        //                 sync:  {
+        //                     url: REALM_URL,
+        //                     fullSynchronization: true
+        //                 }
+        //             });
+        //             Realm.open(admin1Config).then((admin1Realm) => {
+        //                 admin1Realm.write(() => { admin1Realm.create('CompletionHandlerObject', { 'name': 'foo'}); });
+        //                 admin1Realm.syncSession.uploadAllLocalChanges().then(() => {
+        //                     admin1Realm.close();
+        //                     Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin2", true))
+        //                         .then((admin2) => {
+        //                             const admin2Config = admin2.createConfiguration({
+        //                                 sync:  {
+        //                                     url: REALM_URL,
+        //                                     fullSynchronization: true
+        //                                 }
+        //                             });
+        //                             Realm.open(admin2Config).then(admin2Realm => {
+        //                                 admin2Realm.syncSession.downloadAllServerChanges().then(() => {
+        //
+        //                                 }).catch(e => { reject(e); });
+        //                             });
+        //                         }).catch(e => { reject(e); });
+        //                 }).catch(e => { reject(e); });;
+        //             }).catch(e => { reject(e); });
+        //         }).catch(e => { reject(e); });
+        // });
+    },
+
+    testDownloadAllLocalChanges() {
+
+    }
 }

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1327,6 +1327,7 @@ module.exports = {
             return;
         }
 
+        const AUTH_URL = 'http://localhost:9080';
         const REALM_URL = 'realm://localhost:9080/timeout_download_realm';
         return new Promise((resolve, reject) => {
             Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))
@@ -1352,6 +1353,7 @@ module.exports = {
             return;
         }
 
+        const AUTH_URL = 'http://localhost:9080';
         const REALM_URL = 'realm://localhost:9080/timeout_upload_realm';
         return new Promise((resolve, reject) => {
             Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1287,7 +1287,7 @@ module.exports = {
         }
 
         return new Promise((resolve, reject) => {
-            Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin1", true))
+            Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin1", true))
                 .then((admin1) => {
                     const admin1Config = admin1.createConfiguration({
                         sync:  {
@@ -1299,7 +1299,7 @@ module.exports = {
                         admin1Realm.write(() => { admin1Realm.create('CompletionHandlerObject', { 'name': 'foo'}); });
                         admin1Realm.syncSession.uploadAllLocalChanges().then(() => {
                             admin1Realm.close();
-                            Realm.Sync.User.login(AUTH_URL, new Realm.Sync.Credentials.nickname("admin2", true))
+                            Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin2", true))
                                 .then((admin2) => {
                                     const admin2Config = admin2.createConfiguration({
                                         sync:  {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1290,6 +1290,7 @@ module.exports = {
             Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin1", true))
                 .then((admin1) => {
                     const admin1Config = admin1.createConfiguration({
+                        schema: [schema],
                         sync:  {
                             url: REALM_URL,
                             fullSynchronization: true
@@ -1302,6 +1303,7 @@ module.exports = {
                             Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin2", true))
                                 .then((admin2) => {
                                     const admin2Config = admin2.createConfiguration({
+                                        schema: [schema],
                                         sync:  {
                                             url: REALM_URL,
                                             fullSynchronization: true

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1272,7 +1272,7 @@ module.exports = {
         })
     },
 
-    testUploadAllLocalChanges() {
+    testUploadDownloadAllChanges() {
         if(!isNodeProccess) {
             return;
         }
@@ -1284,7 +1284,7 @@ module.exports = {
             properties: {
                 'name': { type: 'string'}
             }
-        }
+        };
 
         return new Promise((resolve, reject) => {
             Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin1", true))
@@ -1309,21 +1309,66 @@ module.exports = {
                                             fullSynchronization: true
                                         }
                                     });
-                                    Realm.open(admin2Config).then(admin2Realm => {
-                                        admin2Realm.syncSession.downloadAllServerChanges().then(() => {
-                                            TestCase.assertEqual(1,  admin2Realm.objects('CompletionHandlerObject').length);
-                                            admin2Realm.close();
-                                            resolve();
-                                        }).catch(e => { reject(e); });
-                                    });
+                                    let admin2Realm = new Realm(admin2Config);
+                                    admin2Realm.syncSession.downloadAllServerChanges().then(() => {
+                                        TestCase.assertEqual(1,  admin2Realm.objects('CompletionHandlerObject').length);
+                                        admin2Realm.close();
+                                        resolve();
+                                    }).catch(e => { reject(e); });
                                 }).catch(e => { reject(e); });
-                        }).catch(e => { reject(e); });;
+                        }).catch(e => { reject(e); });
                     }).catch(e => { reject(e); });
                 }).catch(e => { reject(e); });
         });
     },
 
-    testDownloadAllLocalChanges() {
+    testDownloadAllServerChangesTimeout() {
+        if(!isNodeProccess) {
+            return;
+        }
 
+        const REALM_URL = 'realm://localhost:9080/timeout_download_realm';
+        return new Promise((resolve, reject) => {
+            Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))
+                .then((admin1) => {
+                    const admin1Config = admin1.createConfiguration({
+                        sync: {
+                            url: REALM_URL,
+                            fullSynchronization: true
+                        }
+                    });
+                    let realm = new Realm(admin1Config);
+                    realm.syncSession.downloadAllServerChanges(1).then(() => {
+                        reject("Download did not time out");
+                    }).catch(e => {
+                        resolve();
+                    });
+                });
+        });
+    },
+
+    testUploadAllLocalChangesTimeout() {
+        if(!isNodeProccess) {
+            return;
+        }
+
+        const REALM_URL = 'realm://localhost:9080/timeout_upload_realm';
+        return new Promise((resolve, reject) => {
+            Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))
+                .then((admin1) => {
+                    const admin1Config = admin1.createConfiguration({
+                        sync: {
+                            url: REALM_URL,
+                            fullSynchronization: true
+                        }
+                    });
+                    let realm = new Realm(admin1Config);
+                    realm.syncSession.uploadAllLocalChanges(1).then(() => {
+                        reject("Upload did not time out");
+                    }).catch(e => {
+                        resolve();
+                    });
+                });
+        });
     }
-}
+};


### PR DESCRIPTION
Closes https://github.com/realm/realm-js/issues/2122

This PR adds two new API's:
```
Realm.Sync.Session.uploadAllLocalChanges(timeout): Promise<void>
Realm.Sync.Session.downloadAllServerChanges(timeout): Promise<void>
```

These match the methods found in Realm Java.

TODO:
- [x] Fix tests
- [x] Changelog
- [x] Cleanup