### PR TITLE
Protect the context from being GCed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Prevent automatic token refreshes for Realms that have been closed. Previously, these could have resulted in obscure `Unhandled session token refresh error` messages in the logs that were benign. ([#2119](https://github.com/realm/realm-js/pull/2119))
 * When trying to debug, users could experience a crash with the message `this._constructor is not a function`.  (https://github.com/realm/realm-js/issues/491#issuecomment-438688937, since v2.19.0-rc.4)
 * Check the correct name when automatically adding the permission object schemas to the schema for query-based sync realms so that defining types with the same name works correctly. ([#2121](https://github.com/realm/realm-js/pull/2121), since 2.15.0)
+* Fixes a bug where the JS engine might garbage collect an object prematurely. ([#496](https://github.com/realm/realm-js-private/issues/496), since v2.19.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Prevent automatic token refreshes for Realms that have been closed. Previously, these could have resulted in obscure `Unhandled session token refresh error` messages in the logs that were benign. ([#2119](https://github.com/realm/realm-js/pull/2119))
 * When trying to debug, users could experience a crash with the message `this._constructor is not a function`.  (https://github.com/realm/realm-js/issues/491#issuecomment-438688937, since v2.19.0-rc.4)
 * Check the correct name when automatically adding the permission object schemas to the schema for query-based sync realms so that defining types with the same name works correctly. ([#2121](https://github.com/realm/realm-js/pull/2121), since 2.15.0)
-* Fixes a bug where the JS engine might garbage collect an object prematurely. ([#496](https://github.com/realm/realm-js-private/issues/496), since v2.19.0)
+* Fixes a bug where the JS engine might garbage collect an object prematurely leading to a native crash. ([#496](https://github.com/realm/realm-js-private/issues/496), since v2.19.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -890,7 +890,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
         realm->close();
 
         // Reopen it with the real configuration and pass that Realm back to the callback
-        auto final_realm = create_shared_realm(ctx, std::move(config),
+        auto final_realm = create_shared_realm(protected_ctx, std::move(config),
                                                schema_updated, std::move(defaults),
                                                std::move(constructors));
         ObjectType object = create_object<T, RealmClass<T>>(protected_ctx, new SharedRealm(final_realm));


### PR DESCRIPTION
## What, How & Why?
When a JS object isn't protected in a callback, it might be GCed prematurely.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
