### PR TITLE
Add better error message for wrong Realm types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Using methods only available for Query-based Realms now throw a better error message if called on the wrong Realm type.
 
 ### Fixed
 * `_initializeSyncManager` missing when debugging React Native. Resulted in messages like `realmConstructor.Sync._initializeSyncManager is not a function` ([#2128](https://github.com/realm/realm-js/issues/2128), since v2.20.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Using methods only available for Query-based Realms now throw a better error message if called on the wrong Realm type.
+* Using methods only available for Query-based Realms now throw a better error message if called on the wrong Realm file type.
 
 ### Fixed
 * `_initializeSyncManager` missing when debugging React Native. Resulted in messages like `realmConstructor.Sync._initializeSyncManager is not a function` ([#2128](https://github.com/realm/realm-js/issues/2128), since v2.20.0)
-* None.
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -389,6 +389,9 @@ module.exports = function(realmConstructor) {
         // Add instance methods to the Realm object that are only applied if Sync is
         Object.defineProperties(realmConstructor.prototype, getOwnPropertyDescriptors({
             permissions(arg) {
+                if (!this._isPartialRealm) {
+                    throw new Error("Wrong Realm type. 'permissions()' is only available for Query-based Realms.");
+                }
                 // If no argument is provided, return the Realm-level permissions
                 if (arg === undefined) {
                     return this.objects('__Realm').filtered(`id = 0`)[0];
@@ -404,6 +407,9 @@ module.exports = function(realmConstructor) {
             },
 
             subscriptions(name) {
+                if (!this._isPartialRealm) {
+                    throw new Error("Wrong Realm type. 'subscriptions()' is only available for Query-based Realms.");
+                }
                 let all_subscriptions = this.objects('__ResultSets');
                 if (name) {
                     if (typeof(name) !== 'string') {
@@ -429,6 +435,9 @@ module.exports = function(realmConstructor) {
             },
 
             unsubscribe(name) {
+                if (!this._isPartialRealm) {
+                    throw new Error("Wrong Realm type. 'unsubscribe()' is only available for Query-based Realms.");
+                }
                 if (typeof(name) === 'string') {
                     if (name !== '') {
                         let named_subscriptions = this.objects('__ResultSets').filtered(`name == '${name}'`);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -821,7 +821,6 @@ declare class Realm {
      */
     writeCopyTo(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): void;
 
-    privileges() : Realm.Permissions.Realm;
     privileges() : Realm.Permissions.RealmPrivileges;
     privileges(objectType: string | Realm.ObjectSchema | Function) : Realm.Permissions.ClassPrivileges;
     privileges(obj: Realm.Object) : Realm.Permissions.ObjectPrivileges;

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1224,10 +1224,12 @@ void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this
     return_value.set(object_schema.name);
 }
 
+if
 template<typename T>
 void RealmClass<T>::privileges(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
     args.validate_maximum(1);
 
+#if REALM_ENABLE_SYNC
     using Privilege = realm::ComputedPrivileges;
     auto has_privilege = [](Privilege actual, Privilege expected) {
         return (static_cast<int>(actual) & static_cast<int>(expected)) == static_cast<int>(expected);
@@ -1274,6 +1276,9 @@ void RealmClass<T>::privileges(ContextType ctx, ObjectType this_object, Argument
     Object::set_property(ctx, object, "subscribe", Value::from_boolean(ctx, has_privilege(p, Privilege::Query)));
     Object::set_property(ctx, object, "setPermissions", Value::from_boolean(ctx, has_privilege(p, Privilege::SetPermissions)));
     return_value.set(object);
+#else
+    throw std::logic_error("Realm.privileges() can only be used with Query-based Realms.");
+#endif
 }
 
 } // js

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1224,7 +1224,6 @@ void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this
     return_value.set(object_schema.name);
 }
 
-if
 template<typename T>
 void RealmClass<T>::privileges(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
     args.validate_maximum(1);

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1465,4 +1465,27 @@ module.exports = {
         realm.close();
     },
 
+
+    testQueryBasedOnlyMethods: function() {
+        const realm = new Realm({sync: true});
+        TestCase.assertThrowsContaining(() =>  {
+            realm.privileges();
+        }, 'Wrong Realm type');
+        TestCase.assertThrowsContaining(() =>  {
+            realm.privileges('__Role');
+        }, 'Wrong Realm type');
+        TestCase.assertThrowsContaining(() =>  {
+            realm.permissions();
+        }, 'Wrong Realm type');
+        TestCase.assertThrowsContaining(() =>  {
+            realm.permissions('__Class');
+        }, 'Wrong Realm type');
+        TestCase.assertThrowsContaining(() =>  {
+            realm.subscriptions();
+        }, 'Wrong Realm type');
+        TestCase.assertThrowsContaining(() =>  {
+            realm.unsubscribe('foo');
+        }, 'Wrong Realm type');
+    } ,
+
 };

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1467,6 +1467,10 @@ module.exports = {
 
 
     testQueryBasedOnlyMethods: function() {
+        if (!global.enableSyncTests) {
+            return;
+        }
+
         const realm = new Realm({sync: true});
         TestCase.assertThrowsContaining(() =>  {
             realm.privileges();


### PR DESCRIPTION
Some methods are only available for Query-based Realms. Previously they would fail with non-sensical error messages.

The type of Realm is now checked and a better error message is thrown.

This fixes the problems reported in https://github.com/realm/realm-js/issues/2131