### PR TITLE
change the default for argv because child process expects argv to be an array

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -33,7 +33,8 @@ class Worker {
         this.modulePath = modulePath;
         this.maxWorkers = options.maxWorkers || os.cpus().length;
         this.env = options.env || {};
-        this.execArgv = options.execArgv || {};
+        //change the default for argv because child process expects argv to be an array
+        this.execArgv = options.execArgv || [];
 
         this._workers = [];
         this._waiting = [];


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [x] 🚦 Tests
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
