### PR TITLE
Fix return type in API documentation of Realm.permissions() and Realm…

### DIFF
--- a/docs/realm.js
+++ b/docs/realm.js
@@ -168,7 +168,7 @@ class Realm {
      *
      * @param {(Realm~ObjectType|Realm.Object)} arg - the object type or the object to compute privileges from. If no
      *   argument is given, the privileges for the Realm is returned.
-     * @returns {Object} as the computed privileges as properties
+     * @returns {Realm.Permissions.RealmPrivileges|Realm.Permissions.ClassPrivileges|Realm.Permissions.ObjectPrivileges} as the computed privileges as properties
      * @since 2.3.0
      * @see {Realm.Permissions} for details of privileges and roles.
      */
@@ -179,7 +179,7 @@ class Realm {
      *
      * @param {Realm~ObjectType} [arg] - If no argument is provided, the Realm-level permissions are returned.
      *   Otherwise, the Class-level permissions for the provided type is returned.
-     * @returns {Object} The permissions object
+     * @returns {Realm.Permissions.Realm|Realm.Permissions.Class} The permissions object
      * @since 2.18.0
      * @see {Realm.Permissions} for details of priviliges and roles.
      */


### PR DESCRIPTION
….privileges()

<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #2202

## ☑️ ToDos
<!-- Add your own todos here -->
* ~[ ] 📝 Changelog entry~
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
