### PR TITLE
Don't include headers from the developers JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Upgraded to Realm Core v5.13.0.
 * Upgraded to Realm Sync v3.14.14.
+* Stopped including headers from developers JDK when building the Android native module. ([#2223](https://github.com/realm/realm-js/pull/2223))
 
 2.22.0 Release notes (2019-1-10)
 =============================================================

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -95,9 +95,6 @@ LOCAL_C_INCLUDES += src/jsc
 LOCAL_C_INCLUDES += src/object-store/src
 LOCAL_C_INCLUDES += src/object-store/src/impl
 LOCAL_C_INCLUDES += vendor
-LOCAL_C_INCLUDES += $(JAVA_HOME)/include
-LOCAL_C_INCLUDES += $(JAVA_HOME)/include/darwin
-LOCAL_C_INCLUDES += $(JAVA_HOME)/include/linux
 LOCAL_C_INCLUDES += core/include
 LOCAL_C_INCLUDES += core/openssl-release-1.0.2k-Android-$(TARGET_ARCH_ABI)/include
 ifeq ($(strip $(BUILD_TYPE_SYNC)),1)

--- a/src/android/jni_utils.cpp
+++ b/src/android/jni_utils.cpp
@@ -37,7 +37,7 @@ JNIEnv* JniUtils::get_env(bool attach_if_needed)
     JNIEnv* env;
     if (s_instance->m_vm->GetEnv(reinterpret_cast<void**>(&env), s_instance->m_vm_version) != JNI_OK) {
         if (attach_if_needed) {
-            jint ret = s_instance->m_vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
+            jint ret = s_instance->m_vm->AttachCurrentThread(&env, nullptr);
         }
     }
 


### PR DESCRIPTION
## What, How & Why?

This fixes a build failure that happened when building the react native native module for Android when the developers machine does not have JDK installed: It turns out the makefile was including headers from the developers JDK, which could override the includes provided by the Android NDK.

This fixes the issue by not including the said header files in the Android.mk makefile and removed a cast to `void**`.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 ~Tests~
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
