### PR TITLE
Add support for proxy when downloading realm-sync-cocoa

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "decompress": "^4.2.0",
     "deepmerge": "2.1.0",
     "fs-extra": "^4.0.2",
+    "https-proxy-agent": "^2.2.1",
     "ini": "^1.3.4",
     "nan": "^2.10.0",
     "node-fetch": "^1.6.3",

--- a/scripts/download-realm.js
+++ b/scripts/download-realm.js
@@ -23,6 +23,7 @@ const path = require('path');
 const os = require('os');
 const child_process = require('child_process');
 const fetch = require('node-fetch');
+const HttpsProxyAgent = require('https-proxy-agent');
 const ini = require('ini');
 const decompress = require('decompress');
 const crypto = require('crypto');
@@ -90,7 +91,13 @@ function printProgress(input, totalBytes, archive) {
 function download(serverFolder, archive, destination) {
     const url = `https://static.realm.io/downloads/${serverFolder}/${archive}`;
     console.log(`Download url: ${url}`);
-    return fetch(url).then((response) => {
+    const proxyUrl = process.env.HTTP_PROXY || process.env.http_proxy || process.env.HTTPS_PROXY || process.env.https_proxy;
+    let agent;
+    if (proxyUrl) {
+        const agentOpts = require('url').parse(proxyUrl);
+        agent = new HttpsProxyAgent(agentOpts);
+    }
+    return fetch(url, { agent }).then((response) => {
         if (response.status !== 200) {
             throw new Error(`Error downloading ${url} - received status ${response.status} ${response.statusText}`);
         }


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

I had trouble building for iOS due to network (proxy) issues. I tried the fix proposed here : https://realm.io/docs/javascript/latest/#cannot-download-realm-sync-cocoa but couldn't make it work.

I believe this patch fixes issues related to proxy by adding a proxy configuration to the node-fetch call for downloading the realm-sync-cocoa package.

