### PR TITLE
Implement _asyncOpen as a RPC call for the RN debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Realm initialized the filesystem when being imported instead of waiting for the first Realm to be opened. ([#2218] (https://github.com/realm/realm-js/issues/2218), since v2.22.0).
+* When debugging with React Native, calling `Realm.open()` will crach since `Realm._asyncOpen()` is not available in the debugger. ([](), since v2.20.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Realm initialized the filesystem when being imported instead of waiting for the first Realm to be opened. ([#2218] (https://github.com/realm/realm-js/issues/2218), since v2.22.0).
-* When debugging with React Native, calling `Realm.open()` will crach since `Realm._asyncOpen()` is not available in the debugger. ([#2234](https://github.com/realm/realm-js/pull/2234), since v2.20.0)
+* When debugging with React Native, calling `Realm.open()` would crash since `Realm._asyncOpen()` was not available in the debugger. ([#2234](https://github.com/realm/realm-js/pull/2234), since v2.20.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Realm initialized the filesystem when being imported instead of waiting for the first Realm to be opened. ([#2218] (https://github.com/realm/realm-js/issues/2218), since v2.22.0).
-* When debugging with React Native, calling `Realm.open()` will crach since `Realm._asyncOpen()` is not available in the debugger. ([](), since v2.20.0)
+* When debugging with React Native, calling `Realm.open()` will crach since `Realm._asyncOpen()` is not available in the debugger. ([#2234](https://github.com/realm/realm-js/pull/2234), since v2.20.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -132,7 +132,6 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'close',
     '_waitForDownload',
     '_objectForObjectId',
-    '_asyncOpen',
 ]);
 
 // Mutating methods:
@@ -199,6 +198,11 @@ Object.defineProperties(Realm, {
             collections.clearMutationListeners();
             objects.clearRegisteredConstructors();
             rpc.clearTestState();
+        },
+    },
+    _asyncOpen: {
+        value: function() {
+            return rpc.callMethod(undefined, Realm[keys.id], '_asyncOpen', Array.from(arguments));
         },
     },
 });

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -316,6 +316,24 @@ RPCServer::RPCServer() {
         jsc::Function::call(m_context, initialize_sync_manager_method, arg_count, arg_values);
         return json::object();
     };
+    m_requests["/_asyncOpen"] = [this](const json dict) {
+        JSObjectRef realm_constructor = m_session_id ? JSObjectRef(m_objects[m_session_id]) : NULL;
+        if (!realm_constructor) {
+            throw std::runtime_error("Realm constructor not found!");
+        }
+
+        JSObjectRef _asyncOpen_method = (JSObjectRef)jsc::Object::get_property(m_context, realm_constructor, "_asyncOpen");
+        json::array_t args = dict["arguments"];
+        size_t arg_count = args.size();
+        JSValueRef arg_values[arg_count];
+
+        for (size_t i = 0; i < arg_count; i++) {
+            arg_values[i] = deserialize_json_value(args[i]);
+        }
+
+        jsc::Function::call(m_context, _asyncOpen_method, arg_count, arg_values);
+        return json::object();
+    };
     m_requests["/call_method"] = [this](const json dict) {
         JSObjectRef object = m_objects[dict["id"].get<RPCObjectID>()];
         std::string method_string = dict["name"].get<std::string>();


### PR DESCRIPTION

* Implement _asyncOpen as a RPC call for the RN debugger

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* [x] Chrome debug API is updated if API is available on React Native
