### PR TITLE
Reduce bundled size from 42KB to 24KB

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,12 @@ switch(context) {
 
     case 'chromedebugger':
     case 'vscodedebugger':
-        realmConstructor = require('./browser').default; // (exported as ES6 module)
+        // This condition is for stripping "browser" folder from production bundles.
+        if (__DEV__) {
+            realmConstructor = require('./browser').default; // (exported as ES6 module)
+        } else {
+            throw new Error('Can\'t use debugger if __DEV__ isn\'t true.');
+        }
         break;
 }
 


### PR DESCRIPTION
## What, How & Why?
By using `source-map-explorer` with my production bundle I've noticed that `realm` includes `browser` folder, which makes it's bundled size 42KB total.

![Current bundled realm-js](https://user-images.githubusercontent.com/5000549/51808739-05ee1680-22c2-11e9-8af3-e171eddcb84e.png)

Metro Bundler of React Native lacks tree shaking feature, however it's possible to exclude `browser` folder from production bundles by making it's require conditional with `__DEV__`.

![Bundled realm-js with this PR applied](https://user-images.githubusercontent.com/5000549/51808768-45b4fe00-22c2-11e9-9c96-6160087fec4c.png)

I tested this patch on Android in production mode and in debug mode with Chrome debugger. It works fine.
I didn't test it on iOS, but it should works without any changes too.
And I didn't test with VSCode debugger. I haven't VSCode and can't test this patch with it. It could break if with VSCode debugger `__DEV__` global isn't set for some reason. But I assume that it should work as that global is set by React Native bundler, and not by VScode.