### PR TITLE
Updated pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
+<!-- Make sure to assign one and only one Type (`T:`) label.
  Select reviewers if ready for review. Our bot will automatically assign you. -->
 
 ## What, How & Why?


### PR DESCRIPTION
## What, How & Why?

It seems out PR template mentions state labels which are no longer present at this repository.

## ☑️ ToDos
* [ ] 📝 ~Changelog entry~
* [ ] 📝 ~`Compatibility` label is updated or copied from previous entry~
* [ ] 🚦 ~Tests~
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary