### PR TITLE
Fix a flaky test

### DIFF
--- a/tests/electron/app/main.js
+++ b/tests/electron/app/main.js
@@ -55,15 +55,11 @@ app.on("ready", () => {
     console.log("Running tests in the main process.");
     const jasmine = require("./jasmine.js").execute(filter);
     jasmine.onComplete((passed) => {
-      process.exit(passed ? 0 : -1);
+      console.log(`Testing completed with status ${passed ? 0 : -1}`)
     });
   } else if(runIn === "render") {
     console.log("Running tests in the render process.");
   } else {
     throw new Error("Can only run the tests in the 'main' or 'render' process");
   }
-});
-
-app.on("quit", (e, exitCode) => {
-  console.log("Electron process stopped, with status", exitCode);
 });

--- a/tests/electron/app/renderer.js
+++ b/tests/electron/app/renderer.js
@@ -6,7 +6,6 @@ const options = remote.getGlobal("options");
 if (options.runIn === "render") {
   const jasmine = require("./jasmine.js").execute(options.filter);
   jasmine.onComplete((passed) => {
-    // Add a delay if this happens too fast, to allow the WebDriver to connect first.
-    remote.process.exit(passed ? 0 : -1);
+    console.log(`Testing completed with status ${passed ? 0 : -1}`)
   });
 }

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -175,8 +175,9 @@ module.exports = {
   },
 
   testLoginTowardsMisbehavingServer() {
-    // Try authenticating towards a server thats clearly not ROS
-    return Realm.Sync.User.login('https://github.com/realm/realm-js', Realm.Sync.Credentials.anonymous())
+    // Try authenticating using an endpoint that doesn't exist
+    return Realm.Sync.User.login('http://localhost:9080/invalid-auth-endpoint', Realm.Sync.Credentials.anonymous())
+      .then(() => { throw new Error('Login should have failed'); })
       .catch((e) => {
         assertIsError(e);
         TestCase.assertEqual(


### PR DESCRIPTION
The testLoginTowardsMisbehavingServer() would sometimes fail on CI due to failing to connect to the server at all rather than getting an invalid response from the server. Fix this by instead pointing at a local endpoint that won't give a valid response.

Fixes #2274.
