### PR TITLE
Removing Realm as dev dependency of the integration test suite

### DIFF
--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p .",
     "start": "ts-mocha --project ./tsconfig.json --require src/utils/segfault-handler.js --require src/utils/inject-globals.js --watch-extensions ts,js --watch src/index.ts",
-    "prepack": "(test -d node_modules || npm ci) && npm run build",
+    "prepack": "(test -d node_modules || npm ci --build-from-source=realm) && npm run build",
     "lint": "tslint -p ."
   },
   "peerDependencies": {


### PR DESCRIPTION
## What, How & Why?

This fixes an issue where integration tests suite would fail to install because Realm JS was not published. This happens when the integration test environments tries to pack up the integration test suite while the package.json of the Realm JS has a version that has not been published yet.

Instead of a dev dependency on Realm the test suite will `npm link` Realm at runtime when running the tests using `npm run dev`.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
