### PR TITLE
Fixed adding property to existing class using _updateSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Fixing the Electron integration tests. ([#2286](https://github.com/realm/realm-js/pull/2286))
+* Fixed adding a property to an existing object schema using the internal `realm._updateSchema`. ([#2283](https://github.com/realm/realm-js/pull/2283), since v2.24.0)
 
 2.25.0 Release notes (2019-3-12)
 =============================================================

--- a/integration-tests/tests/src/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/dynamic-schema-updates.ts
@@ -91,8 +91,9 @@ describe("realm._updateSchema", () => {
                 },
                 friends: {
                     indexed: false,
-                    name: "owner",
+                    name: "friends",
                     objectType: "Dog",
+                    optional: false,
                     type: "list"
                 },
                 name: {

--- a/integration-tests/tests/src/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/dynamic-schema-updates.ts
@@ -66,6 +66,52 @@ describe("realm._updateSchema", () => {
         });
     });
 
+    it("creates a property on an existing class", () => {
+        const realm = new Realm({ schema: PersonAndDogSchema });
+        // Copy the schema
+        const updatedSchema = [...realm.schema];
+        // Locate the Dog schema
+        const dogSchema = updatedSchema.find(s => s.name === "Dog");
+        // Add a fields property
+        dogSchema.properties.friends = "Dog[]";
+        // Update the schema
+        realm.write(() => {
+            realm._updateSchema(updatedSchema);
+        });
+
+        const ModifiedDogSchema = realm.schema.find(s => s.name === "Dog");
+        expect(ModifiedDogSchema).to.deep.equal({
+            name: "Dog",
+            properties: {
+                age: {
+                    indexed: false,
+                    name: "age",
+                    optional: false,
+                    type: "int"
+                },
+                friends: {
+                    indexed: false,
+                    name: "owner",
+                    objectType: "Dog",
+                    type: "list"
+                },
+                name: {
+                    indexed: false,
+                    name: "name",
+                    optional: false,
+                    type: "string"
+                },
+                owner: {
+                    indexed: false,
+                    name: "owner",
+                    objectType: "Person",
+                    optional: true,
+                    type: "object"
+                }
+            }
+        });
+    });
+
     it("can use a newly added class", () => {
         const realm = new Realm({ schema: PersonAndDogSchema });
         realm.write(() => {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -71,12 +71,17 @@ declare namespace Realm {
     }
 
     /**
+     * A function which can be called to migrate a Realm from one version of the schema to another.
+     */
+    type MigrationCallback = (oldRealm: Realm, newRealm: Realm) => void;
+
+    /**
      * realm configuration
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.html#~Configuration }
      */
     interface Configuration {
         encryptionKey?: ArrayBuffer | ArrayBufferView | Int8Array;
-        migration?: (oldRealm: Realm, newRealm: Realm) => void;
+        migration?: MigrationCallback;
         shouldCompactOnLaunch?: (totalBytes: number, usedBytes: number) => boolean;
         path?: string;
         fifoFilesFallbackPath?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,7 +221,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "dev": true,
       "requires": {
         "typical": "^2.6.1"
       }
@@ -471,7 +470,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "find-replace": "^1.0.3",
@@ -1022,7 +1020,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-      "dev": true,
       "requires": {
         "array-back": "^1.0.4",
         "test-value": "^2.1.0"
@@ -1032,7 +1029,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2636,7 +2632,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "dev": true,
       "requires": {
         "array-back": "^1.0.3",
         "typical": "^2.6.0"
@@ -2646,7 +2641,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2768,8 +2762,7 @@
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-      "dev": true
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "unbzip2-stream": {
       "version": "1.3.2",

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1321,7 +1321,7 @@ void RealmClass<T>::update_schema(ContextType ctx, ObjectType this_object, Argum
     // Perform the schema update
     realm->update_schema(
         parsed_schema,
-        realm->schema_version(),
+        realm->schema_version() + 1,
         nullptr,
         nullptr,
         true


### PR DESCRIPTION
## What, How & Why?

This fixes adding a property to an existing class (part of #2216).

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
