### PR TITLE
Adding a global notifier listener that triggers at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* [Sync] Emit a `startup` event to the Sync event listener when a Realm matching the regex is detected upon the listener startup.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -1037,8 +1037,7 @@ class Subscription {
  *    console.log(`Realm at ${path} deleted`);
  * }
  * 
-
- * module.exports = {onchange, oncavailable, ondelete};
+ * module.exports = {onstartup, onchange, oncavailable, ondelete};
  *
  * // server script
  * Realm.Sync.addListener(realmServerURL, adminUser, '.*', new Realm.Worker('my-worker'));

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -122,6 +122,10 @@ class Sync {
      *
      * Currently supported events:
      *
+     *  * `'startup'`: Emitted when the listener start. It returns the Realm(s) matching the filter
+     *    regex. A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument
+     *    containing the `path` and `realm` properties (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} 
+     *    properties are N/A). 
      *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
      *    path matching the filter regex, either due to the Realm being newly created
      *    or the listener being added. The virtual path (i.e. the portion of the
@@ -150,7 +154,11 @@ class Sync {
      * Only events on Realms with a _virtual path_ that matches the filter regex are emitted.
      *
      * Currently supported events:
-     *
+     * 
+     *  * `'startup'`: Emitted when the listener start. It returns the Realm(s) matching the filter
+     *    regex. A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument
+     *    containing the `path` and `realm` properties (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} 
+     *    properties are N/A). 
      *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
      *    path matching the filter regex, either due to the Realm being newly created
      *    or the listener being added. The virtual path (i.e. the portion of the
@@ -990,6 +998,10 @@ class Subscription {
  *
  * Currently supported events:
  *
+ *  * `'startup'`: Emitted when the listener start. It returns the Realm(s) matching the filter
+ *    regex. A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument
+ *    containing the `path` and `realm` properties (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} 
+ *    properties are N/A).    
  *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
  *    path matching the filter regex, either due to the Realm being newly created
  *    or the listener being added. The virtual path (i.e. the portion of the
@@ -1009,18 +1021,23 @@ class Subscription {
  *
  * @example
  * // my-worker.js
- * function onchange(path) {
- *    console.log(`Realm created at ${path}`);
+ * function onstartup(path) {
+ *    console.log(`Realm at ${path} deleted`);
  * }
- *
- * function onavailable(change) {
+ * 
+ * function onavailable(startup) {
+ *    console.log(`Realm startup at ${startup.path}`);
+ * }
+ * 
+ * function onchange(change) {
  *    console.log(`Realm at ${change.path} changed`);
  * }
  *
  * function ondelete(path) {
  *    console.log(`Realm at ${path} deleted`);
  * }
- *
+ * 
+
  * module.exports = {onchange, oncavailable, ondelete};
  *
  * // server script

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -155,10 +155,9 @@ class Sync {
      *
      * Currently supported events:
      * 
-     *  * `'startup'`: Emitted when the listener start. It returns the Realm(s) matching the filter
-     *    regex. A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument
-     *    containing the `path` and `realm` properties (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} 
-     *    properties are N/A). 
+     *  * `'startup'`: Emitted for every Realm matching the filter regex, before the corresponding Realm is opened for Sync.
+     *    A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument is passed containing containing the `path` and `realm`
+     *    properties, (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} properties are N/A).
      *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
      *    path matching the filter regex, either due to the Realm being newly created
      *    or the listener being added. The virtual path (i.e. the portion of the
@@ -998,10 +997,9 @@ class Subscription {
  *
  * Currently supported events:
  *
- *  * `'startup'`: Emitted when the listener start. It returns the Realm(s) matching the filter
- *    regex. A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument
- *    containing the `path` and `realm` properties (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} 
- *    properties are N/A).    
+ *  * `'startup'`: Emitted for every Realm matching the filter regex, before the corresponding Realm is opened for Sync.
+ *    A [ChangeEvent]{@link Realm.Sync.ChangeEvent} argument is passed containing containing the `path` and `realm`
+ *    properties, (other [ChangeEvent]{@link Realm.Sync.ChangeEvent} properties are N/A).
  *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
  *    path matching the filter regex, either due to the Realm being newly created
  *    or the listener being added. The virtual path (i.e. the portion of the
@@ -1021,12 +1019,12 @@ class Subscription {
  *
  * @example
  * // my-worker.js
- * function onstartup(path) {
- *    console.log(`Realm at ${path} deleted`);
+ * function onstartup(startup) {
+ *    console.log(`Realm at ${startup.path} startup`);
  * }
  * 
- * function onavailable(startup) {
- *    console.log(`Realm startup at ${startup.path}`);
+ * function onavailable(path) {
+ *    console.log(`Realm available at ${path}`);
  * }
  * 
  * function onchange(change) {
@@ -1036,7 +1034,7 @@ class Subscription {
  * function ondelete(path) {
  *    console.log(`Realm at ${path} deleted`);
  * }
- * 
+ *
  * module.exports = {onstartup, onchange, oncavailable, ondelete};
  *
  * // server script

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -589,7 +589,7 @@ declare namespace Realm.Sync {
         readonly realm: Realm;
     }
 
-    type RealmListenerEventName = 'available' | 'change' | 'delete';
+    type RealmListenerEventName = 'startup' | 'available' | 'change' | 'delete';
 
     interface RealmListenerConfiguration {
         serverUrl: string;

--- a/lib/notification-worker.js
+++ b/lib/notification-worker.js
@@ -60,6 +60,21 @@ process.on('message', (m) => {
             }
             process.send({change: m.change});
             break;
+        case 'startup':
+            if (impl['on' + m.message]) {
+                const startupRealm = Realm.Sync._deserializeStartup(m.change);
+                try {
+                    impl.onstartup(startupRealm);
+                }
+                catch (e) {
+                    startupRealm.close();
+                    process.send({change: m.change});
+                    throw e;
+                }
+                startupRealm.close();
+            }
+            process.send({change: m.change});
+            break;
         case 'message':
             if (impl.onmessage) {
                 impl.onmessage(m.body);

--- a/lib/notification-worker.js
+++ b/lib/notification-worker.js
@@ -61,17 +61,17 @@ process.on('message', (m) => {
             process.send({change: m.change});
             break;
         case 'startup':
-            if (impl['on' + m.message]) {
-                const startupRealm = Realm.Sync._deserializeStartup(m.change);
+            if (impl['onstartup']) {
+                const startupObject = Realm.Sync._deserializeStartup(m.change);
                 try {
-                    impl.onstartup(startupRealm);
+                    impl.onstartup(startupObject);
                 }
                 catch (e) {
-                    startupRealm.close();
+                    startupObject.close();
                     process.send({change: m.change});
                     throw e;
                 }
-                startupRealm.close();
+                startupObject.close();
             }
             process.send({change: m.change});
             break;

--- a/lib/notification-worker.js
+++ b/lib/notification-worker.js
@@ -27,8 +27,10 @@ function nodeRequire(module) {
 
 const Realm = nodeRequire('.');
 
+let stop = false;
+let startupInProgress = false;
 let impl;
-process.on('message', (m) => {
+process.on('message', async (m) => {
     switch (m.message) {
         case 'load':
             impl = require(m.module);
@@ -62,18 +64,24 @@ process.on('message', (m) => {
             break;
         case 'startup':
             if (impl['onstartup']) {
+                startupInProgress = true;
                 const startupObject = Realm.Sync._deserializeStartup(m.change);
                 try {
-                    impl.onstartup(startupObject);
+                    await impl.onstartup(startupObject);
                 }
                 catch (e) {
                     startupObject.close();
-                    process.send({change: m.change});
+                    process.send({message: 'startup', change: m.change});
                     throw e;
-                }
+                }                
                 startupObject.close();
+                startupInProgress = false;
             }
-            process.send({change: m.change});
+            process.send({message: 'startup', change: m.change});
+            // close the process if reuested to do so
+            if (stop) {
+                process.exit(0);
+            }
             break;
         case 'message':
             if (impl.onmessage) {
@@ -82,6 +90,9 @@ process.on('message', (m) => {
             process.send({});
             break;
         case 'stop':
-            process.exit(0);
+            stop = true;
+            if (!startupInProgress) {
+                process.exit(0);
+            }           
     }
 });

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -59,7 +59,7 @@ class FunctionListener {
     invoke(changes, arg) {
         let promise;
         try {
-            promise = Promise.resolve(this.fn(arg));
+            promise = Promise.resolve(this.fn(...arg));
         }
         catch (e) {
             changes.release();
@@ -87,7 +87,7 @@ class FunctionListener {
             return;
         }
 
-        this.invoke(changes, changes);
+        this.invoke(changes, [changes]);
     }
 
     ondelete(changes) {
@@ -96,7 +96,14 @@ class FunctionListener {
             return;
         }
 
-        this.invoke(changes, changes.path);
+        this.invoke(changes, [changes.path]);
+    }
+
+    onstartup(virtualPath,  realm) {
+        if (this.event === 'startup' && this.regex.test(virtualPath)) {
+            this.invoke(realm, [virtualPath, realm]);
+        }
+        realm.release();
     }
 }
 
@@ -139,6 +146,13 @@ class OutOfProcListener {
             return;
         }
         this.worker.ondelete(changes);
+    }
+
+    onstartup(path, id) {
+        if (!this.regex.test(path)) {
+            return;
+        }
+        this.worker.onstartup(path, id);
     }
 }
 
@@ -190,6 +204,23 @@ class Listener {
             }
         }
         return watch;
+    }
+
+    startup(virtualPath, id) {
+        var realm = this.notifier.get_realm_by_id(id);
+        if (realm) {
+            let refCount = 1;
+            realm.release = () => {
+                if (--refCount === 0) {
+                    realm.close();
+                }
+            }
+            for (const callback of this.callbacks) {
+                ++refCount;
+                callback.onstartup(virtualPath,  realm);
+            }
+            realm.release();
+        }
     }
 
     // public API implementation
@@ -263,7 +294,7 @@ function addListener(server, user, regex, event, callback) {
 
     // If the old API is used, convert all arguments to the new API
     // If `event` is a Worker, only 4 arguments are provided
-    if (arguments.length === 4 || arguments.length === 5) {
+    if (arguments.length > 3) {
         _config = {
             serverUrl: server,
             adminUser:  user,
@@ -278,42 +309,6 @@ function addListener(server, user, regex, event, callback) {
         listener = new Listener(this, _config);
     }
     return listener.add(_config.filterRegex, _event, _callback);
-}
-
-function addStartupListener(config, callback) {
-    if (!config.serverUrl || !config.adminUser || !config.filterRegex) {
-        throw new Error(`Invalid 'config' parameter ${JSON.stringify(config)},'serverUrl', 'adminUser' and 'filterRegex' are required parameters`);
-    }
-    // let config = {
-    //     serverUrl: server,
-    //     adminUser:  user,
-    //     filterRegex: regex,
-    //     sslConfiguration: sslConfiguration
-    // };
-
-    if (!listener) {
-        listener = new Listener(this, config);
-    }
-
-    const realmAvailableCallback = (realmPath, realmId) => {
-        const absolutePath = require('path').join(require('process').cwd(), 'realm-object-server/listener/realms', realmPath, `${realmId}.realm`);
-        if (require('fs').existsSync(absolutePath)) {
-            new Promise(async (resolve) => {
-                var realm = new Realm({
-                    path: absolutePath,
-                    sync: true
-                });        
-                await callback(realmPath, realm); // callback could be an async or sync function.  
-                realm.close(); // close the Realm to avoid realm::MismatchedConfigException realm already opened with different sync configurations.
-                // remove this callback (this should only run the first time on startup)
-                listener.remove(config.filterRegex, 'available', realmAvailableCallback);
-                resolve();
-             });
-        }// do not trigger if the Realm is not yet downloaded, in this case it doesn't makes sense to trigger this callback, since the user will 
-        //  get the 'change' event callback.        
-    };
-    // register a one time callback to be triggered when the Realm becomes available.
-    return listener.add(config.filterRegex, 'available', realmAvailableCallback);
 }
 
 function removeListener(regex, event, callback) {

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -56,7 +56,7 @@ class FunctionListener {
                 this.fn(path);
                 this.seen[id] = true;
             }
-            return true;
+            return this.event === 'change';
         }
         return false;
     }

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -99,11 +99,11 @@ class FunctionListener {
         this.invoke(changes, [changes.path]);
     }
 
-    onstartup(virtualPath,  realm) {
+    onstartup(virtualPath, startupObject) {
         if (this.event === 'startup' && this.regex.test(virtualPath)) {
-            this.invoke(realm, [virtualPath, realm]);
+            this.invoke(startupObject, [virtualPath, startupObject]);
         }
-        realm.release();
+        startupObject.release();
     }
 }
 
@@ -148,11 +148,11 @@ class OutOfProcListener {
         this.worker.ondelete(changes);
     }
 
-    onstartup(path, id) {
-        if (!this.regex.test(path)) {
+    onstartup(changes) {
+        if (!this.regex.test(changes.path)) {
             return;
         }
-        this.worker.onstartup(path, id);
+        this.worker.onstartup(changes);
     }
 }
 
@@ -206,21 +206,18 @@ class Listener {
         return watch;
     }
 
-    startup(virtualPath, id) {
-        var realm = this.notifier.get_realm_by_id(id);
-        if (realm) {
-            let refCount = 1;
-            realm.release = () => {
-                if (--refCount === 0) {
-                    realm.close();
-                }
+    startup(startupObject) {
+        let refCount = 1;
+        startupObject.release = () => {
+            if (--refCount === 0) {
+                startupObject.close();
             }
-            for (const callback of this.callbacks) {
-                ++refCount;
-                callback.onstartup(virtualPath,  realm);
-            }
-            realm.release();
         }
+        for (const callback of this.callbacks) {
+            ++refCount;
+            callback.onstartup(startupObject);
+        }
+        startupObject.release();
     }
 
     // public API implementation

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -77,6 +77,16 @@ class FunctionListener {
         });
     }
 
+    async invokeAsync(changes, arg) {
+        try {
+            await Promise.resolve(this.fn(arg));
+            changes.release();
+        } catch (e) {
+            changes.release();
+            throw e;
+        }
+    }
+
     onchange(changes) {
         if (this.event !== 'change' || !this.regex.test(changes.path)) {
             changes.release();
@@ -99,11 +109,12 @@ class FunctionListener {
         this.invoke(changes, changes.path);
     }
 
-    onstartup(startupObject) {
-        if (this.event === 'startup' && this.regex.test(startupObject.path)) {
-            this.invoke(startupObject, startupObject);
+    async onstartup(startupObject) {
+        if (this.event !== 'startup' || !this.regex.test(startupObject.path)) {
+            startupObject.release();
+            return;
         }
-        startupObject.release();
+        await this.invokeAsync(startupObject, startupObject);        
     }
 }
 
@@ -148,19 +159,27 @@ class OutOfProcListener {
         this.worker.ondelete(changes);
     }
 
-    onstartup(changes) {
+    async onstartup(changes) {
         if (!this.regex.test(changes.path)) {
             return;
         }
-        this.worker.onstartup(changes);
+        await this.worker.onstartup(changes);
     }
 }
 
 class Listener {
     constructor(Sync, config) {
-        this.notifier = Sync._createNotifier(config.serverUrl, config.adminUser, (event, a1, a2) => this[event](a1, a2), config.sslConfiguration);
+        this.notifier = Sync._createNotifier(config.serverUrl, config.adminUser, this.eventHandler.bind(this), config.sslConfiguration);
         this.initPromises = [];
         this.callbacks = [];
+    }
+
+    async eventHandler(event, arg1, arg2) {
+        if (event === 'startup') {
+            await this.startup(arg1);                       
+        } else {
+            this[event](arg1, arg2);
+        }        
     }
 
     // callbacks for C++ functions
@@ -176,11 +195,10 @@ class Listener {
     }
 
     change() {
-        const changes = this.notifier.next();
+        const changes = this.notifier.next();        
         if (!changes) {
             return;
         }
-
         let refCount = 1;
         changes.release = () => {
             if (--refCount === 0) {
@@ -206,7 +224,7 @@ class Listener {
         return watch;
     }
 
-    startup(startupObject) {
+    async startup(startupObject) {
         let refCount = 1;
         startupObject.release = () => {
             if (--refCount === 0) {
@@ -215,8 +233,9 @@ class Listener {
         }
         for (const callback of this.callbacks) {
             ++refCount;
-            callback.onstartup(startupObject);
+            await callback.onstartup(startupObject);
         }
+        startupObject.register_realm();
         startupObject.release();
     }
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -280,6 +280,42 @@ function addListener(server, user, regex, event, callback) {
     return listener.add(_config.filterRegex, _event, _callback);
 }
 
+function addStartupListener(config, callback) {
+    if (!config.serverUrl || !config.adminUser || !config.filterRegex) {
+        throw new Error(`Invalid 'config' parameter ${JSON.stringify(config)},'serverUrl', 'adminUser' and 'filterRegex' are required parameters`);
+    }
+    // let config = {
+    //     serverUrl: server,
+    //     adminUser:  user,
+    //     filterRegex: regex,
+    //     sslConfiguration: sslConfiguration
+    // };
+
+    if (!listener) {
+        listener = new Listener(this, config);
+    }
+
+    const realmAvailableCallback = (realmPath, realmId) => {
+        const absolutePath = require('path').join(require('process').cwd(), 'realm-object-server/listener/realms', realmPath, `${realmId}.realm`);
+        if (require('fs').existsSync(absolutePath)) {
+            new Promise(async (resolve) => {
+                var realm = new Realm({
+                    path: absolutePath,
+                    sync: true
+                });        
+                await callback(realmPath, realm); // callback could be an async or sync function.  
+                realm.close(); // close the Realm to avoid realm::MismatchedConfigException realm already opened with different sync configurations.
+                // remove this callback (this should only run the first time on startup)
+                listener.remove(config.filterRegex, 'available', realmAvailableCallback);
+                resolve();
+             });
+        }// do not trigger if the Realm is not yet downloaded, in this case it doesn't makes sense to trigger this callback, since the user will 
+        //  get the 'change' event callback.        
+    };
+    // register a one time callback to be triggered when the Realm becomes available.
+    return listener.add(config.filterRegex, 'available', realmAvailableCallback);
+}
+
 function removeListener(regex, event, callback) {
     if (!listener) {
         return Promise.resolve();

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -59,7 +59,7 @@ class FunctionListener {
     invoke(changes, arg) {
         let promise;
         try {
-            promise = Promise.resolve(this.fn(...arg));
+            promise = Promise.resolve(this.fn(arg));
         }
         catch (e) {
             changes.release();
@@ -87,7 +87,7 @@ class FunctionListener {
             return;
         }
 
-        this.invoke(changes, [changes]);
+        this.invoke(changes, changes);
     }
 
     ondelete(changes) {
@@ -96,12 +96,12 @@ class FunctionListener {
             return;
         }
 
-        this.invoke(changes, [changes.path]);
+        this.invoke(changes, changes.path);
     }
 
-    onstartup(virtualPath, startupObject) {
-        if (this.event === 'startup' && this.regex.test(virtualPath)) {
-            this.invoke(startupObject, [virtualPath, startupObject]);
+    onstartup(startupObject) {
+        if (this.event === 'startup' && this.regex.test(startupObject.path)) {
+            this.invoke(startupObject, startupObject);
         }
         startupObject.release();
     }

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -45,13 +45,18 @@ class FunctionListener {
         return this.regexStr === regex && this.event === event && this.fn === fn;
     }
 
+    _isPathObserved(path) {
+        if (this.regex.test(path)) return true;
+        return false;
+    }
+
     onavailable(path, id) {
         if (this.regex.test(path)) {
             if (this.event === 'available' && !this.seen[id]) {
                 this.fn(path);
                 this.seen[id] = true;
             }
-            return this.event === 'change';
+            return true;
         }
         return false;
     }
@@ -134,6 +139,11 @@ class OutOfProcListener {
         return this.regexStr === regex && this.worker === worker;
     }
 
+    _isPathObserved(path) {
+        if (this.regex.test(path)) return true;
+        return false;
+    }
+
     onavailable(path, id) {
         if (this.regex.test(path)) {
             if (!this.seen[id]) {
@@ -169,17 +179,9 @@ class OutOfProcListener {
 
 class Listener {
     constructor(Sync, config) {
-        this.notifier = Sync._createNotifier(config.serverUrl, config.adminUser, this.eventHandler.bind(this), config.sslConfiguration);
+        this.notifier = Sync._createNotifier(config.serverUrl, config.adminUser, (event, a1, a2) => this[event](a1, a2), config.sslConfiguration);
         this.initPromises = [];
         this.callbacks = [];
-    }
-
-    async eventHandler(event, arg1, arg2) {
-        if (event === 'startup') {
-            await this.startup(arg1);                       
-        } else {
-            this[event](arg1, arg2);
-        }        
     }
 
     // callbacks for C++ functions
@@ -298,6 +300,19 @@ class Listener {
             }
         }
         this.initPromises = [];
+    }
+
+    // this checks if the path is part of any registered regexp without notifying a user via a callback (as opposed to `onavailable`)
+    _isPathObserved(path) {
+        let observed = false;
+        // check if at least one listener is observing
+        for (let i = 0; i < this.callbacks.length; ++i) {
+            if (this.callbacks[i]._isPathObserved(path)) {
+                observed = true;
+                break;
+            }
+        }
+        return observed;
     }
 }
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -197,7 +197,7 @@ class Listener {
     }
 
     change() {
-        const changes = this.notifier.next();        
+        const changes = this.notifier.next();
         if (!changes) {
             return;
         }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,6 +62,13 @@ class Worker {
         this._push({message: 'change', change: serialized});
     }
 
+    onstartup(change) {
+        const serialized = change.serialize();
+        change.refCount = (change.refCount || 0) + 1;
+        this._changeObjects[serialized] = change;
+        this._push({message: 'startup', change: serialized});
+    }
+
     stop() {
         this._stopping = true;
         return new Promise((r) => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,7 +123,7 @@ class Worker {
     }
 
     _next() {
-        if (this._stopping && this._workQueue.length === 0) {//we should wait for the other process not completing before exiting (this._waiting)
+        if (this._stopping && this._workQueue.length === 0) {
             for (const worker of this._workers) {
                 if (!worker.stopping) {
                     worker.send({message: 'stop'});

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -40,6 +40,7 @@ class Worker {
         this._waiting = [];
         this._workQueue = [];
         this._changeObjects = {};
+        this._startupCompleted = {};
 
         this._startWorker();
     }
@@ -62,11 +63,15 @@ class Worker {
         this._push({message: 'change', change: serialized});
     }
 
-    onstartup(change) {
+    async onstartup(change) {
         const serialized = change.serialize();
         change.refCount = (change.refCount || 0) + 1;
         this._changeObjects[serialized] = change;
         this._push({message: 'startup', change: serialized});
+        let promise = new Promise(resolve => {
+            this._startupCompleted[serialized] = resolve;
+        });
+        await promise;
     }
 
     stop() {
@@ -95,6 +100,11 @@ class Worker {
             if (m.change) {
                 const changeObj = this._changeObjects[m.change];
                 delete this._changeObjects[m.change];
+                if (m.message === 'startup') {
+                    let resolve = this._startupCompleted[m.change];
+                    resolve();
+                    delete this._startupCompleted[m.change];
+                }
                 changeObj.release();
             }
             this._waiting.push(child);
@@ -113,7 +123,7 @@ class Worker {
     }
 
     _next() {
-        if (this._stopping && this._workQueue.length === 0) {
+        if (this._stopping && this._workQueue.length === 0) {//we should wait for the other process not completing before exiting (this._waiting)
             for (const worker of this._workers) {
                 if (!worker.stopping) {
                     worker.send({message: 'stop'});


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
This closes https://github.com/realm/realm-js-private/issues/521 
see https://github.com/realm/realm-js-private/pull/522

This will allow the client to listen for a new event `startup`, which triggers before we open the Realm for sync.
```Javascript
var startupCallback = function (startupObject) {    
    console.log(`Realm at virtualPath := ${startupObject.path}`);
    // use the Realm
   let realm = startupObject.realm;
}

Realm.Sync.addListener(`realm://${SERVER_URL}`, adminUser, NOTIFIER_PATH, 'startup', startupCallback);
````

#### Using the `Realm.Worker` API
```Javascript
// worker.js
function onstartup(startupObject) {
     console.log(`Realm at virtualPath := ${startupObject.path}`);
    // use the Realm
   let realm = changes.realm;
}

function onchange(change) {
}

function onavailable(path) {
}

function ondelete(path) {
}

module.exports = {onchange, onavailable, ondelete, onstartup};

// server.js
await Realm.Sync.addListener(`realm://${SERVER_URL}`, adminUser, NOTIFIER_PATH, new Realm.Worker('worker.js'));
```

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
