### PR TITLE
Always include the memmove hack (on Android).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Fixed retrying authentication requests. The issue could be observed as "Cannot read property 'get' of undefined." errors being thrown when the authenticate requests were retried. ([#2297](https://github.com/realm/realm-js/issues/2297), since v2.24.0)
-* The `memmove` hack was never included in releases. ([#1895](https://github.com/realm/realm-js/issues/1895), since v2.11.0)
+* Due to a rare race condition in some Android devices (including Samsung SM-T111), an app could crash hard. A workaround was introduced but never included in any releases. ([#1895](https://github.com/realm/realm-js/issues/1895), since v2.11.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Fixed retrying authentication requests. The issue could be observed as "Cannot read property 'get' of undefined." errors being thrown when the authenticate requests were retried. ([#2297](https://github.com/realm/realm-js/issues/2297), since v2.24.0)
+* The `memmove` hack was never included in releases. ([#1895](https://github.com/realm/realm-js/issues/1895), since v2.11.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -84,13 +84,6 @@ LOCAL_SRC_FILES += src/object-store/src/sync/impl/sync_metadata.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/impl/work_queue.cpp
 endif
 
-# Workaround for memmove/memcpy bug
-ifeq ($(strip $(TARGET_ARCH_ABI)),armeabi-v7a)
-BUILD_WRAP_MEMMOVE = 1
-else
-BUILD_WRAP_MEMMOVE = 0
-endif
-
 LOCAL_C_INCLUDES := src
 LOCAL_C_INCLUDES += src/jsc
 LOCAL_C_INCLUDES += src/object-store/src

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -108,6 +108,14 @@ LOCAL_STATIC_LIBRARIES += realm-android-$(TARGET_ARCH_ABI)
 LOCAL_STATIC_LIBRARIES += crypto-$(TARGET_ARCH_ABI)
 endif
 
+# Workaround for memmove/memcpy bug
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+LOCAL_CPPFLAGS += -DREALM_WRAP_MEMMOVE=1
+LOCAL_LDFLAGS += -Wl,--wrap,memmove
+LOCAL_LDFLAGS += -Wl,--wrap,memcpy
+else
+LOCAL_CPPFLAGS += -DREALM_WRAP_MEMMOVE=0
+endif
 
 LOCAL_SHARED_LIBRARIES := libjsc
 include $(BUILD_SHARED_LIBRARY)

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -26,13 +26,9 @@ APP_LDFLAGS += -fvisibility=hidden
 APP_CPPFLAGS += -D__STDC_LIMIT_MACROS=1
 
 # Workaround for memmove/memcpy bug
-ifeq ($(strip $(BUILD_WRAP_MEMMOVE)),1)
 APP_CPPFLAGS += -DREALM_WRAP_MEMMOVE=1
 APP_LDFLAGS += -Wl,--wrap,memmove
 APP_LDFLAGS += -Wl,--wrap,memcpy
-else
-APP_CPPFLAGS += -DREALM_WRAP_MEMMOVE=0
-endif
 
 ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
 APP_CPPFLAGS += -DREALM_ENABLE_SYNC=1

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -25,11 +25,6 @@ APP_LDFLAGS += -fvisibility=hidden
 # https://stackoverflow.com/questions/16748392/cant-find-symbols-in-stdint-h
 APP_CPPFLAGS += -D__STDC_LIMIT_MACROS=1
 
-# Workaround for memmove/memcpy bug
-APP_CPPFLAGS += -DREALM_WRAP_MEMMOVE=1
-APP_LDFLAGS += -Wl,--wrap,memmove
-APP_LDFLAGS += -Wl,--wrap,memcpy
-
 ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
 APP_CPPFLAGS += -DREALM_ENABLE_SYNC=1
 APP_LDFLAGS += -lz


### PR DESCRIPTION
This closes #1895

For some reason the `memmove` hack was never included in builds and releases.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
