### PR TITLE
Build using the macOS 10.13 SDK on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,6 +233,7 @@ def doMacBuild(target, postStep = null) {
   return {
     node('osx_vegas') {
       withEnv(['DEVELOPER_DIR=/Applications/Xcode-9.4.app/Contents/Developer',
+               'SDKROOT=macosx10.13',
                'REALM_SET_NVM_ALIAS=1']) {
         doInside("./scripts/test.sh", target, postStep)
       }


### PR DESCRIPTION
The combination of Xcode 9 + 10.14 SDK no longer works due to recent changes to the SDK, so we need to go back to building against the 10.13 SDK.

This is only applicable to the things built with node-(pre-)gyp; everything building via xcodebuild (i.e. react native) automatically uses the SDK version corresponding to the Xcode version used and so was already using the 10.13 SDK.

Fixes https://github.com/realm/realm-js-private/issues/523.