### PR TITLE
Ensures proper headers are set when calling logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixes an issue where calling `user.logout()` would not revoke the refresh token on the server. (Since v2.24.0)
 
 ### Compatibility
 * Realm Object Server: 3.11.0 or later.
@@ -40,11 +40,11 @@ x.x.x Release notes (yyyy-MM-dd)
 * Add `Realm.Results.description()` which returns a string representation of the query.
 * Add support for defining mapped properties in the schema using `name: { type: 'int', mapTo: 'internalName' }`. In that case the mapped name is used internally in the underlying Realm file, while the property key is used for reading/writing the property as well as querying it.
 * Add `RealmObject.addListener()`, `RealmObject.removeListener()`, and `RealmObject.removeAllListeners()` to set up and remove object-level notifications. ([#763](https://github.com/realm/realm-js/issues/763))
-* Add a new `Realm.UpdateMode` enum with the values: `never`, `modified`, `all`. This replaces the current 
+* Add a new `Realm.UpdateMode` enum with the values: `never`, `modified`, `all`. This replaces the current
   `Realm.create(type, properties, update)` with `Realm.create(type, properties, updateMode)`.
   `Realm.create(type, properties, 'modified')` is a new mode that only update existing properties that actually
   changed, while `Realm.create(type, properties, 'never')` is equal to `Realm.create(type, properties, false)` and
-  `Realm.create(type, properties, 'all')` is equal to `Realm.create(type, properties, true)`. 
+  `Realm.create(type, properties, 'all')` is equal to `Realm.create(type, properties, true)`.
   `Realm.create(type, properties, update)` is now deprecated. ([#2089](https://github.com/realm/realm-js/issues/2089))
 
 ### Fixed

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -120,6 +120,27 @@ const performFetch = (function() {
             return;
         }
         const [url, options, resolve, reject] = req;
+
+        if (options.headers === undefined) {
+            options.headers = {};
+        }
+
+        if (typeof options.body !== "undefined") {
+            // fetch expects a stringified body
+            if (typeof options.body === "object") {
+                options.body = JSON.stringify(options.body);
+            }
+
+            // If content-type header is not explicitly set, we should set it ourselves
+            if (typeof options.headers['content-type'] === "undefined") {
+                options.headers['content-type'] = 'application/json;charset=utf-8';
+            }
+        }
+
+        if (!options.headers['accept']){
+            options.headers['accept'] = 'application/json';
+        }
+
         ++count;
         // node doesn't support Promise.prototype.finally until 10
         doFetch(url, options)
@@ -143,11 +164,6 @@ const performFetch = (function() {
 })();
 
 const url_parse = require('url-parse');
-
-const postHeaders = {
-    'content-type': 'application/json;charset=utf-8',
-    'accept': 'application/json'
-};
 
 function append_url(server, path) {
     return server + (server.charAt(server.length - 1) != '/' ? '/' : '') + path;
@@ -204,7 +220,7 @@ function refreshAdminToken(user, localRealmPath, realmUrl) {
     // we're accessing the file and get the sync label for multiplexing
     let parsedRealmUrl = url_parse(realmUrl);
     const url = append_url(user.server, 'realms/files/' + encodeURIComponent(parsedRealmUrl.pathname));
-    performFetch(url, {method: 'GET', timeout: 10000.0, headers: {Authorization: user.token}})
+    performFetch(url, { method: 'GET', timeout: 10000.0, headers: { Authorization: user.token }})
     .then((response) => {
         // There may not be a Realm Directory Service running on the server
         // we're talking to. If we're talking directly to the sync service
@@ -263,13 +279,12 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
     const url = append_url(user.server, 'auth');
     const options = {
         method: 'POST',
-        body: JSON.stringify({
+        body: {
             data: user.token,
             path,
             provider: 'realm',
             app_id: ''
-        }),
-        headers: postHeaders,
+        },
         // FIXME: This timeout appears to be necessary in order for some requests to be sent at all.
         // See https://github.com/realm/realm-js-private/issues/338 for details.
         timeout: 10000.0
@@ -328,8 +343,7 @@ function _authenticate(userConstructor, server, json, retries) {
     const url = append_url(server, 'auth');
     const options = {
         method: 'POST',
-        body: JSON.stringify(json),
-        headers: postHeaders,
+        body: json,
         open_timeout: 5000,
         timeout: 5000
     };
@@ -368,8 +382,7 @@ function _updateAccount(userConstructor, server, json) {
     const url = append_url(server, 'auth/password/updateAccount');
     const options = {
         method: 'POST',
-        body: JSON.stringify(json),
-        headers: postHeaders,
+        body: json,
         open_timeout: 5000
     };
 
@@ -596,16 +609,10 @@ const instanceMethods = {
 
         const url = url_parse(this.server);
         url.set('pathname', '/auth/revoke');
-        const headers = {
-            Authorization: this.token
-        };
-        const body = JSON.stringify({
-            token: this.token
-        });
         const options = {
             method: 'POST',
-            headers,
-            body: body,
+            headers: { Authorization: this.token },
+            body: { token: this.token },
             open_timeout: 5000
         };
 
@@ -651,12 +658,9 @@ const instanceMethods = {
         checkTypes(arguments, ['string', 'string']);
         const url = url_parse(this.server);
         url.set('pathname', `/auth/users/${provider}/${provider_id}`);
-        const headers = {
-            Authorization: this.token
-        };
         const options = {
             method: 'GET',
-            headers,
+            headers: { Authorization: this.token },
             open_timeout: 5000
         };
         return performFetch(url.href, options)


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?

Original problem was that `user.logout` didn't include `content-type` header, so ROS would reject the request. The surrounding refactoring was to simplify the usage a little and avoid similar problems in the future.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
