### PR TITLE
Add arm64-v8a build support [WIP] 

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -237,7 +237,7 @@ def getNdkBuildFullPath() {
             null)
     }
 
-    checkNdkVersion(ndkBuildFullPath);
+    // checkNdkVersion(ndkBuildFullPath);
 
     return ndkBuildFullPath
 }

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -113,11 +113,26 @@ task downloadOpenSSL_arm(type: Download) {
     dest new File(downloadsDir, "openssl-release-1.0.2k-Android-armeabi-v7a.tar.gz")
 }
 
+task downloadOpenSSL_arm64(type: Download) {
+    src "https://static.realm.io/downloads/openssl/1.0.2k/Android/arm64-v8a/openssl-release-1.0.2k-Android-arm64-v8a.tar.gz"
+    onlyIfNewer true
+    overwrite true
+    dest new File(downloadsDir, "openssl-release-1.0.2k-Android-arm64-v8a.tar.gz")
+}
+
 task prepareOpenSSL_arm(dependsOn: downloadOpenSSL_arm, type:Copy) {
     from tarTree(downloadOpenSSL_arm.dest)
     into "$coreDownloadDir/core"
     rename { String fileName ->
         fileName.replace("-arm-", "-armeabi-")
+    }
+}
+
+task prepareOpenSSL_arm64(dependsOn: downloadOpenSSL_arm64, type:Copy) {
+    from tarTree(downloadOpenSSL_arm64.dest)
+    into "$coreDownloadDir/core"
+    rename { String fileName ->
+        fileName.replace("-arm-", "-arm64-")
     }
 }
 
@@ -227,7 +242,7 @@ def getNdkBuildFullPath() {
     return ndkBuildFullPath
 }
 
-task buildReactNdkLib(dependsOn: [downloadJSCHeaders,prepareRealmCore,prepareOpenSSL_x86,prepareOpenSSL_arm], type: Exec) {
+task buildReactNdkLib(dependsOn: [downloadJSCHeaders,prepareRealmCore,prepareOpenSSL_x86,prepareOpenSSL_arm64,prepareOpenSSL_arm], type: Exec) {
     inputs.files('src/main/jni')
     outputs.dir("$buildDir/realm-react-ndk/all")
     commandLine getNdkBuildFullPath(),

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -237,7 +237,7 @@ def getNdkBuildFullPath() {
             null)
     }
 
-    // checkNdkVersion(ndkBuildFullPath);
+    checkNdkVersion(ndkBuildFullPath);
 
     return ndkBuildFullPath
 }

--- a/react-native/android/gradle.properties
+++ b/react-native/android/gradle.properties
@@ -6,4 +6,4 @@ POM_PACKAGING=aar
 POM_DESCRIPTION=Android Realm React Native module. Realm is a mobile database: a replacement for SQLite & ORMs
 DEBUG_BUILD=true
 android.useDeprecatedNdk=true
-ndkVersion=r10e
+ndkVersion=16.1.4479499

--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -109,7 +109,7 @@ LOCAL_STATIC_LIBRARIES += crypto-$(TARGET_ARCH_ABI)
 endif
 
 # Workaround for memmove/memcpy bug
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a,arm64-v8a)
 LOCAL_CPPFLAGS += -DREALM_WRAP_MEMMOVE=1
 LOCAL_LDFLAGS += -Wl,--wrap,memmove
 LOCAL_LDFLAGS += -Wl,--wrap,memcpy

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -1,6 +1,6 @@
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a x86 arm64-v8a
 APP_PLATFORM := android-9
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -1,13 +1,13 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86 arm64-v8a
-APP_PLATFORM := android-9
+APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)
 
-APP_STL := gnustl_static
+APP_STL := c++_shared
 APP_CPPFLAGS := -std=c++14
 APP_CPPFLAGS += -frtti
 APP_CPPFLAGS += -fexceptions
@@ -30,4 +30,4 @@ APP_CPPFLAGS += -DREALM_ENABLE_SYNC=1
 APP_LDFLAGS += -lz
 endif
 
-NDK_TOOLCHAIN_VERSION := 4.9
+NDK_TOOLCHAIN_VERSION := clang


### PR DESCRIPTION
I've been trying to make Realm 64bit compatible for my react native app, but apparently this did not work so far. I'm stuck currently. The message I get on app startup before it crashed is the following:

```
java.lang.UnsatisfiedLinkError: couldn't find DSO to load: librealmreact.so caused by: dlopen failed: cannot locate symbol "_ZN5realm16ColumnBaseSimple18replace_root_arrayENSt6__ndk110unique_ptrINS_5ArrayENS1_14default_deleteIS3_EEEE"
```

Maybe someone has an idea on how to proceed.

This is a Draft.

This closes #2221 #2282 
