### PR TITLE
Improve performance and correctness of chrome debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Improve performance when using Chrome Debugging with React Native by adding caching and reducing the number of RPC calls required. Read-heavy workflows are as much as 10x faster. Write-heavy workflows will see a much smaller improvement, but also had a smaller performance hit to begin with. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+* Improve performance when using Chrome Debugging with React Native by adding caching and reducing the number of RPC calls required. Read-heavy workflows are as much as 10x faster. Write-heavy workflows will see a much smaller improvement, but also had a smaller performance hit to begin with. (Issue: [#491](https://github.com/realm/realm-js/issues/491), PR: [#2373](https://github.com/realm/realm-js/pull/2373)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* Opening a query-based Realm using `new Realm` did not automatically add the required types to the schema when running in Chrome, resulting in errors when trying to manage subscriptions. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
-* The Chrome debugger did not properly enforce read isolation, meaning that reading a property twice in a row could produce different values if another thread performed a write in between the reads. This was typically only relevant to synchronized Realms due to the lack of multithreading support in the supported Javascript environments. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
-* The RPC server for Chrome debugging would sometimes deadlock if a notification fired at the same time as a Realm function which takes a callback was called. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+* Opening a query-based Realm using `new Realm` did not automatically add the required types to the schema when running in Chrome, resulting in errors when trying to manage subscriptions. (PR: [#2373](https://github.com/realm/realm-js/pull/2373), since v2.15.0).
+* The Chrome debugger did not properly enforce read isolation, meaning that reading a property twice in a row could produce different values if another thread performed a write in between the reads. This was typically only relevant to synchronized Realms due to the lack of multithreading support in the supported Javascript environments. (PR: [#2373](https://github.com/realm/realm-js/pull/2373), since v1.0.0).
+* The RPC server for Chrome debugging would sometimes deadlock if a notification fired at the same time as a Realm function which takes a callback was called. (PR: [#2373](https://github.com/realm/realm-js/pull/2373), since v1.0.0 in various forms).
 
 ### Compatibility
-* Realm Object Server: 3.11.0 or later.
+* Realm Object Server: 3.21.0 or later.
 * APIs are backwards compatible with all previous release of realm in the 2.x.y series.
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* Improve performance when using Chrome Debugging with React Native by adding caching and reducing the number of RPC calls required. Read-heavy workflows are as much as 10x faster. Write-heavy workflows will see a much smaller improvement, but also had a smaller performance hit to begin with. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* Opening a query-based Realm using `new Realm` did not automatically add the required types to the schema when running in Chrome, resulting in errors when trying to manage subscriptions. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+* The Chrome debugger did not properly enforce read isolation, meaning that reading a property twice in a row could produce different values if another thread performed a write in between the reads. This was typically only relevant to synchronized Realms due to the lack of multithreading support in the supported Javascript environments. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+* The RPC server for Chrome debugging would sometimes deadlock if a notification fired at the same time as a Realm function which takes a callback was called. (PR: ([#2373](https://github.com/realm/realm-js/pull/2373))).
+
+### Compatibility
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous release of realm in the 2.x.y series.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+
+### Internal
+* None.
+
 2.27.0 Release notes (2019-5-15)
 =============================================================
 NOTE: The minimum version of Realm Object Server has been increased to 3.21.0 and attempting to connect to older versions will produce protocol mismatch errors. Realm Cloud has already been upgraded to this version, and users using that do not need to worry about this.

--- a/lib/browser/collections.js
+++ b/lib/browser/collections.js
@@ -121,10 +121,10 @@ export function createCollection(prototype, realmId, info, _mutable) {
             get: getterForProperty('length'),
         },
         'type': {
-            get: getterForProperty('type'),
+            value: info.dataType,
         },
         'optional': {
-            get: getterForProperty('optional'),
+            value: info.optional,
         },
     });
 

--- a/lib/browser/collections.js
+++ b/lib/browser/collections.js
@@ -19,37 +19,12 @@
 'use strict';
 
 import { keys } from './constants';
-import { getterForProperty } from './util';
-import { getProperty, setProperty } from './rpc';
-
-let mutationListeners = {};
+import * as util from './util';
+import * as rpc from './rpc';
 
 export default class Collection {
     constructor() {
         throw new TypeError('Illegal constructor');
-    }
-}
-
-export function addMutationListener(realmId, callback) {
-    let listeners = mutationListeners[realmId] || (mutationListeners[realmId] = new Set());
-    listeners.add(callback);
-}
-
-export function removeMutationListener(realmId, callback) {
-    let listeners = mutationListeners[realmId];
-    if (listeners) {
-        listeners.delete(callback);
-    }
-}
-
-export function clearMutationListeners() {
-    mutationListeners = {};
-}
-
-export function fireMutationListeners(realmId) {
-    let listeners = mutationListeners[realmId];
-    if (listeners) {
-        listeners.forEach((cb) => cb());
     }
 }
 
@@ -62,7 +37,7 @@ const mutable = Symbol('mutable');
 const traps = {
     get(collection, property, receiver) {
         if (isIndex(property)) {
-            return getProperty(collection[keys.realm], collection[keys.id], property);
+            return util.getProperty(collection, property);
         }
 
         return Reflect.get(collection, property, collection);
@@ -73,13 +48,8 @@ const traps = {
                 return false;
             }
 
-            setProperty(collection[keys.realm], collection[keys.id], property, value);
-
-            // If this isn't a primitive value, then it might create a new object in the Realm.
-            if (value && typeof value == 'object') {
-                fireMutationListeners(collection[keys.realm]);
-            }
-
+            util.invalidateCache(collection[keys.realm]);
+            rpc.setProperty(collection[keys.realm], collection[keys.id], property, value);
             return true;
         }
 
@@ -118,7 +88,7 @@ export function createCollection(prototype, realmId, info, _mutable) {
 
     Object.defineProperties(collection, {
         'length': {
-            get: getterForProperty('length'),
+            get: util.getterForProperty('length'),
         },
         'type': {
             value: info.dataType,

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -20,7 +20,7 @@
 
 import { NativeModules } from 'react-native';
 import { keys, objectTypes } from './constants';
-import Collection, * as collections from './collections';
+import Collection from './collections';
 import List, { createList } from './lists';
 import Results, { createResults } from './results';
 import RealmObject, * as objects from './objects';
@@ -49,7 +49,7 @@ function createRealm(_, info) {
 
 function setupRealm(realm, info) {
     realm[keys.id] = info.id;
-    realm[keys.realm] = info.id;
+    realm[keys.realm] = info.realmId;
     realm[keys.type] = objectTypes.REALM;
 
     [
@@ -103,7 +103,7 @@ export default class Realm {
         setupRealm(this, info);
 
         // This will create mappings between the id, path, and potential constructors.
-        objects.registerConstructors(info.id, this.path, constructors);
+        objects.registerConstructors(info.realmId, this.path, constructors);
     }
 
     create(type, ...args) {
@@ -127,7 +127,6 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'addListener',
     'removeListener',
     'removeAllListeners',
-    'close',
     'privileges',
     'writeCopyTo',
     '_waitForDownload',
@@ -141,6 +140,7 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'deleteAll',
     'write',
     'compact',
+    'close',
     'beginTransaction',
     'commitTransaction',
     'cancelTransaction',
@@ -172,7 +172,7 @@ Object.defineProperties(Realm, {
         value: Sync,
     },
     defaultPath: {
-        get: util.getterForProperty('defaultPath'),
+        get: util.getterForProperty('defaultPath', false),
         set: util.setterForProperty('defaultPath'),
     },
     schemaVersion: {
@@ -192,8 +192,8 @@ Object.defineProperties(Realm, {
     },
     clearTestState: {
         value: function() {
-            collections.clearMutationListeners();
             objects.clearRegisteredConstructors();
+            util.invalidateCache();
             rpc.clearTestState();
         },
     },

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -43,30 +43,27 @@ rpc.registerTypeConverter(objectTypes.SUBSCRIPTION, createSubscription);
 
 function createRealm(_, info) {
     let realm = Object.create(Realm.prototype);
-
-    setupRealm(realm, info.id);
+    setupRealm(realm, info);
     return realm;
 }
 
-function setupRealm(realm, realmId) {
-    realm[keys.id] = realmId;
-    realm[keys.realm] = realmId;
+function setupRealm(realm, info) {
+    realm[keys.id] = info.id;
+    realm[keys.realm] = info.id;
     realm[keys.type] = objectTypes.REALM;
 
     [
         'empty',
-        'path',
-        'readOnly',
-        'inMemory',
         'schema',
         'schemaVersion',
-        'syncSession',
         'isInTransaction',
         'isClosed',
-        '_isPartialRealm',
     ].forEach((name) => {
         Object.defineProperty(realm, name, {get: util.getterForProperty(name)});
     });
+    for (let key in info.data) {
+        realm[key] = rpc.deserialize(info.id, info.data[key]);
+    }
 }
 
 function getObjectType(realm, type) {
@@ -102,11 +99,11 @@ export default class Realm {
             }
         }
 
-        let realmId = rpc.createRealm(Array.from(arguments));
-        setupRealm(this, realmId);
+        let info = rpc.createRealm(Array.from(arguments));
+        setupRealm(this, info);
 
         // This will create mappings between the id, path, and potential constructors.
-        objects.registerConstructors(realmId, this.path, constructors);
+        objects.registerConstructors(info.id, this.path, constructors);
     }
 
     create(type, ...args) {

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -75,8 +75,22 @@ function getObjectType(realm, type) {
 
 export default class Realm {
     constructor(config) {
-        let schemas = typeof config == 'object' && config.schema;
+        let schemas = typeof config === 'object' && config.schema;
         let constructors = schemas ? {} : null;
+
+        let isPartial = false;
+        if (config && typeof config.sync === 'object') {
+            if (typeof config.sync.fullSynchronization !== 'undefined') {
+                isPartial = !config.sync.fullSynchronization;
+            }
+            else if (typeof config.sync.partial !== 'undefined') {
+                isPartial = config.sync.partial;
+            }
+        }
+
+        if (schemas && isPartial) {
+            Realm._extendQueryBasedSchema(schemas);
+        }
 
         for (let i = 0, len = schemas ? schemas.length : 0; i < len; i++) {
             let item = schemas[i];

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -198,8 +198,8 @@ Object.defineProperties(Realm, {
         },
     },
     _asyncOpen: {
-        value: function() {
-            return rpc.callMethod(undefined, Realm[keys.id], '_asyncOpen', Array.from(arguments));
+        value: function(config, callback) {
+            return rpc.asyncOpenRealm(Realm[keys.id], config, callback);
         },
     },
 });

--- a/lib/browser/objects.js
+++ b/lib/browser/objects.js
@@ -19,7 +19,8 @@
 'use strict';
 
 import { keys, objectTypes } from './constants';
-import { getterForProperty, setterForProperty, createMethods } from './util';
+import { getterForProperty, setterForProperty, createMethods, cacheObject } from './util';
+import * as rpc from './rpc'
 
 let registeredConstructors = {};
 let registeredRealmPaths = {};
@@ -69,6 +70,10 @@ export function createObject(realmId, info) {
             throw new Error('Realm object constructor must not return another value');
         }
     }
+    for (let key in info.cache) {
+        info.cache[key] = rpc.deserialize(undefined, info.cache[key])
+    }
+    cacheObject(realmId, info.id, info.cache);
 
     return object;
 }

--- a/lib/browser/results.js
+++ b/lib/browser/results.js
@@ -27,6 +27,7 @@ export default class Results extends Collection {
 
 // Non-mutating methods:
 createMethods(Results.prototype, objectTypes.RESULTS, [
+    'description',
     'filtered',
     'sorted',
     'snapshot',

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -19,6 +19,7 @@
 'use strict';
 
 import * as base64 from './base64';
+import * as util from './util';
 import { keys, objectTypes } from './constants';
 
 const { id: idKey, realm: _realmKey } = keys;
@@ -58,9 +59,16 @@ export function createSession(refreshAccessToken, host) {
 }
 
 function beforeNotify(realm) {
-    // No body required: the mere act of invoking this callback requires
-    // waiting for an event loop cycle in the browser and so achieves the goal
-    // of not letting notify() run when it wouldn't in normal usage
+    // NOTE: the mere existence of this function is important for read
+    // isolation even independent of what it does in its body. By having a
+    // beforenotify listener, we ensure that the RPC server can't proceed in
+    // notify() to autorefresh until the browser performs a callback poll.
+    // Without this, the RPC server could autorefresh in between two subsequent
+    // property reads from the browser.
+
+    // Clear the cache for this Realm, and reenable caching if it was disabled
+    // by a write transaction.
+    util.invalidateCache(realm[keys.realm]);
 }
 
 export function createRealm(args) {
@@ -125,6 +133,17 @@ export function callMethod(realmId, id, name, args) {
 
     let result = sendRequest('call_method', { realmId, id, name, arguments: args });
     return deserialize(realmId, result);
+}
+
+export function getObject(realmId, id, name) {
+    let result = sendRequest('get_object', { realmId, id, name });
+    if (!result) {
+        return result;
+    }
+    for (let key in result) {
+        result[key] = deserialize(realmId, result[key]);
+    }
+    return result;
 }
 
 export function getProperty(realmId, id, name) {
@@ -317,7 +336,6 @@ function sendRequest(command, data, host = sessionHost) {
 
             throw new Error(error || `Invalid response for "${command}"`);
         }
-        let callback = response.callback;
         if (callback != null) {
             let result, error, stack;
             try {

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -57,12 +57,34 @@ export function createSession(refreshAccessToken, host) {
     return sessionId;
 }
 
+function beforeNotify(realm) {
+    // No body required: the mere act of invoking this callback requires
+    // waiting for an event loop cycle in the browser and so achieves the goal
+    // of not letting notify() run when it wouldn't in normal usage
+}
+
 export function createRealm(args) {
     if (args) {
         args = args.map((arg) => serialize(null, arg));
     }
 
-    return sendRequest('create_realm', { arguments: args });
+    return sendRequest('create_realm', { arguments: args, beforeNotify: serialize(null, beforeNotify) });
+}
+
+export function asyncOpenRealm(id, config, callback) {
+    sendRequest('call_method', {
+        id,
+        name: '_asyncOpen',
+        arguments: [
+            serialize(null, config),
+            serialize(null, (realm, error) => {
+                if (realm) {
+                    realm.addListener('beforenotify', beforeNotify);
+                }
+                callback(realm, error);
+            })
+        ]
+    });
 }
 
 export function createUser(args) {

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -231,6 +231,7 @@ function makeRequest(url, data) {
 }
 
 let pollTimeoutId;
+let pollTimeout = 10;
 
 //returns an object from rpc serialized json value
 function deserialize_json_value(value) {
@@ -260,6 +261,17 @@ function sendRequest(command, data, host = sessionHost) {
 
         let url = 'http://' + host + '/' + command;
         let response = makeRequest(url, data);
+        let callback = response && response.callback;
+
+        // Reset the callback poll interval to 10ms every time we either hit a
+        // callback or call any other method, and double it each time we poll
+        // for callbacks and get nothing until it's over a second.
+        if (callback || command !== 'callbacks_poll') {
+            pollTimeout = 10;
+        }
+        else if (pollTimeout < 1000) {
+            pollTimeout *= 2;
+        }
 
         if (!response || response.error) {
             let error = response && response.error;
@@ -315,6 +327,6 @@ function sendRequest(command, data, host = sessionHost) {
         return response.result;
     }
     finally {
-        pollTimeoutId = setTimeout(() => sendRequest('callbacks_poll'), 100);
+        pollTimeoutId = setTimeout(() => sendRequest('callbacks_poll'), pollTimeout);
     }
 }

--- a/lib/browser/session.js
+++ b/lib/browser/session.js
@@ -27,9 +27,9 @@ export default class Session {
 }
 
 Object.defineProperties(Session.prototype, {
-    connectionState: { get: getterForProperty('connectionState') },
-    state: { get: getterForProperty('state') },
-    url: { get: getterForProperty('url') },
+    connectionState: { get: getterForProperty('connectionState', false) },
+    state: { get: getterForProperty('state', false) },
+    url: { get: getterForProperty('url', false) },
 });
 
 createMethods(Session.prototype, objectTypes.SESSION, [

--- a/lib/browser/subscription.js
+++ b/lib/browser/subscription.js
@@ -32,18 +32,20 @@ Object.defineProperties(Subscription.prototype, {
 
 // Non-mutating methods:
 createMethods(Subscription.prototype, objectTypes.SUBSCRIPTION, [
-    'unsubscribe',
     'addListener',
     'removeListener',
     'removeAllListeners'
 ]);
 
+// Mutating methods:
+createMethods(Subscription.prototype, objectTypes.SUBSCRIPTION, [
+    'unsubscribe',
+], true);
+
 export function createSubscription(realmId, info) {
     let subscription = Object.create(Subscription.prototype);
-
-    subscription[keys.realm] = "(Subscription object)";
+    subscription[keys.realm] = realmId;
     subscription[keys.id] = info.id;
     subscription[keys.type] = objectTypes.SUBSCRIPTION;
-
     return subscription;
 }

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -43,9 +43,6 @@ export default class User {
 
 Object.defineProperties(User.prototype, {
     token: { get: getterForProperty('token') },
-    server: { get: getterForProperty('server') },
-    identity: { get: getterForProperty('identity') },
-    isAdminToken: { get: getterForProperty('isAdminToken') },
 });
 
 createMethods(User.prototype, objectTypes.USER, [

--- a/lib/browser/util.js
+++ b/lib/browser/util.js
@@ -18,23 +18,22 @@
 
 'use strict';
 
-import { fireMutationListeners } from './collections';
 import { keys } from './constants';
 import * as rpc from './rpc';
 
-export function createMethods(prototype, type, methodNames, mutates) {
+export function createMethods(prototype, type, methodNames, mutating) {
     let props = {};
 
     methodNames.forEach((name) => {
         props[name] = {
-            value: createMethod(type, name, mutates),
+            value: createMethod(type, name, mutating),
         };
     });
 
     Object.defineProperties(prototype, props);
 }
 
-export function createMethod(type, name, mutates) {
+export function createMethod(type, name, mutating) {
     return function() {
         let realmId = this[keys.realm];
         let id = this[keys.id];
@@ -46,31 +45,72 @@ export function createMethod(type, name, mutates) {
             throw new TypeError(`${type}.${name} was called on Realm object of type ${this[keys.type]}!`);
         }
 
+        if (mutating) {
+            invalidateCache(realmId);
+        }
         try {
             return rpc.callMethod(realmId, id, name, Array.from(arguments));
-        } finally {
-            if (mutates) {
-                fireMutationListeners(realmId);
+        }
+        finally {
+            if (mutating) {
+                invalidateCache(realmId);
             }
         }
     };
 }
 
-export function getterForProperty(name) {
+let propertyCache = {};
+
+export function invalidateCache(realmId) {
+    if (realmId) {
+        propertyCache[realmId] = {};
+    }
+    else {
+        propertyCache = {};
+    }
+}
+
+function getRealmCache(realmId) {
+    let realmCache = propertyCache[realmId];
+    if (!realmCache) {
+        realmCache = propertyCache[realmId] = {};
+    }
+    return realmCache;
+}
+
+export function cacheObject(realmId, id, value) {
+    getRealmCache(realmId)[id] = value;
+}
+
+export function getProperty(obj, name, cache = true) {
+    let realmId = obj[keys.realm];
+    let id = obj[keys.id];
+    if (!cache || realmId === undefined) {
+        return rpc.getProperty(realmId, id, name);
+    }
+
+    let realmCache = getRealmCache(realmId);
+    let objCache = realmCache[id];
+    if (!objCache) {
+        objCache = realmCache[id] = rpc.getObject(realmId, id, name);
+        return objCache[name];
+    }
+
+    if (name in objCache) {
+        return objCache[name];
+    }
+    return objCache[name] = rpc.getProperty(realmId, id, name);
+}
+
+export function getterForProperty(name, cache = true) {
     return function() {
-        return rpc.getProperty(this[keys.realm], this[keys.id], name);
+        return getProperty(this, name, cache);
     };
 }
 
 export function setterForProperty(name) {
     return function(value) {
-        let realmId = this[keys.realm];
-
-        rpc.setProperty(realmId, this[keys.id], name, value);
-
-        // If this isn't a primitive value, then it might create a new object in the Realm.
-        if (value && typeof value == 'object') {
-            fireMutationListeners(realmId);
-        }
+        invalidateCache(this[keys.realm]);
+        rpc.setProperty(this[keys.realm], this[keys.id], name, value);
     };
 }

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -7,5 +7,6 @@
 /object-store/**/*.sh
 /object-store/**/CMake*
 /object-store/**/Makefile
+/object-store/.git
 /object-store/external/catch/
 /object-store/tests/

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -69,15 +69,18 @@ template<typename T>
 class RealmDelegate : public BindingContext {
 private:
     void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override {
+        HANDLESCOPE
         notify(m_notifications, "change");
     }
 
     void schema_did_change(realm::Schema const& schema) override {
+        HANDLESCOPE
         ObjectType schema_object = Schema<T>::object_for_schema(m_context, schema);
         notify(m_schema_notifications, "schema", schema_object);
     }
 
     void before_notify() override {
+        HANDLESCOPE
         notify(m_before_notify_notifications, "beforenotify");
     }
 
@@ -168,8 +171,6 @@ public:
     // from inside the handler
     template<typename... Args>
     void notify(std::list<Protected<FunctionType>> notifications, const char *name, Args&&... args) {
-        HANDLESCOPE
-
         auto realm = m_realm.lock();
         if (!realm) {
             throw std::runtime_error("Realm no longer exists");

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -211,6 +211,14 @@ RPCServer::RPCServer() {
         }
 
         JSObjectRef realm_object = jsc::Function::construct(m_context, realm_constructor, arg_count, arg_values);
+
+        JSObjectRef add_listener_method = (JSObjectRef)jsc::Object::get_property(m_context, realm_object, "addListener");
+        JSValueRef listener_args[] = {
+            jsc::Value::from_string(m_context, "beforenotify"),
+            deserialize_json_value(dict["beforeNotify"])
+        };
+        jsc::Function::call(m_context, add_listener_method, realm_object, 2, listener_args);
+
         return (json){{"result", serialize_json_value(realm_object)}};
     };
     m_requests["/create_user"] = [this](const json dict) {

--- a/src/rpc.hpp
+++ b/src/rpc.hpp
@@ -56,6 +56,7 @@ class RPCWorker {
 
   private:
     bool m_stop = false;
+    int m_depth = 0;
 #if __APPLE__
     std::thread m_thread;
     CFRunLoopRef m_loop;

--- a/src/rpc.hpp
+++ b/src/rpc.hpp
@@ -86,6 +86,7 @@ class RPCServer {
     RPCObjectID m_session_id;
     RPCWorker m_worker;
     u_int64_t m_callback_call_counter;
+    uint64_t m_reset_counter = 0;
 
     std::mutex m_pending_callbacks_mutex;
     std::map<std::pair<uint64_t, uint64_t>, std::promise<json>> m_pending_callbacks;

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -44,7 +44,6 @@ const schemas = require('./schemas');
 
 let pathSeparator = '/';
 const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';
-const isChromeWorker = !isNodeProcess && typeof WorkerGlobalScope !== 'undefined' && navigator instanceof WorkerNavigator;
 if (isNodeProcess && process.platform === 'win32') {
     pathSeparator = '\\';
 }
@@ -1520,12 +1519,7 @@ module.exports = {
             .then(user1 => {
                 config.sync.user = user1;
                 const realm = new Realm(config);
-                if (isChromeWorker) {
-                    TestCase.assertEqual(realm.schema.length, 1); // 1 test object
-                }
-                else {
-                    TestCase.assertEqual(realm.schema.length, 7); // 5 permissions, 1 results set, 1 test object
-                }
+                TestCase.assertEqual(realm.schema.length, 7); // 5 permissions, 1 results set, 1 test object
                 return closeAfterUpload(realm);
             })
             .then(() => {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1011,7 +1011,7 @@ module.exports = {
         TestCase.assertEqual(secondNotificationCount, 1);
 
         TestCase.assertThrowsContaining(() => realm.addListener('invalid', () => {}),
-                                        "Only the 'change' and 'schema' notification names are supported.");
+                                        "Unknown event name 'invalid': only 'change', 'schema' and 'beforenotify' are supported.");
 
         realm.addListener('change', () => {
             throw new Error('expected error message');

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1489,11 +1489,8 @@ module.exports = {
             });
 
             let realm2 = new Realm({ schema: schema, _cache: false });
-            if (!isChromeWorker) {
-                // Not updated until we return to the event loop and the autorefresh can happen
-                // When running in Chrome this can happen at any time due to the async RPC
-                TestCase.assertEqual(realm1.schema.length, 0);
-            }
+            // Not updated until we return to the event loop and the autorefresh can happen
+            TestCase.assertEqual(realm1.schema.length, 0);
             TestCase.assertEqual(realm2.schema.length, 1);
 
             // give some time to let advance_read to complete

--- a/tests/js/subscription-tests.js
+++ b/tests/js/subscription-tests.js
@@ -34,34 +34,32 @@ function uuid() {
 function getRealm() {
     const AUTH_URL = 'http://127.0.0.1:9080';
     const REALM_URL = 'realm://127.0.0.1:9080/~/' + uuid().replace("-", "_");
-    return new Promise((resolve, reject) => {
-        Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))
-            .then((user) => {
-                const schemas = [
-                    {
-                        name: 'Parent',
-                        properties: {
-                            name: { type: 'string' },
-                            child: 'ObjectA',
-                        }
-                    },
-                    {
-                        name: 'ObjectA',
-                        properties: {
-                            name: { type: 'string' },
-                            parents: { type: 'linkingObjects', objectType: 'Parent', property: 'child' },
-                        }
-                    },
-                ];
-
-                const config = user.createConfiguration({
-                    schema: schemas,
-                    sync: {
-                        url: REALM_URL,
+    return Realm.Sync.User.login(AUTH_URL, Realm.Sync.Credentials.nickname("admin", true))
+        .then((user) => {
+            const schemas = [
+                {
+                    name: 'Parent',
+                    properties: {
+                        name: { type: 'string' },
+                        child: 'ObjectA',
                     }
-                });
-                resolve(new Realm(config));
+                },
+                {
+                    name: 'ObjectA',
+                    properties: {
+                        name: { type: 'string' },
+                        parents: { type: 'linkingObjects', objectType: 'Parent', property: 'child' },
+                    }
+                },
+            ];
+
+            const config = user.createConfiguration({
+                schema: schemas,
+                sync: {
+                    url: REALM_URL,
+                }
             });
+            return new Realm(config);
     });
 }
 
@@ -126,12 +124,9 @@ module.exports = {
 
     testSubscriptionWrapperProperties() {
         return getRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                const subscription = realm.objects("ObjectA").subscribe("test");
-                TestCase.assertEqual(subscription.name, "test");
-                TestCase.assertEqual(subscription.state, Realm.Sync.SubscriptionState.Creating);
-                resolve();
-            });
+            const subscription = realm.objects("ObjectA").subscribe("test");
+            TestCase.assertEqual(subscription.name, "test");
+            TestCase.assertEqual(subscription.state, Realm.Sync.SubscriptionState.Creating);
         });
     },
 
@@ -328,21 +323,15 @@ module.exports = {
 
     testSubscribeWithoutName() {
         return getRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let query = realm.objects("ObjectA");
-                query.subscribe({ update: true, timeToLive: 1000}); // Missing name, doesn't throw
-                resolve();
-            });
+            let query = realm.objects("ObjectA");
+            query.subscribe({ update: true, timeToLive: 1000}); // Missing name, doesn't throw
         });
     },
 
     testSubscribeWithMisspelledConfigParameter() {
         return getRealm().then(realm => {
-            return new Promise((resolve, reject) => {
-                let query = realm.objects("ObjectA");
-                TestCase.assertThrowsContaining(() => query.subscribe({ naem: "myName" }), "Unexpected property in subscription options: 'naem'");
-                resolve();
-            });
+            let query = realm.objects("ObjectA");
+            TestCase.assertThrowsContaining(() => query.subscribe({ naem: "myName" }), "Unexpected property in subscription options: 'naem'");
         });
     },
 

--- a/tests/js/subscription-tests.js
+++ b/tests/js/subscription-tests.js
@@ -20,32 +20,9 @@
 
 'use strict';
 
-/* global REALM_MODULE_PATH */
-
 const Realm = require('realm');
 const TestCase = require('./asserts');
-let schemas = require('./schemas');
-
-const isElectronProcess = typeof process === 'object' && process.type === 'renderer';
-const isNodeProccess = typeof process === 'object' && process + '' === '[object process]' && !isElectronProcess;
-
-const require_method = require;
-function node_require(module) {
-    return require_method(module);
-}
-
-let tmp;
-let fs;
-let execFile;
-let path;
-
-if (isNodeProccess) {
-    tmp = node_require('tmp');
-    fs = node_require('fs');
-    execFile = node_require('child_process').execFile;
-    tmp.setGracefulCleanup();
-    path = node_require("path");
-}
+const schemas = require('./schemas');
 
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
@@ -144,10 +121,6 @@ function verifySubscriptionWithParents(parentToInclude, filterClause) {
 module.exports = {
 
     testSubscriptionWrapperProperties() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 const subscription = realm.objects("ObjectA").subscribe("test");
@@ -159,10 +132,6 @@ module.exports = {
     },
 
     testNamedSubscriptionProperties() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 const now = new Date();
@@ -188,10 +157,6 @@ module.exports = {
     },
 
     testUpdateQuery: function () {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 const sub = realm.objects("ObjectA").filtered("name = 'Foo'").subscribe("update-named-sub-query");
@@ -206,7 +171,7 @@ module.exports = {
                             // Updating the query must either be a string or a Results objects
                             TestCase.assertThrows(() => namedSub.query = 0);
                             TestCase.assertThrows(() => namedSub.query = true);
-    
+
                             // Updating the query using a string
                             namedSub.query = "truepredicate";
                             TestCase.assertEqual(namedSub.query, "truepredicate");
@@ -214,7 +179,7 @@ module.exports = {
                             TestCase.assertEqual(namedSub.error, undefined);
                             TestCase.assertTrue(updated.getTime() < namedSub.updatedAt.getTime());
                             updated = namedSub.updatedAt;
-                            
+
                             setTimeout(function() {
                                 // Updating the query using a Results object
                                 namedSub.query = realm.objects('ObjectA').filtered('name = "Bar"');
@@ -230,10 +195,6 @@ module.exports = {
     },
 
     testUpdateTtl() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             const sub = realm.objects("ObjectA").filtered("name = 'Foo'").subscribe("update-named-sub-query");
             return new Promise((resolve, reject) => {
@@ -259,10 +220,6 @@ module.exports = {
     },
 
     testUpdateReadOnlyProperties() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 const sub = realm.objects("ObjectA").subscribe("read-only-test");
@@ -284,10 +241,6 @@ module.exports = {
     },
 
     testSubscribeWithTtl() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 const now = new Date();
@@ -310,9 +263,6 @@ module.exports = {
     },
 
     testSubscribeAndUpdateQuery() {
-        if (!isNodeProccess) {
-            return;
-        }
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 let query1 = realm.objects("ObjectA");
@@ -333,7 +283,7 @@ module.exports = {
                                     resolve();
                                 }
                             });
-                        }, 2);    
+                        }, 2);
                     }
                 });
             });
@@ -341,10 +291,6 @@ module.exports = {
     },
 
     testSubscribeAndUpdateTtl() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             const query1 = realm.objects("ObjectA");
 
@@ -377,10 +323,6 @@ module.exports = {
     },
 
     testSubscribeWithoutName() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 let query = realm.objects("ObjectA");
@@ -391,10 +333,6 @@ module.exports = {
     },
 
     testSubscribeWithMisspelledConfigParameter() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             return new Promise((resolve, reject) => {
                 let query = realm.objects("ObjectA");
@@ -405,10 +343,6 @@ module.exports = {
     },
 
     testSubscribeToChildrenWithoutParents() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             realm.write(() => {
                 let obj_a1 = realm.create('ObjectA', {name: "a1"});
@@ -438,10 +372,6 @@ module.exports = {
     },
 
     testSubscribeParentsWithForwardLinks() {
-        if (!isNodeProccess) {
-            return;
-        }
-
         return getRealm().then(realm => {
             realm.write(() => {
                 let obj_a1 = realm.create('ObjectA', {name: "a1"});
@@ -471,23 +401,14 @@ module.exports = {
     },
 
     testSubscribeToChildrenWithNamedParents() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("parents");
     },
 
     testSubscribeToChildrenWithUnnamedParents() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("@links.Parent.child");
     },
 
     testSubscribeToChildrenWithMalformedInclusion1() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("something.wrong").then(() => {
             throw new Error('subscription should have failed')
         },
@@ -496,9 +417,6 @@ module.exports = {
     },
 
     testSubscribeToChildrenWithMalformedInclusion2() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("@links.Parent.missing_property").then(() => {
             throw new Error('subscription should have failed')
         },
@@ -507,9 +425,6 @@ module.exports = {
     },
 
     testSubscribeToChildrenWithMalformedInclusion3() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents(4.2).then(() => {
             throw new Error('subscription should have failed')
         },
@@ -521,17 +436,10 @@ module.exports = {
     // but it should not be encouraged nor documented. It is mostly to enable users to run
     // subscription queries that are directly copied from Studio.
     testSubscribeWithManualInclusion1() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("", "TRUEPREDICATE INCLUDE(@links.Parent.child)");
     },
 
     testSubscribeWithManualInclusion2() {
-        if (!isNodeProccess) {
-            return;
-        }
         return verifySubscriptionWithParents("", "TRUEPREDICATE INCLUDE(parents)");
     },
-
 };


### PR DESCRIPTION
This does a few things:

1. It adds proper read isolation support to the RPC server. We didn't actually enforce the inteded MVCC semantics when using chrome debugging since we rely on autorefreshes only being able to happen via the event loop, which means that they can't happen in the middle of a user's function. However, that isn't the case with the RPC server, because there's *two* event loops involved, and an autorefresh could happen in between two RPC calls even though the JS running in chrome never did any async operations. This used to be mostly a non-issue due to the lack of threads, but with synchronized Realms background writes happen even in JS. Most users are unlikely to have ever noticed this, but it resulted in some of the tests which relied on read isolation working failing inconsistently.
   
   The fix for this was to add a `beforenotify` listener, which merely by existing forces the RPC server to block autorefreshes until the browser calls `/callbacks_poll`.
2. Add a caching layer to the browser library to cut down on RPC requests. Repeated reads on the same property without a call to a mutating function in between now just return the same value, and the values of primitive properties on objects are sent along with the object id to enable pre-caching them. The caching is currently very cautious and flushes the entire cache after any possibly-mutating function is called or after a refresh. There's probably a lot of room to improve this later.
3. Add some missing bits to the RPC wrapper to make query-based Realms actually work and enable the subscription tests.
4. Fix some assorted bugs in the tests and test support stuff.

The caching doesn't help our tests much (they mostly just change something, then read only exactly the thing which should have changed), but seems to help a *lot* for real apps. Testing with [Rocket.Chat's react native client](https://github.com/RocketChat/Rocket.Chat.ReactNative), opening a channel previously performed 13k requests and took 110 seconds to fully load. With the caching, doing the same thing performs 4k requests and takes 20 seconds. This is still pretty painfully slow (it takes around a second when not using chrome debugging), but at least is a pretty big step towards being usable.
