### PR TITLE
Add test where objects are created during schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * A React Native iOS app could crash on the first launch. Thanks to @max-zu. ([#2400](https://github.com/realm/realm-js/issues/2400), since v1.0.0)
+* When creating objects using migration, a native crash could occur if a new optional property was added to the schema. ([#1612](https://github.com/realm/realm-js/issues/1612), since v1.0.0)
 
 ### Compatibility
 * Realm Object Server: 3.21.0 or later.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -571,7 +571,9 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
 
                 config.migration_function = [=](SharedRealm old_realm, SharedRealm realm, realm::Schema&) {
                     // the migration function called early so the binding context might not be set
-                    realm->m_binding_context.reset(new RealmDelegate<T>(realm, Context<T>::get_global_context(ctx)));
+                    if (!realm->m_binding_context) {
+                        realm->m_binding_context.reset(new RealmDelegate<T>(realm, Context<T>::get_global_context(ctx)));
+                    }
 
                     auto old_realm_ptr = new SharedRealm(old_realm);
                     auto realm_ptr = new SharedRealm(realm);

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -570,6 +570,9 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 }
 
                 config.migration_function = [=](SharedRealm old_realm, SharedRealm realm, realm::Schema&) {
+                    // the migration function called early so the binding context might not be set
+                    realm->m_binding_context.reset(new RealmDelegate<T>(realm, Context<T>::get_global_context(ctx)));
+
                     auto old_realm_ptr = new SharedRealm(old_realm);
                     auto realm_ptr = new SharedRealm(realm);
                     ValueType arguments[2] = {

--- a/tests/js/migration-tests.js
+++ b/tests/js/migration-tests.js
@@ -225,7 +225,7 @@ module.exports = {
             name: 'Person',
             properties: {
                 name: 'string',
-                firstName: 'string?'
+                firstName: { type: 'string', optional: true }
             }
         };
 
@@ -242,14 +242,14 @@ module.exports = {
             schemaVersion: 1,
             schema: [schemaV1],
             migration: (oldRealm, newRealm) => {
-                console.log('old', JSON.stringify(oldRealm.schema));
-                console.log('new', JSON.stringify(newRealm.schema));
                 newRealm.create('Person', { name: 'Freddy Bloggson', firstName: 'Freddy' });
                 newRealm.create('Person', { name: 'Blogs Fredson' });
             }
         });
 
-        realm.create('Person', { name: 'Bloggy Freddy' });
+        realm.write(() => {
+            realm.create('Person', { name: 'Bloggy Freddy' });
+        });
 
         const objs = realm.objects('Person');
         TestCase.assertEqual(objs.length, 4);


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #1612 

Creating objects during a schema migration might crash if the new schema has an optional property and it is not set. A crash could look like:

```
PID 4718 received SIGSEGV for address: 0x20
0   segfault-handler.node               0x000000010272dfa8 _ZL16segfault_handleriP9__siginfoPv + 312
1   libsystem_platform.dylib            0x00007fff6017db5d _sigtramp + 29
2   ???                                 0x00003a4f7f689cf9 0x0 + 64113114389753
3   realm.node                          0x0000000105264125 _ZNSt3__16__treeINS_12__value_typeINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_3mapIS7_N5realm2js9ProtectedIN2v85LocalINSC_5ValueEEEEENS_4lessIS7_EENS5_INS_4pairIKS7_SG_EEEEEEEENS_19__map_value_compareIS7_SO_SI_Lb1EEENS5_ISO_EEE25__emplace_unique_key_argsIS7_JRKNS_21piecewise_construct_tENS_5tupleIJRSK_EEENSX_IJEEEEEENSJ_INS_15__tree_iteratorISO_PNS_11__tree_nodeISO_PvEElEEbEERKT_DpOT0_ + 45
4   realm.node                          0x00000001052632cd _ZN5realm2js14NativeAccessorINS_4node5TypesEE26default_value_for_propertyERKNS_12ObjectSchemaERKNS_8PropertyE + 63
5   realm.node                          0x0000000105262d6a _ZN5realm6Object6createIN2v85LocalINS2_5ValueEEENS_2js14NativeAccessorINS_4node5TypesEEEEES0_RT0_RKNSt3__110shared_ptrINS_5RealmEEERKNS_12ObjectSchemaET_bbmPNS_8BasicRowINS_5TableEEE + 990
6   realm.node                          0x0000000105284a1e _ZN5realm2js10RealmClassINS_4node5TypesEE6createEPN2v87IsolateENS5_5LocalINS5_6ObjectEEERNS0_9ArgumentsIS3_EERNS0_11ReturnValueIS3_EE + 468
7   realm.node                          0x000000010527ee02 _ZN5realm2js4wrapIXadL_ZNS0_10RealmClassINS_4node5TypesEE6createEPN2v87IsolateENS6_5LocalINS6_6ObjectEEERNS0_9ArgumentsIS4_EERNS0_11ReturnValueIS4_EEEEEEvRKN3Nan20FunctionCallbackInfoINS6_5ValueEEE + 238
8   realm.node                          0x000000010522952e _ZN3Nan3impL23FunctionCallbackWrapperERKN2v820FunctionCallbackInfoINS1_5ValueEEE + 136
9   node                                0x0000000100192d32 _ZN2v88internal25FunctionCallbackArguments4CallEPFvRKNS_20FunctionCallbackInfoINS_5ValueEEEE + 466
10  node                                0x00000001001f3520 _ZN2v88internal12_GLOBAL__N_119HandleApiCallHelperILb0EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateENS0_6HandleINS0_10HeapObjectEEESA_NS8_INS0_20FunctionTemplateInfoEEENS8_IS4_EENS0_16BuiltinArgumentsE + 816
11  node                                0x00000001001f2b60 _ZN2v88internalL26Builtin_Impl_HandleApiCallENS0_16BuiltinArgumentsEPNS0_7IsolateE + 288
12  ???                                 0x000008e1146842fd 0x0 + 9762803041021
```

The problem seems to be that the binding context is null for the new Realm during migration.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
