### PR TITLE
[FIX] #2193 Add extra condition to coop with Jitsi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed Coop with Jitsi-Meet iOS SDK ([2193](https://github.com/realm/realm-js/issues/2193)).
 
 ### Compatibility
 * Realm Object Server: 3.21.0 or later.

--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -306,7 +306,7 @@ void _initializeOnJSThread(JSContextRefExtractor jsContextExtractor) {
 #else
         @throw [NSException exceptionWithName:@"Invalid Executor" reason:@"Chrome debug mode not supported in Release builds" userInfo:nil];
 #endif
-    } else if ([bridge isKindOfClass:objc_lookUpClass("RCTCxxBridge")]) {
+    } else if ([bridge isKindOfClass:objc_lookUpClass("RCTCxxBridge")] || [NSStringFromClass([bridge class]) isEqual: @"RCTCxxBridge"]) {
         // probe for the new C++ bridge in React Native 0.45+
 
         __weak __typeof__(self) weakSelf = self;


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
I have changed the condition to setBridge because if have cooperation between RealmJS and another framework in React-Native with setBridge ```bridge isKindOfClass:objc_lookUpClass("RCTCxxBridge")]``` returns  ```null```.

This closes #2193 

## ☑️ ToDos
<!-- Add your own todos here -->
* [X] 📝 Changelog entry
* [X] 📝 `Compatibility` label is updated or copied from previous entry
* [X] 🚦 Tests
* [X] 📝 Public documentation PR created or is not necessary
* [X] 💥 `Breaking` label has been applied or is not necessary