### PR TITLE
Android Studio 3.5+: Gradle task configuration avoidance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed Gradle build error with Android Studio 3.5+.
 
 ### Compatibility
 * Realm Object Server: 3.21.0 or later.

--- a/react-native/android/publish_android_template
+++ b/react-native/android/publish_android_template
@@ -21,7 +21,7 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-task forwardDebugPort(type: Exec) {
+tasks.register('forwardDebugPort', Exec) {
     def adb = android.getAdbExe()?.toString() ?: 'false'
     commandLine adb, 'forward', 'tcp:8083', 'tcp:8083'
     ignoreExitValue true


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
Updates task to avoid configuring the task before it's necessary. This fixes an error (with newer Gradle versions using version 3.5.0+ of the Android Gradle plugin) which prevents Android builds (that include realm-js via React Native) from succeeding.

As of Gradle 5.1, it's suggested to use configuration avoidance strategies for all custom tasks. Seemingly as of Gradle 5.4 and/or Android gradle plugin 3.5.x, this is required for the call being made in the `forwardDebugPort` task. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

This change does also work with the current Gradle (5.0) and Android Gradle plugin (3.2.1) used by this repo.

Without this change, the Android build fails with the message:
```
FAILURE: Build completed with 2 failures.
 
1: Task failed with an exception.
-----------
* Where:
Build file '/Users/hudl/buildAgent/work/94b0198fa43bd9ff/node_modules/realm/android/build.gradle' line: 25
 
* What went wrong:
A problem occurred evaluating project ':realm'.
> Extension not initialized yet, couldn't access compileSdkVersion.
 
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================
 
2: Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring project ':realm'.
> compileSdkVersion is not specified.
```

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

~*If this PR adds or changes public API's:*~
* [ ] ~typescript definitions file is updated~
* [ ] ~jsdoc files updated~
* [ ] ~Chrome debug API is updated if API is available on React Native~
