### PR TITLE
Bring back Realm.Sync to generated API doc

### DIFF
--- a/docs/async_open_task.js
+++ b/docs/async_open_task.js
@@ -17,12 +17,15 @@
 ////////////////////////////////////////////////////////////////////////////
 
 
+/**
+ * @memberof Realm.Sync
+ */
 class AsyncOpenTask {
 
     /**
      * Cancels any current running download.
      * If multiple AsyncOpenTasks are all in the progress for the same Realm, then canceling one of them
-     * wil cancel all of them.
+     * will cancel all of them.
      */
     cancel() { }
 

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -98,17 +98,6 @@
  */
 
 /**
- * When opening a Realm created with Realm Mobile Platform v1.x, it is automatically
- * migrated to the v2.x format. In case this migration
- * is not possible, an exception is thrown. The exception´s `message` property will be equal
- * to `IncompatibleSyncedRealmException`. The Realm is backed up, and the property `configuration`
- * is a {Realm~Configuration} which refers to it. You can open it as a local, read-only Realm, and
- * copy objects to a new synced Realm.
- *
- * @memberof Realm
- */
-
-/**
  * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
  * If this is the first time you open the Realm, it will be empty while the server data is being downloaded
  * in the background.
@@ -123,6 +112,16 @@
  * @typedef {Object} Realm.Sync.downloadBeforeOpenBehavior
  */
 
+/**
+ * When opening a Realm created with Realm Mobile Platform v1.x, it is automatically
+ * migrated to the v2.x format. In case this migration
+ * is not possible, an exception is thrown. The exception´s `message` property will be equal
+ * to `IncompatibleSyncedRealmException`. The Realm is backed up, and the property `configuration`
+ * is a {Realm~Configuration} which refers to it. You can open it as a local, read-only Realm, and
+ * copy objects to a new synced Realm.
+ *
+ * @memberof Realm
+ */
 class Sync {
     /**
      * Add a sync listener to listen to changes across multiple Realms.
@@ -166,7 +165,7 @@ class Sync {
      * Only events on Realms with a _virtual path_ that matches the filter regex are emitted.
      *
      * Currently supported events:
-     * 
+     *
      *  * `'available'`: Emitted whenever there is a new Realm which has a virtual
      *    path matching the filter regex, either due to the Realm being newly created
      *    or the listener being added. The virtual path (i.e. the portion of the
@@ -1065,7 +1064,7 @@ class Subscription {
  * function onavailable(path) {
  *    console.log(`Realm available at ${path}`);
  * }
- * 
+ *
  * function onchange(change) {
  *    console.log(`Realm at ${change.path} changed`);
  * }


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
When merging #2381 we stopped generating API doc for `Realm.Sync`. It is now fixed.

## ☑️ ToDos
<!-- Add your own todos here -->
* ~[ ] 📝 Changelog entry~
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
