### PR TITLE
[RJS-6] Bypass the sync proxy on Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+X.Y.Z Release notes (TBD)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* None.
+
+### Compatibility
+* Realm Object Server: 3.21.0 or later.
+* APIs are backwards compatible with all previous release of realm in the 2.x.y series.
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+
+### Internal
+* Add support for direct access to sync workers on Cloud, bypassing the Sync Proxy [RJS-6](https://jira.mongodb.org/browse/RJS-6)
+
 2.29.2 Release notes (2019-8-14)
 =============================================================
 ### Enhancements

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -310,9 +310,15 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
             }
 
             const tokenData = json.access_token.token_data;
+            let syncWorkerPathPrefix = undefined;
+
+            // returned by Cloud instance where sync workers are exposed with ingress and not sync proxy
+            if (json.sync_worker) {
+                syncWorkerPathPrefix = json.sync_worker.path;
+            }
 
             parsedRealmUrl.set('pathname', tokenData.path);
-            session._refreshAccessToken(json.access_token.token, parsedRealmUrl.href, tokenData.sync_label);
+            session._refreshAccessToken(json.access_token.token, parsedRealmUrl.href, tokenData.sync_label, syncWorkerPathPrefix);
 
             const errorHandler = session.config.error;
             if (errorHandler && errorHandler._notifyOnAccessTokenRefreshed) {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -558,11 +558,16 @@ void SessionClass<T>::simulate_error(ContextType ctx, ObjectType this_object, Ar
 
 template<typename T>
 void SessionClass<T>::refresh_access_token(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &) {
-    args.validate_count(3);
+    args.validate_between(3, 4);
 
     if (auto session = get_internal<T, SessionClass<T>>(this_object)->lock()) {
         std::string sync_label = Value::validated_to_string(ctx, args[2], "syncLabel");
         session->set_multiplex_identifier(std::move(sync_label));
+
+        if (args.count == 4 && !Value::is_undefined(ctx, args[3])) {
+            std::string url_prefix = Value::validated_to_string(ctx, args[3], "urlPrefix");
+            session->set_url_prefix(std::move(url_prefix));
+        }
 
         std::string access_token = Value::validated_to_string(ctx, args[0], "accessToken");
         std::string realm_url = Value::validated_to_string(ctx, args[1], "realmUrl");


### PR DESCRIPTION
## What, How & Why?
See https://github.com/realm/realm-object-store/pull/824

I'm not sure how to add tests, because this relies on functionality that resides entirely on Cloud and not in ROS.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
