### PR TITLE
fix error on refreshAdminToken and refreshAccessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ X.Y.Z Release notes (TBD)
 * None.
 
 ### Fixed
-* None.
+* fix error screen shown in React Native when refreshAdminToken and refreshAccessToken receive error result
 
 ### Compatibility
 * Realm Object Server: 3.21.0 or later.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -325,6 +325,7 @@ module.exports = function(realmConstructor, context) {
             });
         }
 
+        //back compat. setSyncLogger is deprecated.
         if (!realmConstructor.Sync.setSyncLogger) {
             realmConstructor.Sync.setSyncLogger = function (level, message) {
                 realmConstructor.Sync.setLogger(level, message);

--- a/lib/user-methods.js
+++ b/lib/user-methods.js
@@ -249,7 +249,6 @@ function refreshAdminToken(user, localRealmPath, realmUrl) {
         }
     })
     .catch((e) => {
-        print_error(e);
         setTimeout(() => refreshAccessToken(user, localRealmPath, realmUrl), retryInterval);
     });
 }
@@ -329,7 +328,6 @@ function refreshAccessToken(user, localRealmPath, realmUrl) {
             scheduleAccessTokenRefresh(newUser, localRealmPath, realmUrl, tokenExpirationDate);
         })
         .catch((e) => {
-            print_error(e);
             // in case something lower in the HTTP stack breaks, try again in `retryInterval` seconds
             setTimeout(() => refreshAccessToken(user, localRealmPath, realmUrl), retryInterval);
         })


### PR DESCRIPTION
This fixes RN apps when going offline to not show error dialogs while refreshing tokens