### PR TITLE
Checking if VS Code is debugging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,11 @@ function getContext() {
     }
 
     if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') { // eslint-disable-line no-undef
+        // Visual Studio Code defines the global.__debug__ object.
+        if (typeof global !== 'undefined' && global.__debug__) {
+            return 'vscodedebugger'
+        }
+
         // If the navigator.userAgent contains the string "Chrome", we're likely
         // running via the chrome debugger.
         if (typeof navigator !== 'undefined' &&


### PR DESCRIPTION
## What, How & Why?
Inside a VSCode debugger running Node 10.16.3 `process + ''` is not equal to `[object process]`:

<img width="1518" alt="Screen Shot 2019-09-26 at 3 22 38 PM" src="https://user-images.githubusercontent.com/8790386/65687158-7c216380-e071-11e9-9cb0-12186924aca5.png">

This closes #2210 (maybe, at least in my case)
