### PR TITLE
Add predicate function filter option to Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
-
-### Enhancements
 * `Realm.Sync.Adapter` can now accept a predicate function filter instead of a regex.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Enhancements
 * None.
 
+### Enhancements
+* `Realm.Sync.Adapter` can now accept a predicate function filter instead of a regex.
+
 ### Fixed
 * Fixed VS Code React Native debugger context
 

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -1124,7 +1124,7 @@ class Adapter {
 	 * @param {string} serverUrl - the sync server to listen to
 	 * @param {SyncUser} adminUser - an admin user obtained by calling {@linkcode Realm.Sync.User.login|User.login} with admin credentials.
 	 * @param {(string|Realm.Sync.Adapter~RealmWatchPredicate)} filter - a filter used to determine which changed Realms should be monitored -
-	 *  can be a regular expression string or a predicate function. Use `.*` to match all all Realms.
+	 *  can be a regular expression string or a predicate function. Use `'.*'` to match all Realms.
 	 * @param {Realm.Sync.Adapter~RealmChangeCallback} changeCallback - called when a new transaction is available
 	 *  to process for the given realm_path
      * @param {Realm.Sync~SSLConfiguration} [ssl] - SSL configuration for the spawned sync sessions.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -1123,7 +1123,7 @@ class Adapter {
 	 * @param {string} localPath - the local path where realm files are stored
 	 * @param {string} serverUrl - the sync server to listen to
 	 * @param {SyncUser} adminUser - an admin user obtained by calling {@linkcode Realm.Sync.User.login|User.login} with admin credentials.
-	 * @param {(string|Realm.Sync.Adapter~RealmWatchPredicate)} filter - a filtered used to determine which changed Realms should be monitored -
+	 * @param {(string|Realm.Sync.Adapter~RealmWatchPredicate)} filter - a filter used to determine which changed Realms should be monitored -
 	 *  can be a regular expression string or a predicate function. Use `.*` to match all all Realms.
 	 * @param {Realm.Sync.Adapter~RealmChangeCallback} changeCallback - called when a new transaction is available
 	 *  to process for the given realm_path

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -123,14 +123,14 @@
  * If this is the first time you open the Realm, it will be empty while the server data is being downloaded
  * in the background.
  *
- * @typedef {Object} Realm.Sync.openLocalRealmBehavior
+ * @typedef {Object} Realm.Sync~openLocalRealmBehavior
  */
 
 /**
  * The default behavior settings if you want to fully synchronize a Realm before it is opened.
  * If this takes more than 30 seconds, an exception will be thrown.
  *
- * @typedef {Object} Realm.Sync.downloadBeforeOpenBehavior
+ * @typedef {Object} Realm.Sync~downloadBeforeOpenBehavior
  */
 
 /**
@@ -1123,9 +1123,9 @@ class Adapter {
 	 * @param {string} localPath - the local path where realm files are stored
 	 * @param {string} serverUrl - the sync server to listen to
 	 * @param {SyncUser} adminUser - an admin user obtained by calling {@linkcode Realm.Sync.User.login|User.login} with admin credentials.
-	 * @param {string} regex - a regular expression used to determine which changed Realms should be monitored -
-	 *  use `.*` to match all all Realms
-	 * @param {function(realmPath)} changeCallback - called when a new transaction is available
+	 * @param {(string|Realm.Sync.Adapter~RealmWatchPredicate)} filter - a filtered used to determine which changed Realms should be monitored -
+	 *  can be a regular expression string or a predicate function. Use `.*` to match all all Realms.
+	 * @param {Realm.Sync.Adapter~RealmChangeCallback} changeCallback - called when a new transaction is available
 	 *  to process for the given realm_path
      * @param {Realm.Sync~SSLConfiguration} [ssl] - SSL configuration for the spawned sync sessions.
 	 */
@@ -1212,3 +1212,14 @@ class Adapter {
 	 */
     close() { }
 }
+
+/**
+ * @callback Realm.Sync.Adapter~RealmWatchPredicate
+ * @param {string} path - the path of the realm to consider for change tracking
+ * @returns {boolean} - whether or not to track changes for the realm 
+ */
+
+/**
+ * @callback Realm.Sync.Adapter~RealmChangeCallback
+ * @param {string} path - the path of the realm for which a new transaction is available
+ */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -650,6 +650,8 @@ declare namespace Realm.Sync {
         realm (): Realm;
     }
 
+    type RealmWatchPredicate = (realmPath: string) => boolean;
+
     /**
      * @deprecated, to be removed in future versions
      */
@@ -693,7 +695,7 @@ declare namespace Realm.Sync {
             local_path: string,
             server_url: string,
             admin_user: User,
-            regex: string,
+            filter: string | RealmWatchPredicate,
             change_callback: Function,
             ssl?: SSLConfiguration
         )


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
Make it possible for the Adapter to filter realms to observe with a predicate function instead of a regular expression. Needs https://github.com/realm/realm-object-store/pull/850 to be merged first.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
