### PR TITLE
Fix #2294 null _NativeModules$Realm.debugHosts without remote debug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,12 +56,6 @@ function getContext() {
             return 'chromedebugger';
         }
 
-        // Check if its in remote js debugging mode
-        // https://stackoverflow.com/a/42839384/3090989
-        if (typeof atob !== 'undefined') {
-            return 'chromedebugger';
-        }
-
         // Otherwise, we must be in a "normal" react native situation.
         // In that case, the Realm type should have been injected by the native code.
         // If it hasn't, the user likely forgot to run link.


### PR DESCRIPTION
## What, How & Why?
If some libraries in project use `atob` realm always run in chrome debugger mode.
It is not reliable check as is mentioned in StackOverflow commented above this check. ([link](https://stackoverflow.com/a/42839384/3090989))
Removing this fixed my issue similar to #2294

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
