### PR TITLE
fixes can't dereference out of range vector iterator

### DIFF
--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -65,10 +65,14 @@ public:
 		, m_realm(parent.m_realm)
 		, m_object_schema(nullptr) 
 	{
+#if defined(WIN32) && WIN32
 		auto schema = m_realm->schema().find(prop.object_type);
 		if (schema != m_realm->schema().end()) {
 			m_object_schema = &*schema;
 		}
+#else
+		m_object_schema = &*schema;
+#endif
 	}
 
     OptionalValue value_for_property(ValueType dict, Property const& prop, size_t) {

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -66,13 +66,9 @@ public:
 		, m_object_schema(nullptr) 
 	{
 		auto schema = m_realm->schema().find(prop.object_type);
-#if defined(WIN32) && WIN32
 		if (schema != m_realm->schema().end()) {
 			m_object_schema = &*schema;
 		}
-#else
-		m_object_schema = &*schema;
-#endif
 	}
 
     OptionalValue value_for_property(ValueType dict, Property const& prop, size_t) {

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -65,8 +65,8 @@ public:
 		, m_realm(parent.m_realm)
 		, m_object_schema(nullptr) 
 	{
-#if defined(WIN32) && WIN32
 		auto schema = m_realm->schema().find(prop.object_type);
+#if defined(WIN32) && WIN32
 		if (schema != m_realm->schema().end()) {
 			m_object_schema = &*schema;
 		}

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -61,10 +61,15 @@ public:
     { }
 
     NativeAccessor(NativeAccessor& parent, const Property& prop)
-    : m_ctx(parent.m_ctx)
-    , m_realm(parent.m_realm)
-    , m_object_schema(&*m_realm->schema().find(prop.object_type))
-    { }
+		: m_ctx(parent.m_ctx)
+		, m_realm(parent.m_realm)
+		, m_object_schema(nullptr) 
+	{
+		auto schema = m_realm->schema().find(prop.object_type);
+		if (schema != m_realm->schema().end()) {
+			m_object_schema = &*schema;
+		}
+	}
 
     OptionalValue value_for_property(ValueType dict, Property const& prop, size_t) {
         ObjectType object = Value::validated_to_object(m_ctx, dict);


### PR DESCRIPTION
This exists only on Windows in debug builds cause checked iterators