### PR TITLE
Fix a seg.fault when calling Realm.deleteAll() after Realm.deleteModel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed a segmentation fault when calling `Realm.deleteAll()` after `Realm.deleteModel()`. ([#2597](https://github.com/realm/realm-js/issues/2597))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fixed a segmentation fault when calling `Realm.deleteAll()` after `Realm.deleteModel()`. ([#2597](https://github.com/realm/realm-js/issues/2597))
+* Fixed a segmentation fault when calling `Realm.deleteAll()` after `Realm.deleteModel()`. ([#2597](https://github.com/realm/realm-js/issues/2597), since v1.12.0)
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -214,6 +214,7 @@ class Realm {
 
     /**
      * Deletes a Realm model, including all of its objects.
+     * If called outside a migration function, {@link Realm#schema schema} and {@link Realm#schemaVersion schemaVersion} are updated.
      * @param {string} name - the model name
      */
     deleteModel(name) { }

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -783,8 +783,17 @@ void RealmClass<T>::delete_model(ContextType ctx, ObjectType this_object, Argume
 
     SharedRealm& realm = *get_internal<T, RealmClass<T>>(this_object);
 
+    Group& group = realm->read_group();
     std::string model_name = Value::validated_to_string(ctx, value, "deleteModel");
-    ObjectStore::delete_data_for_object(realm->read_group(), model_name);
+    ObjectStore::delete_data_for_object(group, model_name);
+    if (!realm->is_in_migration()) {
+        realm::Schema new_schema = ObjectStore::schema_from_group(group);
+        realm->update_schema(new_schema,
+                             realm->schema_version() + 1,
+                             nullptr,
+                             nullptr,
+                             true);
+    }
 }
 
 template<typename T>

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -942,6 +942,31 @@ module.exports = {
         TestCase.assertEqual(realm.objects('IntPrimaryObject').length, 0);
     },
 
+    testDeleteAllAfterDeleteModel: function() {
+        const realm = new Realm({schema: [schemas.TestObject, schemas.IntPrimary]});
+
+        realm.write(() => {
+            realm.create('TestObject', {doubleCol: 1});
+            realm.create('TestObject', {doubleCol: 2});
+            realm.create('IntPrimaryObject', {primaryCol: 2, valueCol: 'value'});
+        });
+
+        TestCase.assertEqual(realm.objects('TestObject').length, 2);
+        TestCase.assertEqual(realm.objects('IntPrimaryObject').length, 1);
+
+        console.log('FISK 0', realm.schema);
+        realm.write(() => {
+            realm.deleteModel('IntPrimaryObject');
+        });
+        console.log('FISK 1', realm.schema);
+        realm.write(() => {
+            realm.deleteAll();
+        });
+
+        TestCase.assertEqual(realm.objects('TestObject').length, 0);
+        TestCase.assertThrows(() => realm.objects('IntPrimaryObject'));
+    },
+
     testRealmObjects: function() {
         const realm = new Realm({schema: [schemas.PersonObject, schemas.DefaultValues, schemas.TestObject]});
 


### PR DESCRIPTION
## What, How & Why?
This closes #2597

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
