### PR TITLE
Call ObjectStore::table_for_object_type() in outer loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Upgraded the React Native integration tests app (now using RN v0.61.3). ([#2603](https://github.com/realm/realm-js/pull/2603))
+* Optimized some utility functions to improve performance. ([RJS-350](https://jira.mongodb.org/browse/RJS-340))
 
 3.4.2 Release notes (2019-11-14)
 =============================================================

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -160,17 +160,16 @@ inline void setup_aliases(parser::KeyPathMapping &mapping, const realm::SharedRe
 {
     const realm::Schema &schema = realm->schema();
     for (auto it = schema.begin(); it != schema.end(); ++it) {
+        const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
         for (const Property &property : it->computed_properties) {
             if (property.type == realm::PropertyType::LinkingObjects) {
                 auto target_object_schema = schema.find(property.object_type);
-                const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
                 std::string native_name = "@links." + target_object_schema->name + "." + property.link_origin_property_name;
                 mapping.add_mapping(table, property.name, native_name);
             }
         }
 
         for (const Property &property : it->persisted_properties) {
-            const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
             mapping.add_mapping(table, property.public_name, property.name);
         }
     }


### PR DESCRIPTION
## What, How & Why?

A fall-out of a profiling of the data adapters benchmark, we observed that `setup_aliases()` and in particular `ObjectStore::table_for_object_type()` took much CPU time. This is a trivial optimization by moving the call from the inner to the outer loop.

This closes #2610 (https://jira.mongodb.org/browse/RJS-340)

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
