### PR TITLE
if there are not listeners do nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Upgraded the React Native integration tests app (now using RN v0.61.3). ([#2603](https://github.com/realm/realm-js/pull/2603))
+* Optimized notification logic when there are no listeners
 
 3.4.2 Release notes (2019-11-14)
 =============================================================

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -175,6 +175,10 @@ public:
     // from inside the handler
     template<typename... Args>
     void notify(std::list<Protected<FunctionType>> notifications, const char *name, Args&&... args) {
+        if (notifications.empty()) {
+            return;
+        }
+        
         auto realm = m_realm.lock();
         if (!realm) {
             throw std::runtime_error("Realm no longer exists");


### PR DESCRIPTION
this code path is hit on every realm.create regardless existence of listeners
