### PR TITLE
Test that Realm.close() can be called on a closed Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Upgraded the React Native integration tests app (now using RN v0.61.3). ([#2603](https://github.com/realm/realm-js/pull/2603))
+* Added a test to verify that `Realm.close()` is idempotent.
 
 3.4.2 Release notes (2019-11-14)
 =============================================================

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -151,6 +151,7 @@ class Realm {
     /**
      * Closes this Realm so it may be re-opened with a newer schema version.
      * All objects and collections from this Realm are no longer valid after calling this method.
+     * The method is idempotent.
      */
     close() { }
 

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -88,6 +88,14 @@ module.exports = {
         TestCase.assertTrue(realm.isClosed);
     },
 
+    testRealmCallCloseTwice: function () {
+        const realm = new Realm({schema: []});
+        realm.close();
+        TestCase.assertTrue(realm.isClosed);
+        realm.close();
+        TestCase.assertTrue(realm.isClosed);
+    },
+
     testRealmConstructorSchemaVersion: function() {
         const defaultRealm = new Realm({schema: []});
         TestCase.assertEqual(defaultRealm.schemaVersion, 0);


### PR DESCRIPTION
## What, How & Why?

Working on something unrelated, I just became curious to see how calling `Realm.close()` is behaving.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
