### PR TITLE
Call ObjectStore::table_for_object_type() only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Upgraded the React Native integration tests app (now using RN v0.61.3). ([#2603](https://github.com/realm/realm-js/pull/2603))
+* Added a test to verify that an exception is thrown when an object schema has no properties.
 
 3.4.2 Release notes (2019-11-14)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Improved performance for some queries involving links. ([RJS-350](https://jira.mongodb.org/browse/RJS-340))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -160,17 +160,22 @@ inline void setup_aliases(parser::KeyPathMapping &mapping, const realm::SharedRe
 {
     const realm::Schema &schema = realm->schema();
     for (auto it = schema.begin(); it != schema.end(); ++it) {
+        TableRef table;
         for (const Property &property : it->computed_properties) {
             if (property.type == realm::PropertyType::LinkingObjects) {
+                if (!table) {
+                    table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
+                }
                 auto target_object_schema = schema.find(property.object_type);
-                const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
                 std::string native_name = "@links." + target_object_schema->name + "." + property.link_origin_property_name;
                 mapping.add_mapping(table, property.name, native_name);
             }
         }
 
         for (const Property &property : it->persisted_properties) {
-            const TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
+            if (!table) {
+                table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
+            }
             mapping.add_mapping(table, property.public_name, property.name);
         }
     }

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -160,12 +160,9 @@ inline void setup_aliases(parser::KeyPathMapping &mapping, const realm::SharedRe
 {
     const realm::Schema &schema = realm->schema();
     for (auto it = schema.begin(); it != schema.end(); ++it) {
-        TableRef table;
+        TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
         for (const Property &property : it->computed_properties) {
             if (property.type == realm::PropertyType::LinkingObjects) {
-                if (!table) {
-                    table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
-                }
                 auto target_object_schema = schema.find(property.object_type);
                 std::string native_name = "@links." + target_object_schema->name + "." + property.link_origin_property_name;
                 mapping.add_mapping(table, property.name, native_name);
@@ -173,9 +170,6 @@ inline void setup_aliases(parser::KeyPathMapping &mapping, const realm::SharedRe
         }
 
         for (const Property &property : it->persisted_properties) {
-            if (!table) {
-                table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
-            }
             mapping.add_mapping(table, property.public_name, property.name);
         }
     }

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -954,11 +954,9 @@ module.exports = {
         TestCase.assertEqual(realm.objects('TestObject').length, 2);
         TestCase.assertEqual(realm.objects('IntPrimaryObject').length, 1);
 
-        console.log('FISK 0', realm.schema);
         realm.write(() => {
             realm.deleteModel('IntPrimaryObject');
         });
-        console.log('FISK 1', realm.schema);
         realm.write(() => {
             realm.deleteAll();
         });

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1743,4 +1743,15 @@ module.exports = {
         }, 'Wrong Realm type');
     } ,
 
+    testObjectWithoutProperties: function() {
+        const realm = new Realm({schema: [schemas.ObjectWithoutProperties]});
+        realm.write(() => {
+            TestCase.assertThrows(() => {
+                realm.create(schemas.ObjectWithoutProperties.name, {});
+            });
+        });
+        realm.objects(schemas.ObjectWithoutProperties.name);
+        realm.close();
+    }
+
 };

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -354,3 +354,8 @@ exports.Country = {
     }
 };
 
+exports.ObjectWithoutProperties = {
+    name: 'ObjectWithoutProperties',
+    properties: {}
+};
+


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

`ObjectStore::table_for_object_type()` is an expensive call, and we should minimize the number of calls.

This closes https://jira.mongodb.org/browse/RJS-340

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
