### PR TITLE
Fix URLs when building without sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 
 ### Internal
-* None.
+* Fixed download URLs to make it possible to build without sync. ([RJS-355](https://jira.mongodb.org/browse/RJS-355))
 
 3.5.0 Release notes (2019-12-2)
 =============================================================

--- a/scripts/download-realm.js
+++ b/scripts/download-realm.js
@@ -144,8 +144,8 @@ function getCoreRequirements(dependencies, options, required = {}) {
 
     switch (options.platform) {
         case 'mac':
-            required.CORE_SERVER_FOLDER += `/macos/${flavor}`;
-            required.CORE_ARCHIVE = `realm-core-${flavor}-v${dependencies.REALM_CORE_VERSION}-Darwin-devel.tar.gz`;
+            required.CORE_SERVER_FOLDER += `/macosx/${flavor}`;
+            required.CORE_ARCHIVE = `realm-core-${flavor}-v${dependencies.REALM_CORE_VERSION}-macosx-devel.tar.gz`;
             return required;
         case 'ios':
             flavor = flavor === 'Debug' ? 'MinSizeDebug' : flavor;
@@ -160,7 +160,7 @@ function getCoreRequirements(dependencies, options, required = {}) {
             return required;
         }
         case 'linux':
-            required.CORE_SERVER_FOLDER = 'core';
+            required.CORE_SERVER_FOLDER += `/linux/${flavor}`;
             required.CORE_ARCHIVE = `realm-core-${flavor}-v${dependencies.REALM_CORE_VERSION}-Linux-devel.tar.gz`;
             return required;
         default:


### PR DESCRIPTION
## What, How & Why?
Even if we don't pre-gyp without sync, it should be possible to build without (`npm install --build-from-source --realm_enable_sync=0`).

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
