### PR TITLE
A better error message when calling Realm.deleteModel() on a synced Realm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* When calling `Realm.deleteModel()` on a synced Realm could lead to an error message like `Failed while synchronizing Realm: Bad changeset (DOWNLOAD)`. A better error message (`Cannot delete model for a read-only or a synced Realm.`) is introduced. ([RJS-230](https://jira.mongodb.org/browse/RJS-230), since v1.12.0)
+
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -787,6 +787,17 @@ void RealmClass<T>::delete_model(ContextType ctx, ObjectType this_object, Argume
 
     SharedRealm& realm = *get_internal<T, RealmClass<T>>(this_object);
 
+    auto& config = realm->config();
+    if (config.schema_mode == SchemaMode::Immutable || config.schema_mode == SchemaMode::Additive || config.schema_mode == SchemaMode::ReadOnlyAlternative) {
+        throw std::runtime_error("Cannot delete model for a read-only or a synced Realm.");
+    }
+
+    realm->verify_open();
+    if (!realm->is_in_transaction()) {
+        throw std::runtime_error("Can only delete objects within a transaction.");
+    }
+
+
     Group& group = realm->read_group();
     std::string model_name = Value::validated_to_string(ctx, value, "deleteModel");
     ObjectStore::delete_data_for_object(group, model_name);

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1458,5 +1458,28 @@ module.exports = {
                 }
                 TestCase.assertFalse(Realm.Sync._hasExistingSessions());
             });
+    },
+
+    testDeleteModelThrowsWhenSync() {
+        if (!isNodeProcess) {
+            return;
+        }
+
+        return Realm.Sync.User.login('http://127.0.0.1:9080', Realm.Sync.Credentials.anonymous()).then((u) => {
+            let config = {
+                schema: [schemas.TestObject],
+                sync: {
+                    user: u,
+                    url: `realm://127.0.0.1:9080/~/${Utils.uuid()}`,
+                    fullSynchronization: true,
+                }
+            };
+            return Realm.open(config);
+        }).then(realm => {
+            realm.write(() => {
+                TestCase.assertThrows(() => { realm.deleteModel(schemas.TestObject.name); });
+            });
+            realm.close();
+        });
     }
 };


### PR DESCRIPTION
## What, How & Why?
When calling `Realm.deleteModel()` on a synced Realm can give odd error messages. It should not be possible to delete a table (model) when the Realm is opened in additive schema mode (as a synced Realm is). This PR introduces a better error message.

This closes https://jira.mongodb.org/browse/RJS-230

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
