### PR TITLE
Use objectstore populate_keypath_mapping()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Improved performance of constructing queries, especially for large schemas.
 
 ### Fixed
 * When calling `Realm.deleteModel()` on a synced Realm could lead to an error message like `Failed while synchronizing Realm: Bad changeset (DOWNLOAD)`. A better error message (`Cannot delete model for a read-only or a synced Realm.`) is introduced. ([RJS-230](https://jira.mongodb.org/browse/RJS-230), since v1.12.0)

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -22,9 +22,10 @@
 #include "js_realm_object.hpp"
 #include "js_util.hpp"
 
-#include "results.hpp"
+#include "keypath_helpers.hpp"
 #include "list.hpp"
 #include "object_store.hpp"
+#include "results.hpp"
 
 #include <realm/parser/parser.hpp>
 #include <realm/parser/query_builder.hpp>
@@ -156,25 +157,6 @@ typename T::Object ResultsClass<T>::create_instance(ContextType ctx, SharedRealm
     return create_object<T, ResultsClass<T>>(ctx, new realm::js::Results<T>(realm, *table));
 }
 
-inline void setup_aliases(parser::KeyPathMapping &mapping, const realm::SharedRealm &realm)
-{
-    const realm::Schema &schema = realm->schema();
-    for (auto it = schema.begin(); it != schema.end(); ++it) {
-        TableRef table = ObjectStore::table_for_object_type(realm->read_group(), it->name);
-        for (const Property &property : it->computed_properties) {
-            if (property.type == realm::PropertyType::LinkingObjects) {
-                auto target_object_schema = schema.find(property.object_type);
-                std::string native_name = "@links." + target_object_schema->name + "." + property.link_origin_property_name;
-                mapping.add_mapping(table, property.name, native_name);
-            }
-        }
-
-        for (const Property &property : it->persisted_properties) {
-            mapping.add_mapping(table, property.public_name, property.name);
-        }
-    }
-}
-
 template<typename T>
 template<typename U>
 typename T::Object ResultsClass<T>::create_filtered(ContextType ctx, const U &collection, Arguments &args) {
@@ -188,8 +170,7 @@ typename T::Object ResultsClass<T>::create_filtered(ContextType ctx, const U &co
     auto const &object_schema = collection.get_object_schema();
     DescriptorOrdering ordering;
     parser::KeyPathMapping mapping;
-    mapping.set_backlink_class_prefix(ObjectStore::table_name_for_object_type("")); // prefix is "class_" defined by object store
-    setup_aliases(mapping, realm);
+    realm::populate_keypath_mapping(mapping, *realm);
 
     parser::ParserResult result = parser::parse(query_string);
     NativeAccessor<T> accessor(ctx, realm, object_schema);
@@ -354,8 +335,7 @@ void ResultsClass<T>::subscribe(ContextType ctx, ObjectType this_object, Argumen
                 ObjectType property_paths = Value::validated_to_array(ctx, user_includes, available_options[INCLUSIONS]);
 
                 parser::KeyPathMapping mapping;
-                mapping.set_backlink_class_prefix(ObjectStore::table_name_for_object_type("")); // prefix is "class_"
-                setup_aliases(mapping, realm); // this enables user defined linkingObjects property names to be parsed
+                realm::populate_keypath_mapping(mapping, *realm); // this enables user defined linkingObjects property names to be parsed
                 DescriptorOrdering combined_orderings;
 
                 size_t prop_count = Object::validated_get_length(ctx, property_paths);


### PR DESCRIPTION
This eliminates some duplicated code and the objectstore version is significantly faster than the version here. For the following benchmark:

```
    testPerformance() {
        const Person = {
            name: 'Person',
            properties: {
                _name:     {type: 'string', mapTo: 'name'},
                address:  {type: 'string', indexed: true },
                age:      'double',
                _married:  {type: 'bool', default: false, mapTo: 'married'},
                _children: {type: 'list', objectType: 'Person', mapTo: 'children'},
                _parents:  {type: 'linkingObjects', objectType: 'Person', property: 'children', mapTo: 'parents'},
            }
        };

        const realm = new Realm({
            schema: Object.values(schemas).concat([Person])
        });

        const { performance } = require('perf_hooks');
        performance.mark('start');
        for (let i = 0; i < 100000; ++i) {
            realm.objects('Person').filtered('name = ""');
        }
        performance.mark('end');
        performance.measure('run', 'start', 'end');
        console.log(performance.getEntriesByName('run')[0].duration);
    },
```

Runtime drops from 6.8 seconds to 2.5 seconds, and setup_aliases() goes from 80% of the runtime to 25%.

Depends on https://github.com/realm/realm-object-store/pull/887 and should wait for that to be merged.