### PR TITLE
Updated the index.d.ts for Realm.Sync.User.current & subscriptionCallback

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -362,7 +362,7 @@ declare namespace Realm.Sync {
      */
     class User {
         static readonly all: { [identity: string]: User };
-        static readonly current: User;
+        static readonly current: User | undefined;
         readonly identity: string;
         readonly isAdmin: boolean;
         readonly isAdminToken: boolean;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -574,7 +574,7 @@ declare namespace Realm.Sync {
         uploadAllLocalChanges(timeoutMs?: number): Promise<void>;
     }
 
-    type SubscriptionNotificationCallback = (subscription: Subscription, state: number) => void;
+    type SubscriptionNotificationCallback = (subscription: Subscription, state: SubscriptionState) => void;
 
     /**
      * Subscription

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -585,8 +585,8 @@ declare namespace Realm.Sync {
         readonly error: string;
 
         unsubscribe(): void;
-        addListener(subscruptionCallback: SubscriptionNotificationCallback): void;
-        removeListener(subscruptionCallback: SubscriptionNotificationCallback): void;
+        addListener(subscriptionCallback: SubscriptionNotificationCallback): void;
+        removeListener(subscriptionCallback: SubscriptionNotificationCallback): void;
         removeAllListeners(): void;
     }
 


### PR DESCRIPTION
The Realm.Sync.User.current might be undefined (when not authenticated), subscription was misspelled and the callback argument was a `number`, not a `SubscriptionState`.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
