### PR TITLE
Add Realm.Object.globalKey() and Realm.objectForGlobalKey()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ NOTE: Contains all previous releases up to v3.6.0.
 * None.
 
 ### Enhancements
-* None.
+* Added `Realm.Object.globalKey()` which returns a global and unique key for the object. Added `Realm.getObjectByGlobalKey()` to retrieve objects using global keys. ([RJS-383](https://jira.mongodb.org/browse/RJS-383))
 
 ### Fixed
 * None.

--- a/docs/object.js
+++ b/docs/object.js
@@ -91,10 +91,10 @@ class Object {
     removeAllListeners() { }
 
     /**
-     * Returns a unique identifier. For synced objects, the uniqueness is only guaranteed when the object has been
+     * Returns a unique and global key. For synced objects, the uniqueness is only guaranteed when the object has been
      * synchronized.
-     * @see {@link Realm#objectForObjectId objectForObjectId}
+     * @see {@link Realm#objectForGlobalKey objectForGlobalKey}
      * @since 4.0.0
      */
-    objectId() { }
+    globalKey() { }
 }

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -245,6 +245,16 @@ class Realm {
     objectForPrimaryKey(type, key) { }
 
     /**
+     * Searches for a Realm object by its global key.
+     * @param {string} key - The value of the global key of the object to search for.
+     * @throws {Error} If type passed into this method is invalid.
+     * @returns {Realm.Object|undefined} if no object is found.
+     * @see {@link Realm.Object#globalKey Realm.Object.globalKey}
+     * @since 4.0.0
+     */
+    objectForGlobalKey(key) { }
+
+    /**
      * Add a listener `callback` for the specified event `name`.
      * @param {string} name - The name of event that should cause the callback to be called.
      *   _Currently, only the "change" and "schema" events are supported_.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -146,7 +146,7 @@ util.createMethods(Realm.prototype, objectTypes.REALM, [
     'privileges',
     'writeCopyTo',
     '_waitForDownload',
-    '_objectForObjectId',
+    'objectForGlobalKey',
 ]);
 
 // Mutating methods:

--- a/lib/browser/objects.js
+++ b/lib/browser/objects.js
@@ -34,7 +34,7 @@ createMethods(RealmObject.prototype, objectTypes.OBJECT, [
     'objectSchema',
     'linkingObjects',
     'linkingObjectsCount',
-    '_objectId',
+    'globalKey',
     '_isSameObject',
     'addListener',
     'removeListener',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
-        objectId(): string;
+        globalKey(): string;
 
         /**
          * @returns void
@@ -926,6 +926,15 @@ declare class Realm {
      * @returns {T | undefined}
      */
     objectForPrimaryKey<T>(type: string | Realm.ObjectType | Function, id: string): T & Realm.Object | undefined;
+
+    /**
+     *
+     * @param  {string|Realm.ObjectType|Function} type
+     * @param  {string} key
+     * @returns {T | undefined}
+     */
+    objectForGlobalKey<T>(type: string | Realm.ObjectType | Function, key: string) : T & Realm.Object | undefined;
+
 
     /**
      * @param  {string|Realm.ObjectType|Function} type

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -326,7 +326,7 @@ public:
         {"deleteModel", wrap<delete_model>},
         {"privileges", wrap<privileges>},
         {"_updateSchema", wrap<update_schema>},
-        {"_objectForObjectId", wrap<object_for_object_id>},
+        {"objectForGlobalKey", wrap<object_for_object_id>},
         {"_schemaName", wrap<get_schema_name_from_object>},
     };
 

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -95,7 +95,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
         {"objectSchema", wrap<get_object_schema>},
         {"linkingObjects", wrap<linking_objects>},
         {"linkingObjectsCount", wrap<linking_objects_count>},
-        {"_objectId", wrap<get_object_id>},
+        {"globalKey", wrap<get_object_id>},
         {"_isSameObject", wrap<is_same_object>},
         {"_setLink", wrap<set_link>},
         {"addListener", wrap<add_listener>},

--- a/tests/js/adapter-tests.ts
+++ b/tests/js/adapter-tests.ts
@@ -327,7 +327,7 @@ describe('Adapter', () => {
                     actual_object = realm.objectForPrimaryKey(object_type, change_object[object_schema.primaryKey]);
                 }
                 else {
-                    actual_object = realm._objectForObjectId(object_type, identity);
+                    actual_object = realm.objectForGlobalKey(object_type, identity);
                 }
 
                 expect(actual_object).toBeDefined();

--- a/tests/js/linkingobjects-tests.js
+++ b/tests/js/linkingobjects-tests.js
@@ -210,18 +210,18 @@ module.exports = {
         var id;
         realm.write(function() {
             olivier = realm.create('PersonObject', {name: 'Olivier', age: 0});
-            id = olivier._objectId();
+            id = olivier.globalKey();
             realm.create('PersonObject', {name: 'Christine', age: 25, children: [olivier]});
         });
 
         TestCase.assertEqual(olivier.linkingObjectsCount(), 1);
-        TestCase.assertEqual(olivier._objectId(), id);
+        TestCase.assertEqual(olivier.globalKey(), id);
 
         realm.write(function() {
             john.children.push(olivier);
         });
 
-        TestCase.assertEqual(olivier._objectId(), id);
+        TestCase.assertEqual(olivier.globalKey(), id);
         TestCase.assertEqual(john.children.length, 1);
         TestCase.assertEqual(john.children[0]['name'], 'Olivier');
         TestCase.assertEqual(realm.objects('PersonObject').length, 3);

--- a/tests/js/notifier-tests.ts
+++ b/tests/js/notifier-tests.ts
@@ -241,7 +241,7 @@ describe('Notifier', () => {
             throw new Error(`No matching RealmFile for filter "path ENDSWITH '${currentTestName}/test' in admin Realm. `
                             + `These were found: ${adminRealm.objects('RealmFile').map((f) => f.path)}`);
         }
-        expect(fs.existsSync(`${temp.name}/realms${realmFile.path}/${realmFile._objectId()}.realm`)).toBeTruthy();
+        expect(fs.existsSync(`${temp.name}/realms${realmFile.path}/${realmFile.globalKey()}.realm`)).toBeTruthy();
         temp.removeCallback();
     });
 

--- a/tests/js/object-id-tests.js
+++ b/tests/js/object-id-tests.js
@@ -51,17 +51,17 @@ module.exports = {
                     none = realm.create('NoPrimaryKey', ["hello, world"]);
                 });
 
-                let integerId = integer._objectId();
-                let nullIntegerId = nullInteger._objectId();
-                let stringId = string._objectId();
-                let nullStringId = nullString._objectId();
-                let noneId = none._objectId();
+                let integerId = integer.globalKey();
+                let nullIntegerId = nullInteger.globalKey();
+                let stringId = string.globalKey();
+                let nullStringId = nullString.globalKey();
+                let noneId = none.globalKey();
 
-                TestCase.assertTrue(integer._isSameObject(realm._objectForObjectId('IntegerPrimaryKey', integerId)));
-                TestCase.assertTrue(nullInteger._isSameObject(realm._objectForObjectId('IntegerPrimaryKey', nullIntegerId)));
-                TestCase.assertTrue(string._isSameObject(realm._objectForObjectId('StringPrimaryKey', stringId)));
-                TestCase.assertTrue(nullString._isSameObject(realm._objectForObjectId('StringPrimaryKey', nullStringId)));
-                TestCase.assertTrue(none._isSameObject(realm._objectForObjectId('NoPrimaryKey', noneId)));
+                TestCase.assertTrue(integer._isSameObject(realm.objectForGlobalKey('IntegerPrimaryKey', integerId)));
+                TestCase.assertTrue(nullInteger._isSameObject(realm.objectForGlobalKey('IntegerPrimaryKey', nullIntegerId)));
+                TestCase.assertTrue(string._isSameObject(realm.objectForGlobalKey('StringPrimaryKey', stringId)));
+                TestCase.assertTrue(nullString._isSameObject(realm.objectForGlobalKey('StringPrimaryKey', nullStringId)));
+                TestCase.assertTrue(none._isSameObject(realm.objectForGlobalKey('NoPrimaryKey', noneId)));
             });
         });
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Core v6 swaps out the old row index with an object key. But in order to avoid confusion with MongoDB's object id, we can call Realm's object keys for global key.

This closes [RJS-383](https://jira.mongodb.org/browse/RJS-383)

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
