### PR TITLE
Prevent concurrent use of ~/gradle-cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,17 +381,21 @@ def inAndroidContainer(workerFunction) {
         image = buildDockerEnv('ci/realm-js:android-build', '-f Dockerfile.android')
       }
       sh "bash ./scripts/utils.sh set-version ${dependencies.VERSION}"
-      image.inside(
-        // Mounting ~/.android/adbkey(.pub) to reuse the adb keys
-        "-v ${HOME}/.android/adbkey:/home/jenkins/.android/adbkey:ro -v ${HOME}/.android/adbkey.pub:/home/jenkins/.android/adbkey.pub:ro " +
-        // Mounting ~/gradle-cache as ~/.gradle to prevent gradle from being redownloaded
-        "-v ${HOME}/gradle-cache:/home/jenkins/.gradle " +
-        // Mounting ~/ccache as ~/.ccache to reuse the cache across builds
-        "-v ${HOME}/ccache:/home/jenkins/.ccache " +
-        // Mounting /dev/bus/usb with --privileged to allow connecting to the device via USB
-        "-v /dev/bus/usb:/dev/bus/usb --privileged"
-      ) {
-        workerFunction()
+      // Locking on the "android" lock to prevent concurrent usage of the gradle-cache
+      // @see https://github.com/realm/realm-java/blob/master/Jenkinsfile#L65
+      lock("${env.NODE_NAME}-android") {
+        image.inside(
+          // Mounting ~/.android/adbkey(.pub) to reuse the adb keys
+          "-v ${HOME}/.android/adbkey:/home/jenkins/.android/adbkey:ro -v ${HOME}/.android/adbkey.pub:/home/jenkins/.android/adbkey.pub:ro " +
+          // Mounting ~/gradle-cache as ~/.gradle to prevent gradle from being redownloaded
+          "-v ${HOME}/gradle-cache:/home/jenkins/.gradle " +
+          // Mounting ~/ccache as ~/.ccache to reuse the cache across builds
+          "-v ${HOME}/ccache:/home/jenkins/.ccache " +
+          // Mounting /dev/bus/usb with --privileged to allow connecting to the device via USB
+          "-v /dev/bus/usb:/dev/bus/usb --privileged"
+        ) {
+          workerFunction()
+        }
       }
     }
   }


### PR DESCRIPTION
# What, How & Why?

This closes part of #2695 by preventing concurrent use of the Jenkins ~/gradle-cache directory.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary