### PR TITLE
Fix ReactNative iOS integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -215,13 +215,16 @@ def reactNativeIntegrationTests(targetPlatform) {
   def nvm
   if (targetPlatform == "android") {
     nvm = ""
-  }
-  else {
+  } else {
     nvm = "${env.WORKSPACE}/scripts/nvm-wrapper.sh ${nodeVersion}"
   }
 
   dir('integration-tests') {
-    unstash 'android'
+    if (targetPlatform == "android") {
+      unstash 'android'
+    } else {
+      sh "${nvm} npm pack .."
+    }
     // Renaming the package to avoid having to specify version in the apps package.json
     sh 'mv realm-*.tgz realm.tgz'
     // Package up the integration tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ stage('check') {
   }
 }
 
+/*
 stage('pretest') {
   parallelExecutors = [:]
     parallelExecutors["eslint"] = testLinux("eslint-ci Release ${nodeTestVersion}", { // "Release" is not used
@@ -127,21 +128,26 @@ stage('test') {
   //}),
   parallel parallelExecutors
 }
+*/
 
 stage('integration tests') {
   parallel(
+    /*
     'React Native on Android':  inAndroidContainer {
       // Locking the Android device to prevent other jobs from interfering
       lock("${NODE_NAME}-android") {
         reactNativeIntegrationTests('android')
       }
     },
+    */
     'React Native on iOS':      buildMacOS { reactNativeIntegrationTests('ios') },
+    /*
     'Electron on Mac':          buildMacOS { electronIntegrationTests('4.1.4', it) },
     'Electron on Linux':        buildLinux { electronIntegrationTests('4.1.4', it) },
     'Node.js v10 on Mac':       buildMacOS { nodeIntegrationTests('10.15.1', it) },
     'Node.js v8 on Linux':      buildLinux { nodeIntegrationTests('8.15.0', it) },
     'Node.js v10 on Linux':     buildLinux { nodeIntegrationTests('10.15.1', it) }
+    */
   )
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,17 +381,21 @@ def inAndroidContainer(workerFunction) {
         image = buildDockerEnv('ci/realm-js:android-build', '-f Dockerfile.android')
       }
       sh "bash ./scripts/utils.sh set-version ${dependencies.VERSION}"
-      image.inside(
-        // Mounting ~/.android/adbkey(.pub) to reuse the adb keys
-        "-v ${HOME}/.android/adbkey:/home/jenkins/.android/adbkey:ro -v ${HOME}/.android/adbkey.pub:/home/jenkins/.android/adbkey.pub:ro " +
-        // Mounting ~/gradle-cache as ~/.gradle to prevent gradle from being redownloaded
-        "-v ${HOME}/gradle-cache:/home/jenkins/.gradle " +
-        // Mounting ~/ccache as ~/.ccache to reuse the cache across builds
-        "-v ${HOME}/ccache:/home/jenkins/.ccache " +
-        // Mounting /dev/bus/usb with --privileged to allow connecting to the device via USB
-        "-v /dev/bus/usb:/dev/bus/usb --privileged"
-      ) {
-        workerFunction()
+      // Locking on the "android" lock to prevent concurrent usage of the gradle-cache
+      // @see https://github.com/realm/realm-java/blob/master/Jenkinsfile#L65
+      lock("${env.NODE_NAME}-android") {
+        image.inside(
+          // Mounting ~/.android/adbkey(.pub) to reuse the adb keys
+          "-v ${HOME}/.android/adbkey:/home/jenkins/.android/adbkey:ro -v ${HOME}/.android/adbkey.pub:/home/jenkins/.android/adbkey.pub:ro " +
+          // Mounting ~/gradle-cache as ~/.gradle to prevent gradle from being redownloaded
+          "-v ${HOME}/gradle-cache:/home/jenkins/.gradle " +
+          // Mounting ~/ccache as ~/.ccache to reuse the cache across builds
+          "-v ${HOME}/ccache:/home/jenkins/.ccache " +
+          // Mounting /dev/bus/usb with --privileged to allow connecting to the device via USB
+          "-v /dev/bus/usb:/dev/bus/usb --privileged"
+        ) {
+          workerFunction()
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ stage('check') {
   }
 }
 
-/*
 stage('pretest') {
   parallelExecutors = [:]
     parallelExecutors["eslint"] = testLinux("eslint-ci Release ${nodeTestVersion}", { // "Release" is not used
@@ -128,26 +127,21 @@ stage('test') {
   //}),
   parallel parallelExecutors
 }
-*/
 
 stage('integration tests') {
   parallel(
-    /*
     'React Native on Android':  inAndroidContainer {
       // Locking the Android device to prevent other jobs from interfering
       lock("${NODE_NAME}-android") {
         reactNativeIntegrationTests('android')
       }
     },
-    */
     'React Native on iOS':      buildMacOS { reactNativeIntegrationTests('ios') },
-    /*
     'Electron on Mac':          buildMacOS { electronIntegrationTests('4.1.4', it) },
     'Electron on Linux':        buildLinux { electronIntegrationTests('4.1.4', it) },
     'Node.js v10 on Mac':       buildMacOS { nodeIntegrationTests('10.15.1', it) },
     'Node.js v8 on Linux':      buildLinux { nodeIntegrationTests('8.15.0', it) },
     'Node.js v10 on Linux':     buildLinux { nodeIntegrationTests('10.15.1', it) }
-    */
   )
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,7 +381,7 @@ def inAndroidContainer(workerFunction) {
       }
       sh "bash ./scripts/utils.sh set-version ${dependencies.VERSION}"
       // Locking on the "android" lock to prevent concurrent usage of the gradle-cache
-      // @see https://github.com/realm/realm-java/blob/master/Jenkinsfile#L65
+      // @see https://github.com/realm/realm-java/blob/00698d1/Jenkinsfile#L65
       lock("${env.NODE_NAME}-android") {
         image.inside(
           // Mounting ~/.android/adbkey(.pub) to reuse the adb keys

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,6 +223,7 @@ def reactNativeIntegrationTests(targetPlatform) {
     if (targetPlatform == "android") {
       unstash 'android'
     } else {
+      // Pack up Realm JS into a .tar
       sh "${nvm} npm pack .."
     }
     // Renaming the package to avoid having to specify version in the apps package.json
@@ -242,7 +243,7 @@ def reactNativeIntegrationTests(targetPlatform) {
       sh 'adb uninstall io.realm.tests.reactnative || true' // '|| true' because the app might already not be installed
     } else if (targetPlatform == "ios") {
       dir('ios') {
-        sh 'pod install'
+        sh 'pod install --verbose'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,12 +130,7 @@ stage('test') {
 
 stage('integration tests') {
   parallel(
-    'React Native on Android':  inAndroidContainer {
-      // Locking the Android device to prevent other jobs from interfering
-      lock("${NODE_NAME}-android") {
-        reactNativeIntegrationTests('android')
-      }
-    },
+    'React Native on Android':  inAndroidContainer { reactNativeIntegrationTests('android') },
     'React Native on iOS':      buildMacOS { reactNativeIntegrationTests('ios') },
     'Electron on Mac':          buildMacOS { electronIntegrationTests('4.1.4', it) },
     'Electron on Linux':        buildLinux { electronIntegrationTests('4.1.4', it) },

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -114,6 +114,8 @@ async function runApp(platform, junitFilePath) {
         const deviceName = "realm-js-integration-tests";
         ensureSimulator(deviceName, 'com.apple.CoreSimulator.SimDeviceType.iPhone-11');
         console.log("Simulator is ready 🚀");
+        // Open the bundle URL (ensures that the simulator can connect to the Metro server, when the app loads)
+        xcode.simctl.openUrl(deviceName, 'http://localhost:8081');
         // Ask React Native to run the ios app
         rn.sync("run-ios", "--no-packager", "--simulator", deviceName);
     } else {

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -23,51 +23,67 @@ const rn = require("./react-native-cli");
 const android = require("./android-cli");
 const xcode = require("./xcode-cli");
 
+const IOS_DEVICE_NAME = "realm-js-integration-tests";
+const IOS_DEVICE_TYPE_ID = "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
+
 /**
- * Ensure the simulator is created and booted
+ * Ensure a simulator is created and booted
  */
-function ensureSimulator(deviceName, deviceTypeId) {
-    const version = xcode.xcrun("--version").stdout.trim();
-    console.log(`Using ${version}`);
+function ensureSimulator(platform) {
+    if (platform === "android") {
+        const devices = android.adb.devices();
+        const activeDevices = devices.filter(({ state }) => state === "device");
+        if (activeDevices.length === 0) {
+            throw new Error("Missing an active device: Attach a device via USB or start an emulator");
+        } else {
+            // Ensure the device can access the mocha remote server
+            android.adb.reverseServerPort(MochaRemoteServer.DEFAULT_CONFIG.port);
+        }
+    } else if (platform === "ios") {
 
-    // Determine if the system supports the device type id
-    const { devicetypes } = xcode.simctl.list('devicetypes');
-    const deviceType = devicetypes.find(({ identifier }) => identifier === deviceTypeId);
-    if (!deviceType) {
-        throw new Error(`System doesn't have the "${deviceTypeId}" device type`);
+        const version = xcode.xcrun("--version").stdout.trim();
+        console.log(`Using ${version}`);
+    
+        // Determine if the system supports the device type id
+        const { devicetypes } = xcode.simctl.list('devicetypes');
+        const deviceType = devicetypes.find(({ identifier }) => identifier === IOS_DEVICE_TYPE_ID);
+        if (!deviceType) {
+            throw new Error(`System doesn't have the "${IOS_DEVICE_TYPE_ID}" device type`);
+        }
+    
+        // Shutdown all booted simulators (as they might interfeer by loading and executing the Metro bundle)
+        xcode.simctl.shutdown('all');
+    
+        // Determine if the device exists and has the correct IOS_DEVICE_TYPE_ID and latest runtime
+        const { devices: devicesByType } = xcode.simctl.list('devices', 'available');
+        const availableDevices = [].concat(...Object.keys(devicesByType).map(type => devicesByType[type]));
+        // Filter devices, so we're only focussing on devices of the expected name
+        const devices = availableDevices.filter(({ name }) => name === IOS_DEVICE_NAME);
+    
+        // Delete any existing devices with the expected name
+        for (const device of devices) {
+            console.log(`Deleting simulator (id = ${device.udid})`);
+            xcode.simctl.delete(device.udid);
+        }
+    
+        const { runtimes } = xcode.simctl.list('runtimes', 'ios');
+        const [ runtime ] = runtimes.filter(runtime => runtime.isAvailable);
+        if (!runtime) {
+            throw new Error("No available iOS runtimes");
+        }
+        // Create the device
+        const { stdout } = xcode.simctl.create(IOS_DEVICE_NAME, IOS_DEVICE_TYPE_ID, runtime.identifier);
+        const deviceId = stdout.trim();
+        console.log(`Created simulator device (id = ${deviceId})`);
+        // Boot up the device
+        console.log('Booting simulator');
+        xcode.simctl.boot(deviceId);
+        console.log('Simulator is booting');
+        xcode.simctl.bootstatus(deviceId);
+        console.log("Simulator is ready 🚀");
+    } else {
+        throw new Error(`Unexpected platform: '${platform}'`);
     }
-
-    // Shutdown all booted simulators (as they might interfeer by loading and executing the Metro bundle)
-    xcode.simctl.shutdown('all');
-
-    // Determine if the device exists and has the correct deviceTypeId and latest runtime
-    const { devices: devicesByType } = xcode.simctl.list('devices', 'available');
-    const availableDevices = [].concat(...Object.keys(devicesByType).map(type => devicesByType[type]));
-    // Filter devices, so we're only focussing on devices of the expected name
-    const devices = availableDevices.filter(({ name }) => name === deviceName);
-
-    // Delete any existing devices with the expected name
-    for (const device of devices) {
-        console.log(`Deleting simulator (id = ${device.udid})`);
-        xcode.simctl.delete(device.udid);
-    }
-
-    const { runtimes } = xcode.simctl.list('runtimes', 'ios');
-    const [ runtime ] = runtimes.filter(runtime => runtime.isAvailable);
-    if (!runtime) {
-        throw new Error("No available iOS runtimes");
-    }
-    // Create the device
-    const { stdout } = xcode.simctl.create(deviceName, deviceTypeId, runtime.identifier);
-    const deviceId = stdout.trim();
-    console.log(`Created simulator device (id = ${deviceId})`);
-    // Boot up the device
-    console.log('Booting simulator');
-    xcode.simctl.boot(deviceId);
-    console.log('Simulator is booting');
-    xcode.simctl.bootstatus(deviceId);
-    console.log('Simulator is booted');
-    return deviceId;
 }
 
 async function runApp(platform, junitFilePath) {
@@ -101,34 +117,34 @@ async function runApp(platform, junitFilePath) {
         }
     });
 
+    // Ensure the simulator is booted and ready for the app to start
+    ensureSimulator(platform);
+
     if (platform === "android") {
-        const devices = android.adb.devices();
-        const activeDevices = devices.filter(({ state }) => state === "device");
-        if (activeDevices.length === 0) {
-            throw new Error("Missing an active device: Attach a device via USB or start an emulator");
-        } else {
-            // Ensure the device can access the mocha remote server
-            android.adb.reverseServerPort(MochaRemoteServer.DEFAULT_CONFIG.port);
-        }
         // Ask React Native to run the android app
         rn.sync("run-android", "--no-packager");
     } else if (platform === "ios") {
-        const deviceName = "realm-js-integration-tests";
-        ensureSimulator(deviceName, 'com.apple.CoreSimulator.SimDeviceType.iPhone-11');
-        console.log("Simulator is ready 🚀");
-        // Open the bundle URL (ensures that the simulator can connect to the Metro server, when the app loads)
-        xcode.simctl.openUrl(deviceName, 'http://localhost:8081');
         // Ask React Native to run the ios app
-        rn.sync("run-ios", "--no-packager", "--simulator", deviceName);
+        rn.sync("run-ios", "--no-packager", "--simulator", IOS_DEVICE_NAME);
     } else {
         throw new Error(`Unexpected platform: '${platform}'`);
     }
+
+    // Set an interval that calls "react-native run-ios" every minute to make it refetch the bundle if it fails
+    const retryInterval = setInterval(() => {
+        if (platform === "ios") {
+            // Ask React Native to re-run the ios app
+            rn.sync("run-ios", "--no-packager", "--simulator", IOS_DEVICE_NAME);
+        }
+    }, 60000);
 
     // Run tests with a 5 minute timeout
     return timeout(new Promise((resolve) => {
         console.log("Running tests 🏃‍♂️");
         server.run(resolve);
-    }), 60000 * 5);
+    }), 60000 * 5).finally(() => {
+        clearInterval(retryInterval);
+    });
 }
 
 async function run() {

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -120,6 +120,7 @@ async function runApp(platform, junitFilePath) {
     // Ensure the simulator is booted and ready for the app to start
     ensureSimulator(platform);
 
+    console.log("Starting the app");
     if (platform === "android") {
         // Ask React Native to run the android app
         rn.sync("run-android", "--no-packager");
@@ -133,6 +134,7 @@ async function runApp(platform, junitFilePath) {
     // Set an interval that calls "react-native run-ios" every minute to make it refetch the bundle if it fails
     const retryInterval = setInterval(() => {
         if (platform === "ios") {
+            console.log("Retrying starting the iOS app");
             // Ask React Native to re-run the ios app
             rn.sync("run-ios", "--no-packager", "--simulator", IOS_DEVICE_NAME);
         }

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -62,9 +62,11 @@ function ensureSimulator(deviceName, deviceTypeId) {
     const deviceId = stdout.trim();
     console.log(`Created simulator device (id = ${deviceId})`);
     // Boot up the device
-    console.log(`Booting simulator`);
+    console.log('Booting simulator');
     xcode.simctl.boot(deviceId);
-    console.log(`Simulator booted`);
+    console.log('Simulator is booting');
+    xcode.simctl.bootstatus(deviceId);
+    console.log('Simulator is booted');
     return deviceId;
 }
 

--- a/integration-tests/environments/react-native/harness/xcode-cli.js
+++ b/integration-tests/environments/react-native/harness/xcode-cli.js
@@ -95,6 +95,15 @@ function launch(device, appBundleIdentifier) {
     return simctl("launch", device, appBundleIdentifier);
 }
 
+/**
+ * Opens a URL in the device browser
+ * @param {string} device 
+ * @param {string} url 
+ */
+function openUrl(device, url) {
+    return simctl("openurl", device, url);
+}
+
 module.exports = {
     xcrun,
     simctl: {
@@ -106,5 +115,6 @@ module.exports = {
         shutdown,
         terminate,
         launch,
+        openUrl,
     }
 };

--- a/integration-tests/environments/react-native/harness/xcode-cli.js
+++ b/integration-tests/environments/react-native/harness/xcode-cli.js
@@ -104,6 +104,14 @@ function openUrl(device, url) {
     return simctl("openurl", device, url);
 }
 
+/**
+ * An undocumented method that blocks until device is booted.
+ * @param {string} device Device to wait for
+ */
+function bootstatus(device) {
+    return simctl("bootstatus", device);
+}
+
 module.exports = {
     xcrun,
     simctl: {
@@ -116,5 +124,6 @@ module.exports = {
         terminate,
         launch,
         openUrl,
+        bootstatus,
     }
 };


### PR DESCRIPTION
## What, How & Why?

This (hopefully) fixes #2695 by:
- Preventing concurrent use of ~/gradle-cache
- Fixing ReactNative iOS integration tests by introducing retries of the "run-ios" command.

Supersedes https://github.com/realm/realm-js/pull/2697.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
