### PR TITLE
Enable building with Visual Studio 2019

### DIFF
--- a/realm.gypi
+++ b/realm.gypi
@@ -204,13 +204,7 @@
           "libraries": [ "-lrealm-sync<(debug_library_suffix)" ],
           "conditions": [
               ["OS=='win'", {
-                "conditions": [
-                  ["target_arch=='ia32'", {
-                    "libraries": [ "C:\\Program Files (x86)\\Windows Kits\\8.1\\Lib\\winv6.3\\um\\x86\\mincore.lib" ]
-                  }, {
-                    "libraries": [ "C:\\Program Files (x86)\\Windows Kits\\8.1\\Lib\\winv6.3\\um\\x64\\mincore.lib" ]
-                  }]
-                ]
+                "libraries": [ "Mincore.lib" ]
               }]
           ]
       },

--- a/target_defaults.gypi
+++ b/target_defaults.gypi
@@ -32,7 +32,7 @@
           "WIN32=1",
           "_HAS_EXCEPTIONS=1",
           "WIN32_LEAN_AND_MEAN",
-          "_WIN32_WINNT=0x600",
+          "_WIN32_WINNT=0x603", # Build with Windows 8.1 as the minimum supoorted API level
           "_ENABLE_EXTENDED_ALIGNED_STORAGE"
         ]
       }],
@@ -74,7 +74,6 @@
         "ExceptionHandling": 1
       }
     },
-    "msvs_disabled_warnings": [ 4068, 4101, 4244, 4996 ],
-    "msbuild_toolset": "v141"
+    "msvs_disabled_warnings": [ 4068, 4101, 4244, 4996 ]
   }
 }


### PR DESCRIPTION
This fixes some of the hardcoded gyp configuration that locked the build to Visual Studio 2017:
 - remove the hardcoded path to the Windows 8.1 SDK, and instead link against whatever version of the SDK node-gyp found in the Visual Studio installation
 - remove the hardcoded toolset version so gyp can build with newer versions of the MSVC compiler
 - fix the `_WIN32_WINNT` macro define to actually select Windows 8.1 as the minimum supported API level (previously it was Vista).