### PR TITLE
Don't crash on missing file when deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * Connecting via SSL would crash on iOS 11.x due to an incorrect version availability check around an API introduced in iOS 12. ([realm/realm-sync#3230](https://github.com/realm/realm-sync/pull/3230), since v3.6.2).
+* Fix a bug which to lead to a fatal error when deleting a non-existing file. ([realm/realm-object-store#913](https://github.com/realm/realm-object-store/pull/913), since v1.0.0)
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.
@@ -12,6 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 
 ### Internal
+* Updated Realm Object Store to commit 49458da2447499c370da0000c3b47c76e9ce9421.
 * Updated Realm Sync from v4.9.4 to v4.9.5.
 
 3.6.3 Release notes (2020-1-17)

--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -76,7 +76,10 @@ void clear_test_state() {
     }
     s_test_files_path = util::make_temp_dir();
 #endif
-    SyncManager::shared().configure(s_test_files_path, SyncManager::MetadataMode::NoEncryption);
+    SyncClientConfig config;
+    config.base_file_path = s_test_files_path;
+    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+    SyncManager::shared().configure(config);
 #endif
 }
 

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -64,7 +64,12 @@ inline realm::SyncManager& syncManagerShared(typename T::Context &ctx) {
             user_agent_binding_info = js::Value<T>::validated_to_string(ctx, result);
         }
         ensure_directory_exists_for_file(default_realm_file_directory());
-        SyncManager::shared().configure(default_realm_file_directory(), SyncManager::MetadataMode::NoEncryption, user_agent_binding_info);
+
+        SyncClientConfig config;
+        config.base_file_path = default_realm_file_directory();
+        config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+        config.user_agent_binding_info = user_agent_binding_info;
+        SyncManager::shared().configure(config);
     });
     return SyncManager::shared();
 }
@@ -1010,7 +1015,12 @@ void SyncClass<T>::initialize_sync_manager(ContextType ctx, ObjectType this_obje
     args.validate_count(1);
     std::string user_agent_binding_info = Value::validated_to_string(ctx, args[0]);
     ensure_directory_exists_for_file(default_realm_file_directory());
-    SyncManager::shared().configure(default_realm_file_directory(), SyncManager::MetadataMode::NoEncryption, user_agent_binding_info);
+
+    SyncClientConfig config;
+    config.base_file_path = default_realm_file_directory();
+    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+    config.user_agent_binding_info = user_agent_binding_info;
+    SyncManager::shared().configure(config);
 }
 
 template<typename T>


### PR DESCRIPTION
# What, How & Why?

When deleting a non-existing file, the global notifier could crash. This has been fixed in object store.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
