### PR TITLE
Adding a failing test showing that Results listeners are called synchronously

### DIFF
--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -16,24 +16,20 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-if (!global.Realm) {
-    throw new Error("Expected 'Realm' to be available as a global");
-}
+const EXPECTED_GLOBALS = {
+    Realm: "function",
+    title: "string",
+    fs: "object",
+    path: "object",
+    environment: "object",
+    setTimeout: "function",
+    clearTimeout: "function"
+};
 
-if (!global.title) {
-    throw new Error("Expected 'title' to be available as a global");
-}
-
-if (!global.fs) {
-    throw new Error("Expected 'fs' to be available as a global");
-}
-
-if (!global.path) {
-    throw new Error("Expected 'path' to be available as a global");
-}
-
-if (!global.environment || typeof global.environment !== "object") {
-    throw new Error("Expected 'environment' to be available as a global");
+for (const [p, expectedType] of Object.entries(EXPECTED_GLOBALS)) {
+    if (typeof (global as any)[p] !== expectedType) {
+        throw new Error(`Expected '${p}' of type ${expectedType} on global`);
+    }
 }
 
 // Patch in a function that can skip running tests in specific environments
@@ -44,6 +40,7 @@ describe(global.title, () => {
     require("./realm-constructor");
     require("./iterators");
     require("./dynamic-schema-updates");
+    require("./results-listeners");
 });
 
 beforeEach(() => {

--- a/integration-tests/tests/src/results-listeners.ts
+++ b/integration-tests/tests/src/results-listeners.ts
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import { IPerson, PersonAndDogSchema } from "./schemas/person-and-dogs";
+
+interface IEvent {
+    action: string;
+    data?: any;
+}
+
+describe("Realm#Results", () => {
+    let realm: Realm;
+
+    beforeEach(() => {
+        realm = new Realm({ schema: PersonAndDogSchema });
+        realm.write(() => {
+            realm.create<IPerson>("Person", { name: "Alice", age: 17 });
+        });
+    });
+
+    it("calls listeners asynchronously", async () => {
+        const persons = realm.objects<IPerson>("Person");
+        const events: IEvent[] = [{ action: "started-synchronously" }];
+        setTimeout(() => {
+            events.push({ action: "started-asynchronously" });
+        });
+
+        const listenerFired = new Promise(resolve => {
+            persons.addListener((collection, change) => {
+                events.push({ action: "listener-fired", data: change });
+                if (change.insertions.length > 0) {
+                    resolve();
+                }
+            });
+        });
+
+        const objectCreated = new Promise(resolve => {
+            // We need a function object to capture its arguments
+            // tslint:disable-next-line:only-arrow-functions
+
+            // Write an object - asynchronously
+            setTimeout(() => {
+                realm.write(() => {
+                    events.push({ action: "pre-object-creation" });
+                    realm.create<IPerson>("Person", { name: "Bob", age: 42 });
+                    events.push({ action: "post-object-creation" });
+                });
+                // Perform something synchronously
+                events.push({ action: "synchronously-post-creation" });
+                // Perform something asynchronously
+                setTimeout(() => {
+                    events.push({ action: "asynchronously-post-creation" });
+                    resolve();
+                });
+            });
+        });
+
+        await Promise.all([listenerFired, objectCreated]);
+
+        expect(events).to.deep.equal([
+            { action: "started-synchronously" },
+            // FIXME: Some times this fires after the listener callback initially fires
+            { action: "started-asynchronously" },
+            {
+                // FIXME: Why do we fire initially?
+                action: "listener-fired",
+                data: {
+                    deletions: [],
+                    insertions: [],
+                    newModifications: [],
+                    modifications: [],
+                    oldModifications: []
+                }
+            },
+            { action: "pre-object-creation" },
+            { action: "post-object-creation" },
+            { action: "synchronously-post-creation" },
+            { action: "asynchronously-post-creation" },
+            {
+                action: "listener-fired",
+                data: {
+                    deletions: [],
+                    insertions: [1],
+                    newModifications: [],
+                    modifications: [],
+                    oldModifications: []
+                }
+            }
+        ]);
+    });
+});

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -11,6 +11,9 @@ type Require = (id: string) => any;
 
 type Environment = { [key: string]: string };
 
+type SetTimeout = (handler: Function, timeout?: number, ...arguments: any[]) => number;
+type ClearTimeout = (handle: number) => void;
+
 interface Global extends NodeJS.Global {
     Realm: Realm;
     title: string;
@@ -18,6 +21,8 @@ interface Global extends NodeJS.Global {
     path: path;
     environment: Environment;
     require: Require;
+    setTimeout: SetTimeout;
+    clearTimeout: ClearTimeout;
 }
 
 declare var global: Global;
@@ -25,6 +30,8 @@ declare var fs: fs;
 declare var path: path;
 declare var require: Require;
 declare var environment: Environment;
+declare var setTimeout: SetTimeout;
+declare var clearTimeout: ClearTimeout;
 
 // Extend the mocha test function with the skipIf that we patch in from index.ts
 declare namespace Mocha {


### PR DESCRIPTION
## What, How & Why?
I have a theory that #2655 could be fixed by having change listener callbacks (any listener callbacks really) added to a task queue and picked up by the event loop instead of being called synchronously.

This PR adds a failing integration test verifying that change listeners are indeed called synchronously.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
