### PR TITLE
fixed crash on node process exit when destructors for global objects …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import groovy.json.JsonOutput
 repoName = 'realm-js' // This is a global variable
 
 // These versions must be written in ascending order (lowest version is used when testing)
-def nodeVersions = ['10.19.0', "12.16.1", "13.0.0"]
+def nodeVersions = ['10.19.0', "11.15.0", "12.16.1", "13.0.0"]
 nodeTestVersion = nodeVersions[0]
 
 //Changing electron versions for testing requires upgrading the spectron dependency in tests/electron/package.json to a specific version. 

--- a/src/node/node_protected.hpp
+++ b/src/node/node_protected.hpp
@@ -63,7 +63,6 @@ public:
 		std::swap(first.m_env, second.m_env);
 		std::swap(first.m_ref, second.m_ref);
 		std::swap(first.m_isValue, second.m_isValue);
-		std::swap(first.m_isValue, second.m_isValue);
 		std::swap(first.m_suppressDestruct, second.m_suppressDestruct);
 	}
 

--- a/tests/js/download-api-helper.js
+++ b/tests/js/download-api-helper.js
@@ -24,9 +24,6 @@ function trySetElectronVersion() {
 }
 
 // Ensure node-pre-gyp uses the correct binary
-// if (process.env.REALM_ELECTRON_VERSION) {
-//     process.versions.electron = process.env.REALM_ELECTRON_VERSION;
-// }
 trySetElectronVersion();
 
 const Realm = require(realmModule);

--- a/tests/js/worker-tests-script.js
+++ b/tests/js/worker-tests-script.js
@@ -38,9 +38,6 @@ function trySetElectronVersion() {
 }
 
 // // Ensure node-pre-gyp uses the correct binary
-// if (process.env.REALM_ELECTRON_VERSION) {
-//     process.versions.electron = process.env.REALM_ELECTRON_VERSION;
-// }
 trySetElectronVersion();
 
 const Realm = require(process.argv[2]);


### PR DESCRIPTION
Fixed crash on node.js process exit on node.js 12 and 13
Fixes #2759 

adds node 11 to prebuild versions