### PR TITLE
Adding a platform independent print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 
 ### Internal
-* None. 
+* Added a platform independent way of printing to stdout on iOS & Node.js and the log on Android. ([#2789](https://github.com/realm/realm-js/pull/2789))
 
 5.0.2 Release notes (2020-3-21)
 =============================================================

--- a/src/android/platform.cpp
+++ b/src/android/platform.cpp
@@ -18,9 +18,11 @@
 
 #include <string>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <unistd.h>
 #include <cstdio>
 #include <android/asset_manager.h>
+#include <android/log.h>
 
 #include "../platform.hpp"
 
@@ -107,5 +109,13 @@ namespace realm {
     {
         std::string cmd = "rm " + path;
         system(cmd.c_str());
+    }
+
+    void print(const char* fmt, ...)
+    {
+        va_list vl;
+        va_start(vl, fmt);
+        __android_log_vprint(ANDROID_LOG_INFO, "RealmJS", fmt, vl);
+        va_end(vl);
     }
 }

--- a/src/ios/platform.mm
+++ b/src/ios/platform.mm
@@ -21,6 +21,8 @@
 #include <realm/util/to_string.hpp>
 
 #include <string>
+#include <stdarg.h>
+#include <stdio.h>
 
 #import <Foundation/Foundation.h>
 
@@ -145,6 +147,17 @@ void remove_file(const std::string &path)
 void remove_directory(const std::string &path)
 {
     remove_file(path); // works for directories too
+}
+
+
+void print(const char* fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+    std::string format(fmt);
+    format.append("\n");
+    vprintf(format.c_str(), vl);
+    va_end(vl);
 }
 
 }

--- a/src/node/platform.cpp
+++ b/src/node/platform.cpp
@@ -18,6 +18,8 @@
 
 #include <stdexcept>
 #include <vector>
+#include <stdarg.h>
+#include <stdio.h>
 #include <uv.h>
 
 #include "../platform.hpp"
@@ -183,6 +185,16 @@ void remove_file(const std::string &path)
     if (uv_fs_unlink(uv_default_loop(), &delete_req, path.c_str(), nullptr) != 0) {
         throw UVException(static_cast<uv_errno_t>(delete_req.result));
     }
+}
+
+void print(const char* fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+    std::string format(fmt);
+    format.append("\n");
+    vprintf(format.c_str(), vl);
+    va_end(vl);
 }
 
 } // realm

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -47,4 +47,7 @@ void remove_file(const std::string &path);
 // remove directory at the given path
 void remove_directory(const std::string &path);
 
+// print something
+void print(const char* fmt, ...);
+
 }


### PR DESCRIPTION
## What, How & Why?
When working on #2763 I wrote some code that I think could benefit us when debugging on Android in the future. Specifically this adds a `print` function to the `realm` namespace with the same signature as `printf` useful when printing from platform independent code, during debugging.
 
## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
