### PR TITLE
fix object tests on Windows

### DIFF
--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -23,6 +23,7 @@ const isNodeProcess = (typeof process === 'object' && process + '' === '[object 
 const Realm = require('realm');
 const TestCase = require('./asserts');
 const schemas = require('./schemas');
+const buffer = require('buffer');
 
 const RANDOM_DATA = new Uint8Array([
     0xd8, 0x21, 0xd6, 0xe8, 0x00, 0x57, 0xbc, 0xb2, 0x6a, 0x15, 0x77, 0x30, 0xac, 0x77, 0x96, 0xd9,
@@ -307,7 +308,7 @@ module.exports = {
             // The base64 decoder comes from realm-sync
             // Should be able to also set a data property to base64-encoded string.
             realm.write(function() {
-                object.dataCol = require('buffer/').Buffer.from(RANDOM_DATA).toString('base64');
+                object.dataCol = buffer.Buffer.from(RANDOM_DATA).toString('base64');
             });
             TestCase.assertArraysEqual(new Uint8Array(object.dataCol), RANDOM_DATA);
         }


### PR DESCRIPTION
Fixes object tests on Windows and moves a `require` to the top.