### PR TITLE
fix: Update OpenSSL URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y install \
  && yum clean all \
  \
   # TODO: install openssl in /usr/local
- && curl -SL https://www.openssl.org/source/openssl-1.0.2k.tar.gz | tar -zxC / \
+ && curl -SL https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz | tar -zxC / \
  && cd /openssl-1.0.2k \
  && ./Configure -DPIC -fPIC -fvisibility=hidden -fvisibility-inlines-hidden no-zlib-dynamic no-dso linux-x86_64 --prefix=/usr \
  && make && make install_sw \


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

To build the Docker image, OpenSSL 1.0.2k is downloaded from the OpenSSL website. The URL in the Dockerfile, [https://www.openssl.org/source/openssl-1.0.2k.tar.gz](https://www.openssl.org/source/openssl-1.0.2k.tar.gz), now shows "Page Not Found". The new location appears to be [https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz](https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz).

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
