### PR TITLE
Add Electron 7.2.x as a prebuild target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Added a platform independent way of printing to stdout on iOS & Node.js and the log on Android. ([#2789](https://github.com/realm/realm-js/pull/2789))
+* Added Electron 7.2.x as a prebuild target. ([#2833](https://github.com/realm/realm-js/pull/2833))
 
 5.0.3 Release notes (2020-4-01)
 =============================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ repoName = 'realm-js' // This is a global variable
 def nodeVersions = ['10.19.0', "11.15.0", "12.16.1", "13.0.0"]
 nodeTestVersion = nodeVersions[0]
 
-//Changing electron versions for testing requires upgrading the spectron dependency in tests/electron/package.json to a specific version. 
-//For more see https://www.npmjs.com/package/spectron 
-def electronVersions = ['8.1.1']
+//Changing electron versions for testing requires upgrading the spectron dependency in tests/electron/package.json to a specific version.
+//For more see https://www.npmjs.com/package/spectron
+def electronVersions = ['8.1.1', '7.2.3']
 electronTestVersion = electronVersions[0]
 
 def gitTag = null


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
It would be great if Realm could also publish prebuilt binaries for the 7.x line of Electron releases. We would prefer to use Electron 8, but we're currently running into an issue that prevents us from using it. As an open source project we occasionally have third-party developers contribute features or fixes. In particular, Linux users have run into issues with Realm's requirement of a specific OpenSSL version that is not provided with some Linux distros, and have trouble building our app from source as a result.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
