### PR TITLE
docs and tests for query primitive lists

### DIFF
--- a/docs/tutorials/query-language.md
+++ b/docs/tutorials/query-language.md
@@ -119,8 +119,7 @@ let teens = realm.objects('Contact').filtered('SUBQUERY(friends, $friend, $frien
 ### Queries on lists of primitives
 
 The query syntax for a list of primitive values is mostly the same as querying a list of objects via links or lists.
-There are however, some small differences. To illustrate, let's construct a movie database, where each movie has an anyonomous star rating, and a list of string tags.
-Note that a normal list of objects should be used to model more complex relationships, such as if the start or tags should belong to a specific user.
+However, there are some small differences. To illustrate, let's construct a movie database, where each movie has an anonymous star rating and a list of string tags.
 
 ```JS
 const MovieSchema = {
@@ -147,7 +146,7 @@ realm.write(() => {
 ```
 
 Just like with lists of objects, we can use aggregates: `.@count`, `.@avg`, `.@min`, `.@max`, `.@sum`.
-Collection operators (`ANY`, `ALL`, `NONE`) are also available and if nothing is specified then `ANY` is implied.
+Collection operators (`ANY`, `ALL`, `NONE`) are also available. If nothing is specified, then `ANY` is implied.
 Let's look at some example queries from the movie database:
 
 ```JS
@@ -165,9 +164,9 @@ realm.objects('Movie').filtered('ALL ratings > 1')
 realm.objects('Movie').filtered('ANY tags = name')
 ```
 
-There is one unique operation on lists of primives which is `.length`. This operator will compare the length of
-each individual element of type string or binary. This is because the `.@size` operator is already used to specify
-the number of elements in the list.
+Compared to lists of objects, there is one unique operation on lists of primitves which is `.length`.
+This operator will compare the length of each individual element of type string or binary.
+This is because the `.@size` operator is already used to specify the number of elements in the list.
 
 ```JS
 // Find movies that have over 100 tags

--- a/docs/tutorials/query-language.md
+++ b/docs/tutorials/query-language.md
@@ -1,4 +1,4 @@
-The Realm JavaScript SDK supports querying based on a language inspired by [NSPredicate](https://realm.io/news/nspredicate-cheatsheet/).
+The Realm JavaScript SDK supports querying based on a language inspired by [NSPredicate](https://academy.realm.io/posts/nspredicate-cheatsheet/).
 
 The {@link Realm.Collection#filtered Collection.filtered()} method is used to query a Realm:
 
@@ -114,6 +114,66 @@ Example:
 ```JS
 // Find contacts with friends above 21 in SF
 let teens = realm.objects('Contact').filtered('SUBQUERY(friends, $friend, $friend.age > 21 AND $friend.city = "SF").@count > 0');
+```
+
+### Queries on lists of primitives
+
+The query syntax for a list of primitive values is mostly the same as querying a list of objects via links or lists.
+There are however, some small differences. To illustrate, let's construct a movie database, where each movie has an anyonomous star rating, and a list of string tags.
+Note that a normal list of objects should be used to model more complex relationships, such as if the start or tags should belong to a specific user.
+
+```JS
+const MovieSchema = {
+  name: 'Movie',
+  properties: {
+    name: 'string',
+    ratings: 'int[]',
+    tags: 'string[]',
+  }
+};
+let realm = new Realm({schema: [MovieSchema]});
+realm.write(() => {
+  let m0 = realm.create('Movie', {
+    name: 'The Matrix',
+    ratings: [5, 5, 3, 4, 5, 1, 5],
+    tags: ['science fiction', 'artificial reality'],
+  });
+  let m1 = realm.create('Movie', {
+    name: 'Inception',
+    ratings: [3, 5, 3, 4, 5, 5],
+    tags: ['dream', 'science fiction', 'thriller'],
+  })
+});
+```
+
+Just like with lists of objects, we can use aggregates: `.@count`, `.@avg`, `.@min`, `.@max`, `.@sum`.
+Collection operators (`ANY`, `ALL`, `NONE`) are also available and if nothing is specified then `ANY` is implied.
+Let's look at some example queries from the movie database:
+
+```JS
+// Find movies which have a "science fiction" tag, [c] marks a case insensitive string comparison
+realm.objects('Movie').filtered('tags =[c] "science fiction"')
+// Find movies which have any tag that begins with the text "science" (string operators: LIKE, CONTAINS, BEGINSWITH, ENDSWITH are also available)
+realm.objects('Movie').filtered('tags BEGINSWITH[c] "science"')
+// Find movies that have only single word tags by filtering out any words with a space
+realm.objects('Movie').filtered('NONE tags CONTAINS " "')
+// Find movies that have an average rating of more than 4 stars
+realm.objects('Movie').filtered('ratings.@avg >= 4')
+// Find movies that do not have any one star ratings
+realm.objects('Movie').filtered('ALL ratings > 1')
+// Find movies that have a tag that is also the title (multi-property comparison of the same types is allowed)
+realm.objects('Movie').filtered('ANY tags = name')
+```
+
+There is one unique operation on lists of primives which is `.length`. This operator will compare the length of
+each individual element of type string or binary. This is because the `.@size` operator is already used to specify
+the number of elements in the list.
+
+```JS
+// Find movies that have over 100 tags
+realm.objects('Movie').filtered('tags.@size > 100')
+// Find movies that have a tag (ANY is implied) that is over 100 characters in length
+realm.objects('Movie').filtered('tags.length > 100')
 ```
 
 ### Backlink queries

--- a/tests/js/query-tests.js
+++ b/tests/js/query-tests.js
@@ -161,6 +161,9 @@ module.exports = {
     testOrderingQueries: function() {
         runQuerySuite(testCases.orderingTests);
     },
+    testListOfPrimitiveQueries: function() {
+        runQuerySuite(testCases.primitiveListTests);
+    },
     testMalformedQueries: function() {
         var realm = new Realm({ schema: [schemas.StringOnly] });
         TestCase.assertThrowsContaining(function() {

--- a/tests/js/query-tests.json
+++ b/tests/js/query-tests.json
@@ -409,5 +409,32 @@
         ["ObjectSet", [2, 0, 3, 1], "Person", "age > 20 SORT(age ASC, name DESC) DISTINCT(name, age)"],
         ["ObjectSet", [0, 2],       "Person", "age > 20 SORT(age ASC) DISTINCT(age) SORT(name DESC) DISTINCT(name)"]
     ]
+},
+
+"primitiveListTests" : {
+    "schema" : [
+        { "name": "Movie",
+          "properties": [
+              { "name": "name", "type": "string"},
+              { "name": "tags",  "type": "string[]" },
+              { "name": "ratings", "type": "int[]"}
+          ]
+        }
+    ],
+    "objects": [
+        { "type": "Movie", "value": ["Matrix", ["science fiction", "artificial reality"],   [5, 5, 3, 4, 5, 1, 5]]},
+        { "type": "Movie", "value": ["Inception", ["dream", "science fiction", "thriller"], [3, 5, 3, 4, 5, 5]]},
+        { "type": "Movie", "value": ["I, Robot", ["science fiction", "dystopia", "robot"],  [2, 4, 3, 3, 4, 5, 1]]}
+    ],
+    "tests": [
+        ["ObjectSet", [0, 1, 2], "Movie", "tags =[c] 'science fiction'"],
+        ["ObjectSet", [0, 1, 2], "Movie", "tags BEGINSWITH[c] 'science'"],
+        ["ObjectSet", [],        "Movie", "NONE tags CONTAINS ' '"],
+        ["ObjectSet", [0, 1],    "Movie", "ratings.@avg >= 4"],
+        ["ObjectSet", [1],       "Movie", "ALL ratings > 1"],
+        ["ObjectSet", [2],       "Movie", "ANY tags CONTAINS[c] name"],
+        ["ObjectSet", [0, 2],    "Movie", "tags.@size > 6"],
+        ["ObjectSet", [0],       "Movie", "tags.length > 16"]
+    ]
 }
 }

--- a/tests/js/query-tests.json
+++ b/tests/js/query-tests.json
@@ -415,16 +415,18 @@
     "schema" : [
         { "name": "Movie",
           "properties": [
+              { "name": "id", "type": "int"},
               { "name": "name", "type": "string"},
               { "name": "tags",  "type": "string[]" },
               { "name": "ratings", "type": "int[]"}
-          ]
+          ],
+          "primaryKey" : "id"
         }
     ],
     "objects": [
-        { "type": "Movie", "value": ["Matrix", ["science fiction", "artificial reality"],   [5, 5, 3, 4, 5, 1, 5]]},
-        { "type": "Movie", "value": ["Inception", ["dream", "science fiction", "thriller"], [3, 5, 3, 4, 5, 5]]},
-        { "type": "Movie", "value": ["I, Robot", ["science fiction", "dystopia", "robot"],  [2, 4, 3, 3, 4, 5, 1]]}
+        { "type": "Movie", "value": [0, "Matrix", ["science fiction", "artificial reality"],   [5, 5, 3, 4, 5, 1, 5]]},
+        { "type": "Movie", "value": [1, "Inception", ["dream", "science fiction", "thriller"], [3, 5, 3, 4, 5, 5]]},
+        { "type": "Movie", "value": [2, "I, Robot", ["science fiction", "dystopia", "robot"],  [2, 4, 3, 3, 4, 5, 1]]}
     ],
     "tests": [
         ["ObjectSet", [0, 1, 2], "Movie", "tags =[c] 'science fiction'"],
@@ -432,9 +434,12 @@
         ["ObjectSet", [],        "Movie", "NONE tags CONTAINS ' '"],
         ["ObjectSet", [0, 1],    "Movie", "ratings.@avg >= 4"],
         ["ObjectSet", [1],       "Movie", "ALL ratings > 1"],
-        ["ObjectSet", [2],       "Movie", "ANY tags CONTAINS[c] name"],
-        ["ObjectSet", [0, 2],    "Movie", "tags.@size > 6"],
-        ["ObjectSet", [0],       "Movie", "tags.length > 16"]
+        ["ObjectSet", [],        "Movie", "ANY tags CONTAINS[c] name"],
+        ["ObjectSet", [1, 2],    "Movie", "tags.@size > 2"],
+        ["ObjectSet", [0],       "Movie", "tags.length > 16"],
+        ["ObjectSet", [0],       "Movie", "ALL tags.length > 5"],
+        ["ObjectSet", [0, 1],    "Movie", "ratings.@min > id"],
+        ["ObjectSet", [0, 1, 2], "Movie", "ratings.@count > 0"]
     ]
 }
 }


### PR DESCRIPTION
This adds some minimal docs and tests for the query primitive lists feature added to the core query parser (https://github.com/realm/realm-core/pull/3693).