### PR TITLE
Fix OpenSSL linking on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed a crash on Windows and Node.js 10+ when using Sync over HTTPS. ([#2560](https://github.com/realm/realm-js/issues/2560))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/realm.gypi
+++ b/realm.gypi
@@ -236,11 +236,23 @@
           ["OS=='win'", {
             "conditions": [
               ["target_arch=='ia32'", {
-                "libraries": [ "C:\\src\\vcpkg\\installed\\x86-windows-static\\lib\\libeay32.lib", "C:\\src\\vcpkg\\installed\\x86-windows-static\\lib\\ssleay32.lib" ]
+                "library_dirs": [ "C:\\src\\vcpkg\\installed\\x86-windows-static\\lib" ]
               }, {
-                "libraries": [ "C:\\src\\vcpkg\\installed\\x64-windows-static\\lib\\libeay32.lib", "C:\\src\\vcpkg\\installed\\x64-windows-static\\lib\\ssleay32.lib" ]
+                "library_dirs": [ "C:\\src\\vcpkg\\installed\\x64-windows-static\\lib" ]
               }],
-            ]
+            ],
+            # This inserts ssleay32.lib at the beginning of the linker input list,
+            # causing it to be considered before node.lib and its OpenSSL symbols.
+            # Additionally, we request that all the symbols from ssleay32.lib are included
+            # in the final executable.
+            "msvs_settings": {
+              "VCLinkerTool": {
+                "AdditionalDependencies": [ "libeay32.lib", "ssleay32.lib" ],
+                "AdditionalOptions": [
+                  "/WHOLEARCHIVE:ssleay32.lib"
+                ]
+              }
+            }
           }],
           ["OS=='linux'", {
             "libraries": [ "-l:libssl.a", "-l:libcrypto.a" ],


### PR DESCRIPTION
This closes #2560

The Visual Studio linker ends up mixing up OpenSSL imports from the static OpenSSL library we link against and from the OpenSSL symbols that the `node.lib` import library exports. Because Node.js 10 and up ships an OpenSSL version that's incompatible with the one we link against when their symbols mix up we get crashes. This is verifiable by running `dumpbin /exports realm.node` and inspecting the symbols imported from `node.exe` - they contain some OpenSSL functions, which is not desired.

The fix is twofold: we "hack" gyp so that it rearranges the linker input in the generated project files, making sure that the OpenSSL static library we link comes before the Node.js import library, and we also instruct the linker to "whole archive" link the OpenSSL static library in order to make sure that all its symbols make it into the final executable, trumping any OpenSSL symbols that the Node.js import library might export.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary


