### PR TITLE
Include scheduler.hpp to be able to build without Realm Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v10 (reads and upgrades previous file format).
 
 ### Internal
-* None.
+* Fixed compiling without Realm Sync.
 
 6.0.1 Release notes (2020-5-18)
 =============================================================
@@ -35,7 +35,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 6.0.0 Release notes (2020-5-14)
 =============================================================
-NOTE: This version bumps the Realm file format to version 10. It is not possible to downgrade version 9 or earlier. Moreover, older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v1.0.0, might not be upgradeable. Only [Realm Studio 3.11](https://github.com/realm/realm-studio/releases/tag/v3.11.0) or later will be able to open the new file format. 
+NOTE: This version bumps the Realm file format to version 10. It is not possible to downgrade version 9 or earlier. Moreover, older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v1.0.0, might not be upgradeable. Only [Realm Studio 3.11](https://github.com/realm/realm-studio/releases/tag/v3.11.0) or later will be able to open the new file format.
 
 ### Breaking changes
 * Support of the old timestamp type has been removed, and older files cannot be upgraded. The new timestamp type was introduced in v1.0.0.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -578,7 +578,9 @@ def testMacOS(target, postStep = null) {
   return {
     node('osx_vegas') {
       withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.2.app/Contents/Developer',
-               'REALM_SET_NVM_ALIAS=1']) {
+               'REALM_SET_NVM_ALIAS=1',
+               'PATH=/Users/realm/.rbenv/bin:/Users/realm/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/realm/.gems/bin'
+              ]) {
         doInside('./scripts/test.sh', target, postStep)
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -578,9 +578,7 @@ def testMacOS(target, postStep = null) {
   return {
     node('osx_vegas') {
       withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.2.app/Contents/Developer',
-               'REALM_SET_NVM_ALIAS=1',
-               'PATH=/Users/realm/.rbenv/bin:/Users/realm/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/realm/.gems/bin'
-              ]) {
+               'REALM_SET_NVM_ALIAS=1']) {
         doInside('./scripts/test.sh', target, postStep)
       }
     }

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -40,6 +40,7 @@
 #include "results.hpp"
 #include "shared_realm.hpp"
 #include "thread_safe_reference.hpp"
+#include "util/scheduler.hpp"
 
 #include <realm/disable_sync_to_disk.hpp>
 #include <realm/global_key.hpp>


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Building without Realm Sync ( `npm install --build-from-source --realm_enable_sync=0`) would fail with the error `incomplete type 'realm::util::Scheduler' named in nested name specifier`.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
