### PR TITLE
Add support for calling server functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Added support for `customData` readonly property to `Realm.User` objects.
+* Added support for calling server functions from `Realm.User` objects.
 
 ### Fixed
 * It was not possible to make client resync if a table contained binary data.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -422,6 +422,30 @@ class User {
     get customData() { }
 
     /**
+     * Calls the named server function as this user.
+     * @param {string} name - name of the function to call
+     * @param {any[]} args - list of arguments to pass
+     */
+    call_function(name, args) { }
+    
+    /**
+     * Convenience wrapper around `call_function(name, [args])`
+     *
+     * @example
+     * // These are all equivalent:
+     * await user.call_function("do_thing", [a1, a2, a3]);
+     * await user.functions.do_thing(a1, a2, a3);
+     * await user.functions["do_thing"](a1, a2, a3);
+     *
+     * @example
+     * // It it legal to store the functions as first-class values:
+     * const do_thing = user.functions.do_thing;
+     * await do_thing(a1);
+     * await do_thing(a2);
+     */   
+    get functions() { }
+
+    /**
      * Creates the configuration object required to open a synchronized Realm.
      *
      * @param {Realm.PartialConfiguration} config - optional parameters that should override any default settings.

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -25,8 +25,20 @@ import { getterForProperty, createMethods } from './util';
 export default class User {
 }
 
+createMethods(User.prototype, objectTypes.USER, [
+    "logOut",
+    "_sessionForOnDiskPath",
+    "_deleteUser",
+    "_linkCredentials",
+    "_callFunction",
+]);
+
 Object.defineProperties(User.prototype, {
+    identity: { get: getterForProperty('identity') },
     token: { get: getterForProperty('token') },
+    profile: { get: getterForProperty('profile') },
+    isLoggedIn: { get: getterForProperty('isLoggedIn') },
+    state: { get: getterForProperty('state') },
     customData: { get: getterForProperty('customData') },
 });
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -355,7 +355,7 @@ declare namespace Realm {
     }
 
 
-    //FIXME: Fix ts definiton. Is this Realm.User or Realm.Sync.User. 
+    //FIXME: Fix ts definition. Is this Realm.User or Realm.Sync.User. 
     /**
      * User
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Sync.User.html }
@@ -367,9 +367,29 @@ declare namespace Realm {
         readonly state: string;
         readonly customData: object;
 
+        /**
+         * Convenience wrapper around call_function(name, [args]).
+         *
+         * @example
+         * // These are all equivalent:
+         * await user.call_function("do_thing", [a1, a2, a3]);
+         * await user.functions.do_thing(a1, a2, a3);
+         * await user.functions["do_thing"](a1, a2, a3);
+         *
+         * @example
+         * // It it legal to store the functions as first-class values:
+         * const do_thing = user.functions.do_thing;
+         * await do_thing(a1);
+         * await do_thing(a2);
+         */   
+        readonly functions: {
+            [name: string] : (...args: any[]) => Promise<any>
+        };
+
         logOut(): void;
         deleteUser(): Promise<void>;
         linkCredentials(credentials: Credentials): Promise<void>;
+        call_function(name: string, args: any[]): Promise<any>;
     }
 
     interface UserMap {

--- a/lib/user.js
+++ b/lib/user.js
@@ -31,9 +31,9 @@ const instanceMethods = {
         });
     },
 
-    linkUser(credentials) {
+    linkCredentials(credentials) {
         return new Promise((resolve, reject) => {
-            this._linkUser(credentials, (user, error) => {
+            this._linkCredentials(credentials, (user, error) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -41,8 +41,30 @@ const instanceMethods = {
                 }
             });
         });
-    }
+    },
 
+    callFunction(name, args) {
+        return new Promise((resolve, reject) => {
+            this._callFunction(name, args, (result, error) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(result);
+                }
+            });
+        });
+    },
+
+    get functions() {
+        const user = this;
+        return new Proxy({}, {
+            get(target, name) {
+                return (...args) => {
+                    return user.callFunction(name, args);
+                };
+            },
+        });
+    },
 }
 
 const staticMethods = {

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -223,7 +223,8 @@ void AppClass<T>::all_users(ContextType ctx, ObjectType this_object, Arguments& 
 
     auto users = Object::create_empty(ctx);
     for (auto user : app->all_users()) {
-        Object::set_property(ctx, users, user->identity(), create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), std::move(app))), ReadOnly | DontDelete);
+        auto&& identity = user->identity();
+        Object::set_property(ctx, users, identity, create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), app)), ReadOnly | DontDelete);
     }
     return_value.set(users);
 }
@@ -238,7 +239,7 @@ void AppClass<T>::current_user(ContextType ctx, ObjectType this_object, Argument
         return_value.set(create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), std::move(app))));
     }
     else {
-        return_value.set(Value::from_null(ctx));
+        return_value.set_null();
     }
 }
 

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -285,7 +285,7 @@ template<typename T>
 void SessionClass<T>::get_config(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
         ObjectType config = Object::create_empty(ctx);
-        Object::set_property(ctx, config, "user", create_object<T, UserClass<T>>(ctx, new User<T>(std::move(session->config().user), nullptr))); // FIXME: nullptr is not an app object
+        Object::set_property(ctx, config, "user", create_object<T, UserClass<T>>(ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
         // TODO: add app id
         if (auto dispatcher = session->config().error_handler.template target<util::EventLoopDispatcher<SyncSessionErrorHandler>>()) {
             if (auto handler = dispatcher->func().template target<SyncSessionErrorHandlerFunctor<T>>()) {
@@ -308,7 +308,7 @@ void SessionClass<T>::get_config(ContextType ctx, ObjectType object, ReturnValue
 template<typename T>
 void SessionClass<T>::get_user(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
-        return_value.set(create_object<T, UserClass<T>>(ctx, new User<T>(std::move(session->config().user), nullptr))); // FIXME: nullptr is not an app object
+        return_value.set(create_object<T, UserClass<T>>(ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
     } else {
         return_value.set_undefined();
     }

--- a/tests/js/asserts.js
+++ b/tests/js/asserts.js
@@ -140,17 +140,23 @@ module.exports = {
     },
 
     assertThrows: function(func, errorMessage, depth) {
-        let caught = false;
         try {
             func();
         }
         catch (e) {
-            caught = true;
+            return e
         }
+        throw new TestFailureError(errorMessage || `Expected exception not thrown from ${func}`, depth);
+    },
 
-        if (!caught) {
-            throw new TestFailureError(errorMessage || 'Expected exception not thrown', depth);
+    assertThrowsAsync: async function(func, errorMessage, depth) {
+        try {
+            await func();
         }
+        catch (e) {
+            return e
+        }
+        throw new TestFailureError(errorMessage || `Expected exception not thrown from ${func}`, depth);
     },
 
     assertThrowsException: function(func, expectedException) {

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -22,7 +22,7 @@
 
 // TODO: Once we get MongoDB Realm Cloud docker image integrated, we should be able
 //       to obtain the id of the Stitch app.
-const appId = "default-kktps";
+const appId = "realm-sdk-integration-tests-zueke";
 const appConfig = {
   id: appId,
   url: "http://localhost:9090",
@@ -96,14 +96,14 @@ module.exports = {
     let app = new Realm.App(appConfig);
     let credentials = Realm.Credentials.anonymous();
 
-    app.logIn(credentials).then(user => {
+    return app.logIn(credentials).then(user => {
       assertIsUser(user);
 
       assertIsSameUser(user, app.currentUser());
-      user.logout();
+      user.logOut();
 
       // Is now logged out.
-      TestCase.assertUndefined(app.currentUser());
+      TestCase.assertNull(app.currentUser());
     });
   },
 
@@ -156,6 +156,26 @@ module.exports = {
     //    Realm.Sync.Credentials.custom("foo", "bar");
   },
 
+  async testFunctions() {
+    let app = new Realm.App(appConfig);
+    let credentials = Realm.Credentials.anonymous();
+    let user = await app.logIn(credentials);
+
+    TestCase.assertEqual(await user.callFunction('firstArg', [123]), 123);
+    TestCase.assertEqual(await user.functions.firstArg(123), 123);
+    TestCase.assertEqual(await user.functions['firstArg'](123), 123);
+
+    // Test method stashing / that `this` is bound correctly.
+    const firstArg = user.functions.firstArg;
+    TestCase.assertEqual(await firstArg(123), 123);
+    TestCase.assertEqual(await firstArg(123), 123); // Not just one-shot
+
+    TestCase.assertEqual(await user.functions.sum(1, 2, 3), 6);
+
+    const err = await TestCase.assertThrowsAsync(async() => await user.functions.error());
+    TestCase.assertEqual(err.code, 400);
+  },
+
   testAll() {
     let app = new Realm.App(appConfig);
     const all = app.allUsers();
@@ -166,7 +186,7 @@ module.exports = {
     return app.logIn(credentials).then(user1 => {
       const all = app.allUsers();
       TestCase.assertArrayLength(Object.keys(all), 1);
-      assertIsSameUser(all[user.identity], user1);
+      assertIsSameUser(all[user1.identity], user1);
 
       return app.logIn(Realm.Credentials.anonymous()).then(user2 => {
         let all = app.allUsers();
@@ -175,12 +195,12 @@ module.exports = {
         assertIsSameUser(all[user2.identity], user2);
         assertIsSameUser(all[user1.identity], user1);
 
-        user2.logout();
+        user2.logOut();
         all = app.allUsers();
         TestCase.assertArrayLength(Object.keys(all), 1);
         assertIsSameUser(all[user1.identity], user1);
 
-        user1.logout();
+        user1.logOut();
         all = app.allUsers();
         TestCase.assertArrayLength(Object.keys(all), 0);
       });


### PR DESCRIPTION
Note that I cherry-picked @kneth's platform parameters fix, so **ignore the first commit**. Before merging I'll rebase on top of something with that fix and remove the cherry-picked commit.

The tests are using the functions defined in https://github.com/realm/realm-java/tree/v10/tools/sync_test_server/app_config/functions. We should probably get these into a common stitch app (possibly in the object-store repo so it can use the app for testing as well) so that we don't all have to reinvent the wheel.

Does this need a chrome debug API change? It didn't look like other methods on `User` had shimming.


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [X] typescript definitions file is updated
* [X] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
