### PR TITLE
fix building v6 on windows with no sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v10 (reads and upgrades previous file format).
 
 ### Internal
-* None.
+* Fixed compiling without Realm Sync.
 
 6.0.1 Release notes (2020-5-18)
 =============================================================

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -35,6 +35,8 @@
 #include "sync/sync_manager.hpp"
 #endif
 
+#include "util/scheduler.hpp"
+
 #include "binding_context.hpp"
 #include "object_accessor.hpp"
 #include "results.hpp"
@@ -433,8 +435,8 @@ inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx) {
     FunctionType realm_constructor = ObjectWrap<T, RealmClass<T>>::create_constructor(ctx);
     FunctionType collection_constructor = ObjectWrap<T, CollectionClass<T>>::create_constructor(ctx);
     FunctionType list_constructor = ObjectWrap<T, ListClass<T>>::create_constructor(ctx);
-    FunctionType results_constructor = ObjectWrap<T, ResultsClass<T>>::create_constructor(ctx);
     FunctionType realm_object_constructor = ObjectWrap<T, RealmObjectClass<T>>::create_constructor(ctx);
+    FunctionType results_constructor = ObjectWrap<T, ResultsClass<T>>::create_constructor(ctx);
 
     PropertyAttributes attributes = ReadOnly | DontEnum | DontDelete;
     Object::set_property(ctx, realm_constructor, "Collection", collection_constructor, attributes);

--- a/src/node/node_init.cpp
+++ b/src/node/node_init.cpp
@@ -16,12 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+
 #include "node_init.hpp"
 #include "napi.h"
 
 #include "js_realm.hpp"
 #if REALM_ENABLE_SYNC
 #include "js_adapter.hpp"
+#else
+#pragma comment( lib, "ws2_32.lib")
 #endif
 
  namespace realm {


### PR DESCRIPTION
small changes to fix the build of v6 on windows when sync is disabled