### PR TITLE
handle error responses

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -595,7 +595,7 @@ def testMacOS(target, postStep = null) {
     node('osx_vegas') {
       withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.2.app/Contents/Developer',
                'REALM_SET_NVM_ALIAS=1',
-               'DISABLE_REALM_SYNC=1']) {
+               'REALM_DISABLE_SYNC_TESTS=1']) {
         doInside('./scripts/test.sh', target, postStep)
       }
     }

--- a/lib/NetworkTransport.js
+++ b/lib/NetworkTransport.js
@@ -1,55 +1,41 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+function __awaiter(thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+}
+
+class MongoDBRealmError extends Error {
+    constructor(statusCode, statusText, response) {
+        if (typeof response === "object" &&
+            typeof response.error === "string") {
+            super(`${response.error} (status ${statusCode} ${statusText})`);
+            this.statusText = statusText;
+            this.statusCode = statusCode;
+            this.errorCode = response.error_code;
+            this.link = response.link;
+        }
+        else {
+            throw new Error("Unexpected error response format");
+        }
     }
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-var abort_controller_1 = require("abort-controller");
-var DefaultNetworkTransport = /** @class */ (function () {
-    function DefaultNetworkTransport() {
+}
+
+////////////////////////////////////////////////////////////////////////////
+const isNodeProcess = typeof process === "object" && "node" in process.versions;
+class DefaultNetworkTransport {
+    constructor() {
         // Determine the fetch implementation
         if (!DefaultNetworkTransport.fetch) {
             // Try to get it from the global
             if (typeof fetch === "function" && typeof window === "object") {
                 DefaultNetworkTransport.fetch = fetch.bind(window);
             }
-            else if (typeof process === "object" &&
-                typeof require === "function" &&
-                "node" in process.versions) {
+            else if (isNodeProcess && typeof require === "function") {
                 // Making it harder for the static analyzers see this require call
-                var nodeRequire = require;
+                const nodeRequire = require;
                 DefaultNetworkTransport.fetch = nodeRequire("node-fetch");
             }
             else {
@@ -58,14 +44,12 @@ var DefaultNetworkTransport = /** @class */ (function () {
         }
         // Determine the AbortController implementation
         if (!DefaultNetworkTransport.AbortController) {
-            if (typeof abort_controller_1.AbortController !== "undefined") {
-                DefaultNetworkTransport.AbortController = abort_controller_1.AbortController;
+            if (typeof AbortController !== "undefined") {
+                DefaultNetworkTransport.AbortController = AbortController;
             }
-            else if (typeof process === "object" &&
-                typeof require === "function" &&
-                "node" in process.versions) {
+            else if (isNodeProcess && typeof require === "function") {
                 // Making it harder for the static analyzers see this require call
-                var nodeRequire = require;
+                const nodeRequire = require;
                 DefaultNetworkTransport.AbortController = nodeRequire("abort-controller");
             }
             else {
@@ -73,125 +57,108 @@ var DefaultNetworkTransport = /** @class */ (function () {
             }
         }
     }
-    DefaultNetworkTransport.prototype.fetchAndParse = function (request) {
-        return __awaiter(this, void 0, void 0, function () {
-            var response, contentType, err_1;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        _a.trys.push([0, 7, , 8]);
-                        return [4 /*yield*/, this.fetch(request)];
-                    case 1:
-                        response = _a.sent();
-                        contentType = response.headers.get("content-type");
-                        if (!response.ok) return [3 /*break*/, 5];
-                        if (!(contentType && contentType.startsWith("application/json"))) return [3 /*break*/, 3];
-                        return [4 /*yield*/, response.json()];
-                    case 2: 
-                    // Awaiting the response to ensure we'll throw our own error
-                    return [2 /*return*/, _a.sent()];
-                    case 3: throw new Error("Expected a JSON response");
-                    case 4: return [3 /*break*/, 6];
-                    case 5: 
-                    // TODO: Check if a message can be extracted from the response
-                    throw new Error("Unexpected status code (" + response.status + " " + response.statusText + ")");
-                    case 6: return [3 /*break*/, 8];
-                    case 7:
-                        err_1 = _a.sent();
-                        throw new Error("Request failed (" + request.method + " " + request.url + "): " + err_1.message);
-                    case 8: return [2 /*return*/];
+    fetchAndParse(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const response = yield this.fetch(request);
+                const contentType = response.headers.get("content-type");
+                if (response.ok) {
+                    if (contentType === null) {
+                        return null;
+                    }
+                    else if (contentType.startsWith("application/json")) {
+                        // Awaiting the response to ensure we'll throw our own error
+                        return yield response.json();
+                    }
+                    else {
+                        throw new Error("Expected an empty or a JSON response");
+                    }
                 }
-            });
+                else if (contentType &&
+                    contentType.startsWith("application/json")) {
+                    throw new MongoDBRealmError(response.status, response.statusText, yield response.json());
+                }
+                else {
+                    if (contentType && contentType.startsWith("application/json")) {
+                        // Awaiting the response to ensure we'll throw our own error
+                        const json = yield response.json();
+                        throw new MongoDBRealmError(response.status, response.statusText, json);
+                    }
+                    else {
+                        throw new Error(`Unexpected status code (${response.status} ${response.statusText})`);
+                    }
+                }
+            }
+            catch (err) {
+                throw new Error(`Request failed (${request.method} ${request.url}): ${err.message}`);
+            }
         });
-    };
-    DefaultNetworkTransport.prototype.fetchWithCallbacks = function (request, handler) {
-        var _this = this;
+    }
+    fetchWithCallbacks(request, handler) {
         // tslint:disable-next-line: no-console
         this.fetch(request)
-            .then(function (response) { return __awaiter(_this, void 0, void 0, function () {
-            var decodedBody, responseHeaders;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0: return [4 /*yield*/, response.text()];
-                    case 1:
-                        decodedBody = _a.sent();
-if (response.status >= 400) {
-                             throw {
-                                 statusCode: response.status,
-                                 errorMessage: decodedBody,
-                             };
-                         }
-                        responseHeaders = {};
-                        response.headers.forEach(function (value, key) {
-                            responseHeaders[key] = value;
-                        });
-                        return [2 /*return*/, {
-                                statusCode: response.status,
-                                headers: responseHeaders,
-                                body: decodedBody,
-                            }];
-                }
+            .then((response) => __awaiter(this, void 0, void 0, function* () {
+            const decodedBody = yield response.text();
+            // Pull out the headers of the response
+            const responseHeaders = {};
+            response.headers.forEach((value, key) => {
+                responseHeaders[key] = value;
             });
-        }); })
-            .then(function (r) { return handler.onSuccess(r); })
-            .catch(function (e) { return handler.onError(e); });
-    };
-    DefaultNetworkTransport.prototype.fetch = function (request) {
-        return __awaiter(this, void 0, void 0, function () {
-            var method, url, body, timeoutMs, _a, headers, _b, signal, cancelTimeout;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        method = request.method, url = request.url, body = request.body, timeoutMs = request.timeoutMs, _a = request.headers, headers = _a === void 0 ? DefaultNetworkTransport.DEFAULT_HEADERS : _a;
-                        _b = this.createTimeoutSignal(timeoutMs), signal = _b.signal, cancelTimeout = _b.cancelTimeout;
-                        _c.label = 1;
-                    case 1:
-                        _c.trys.push([1, , 3, 4]);
-                        return [4 /*yield*/, DefaultNetworkTransport.fetch(url, {
-                                method: method,
-                                headers: headers,
-                                body: typeof body === "string" ? body : JSON.stringify(body),
-                                signal: signal,
-                            })];
-                    case 2: 
-                    // We'll await the response to catch throw our own error
-                    return [2 /*return*/, _c.sent()];
-                    case 3:
-                        // Whatever happens, cancel any timeout
-                        cancelTimeout();
-                        return [7 /*endfinally*/];
-                    case 4: return [2 /*return*/];
-                }
-            });
+            return {
+                statusCode: response.status,
+                headers: responseHeaders,
+                body: decodedBody,
+            };
+        }))
+            .then(r => handler.onSuccess(r))
+            .catch(e => handler.onError(e));
+    }
+    fetch(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const { method, url, body, timeoutMs, headers = DefaultNetworkTransport.DEFAULT_HEADERS, } = request;
+            const { signal, cancelTimeout } = this.createTimeoutSignal(timeoutMs);
+            try {
+                // We'll await the response to catch throw our own error
+                return yield DefaultNetworkTransport.fetch(url, {
+                    method,
+                    headers,
+                    body: typeof body === "string" ? body : JSON.stringify(body),
+                    signal,
+                });
+            }
+            finally {
+                // Whatever happens, cancel any timeout
+                cancelTimeout();
+            }
         });
-    };
-    DefaultNetworkTransport.prototype.createTimeoutSignal = function (timeoutMs) {
+    }
+    createTimeoutSignal(timeoutMs) {
         if (typeof timeoutMs === "number") {
-            var controller_1 = new DefaultNetworkTransport.AbortController();
+            const controller = new DefaultNetworkTransport.AbortController();
             // Call abort after a specific number of milliseconds
-            var timeout_1 = setTimeout(function () {
-                controller_1.abort();
+            const timeout = setTimeout(() => {
+                controller.abort();
             }, timeoutMs);
             return {
-                signal: controller_1.signal,
-                cancelTimeout: function () {
-                    clearTimeout(timeout_1);
+                signal: controller.signal,
+                cancelTimeout: () => {
+                    clearTimeout(timeout);
                 },
             };
         }
         else {
             return {
                 signal: undefined,
-                cancelTimeout: function () {
+                cancelTimeout: () => {
                     /* No-op */
                 },
             };
         }
-    };
-    DefaultNetworkTransport.DEFAULT_HEADERS = {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-    };
-    return DefaultNetworkTransport;
-}());
-exports.DefaultNetworkTransport = DefaultNetworkTransport;
+    }
+}
+DefaultNetworkTransport.DEFAULT_HEADERS = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+};
+
+export { DefaultNetworkTransport };

--- a/lib/NetworkTransport.js
+++ b/lib/NetworkTransport.js
@@ -1,41 +1,55 @@
-function __awaiter(thisArg, _arguments, P, generator) {
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-}
-
-class MongoDBRealmError extends Error {
-    constructor(statusCode, statusText, response) {
-        if (typeof response === "object" &&
-            typeof response.error === "string") {
-            super(`${response.error} (status ${statusCode} ${statusText})`);
-            this.statusText = statusText;
-            this.statusCode = statusCode;
-            this.errorCode = response.error_code;
-            this.link = response.link;
-        }
-        else {
-            throw new Error("Unexpected error response format");
-        }
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
-}
-
-////////////////////////////////////////////////////////////////////////////
-const isNodeProcess = typeof process === "object" && "node" in process.versions;
-class DefaultNetworkTransport {
-    constructor() {
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var abort_controller_1 = require("abort-controller");
+var DefaultNetworkTransport = /** @class */ (function () {
+    function DefaultNetworkTransport() {
         // Determine the fetch implementation
         if (!DefaultNetworkTransport.fetch) {
             // Try to get it from the global
             if (typeof fetch === "function" && typeof window === "object") {
                 DefaultNetworkTransport.fetch = fetch.bind(window);
             }
-            else if (isNodeProcess && typeof require === "function") {
+            else if (typeof process === "object" &&
+                typeof require === "function" &&
+                "node" in process.versions) {
                 // Making it harder for the static analyzers see this require call
-                const nodeRequire = require;
+                var nodeRequire = require;
                 DefaultNetworkTransport.fetch = nodeRequire("node-fetch");
             }
             else {
@@ -44,12 +58,14 @@ class DefaultNetworkTransport {
         }
         // Determine the AbortController implementation
         if (!DefaultNetworkTransport.AbortController) {
-            if (typeof AbortController !== "undefined") {
-                DefaultNetworkTransport.AbortController = AbortController;
+            if (typeof abort_controller_1.AbortController !== "undefined") {
+                DefaultNetworkTransport.AbortController = abort_controller_1.AbortController;
             }
-            else if (isNodeProcess && typeof require === "function") {
+            else if (typeof process === "object" &&
+                typeof require === "function" &&
+                "node" in process.versions) {
                 // Making it harder for the static analyzers see this require call
-                const nodeRequire = require;
+                var nodeRequire = require;
                 DefaultNetworkTransport.AbortController = nodeRequire("abort-controller");
             }
             else {
@@ -57,108 +73,125 @@ class DefaultNetworkTransport {
             }
         }
     }
-    fetchAndParse(request) {
-        return __awaiter(this, void 0, void 0, function* () {
-            try {
-                const response = yield this.fetch(request);
-                const contentType = response.headers.get("content-type");
-                if (response.ok) {
-                    if (contentType === null) {
-                        return null;
-                    }
-                    else if (contentType.startsWith("application/json")) {
-                        // Awaiting the response to ensure we'll throw our own error
-                        return yield response.json();
-                    }
-                    else {
-                        throw new Error("Expected an empty or a JSON response");
-                    }
+    DefaultNetworkTransport.prototype.fetchAndParse = function (request) {
+        return __awaiter(this, void 0, void 0, function () {
+            var response, contentType, err_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 7, , 8]);
+                        return [4 /*yield*/, this.fetch(request)];
+                    case 1:
+                        response = _a.sent();
+                        contentType = response.headers.get("content-type");
+                        if (!response.ok) return [3 /*break*/, 5];
+                        if (!(contentType && contentType.startsWith("application/json"))) return [3 /*break*/, 3];
+                        return [4 /*yield*/, response.json()];
+                    case 2: 
+                    // Awaiting the response to ensure we'll throw our own error
+                    return [2 /*return*/, _a.sent()];
+                    case 3: throw new Error("Expected a JSON response");
+                    case 4: return [3 /*break*/, 6];
+                    case 5: 
+                    // TODO: Check if a message can be extracted from the response
+                    throw new Error("Unexpected status code (" + response.status + " " + response.statusText + ")");
+                    case 6: return [3 /*break*/, 8];
+                    case 7:
+                        err_1 = _a.sent();
+                        throw new Error("Request failed (" + request.method + " " + request.url + "): " + err_1.message);
+                    case 8: return [2 /*return*/];
                 }
-                else if (contentType &&
-                    contentType.startsWith("application/json")) {
-                    throw new MongoDBRealmError(response.status, response.statusText, yield response.json());
-                }
-                else {
-                    if (contentType && contentType.startsWith("application/json")) {
-                        // Awaiting the response to ensure we'll throw our own error
-                        const json = yield response.json();
-                        throw new MongoDBRealmError(response.status, response.statusText, json);
-                    }
-                    else {
-                        throw new Error(`Unexpected status code (${response.status} ${response.statusText})`);
-                    }
-                }
-            }
-            catch (err) {
-                throw new Error(`Request failed (${request.method} ${request.url}): ${err.message}`);
-            }
+            });
         });
-    }
-    fetchWithCallbacks(request, handler) {
+    };
+    DefaultNetworkTransport.prototype.fetchWithCallbacks = function (request, handler) {
+        var _this = this;
         // tslint:disable-next-line: no-console
         this.fetch(request)
-            .then((response) => __awaiter(this, void 0, void 0, function* () {
-            const decodedBody = yield response.text();
-            // Pull out the headers of the response
-            const responseHeaders = {};
-            response.headers.forEach((value, key) => {
-                responseHeaders[key] = value;
+            .then(function (response) { return __awaiter(_this, void 0, void 0, function () {
+            var decodedBody, responseHeaders;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, response.text()];
+                    case 1:
+                        decodedBody = _a.sent();
+if (response.status >= 400) {
+                             throw {
+                                 statusCode: response.status,
+                                 errorMessage: decodedBody,
+                             };
+                         }
+                        responseHeaders = {};
+                        response.headers.forEach(function (value, key) {
+                            responseHeaders[key] = value;
+                        });
+                        return [2 /*return*/, {
+                                statusCode: response.status,
+                                headers: responseHeaders,
+                                body: decodedBody,
+                            }];
+                }
             });
-            return {
-                statusCode: response.status,
-                headers: responseHeaders,
-                body: decodedBody,
-            };
-        }))
-            .then(r => handler.onSuccess(r))
-            .catch(e => handler.onError(e));
-    }
-    fetch(request) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const { method, url, body, timeoutMs, headers = DefaultNetworkTransport.DEFAULT_HEADERS, } = request;
-            const { signal, cancelTimeout } = this.createTimeoutSignal(timeoutMs);
-            try {
-                // We'll await the response to catch throw our own error
-                return yield DefaultNetworkTransport.fetch(url, {
-                    method,
-                    headers,
-                    body: typeof body === "string" ? body : JSON.stringify(body),
-                    signal,
-                });
-            }
-            finally {
-                // Whatever happens, cancel any timeout
-                cancelTimeout();
-            }
+        }); })
+            .then(function (r) { return handler.onSuccess(r); })
+            .catch(function (e) { return handler.onError(e); });
+    };
+    DefaultNetworkTransport.prototype.fetch = function (request) {
+        return __awaiter(this, void 0, void 0, function () {
+            var method, url, body, timeoutMs, _a, headers, _b, signal, cancelTimeout;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        method = request.method, url = request.url, body = request.body, timeoutMs = request.timeoutMs, _a = request.headers, headers = _a === void 0 ? DefaultNetworkTransport.DEFAULT_HEADERS : _a;
+                        _b = this.createTimeoutSignal(timeoutMs), signal = _b.signal, cancelTimeout = _b.cancelTimeout;
+                        _c.label = 1;
+                    case 1:
+                        _c.trys.push([1, , 3, 4]);
+                        return [4 /*yield*/, DefaultNetworkTransport.fetch(url, {
+                                method: method,
+                                headers: headers,
+                                body: typeof body === "string" ? body : JSON.stringify(body),
+                                signal: signal,
+                            })];
+                    case 2: 
+                    // We'll await the response to catch throw our own error
+                    return [2 /*return*/, _c.sent()];
+                    case 3:
+                        // Whatever happens, cancel any timeout
+                        cancelTimeout();
+                        return [7 /*endfinally*/];
+                    case 4: return [2 /*return*/];
+                }
+            });
         });
-    }
-    createTimeoutSignal(timeoutMs) {
+    };
+    DefaultNetworkTransport.prototype.createTimeoutSignal = function (timeoutMs) {
         if (typeof timeoutMs === "number") {
-            const controller = new DefaultNetworkTransport.AbortController();
+            var controller_1 = new DefaultNetworkTransport.AbortController();
             // Call abort after a specific number of milliseconds
-            const timeout = setTimeout(() => {
-                controller.abort();
+            var timeout_1 = setTimeout(function () {
+                controller_1.abort();
             }, timeoutMs);
             return {
-                signal: controller.signal,
-                cancelTimeout: () => {
-                    clearTimeout(timeout);
+                signal: controller_1.signal,
+                cancelTimeout: function () {
+                    clearTimeout(timeout_1);
                 },
             };
         }
         else {
             return {
                 signal: undefined,
-                cancelTimeout: () => {
+                cancelTimeout: function () {
                     /* No-op */
                 },
             };
         }
-    }
-}
-DefaultNetworkTransport.DEFAULT_HEADERS = {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-};
-
-export { DefaultNetworkTransport };
+    };
+    DefaultNetworkTransport.DEFAULT_HEADERS = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+    };
+    return DefaultNetworkTransport;
+}());
+exports.DefaultNetworkTransport = DefaultNetworkTransport;

--- a/lib/NetworkTransport.js
+++ b/lib/NetworkTransport.js
@@ -115,12 +115,6 @@ var DefaultNetworkTransport = /** @class */ (function () {
                     case 0: return [4 /*yield*/, response.text()];
                     case 1:
                         decodedBody = _a.sent();
-if (response.status >= 400) {
-                             throw {
-                                 statusCode: response.status,
-                                 errorMessage: decodedBody,
-                             };
-                         }
                         responseHeaders = {};
                         response.headers.forEach(function (value, key) {
                             responseHeaders[key] = value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3497,9 +3497,9 @@
       }
     },
     "realm-network-transport": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.2.0.tgz",
-      "integrity": "sha512-3FNtiM3gL2MzI0GPeWZgJeNHHmIftH1HdzMDW8bg0h0cATEFARK9dkzmqH4/+pa7zHBpoNznSSEnOR6bhnOpTg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.3.0.tgz",
+      "integrity": "sha512-xRnE5nECTlXVqLNzrBM+03aLcQxZ8cUB5wdy6UcC6LmTpqXZH1PkGLcy+5lCXnS6GOrLmT11qu3NWeRimTf4uQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "node-pre-gyp": "^0.15.0",
     "progress": "^2.0.3",
     "prop-types": "^15.6.2",
-    "realm-network-transport": "^0.2.0",
+    "realm-network-transport": "^0.3.0",
     "request": "^2.88.0",
     "stream-counter": "^1.0.0",
     "sync-request": "^3.0.1",

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Implements cross-platform fetching used by Realm JS",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/packages/realm-network-transport/src/NetworkTransport.ts
+++ b/packages/realm-network-transport/src/NetworkTransport.ts
@@ -158,12 +158,6 @@ export class DefaultNetworkTransport implements NetworkTransport {
         this.fetch(request)
             .then(async response => {
                 const decodedBody = await response.text();
-                if (response.status >= 400) {
-                    throw {
-                        statusCode: response.status,
-                        errorMessage: decodedBody,
-                    };
-                }
                 // Pull out the headers of the response
                 const responseHeaders: Headers = {};
                 response.headers.forEach((value, key) => {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,9 +20,6 @@ if [ "${CONFIGURATION}" == "Debug" ]; then
 fi
 
 USE_REALM_SYNC=1
-if [ -n "${DISABLE_REALM_SYNC}" ]; then
-  USE_REALM_SYNC=0
-fi
 
 IOS_SIM_DEVICE=${IOS_SIM_DEVICE:-} # use preferentially, otherwise will be set and re-exported
 

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -22,9 +22,7 @@ const Realm = require('realm');
 
 if (typeof Realm.App !== 'undefined' && Realm.App !== null) {
     global.WARNING = "global is not available in React Native. Use it only in tests";
-    global.enableSyncTests = true;
-    global.APPID = "default-wztbd"; // FIXME: Get the app-id from the running server
-    global.APPURL = "http://localhost:9090";
+    global.enableSyncTests = process.env.REALM_DISABLE_SYNC_TESTS ? false : true;
 }
 
 const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';


### PR DESCRIPTION
We should let object store handle the responses, there is logic there already to parse valid json and show the error. Intercepting these here means we would need special handling in the js onError code to parse the json or pass through the entire response like this: `"{"error":"cannot find app using Client App ID 'smurf'"}"`
TODO:
- [x] increment the version of realm-network-transport
- [x] publish this
- [x] upgrade js dependency on v10