### PR TITLE
partitionValue can be a string, number or ObjectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* `partitionValue` can now be specified as a plain string, number or `BSON.ObjectId`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -734,7 +734,7 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         if (!Value::is_undefined(ctx, partition_value_value)) {
             bson::Bson partition_bson;
             if (Value::is_string(ctx, partition_value_value)) {
-                auto pv = Value::validated_to_string(ctx, partition_value_value);
+                std::string pv = Value::validated_to_string(ctx, partition_value_value);
                 partition_bson = bson::Bson(pv);
             }
             else if (Value::is_number(ctx, partition_value_value)) {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -732,9 +732,24 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         ValueType partition_value_value = Object::get_property(ctx, sync_config_object, "partitionValue");
         std::string partition_value;
         if (!Value::is_undefined(ctx, partition_value_value)) {
-            // FIXME: we need a Value::validated_to_bson() function here
-            auto partition_bson = Value::to_bson(ctx, partition_value_value);
-            std::stringstream s;
+            bson::Bson partition_bson;
+            if (Value::is_string(ctx, partition_value_value)) {
+                auto pv = Value::validated_to_string(ctx, partition_value_value);
+                partition_bson = bson::Bson(pv);
+            }
+            else if (Value::is_number(ctx, partition_value_value)) {
+                auto pv = Value::validated_to_number(ctx, partition_value_value);
+                partition_bson = bson::Bson(static_cast<int64_t>(pv));
+            }
+            else if (Value::is_object_id(ctx, partition_value_value)) {
+                auto pv = Value::validated_to_object_id(ctx, partition_value_value);
+                partition_bson = bson::Bson(pv);
+            }
+            else {
+                throw std::runtime_error("partitionValue must be of type 'string', 'number', or 'objectId'.");
+            }
+
+            std::ostringstream s;
             s << partition_bson;
             partition_value = s.str();
         }

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -83,12 +83,20 @@ inline bool node::Value::is_number(Napi::Env env, const Napi::Value& value) {
 
 template<>
 inline bool node::Value::is_decimal128(Napi::Env env, const Napi::Value& value) {
-	return value.IsObject();  // FIXME: can we do better?
+	auto realm = env.Global().Get("Realm");
+    auto _bson = realm.As<Napi::Object>().Get("_bson");
+    auto _decimal128 = _bson.As<Napi::Object>().Get("Decimal128");
+
+	return value.IsObject() && value.As<Napi::Object>().InstanceOf(_decimal128.As<Napi::Function>());
 }
 
 template<>
 inline bool node::Value::is_object_id(Napi::Env env, const Napi::Value& value) {
-	return value.IsObject(); // FIXME: can we do better?
+	auto realm = env.Global().Get("Realm");
+    auto _bson = realm.As<Napi::Object>().Get("_bson");
+    auto _objectId = _bson.As<Napi::Object>().Get("ObjectId");
+
+	return value.IsObject() && value.As<Napi::Object>().InstanceOf(_objectId.As<Napi::Function>());
 }
 
 template<>

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -152,7 +152,7 @@ module.exports = {
               }],
             sync: {
                 user: user,
-                partitionValue: serialize("LoLo"),
+                partitionValue: "LoLo",
             }
         };
         Realm.deleteFile(realmConfig);

--- a/tests/js/download-api-helper.js
+++ b/tests/js/download-api-helper.js
@@ -34,7 +34,7 @@ function createObjects(user) {
     const config = {
         sync: {
             user: user,
-            partitionValue: serialize("LoLo"),
+            partitionValue: "LoLo",
             error: err => console.log(err)
         },
         schema: [{

--- a/tests/js/encryption-tests.js
+++ b/tests/js/encryption-tests.js
@@ -95,7 +95,7 @@ module.exports = {
                 encryptionKey: new Int8Array(64),
                 sync: {
                     user: user,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             });
             user.logOut(); // FIXME: clearTestState() doesn't clean up enough and Realm.Sync.User.current might not work

--- a/tests/js/nested-list-helper.js
+++ b/tests/js/nested-list-helper.js
@@ -38,7 +38,7 @@ function createObjects(user) {
     const config = {
         sync: {
             user,
-            partitionValue: serialize("LoLo"),
+            partitionValue: "LoLo",
             error: err => console.log(err)
         },
         schema: [schemas.ParentObject, schemas.NameObject],

--- a/tests/js/object-id-tests.js
+++ b/tests/js/object-id-tests.js
@@ -49,7 +49,7 @@ module.exports = {
             const config = {
                 sync: {
                     user,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 },
                 schema: [{ name: 'IntegerPrimaryKey', properties: { int: 'int?' }, primaryKey: 'int' },
                     { name: 'StringPrimaryKey', properties: { string: 'string?' }, primaryKey: 'string' },

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -479,7 +479,7 @@ module.exports = {
                     schema: [schemas.TestObject],
                     sync: {
                         user,
-                        partitionValue: serialize("LoLo")
+                        partitionValue: "LoLo"
                     },
                 };
                 TestCase.assertFalse(Realm.exists(config));

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -84,7 +84,7 @@ function getSyncConfiguration(user) {
           }],
         sync: {
             user: user,
-            partitionValue: serialize("LoLo")
+            partitionValue: "LoLo"
         }
     };
     return realmConfig;
@@ -285,7 +285,7 @@ module.exports = {
                 let config = {
                     // FIXME: schema not working yet
                     schema: [schemas.ParentObject, schemas.NameObject],
-                    sync: { user, partitionValue: serialize("LoLo") }
+                    sync: { user, partitionValue: "LoLo" }
                 };
                 Realm.deleteFile(config);
                 return Realm.open(config)
@@ -535,7 +535,7 @@ module.exports = {
             let config = {
                 sync: {
                     user: u,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             };
             return Realm.open(config);
@@ -569,7 +569,7 @@ module.exports = {
             let config = {
                 sync: {
                     user: u,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             };
             return Realm.open(config);
@@ -617,7 +617,7 @@ module.exports = {
         const config = {
             sync: {
                 user: user,
-                partitionValue: serialize("LoLo")
+                partitionValue: "LoLo"
             }
         };
 
@@ -639,7 +639,7 @@ module.exports = {
         const config = {
             sync: {
                 user: user,
-                partitionValue: serialize("LoLo")
+                partitionValue: "LoLo"
             }
         };
 
@@ -662,7 +662,7 @@ module.exports = {
         const config = {
             sync: {
                 user: user,
-                partitionValue: serialize("LoLo")
+                partitionValue: "LoLo"
             }
         };
 
@@ -697,7 +697,7 @@ module.exports = {
                     schema: [schema],
                     sync: {
                         user: user1,
-                        partitionValue: serialize("LoLo")
+                        partitionValue: "LoLo"
                     }
                 };
                 return Realm.open(config1);
@@ -719,7 +719,7 @@ module.exports = {
                     schema: [schema],
                     sync: {
                         user: user2,
-                        partitionValue: serialize("LoLo")
+                        partitionValue: "LoLo"
                     }
                 };
                 return Realm.open(config2).then(r => {
@@ -754,7 +754,7 @@ module.exports = {
                     schema: [schema],
                     sync: {
                         user: user,
-                        partitionValue: serialize("LoLo")
+                        partitionValue: "LoLo"
                     }
                 };
                 realm = new Realm(config);
@@ -787,7 +787,7 @@ module.exports = {
                     schema: [schema],
                     sync: {
                         user: user,
-                        partitionValue: serialize("LoLo")
+                        partitionValue: "LoLo"
                     }
                 };
                 realm = new Realm(config);
@@ -805,7 +805,7 @@ module.exports = {
             const config = {
                 sync: {
                     user: user,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             };
             let realm = new Realm(config);
@@ -825,7 +825,7 @@ module.exports = {
             const config = {
                 sync: {
                     user: user,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             };
             let realm = new Realm(config);
@@ -860,7 +860,7 @@ module.exports = {
                 const config1 = {
                     sync: {
                         user: user,
-                        partitionValue: serialize("LoLo"),
+                        partitionValue: "LoLo",
                         _sessionStopPolicy: 'after-upload'
                     }
                 }
@@ -891,7 +891,7 @@ module.exports = {
                 const config1 = {
                     sync: {
                         user: user,
-                        partitionValue: serialize("LoLo"),
+                        partitionValue: "LoLo",
                         _sessionStopPolicy: 'immediately'
                     }
                 };
@@ -919,7 +919,7 @@ module.exports = {
                 schema: [schemas.TestObject],
                 sync: {
                     user: u,
-                    partitionValue: serialize("LoLo")
+                    partitionValue: "LoLo"
                 }
             };
             return Realm.open(config);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

`partitionValue` should be specified as a string, number or ObjectId.

I have tried with a `Date` and observed it fail. Moreover, we should fix how we check if an object is ObjectId (or Decimal128) for JavaScriptCore.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
