### PR TITLE
build with sync but allow CI to exclude sync tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -595,7 +595,7 @@ def testMacOS(target, postStep = null) {
     node('osx_vegas') {
       withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.2.app/Contents/Developer',
                'REALM_SET_NVM_ALIAS=1',
-               'DISABLE_REALM_SYNC=1']) {
+               'REALM_DISABLE_SYNC_TESTS=1']) {
         doInside('./scripts/test.sh', target, postStep)
       }
     }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,9 +20,6 @@ if [ "${CONFIGURATION}" == "Debug" ]; then
 fi
 
 USE_REALM_SYNC=1
-if [ -n "${DISABLE_REALM_SYNC}" ]; then
-  USE_REALM_SYNC=0
-fi
 
 IOS_SIM_DEVICE=${IOS_SIM_DEVICE:-} # use preferentially, otherwise will be set and re-exported
 

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -22,9 +22,7 @@ const Realm = require('realm');
 
 if (typeof Realm.App !== 'undefined' && Realm.App !== null) {
     global.WARNING = "global is not available in React Native. Use it only in tests";
-    global.enableSyncTests = true;
-    global.APPID = "default-wztbd"; // FIXME: Get the app-id from the running server
-    global.APPURL = "http://localhost:9090";
+    global.enableSyncTests = process.env.REALM_DISABLE_SYNC_TESTS ? false : true;
 }
 
 const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';


### PR DESCRIPTION
build with sync on mac, but don't run the tests there because we don't have docker to spin up a local server