### PR TITLE
Allow Decimal128 to be null

### DIFF
--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -281,6 +281,13 @@ struct Unbox<JSEngine, util::Optional<ObjectId>> {
     }
 };
 
+// template<typename JSEngine>
+// struct Unbox<JSEngine, util::Optional<Decimal128>> {
+//     static util::Optional<Decimal128> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+//         return ctx->template unbox_optional<Decimal128>(value);
+//     }
+// };
+
 template<typename JSEngine>
 struct Unbox<JSEngine, StringData> {
     static StringData call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {

--- a/src/jsc/jsc_value.cpp
+++ b/src/jsc/jsc_value.cpp
@@ -72,6 +72,10 @@ JSValueRef jsc::Value::from_decimal128(JSContextRef ctx, const Decimal128& value
     static jsc::String s_decimal = "_Decimal128";
     static jsc::String s_from_string = "fromString";
 
+    if (value.is_null()) {
+        return JSValueMakeNull(ctx);
+    }
+
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
     JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(ctx, global_object, s_realm);
     JSObjectRef decimal_constructor = jsc::Object::validated_get_constructor(ctx, realm_constructor, s_decimal);

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -242,6 +242,10 @@ template<>
 inline Napi::Value node::Value::from_decimal128(Napi::Env env, const Decimal128& number) {
 	Napi::EscapableHandleScope scope(env);
 
+	if (number.is_null()) {
+		return scope.Escape(Napi::Value(env, env.Null()));
+	}
+
 	Napi::Function realm_constructor = node::RealmClassConstructor.Value();
 	Napi::Object decimal_constructor = realm_constructor.Get("_Decimal128").As<Napi::Object>();
 	Napi::Function fromStringFunc = decimal_constructor.Get("fromString").As<Napi::Function>();

--- a/tests/js/asserts.js
+++ b/tests/js/asserts.js
@@ -29,8 +29,14 @@ module.exports = {
         else if (type === 'float' || type === 'double') {
             this.assertEqualWithTolerance(val1, val2, 0.000001, errorMessage, depth + 1);
         }
+        else if (type === 'decimal128') {
+            this.assertEqual(val1.toString(), val2.toString(), errorMessage, depth + 1);
+        }
         else if (type === 'data') {
             this.assertArraysEqual(new Uint8Array(val1), val2, errorMessage, depth + 1);
+        }
+        else if (type === 'objectId') {
+            this.assertEqual(val1.toString(), val2.toString(), errorMessage, depth + 1);
         }
         else if (type === 'date') {
             this.assertEqual(val1 && val1.getTime(), val2.getTime(), errorMessage, depth + 1);

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -1314,7 +1314,7 @@ module.exports = {
         realm.write(() => {
             realm.create('ParentObject', {
                 id: 1,
-                _id: new ObjectId(), 
+                _id: new ObjectId(),
                 name: [
                     { _id: new ObjectId(), family: 'Larsen', given: ['Hans', 'Jørgen'], prefix: [] },
                     { _id: new ObjectId(), family: 'Hansen', given: ['Ib'], prefix: [] }
@@ -1322,7 +1322,7 @@ module.exports = {
             });
             realm.create('ParentObject', {
                 id: 2,
-                _id: new ObjectId(), 
+                _id: new ObjectId(),
                 name: [
                     {_id: new ObjectId(), family: 'Petersen', given: ['Gurli', 'Margrete'], prefix: [] }
                 ]

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -203,6 +203,7 @@ module.exports = {
         TestCase.assertSimilar('data', prim.optData[0], DATA1);
         TestCase.assertSimilar('date', prim.optDate[0], new Date(1));
         TestCase.assertSimilar('decimal128', prim.optDecimal128[0], Decimal128.fromString('1'));
+        TestCase.assertNull(prim.optDecimal128[1]);
         TestCase.assertSimilar('objectId', prim.optObjectId[0], new ObjectId('0000002a9a7969d24bea4cf2'));
     },
 


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Stupid mistake not to allow nulls.

## ☑️ ToDos
<!-- Add your own todos here -->
* ~[ ] 📝 Changelog entry~
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
