### PR TITLE
Add methods to Realm.Auth providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Added missing methods to `Realm.Auth` classes.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
+* Fixed bugs so `Realm.User.auth.APIKeys` and `Realm.App.auth.EmailPassword` are properties and not functions.
 * Added missing methods to `Realm.Auth` classes.
 
 ### Compatibility

--- a/lib/app.js
+++ b/lib/app.js
@@ -48,9 +48,7 @@ const instanceMethods = {
         return new Proxy({}, {
             get(target, name) {
                 if (name === "emailPassword") {
-                    return () => {
-                        return app._authEmailPassword();
-                    }
+                    return app._authEmailPassword;
                 }
             }
         });

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -363,6 +363,13 @@ module.exports = function(realmConstructor, context) {
         let credentialMethods = require("./credentials");
         Object.defineProperties(realmConstructor.Credentials, getOwnPropertyDescriptors(credentialMethods.static))
 
+        let emailPasswordProviderMethods = require("./email_password_provider_client_methods");
+        Object.defineProperties(realmConstructor.Auth.EmailPasswordProvider.prototype, getOwnPropertyDescriptors(emailPasswordProviderMethods.instance));
+
+        let userAPIKeyProviderMethods = require("./user_apikey_provider_client");
+        Object.defineProperties(realmConstructor.Auth.UserAPIKeyProvider.prototype, getOwnPropertyDescriptors(userAPIKeyProviderMethods.instance));
+
+
         realmConstructor.Sync.AuthError = require("./errors").AuthError;
 
         if (realmConstructor.Sync.removeAllListeners) {

--- a/lib/user.js
+++ b/lib/user.js
@@ -71,9 +71,7 @@ const instanceMethods = {
         return new Proxy({}, {
             get(target, name) {
                 if (name === "apiKeys") {
-                    return () => {
-                        return user._authApiKeys();
-                    }
+                    return user._authApiKeys;
                 }
             }
         });

--- a/lib/user_apikey_provider_client.js
+++ b/lib/user_apikey_provider_client.js
@@ -90,8 +90,6 @@ const instanceMethods = {
             });
         });
     },
-
-
 };
 
 const staticMethods = {

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -60,9 +60,11 @@ public:
     static FunctionType create_constructor(ContextType);
 
     static void get_app_id(ContextType, ObjectType, ReturnValue &);
+    static void get_auth_email_password(ContextType, ObjectType, ReturnValue &);
 
     PropertyMap<T> const properties = {
         {"id", {wrap<get_app_id>, nullptr}},
+        {"_authEmailPassword", {wrap<get_auth_email_password>, nullptr}},
     };
 
     static void login(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -70,7 +72,6 @@ public:
     static void current_user(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void switch_user(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void remove_user(ContextType, ObjectType, Arguments&, ReturnValue&);
-    static void auth_email_password(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const methods = {
         {"_login", wrap<login>},
@@ -78,7 +79,6 @@ public:
         {"currentUser", wrap<current_user>},
         {"switchUser", wrap<switch_user>},
         {"_removeUser", wrap<remove_user>},
-        {"_authEmailPassword", wrap<auth_email_password>},
     };
 };
 
@@ -290,8 +290,7 @@ void AppClass<T>::remove_user(ContextType ctx, ObjectType this_object, Arguments
 }
 
 template<typename T>
-void AppClass<T>::auth_email_password(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
-    args.validate_count(0);
+void AppClass<T>::get_auth_email_password(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
     return_value.set(EmailPasswordProviderClientClass<T>::create_instance(ctx, app));
 }

--- a/src/js_user.hpp
+++ b/src/js_user.hpp
@@ -76,6 +76,7 @@ public:
     static void is_logged_in(ContextType, ObjectType, ReturnValue &);
     static void get_state(ContextType, ObjectType, ReturnValue &);
     static void get_custom_data(ContextType, ObjectType, ReturnValue &);
+    static void get_auth_api_keys(ContextType, ObjectType, ReturnValue &);
 
     PropertyMap<T> const properties = {
         {"identity", {wrap<get_identity>, nullptr}},
@@ -84,6 +85,7 @@ public:
         {"isLoggedIn", {wrap<is_logged_in>, nullptr}},
         {"state", {wrap<get_state>, nullptr}},
         {"customData", {wrap<get_custom_data>, nullptr}},
+        {"_authApiKeys", {wrap<get_auth_api_keys>, nullptr}},
     };
 
     MethodMap<T> const static_methods = {
@@ -93,7 +95,6 @@ public:
     static void session_for_on_disk_path(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void link_credentials(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void call_function(ContextType, ObjectType, Arguments&, ReturnValue&);
-    static void auth_api_keys(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void refresh_custom_data(ContextType, ObjectType, Arguments&, ReturnValue&);
 
 
@@ -102,7 +103,6 @@ public:
         {"_sessionForOnDiskPath", wrap<session_for_on_disk_path>},
         {"_linkCredentials", wrap<link_credentials>},
         {"_callFunction", wrap<call_function>},
-        {"_authApiKeys", wrap<auth_api_keys>},
         {"_refreshCustomData", wrap<refresh_custom_data>},
     };
 };
@@ -271,8 +271,7 @@ void UserClass<T>::call_function(ContextType ctx, ObjectType this_object, Argume
 }
 
 template<typename T>
-void UserClass<T>::auth_api_keys(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
-    args.validate_count(0);
+void UserClass<T>::get_auth_api_keys(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
     return_value.set(UserAPIKeyProviderClientClass<T>::create_instance(ctx, user->m_app, std::move(*user)));
 }

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -189,5 +189,23 @@ module.exports = {
         TestCase.assertEqual(realm2.objects("Dog").length, 2);
         realm2.close();
         user.logOut();
-    }
+    },
+
+    async testEmailPasswordProvider() {
+        let app = new Realm.App(config);
+
+        let credentials = Realm.Credentials.anonymous();
+        let provider = app.auth.emailPassword;
+        TestCase.assertTrue(provider instanceof Realm.Auth.EmailPasswordProvider);
+    },
+
+    async testUserAPIKeyProvider() {
+        let app = new Realm.App(config);
+
+        let credentials = Realm.Credentials.anonymous();
+        let user = await app.logIn(credentials);
+        let provider = user.auth.apiKeys;
+        TestCase.assertTrue(provider instanceof Realm.Auth.UserAPIKeyProvider);
+        user.logOut();
+    },
 };


### PR DESCRIPTION
## What, How & Why?

As part of the big merges recently, adding methods to `Realm.Auth` classes was by accident removed.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
