### PR TITLE
Revert "Default URL for MongoDB Realm Apps (#2942)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* None.
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v11 (reads and upgrades file format v5 or later).
+
+### Internal
+* Reverted back to rely on Realm.App's default URL in Realm Object Store.
+
 10.0.0-beta.5 Release notes (2020-6-8)
 =============================================================
 NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -22,7 +22,7 @@
  * This describes the options used to create a {@link Realm.App} instance.
  * @typedef {Object} Realm.App~AppConfiguration
  * @property {string} id - The id of the MongoDB Realm app.
- * @property {string} url - The URL of the MongoDB Realm end-point (default: https://cloud.mongodb.com/)
+ * @property {string} url - The URL of the MongoDB Realm end-point.
  * @property {number} timeout - General timeout (in millisecs) for requests.
  * @property {Realm.App~LocalAppConfiguration} app - local app configuration
  */

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -116,10 +116,7 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
         }
 
         ValueType config_url_value = Object::get_property(ctx, config_object, config_url);
-        if (Value::is_undefined(ctx, config_url_value)) {
-            config.base_url = util::Optional<std::string>("https://cloud.mongodb.com");
-        }
-        else {
+        if (!Value::is_undefined(ctx, config_url_value)) {
             config.base_url = util::Optional<std::string>(Value::validated_to_string(ctx, config_url_value, "url"));
         }
 


### PR DESCRIPTION
This reverts commit 1cd5785d29b68c0b86da0a994ade0da3c13e17b4.

It seems to be better to have a single source of truth.