### PR TITLE
Consistency between property type names and schema parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * None.
 
 ### Fixed
-* Fixed inconsistency in property type names (`objectId` as `object id` and `decimal128` as `decimal`). (since v10.0.0-beta.1)
+* Fixed inconsistency in property type names (`objectId` as `object id` and `decimal128` as `decimal`). ([#2948](https://github.com/realm/realm-js/issues/2948), since v10.0.0-beta.1)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed inconsistency in property type names (`objectId` as `object id` and `decimal128` as `decimal`). (since v10.0.0-beta.1)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -130,7 +130,7 @@ void ListClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue &r
 template<typename T>
 void ListClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     auto list = get_internal<T, ListClass<T>>(ctx, object);
-    return_value.set(string_for_property_type(list->get_type() & ~realm::PropertyType::Flags));
+    return_value.set(js_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags));
 }
 
 template<typename T>
@@ -315,7 +315,7 @@ void ListClass<T>::validate_value(ContextType ctx, realm::List& list, ValueType 
         object_type = list.get_object_schema().name;
     }
     if (!Value::is_valid_for_property_type(ctx, value, type, object_type)) {
-        throw TypeErrorException("Property", object_type ? object_type : string_for_property_type(type), Value::to_string(ctx, value));
+        throw TypeErrorException("Property", object_type ? object_type : js_string_for_property_type(type), Value::to_string(ctx, value));
     }
 }
 

--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -106,7 +106,7 @@ std::string TypeErrorException::type_string(Property const& prop)
             ret = "decimal128";
             break;
         case PropertyType::ObjectId:
-            ret = "ObjectId";
+            ret = "objectId";
             break;
         case PropertyType::LinkingObjects:
         case PropertyType::Object:

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -403,7 +403,7 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         }
     }
     else {
-        Object::set_property(ctx, object, type_string, Value::from_string(ctx, string_for_property_type(property.type)));
+        Object::set_property(ctx, object, type_string, Value::from_string(ctx, js_string_for_property_type(property.type)));
     }
 
     static const String object_type_string = "objectType";
@@ -411,7 +411,7 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, property.object_type));
     }
     else if (is_array(property.type)) {
-        Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, string_for_property_type(property.type & ~realm::PropertyType::Flags)));
+        Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, js_string_for_property_type(property.type & ~realm::PropertyType::Flags)));
     }
 
     static const String property_string = "property";

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -33,6 +33,7 @@
 #include <realm/mixed.hpp>
 
 #include <object-store/src/util/bson/bson.hpp>
+#include <object-store/src/property.hpp>
 
 #if defined(__GNUC__) && !(defined(DEBUG) && DEBUG)
 # define REALM_JS_INLINE inline __attribute__((always_inline))

--- a/src/js_util.hpp
+++ b/src/js_util.hpp
@@ -121,5 +121,14 @@ void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::Ob
     }
 }
 
+static const char *js_string_for_property_type(realm::PropertyType type) {
+    std::map<realm::PropertyType, const char *> type_map = {
+        { realm::PropertyType::ObjectId, "objectId" },
+        { realm::PropertyType::Decimal, "decimal128" }
+    };
+
+    return realm::string_for_property_type(type, type_map);
+}
+
 } // js
 } // realm

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -72,7 +72,7 @@ json get_type(Container const& c) {
         return serialize_object_schema(c.get_object_schema());
     }
     return {
-        {"type", string_for_property_type(type)},
+        {"type", js_string_for_property_type(type)},
         {"optional", is_nullable(type)}
     };
 }
@@ -721,7 +721,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesList},
             {"id", store_object(js_object)},
-            {"dataType", string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", js_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(list->get_type())},
          };
     }
@@ -730,7 +730,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesResults},
             {"id", store_object(js_object)},
-            {"dataType", string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", js_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(results->get_type())},
         };
     }

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -50,30 +50,30 @@ module.exports = {
 
         let obj, prim;
         realm.write(() => {
-            obj = realm.create('LinkTypesObject', {});
-            prim = realm.create('PrimitiveArrays', {});
+            obj = realm.create("LinkTypesObject", {});
+            prim = realm.create("PrimitiveArrays", {});
         });
 
-        TestCase.assertEqual(obj.arrayCol.type, 'object');
-        TestCase.assertEqual(obj.arrayCol1.type, 'object');
+        TestCase.assertEqual(obj.arrayCol.type, "object");
+        TestCase.assertEqual(obj.arrayCol1.type, "object");
 
-        TestCase.assertEqual(prim.bool.type, 'bool');
-        TestCase.assertEqual(prim.int.type, 'int');
-        TestCase.assertEqual(prim.float.type, 'float');
-        TestCase.assertEqual(prim.double.type, 'double');
-        TestCase.assertEqual(prim.string.type, 'string');
-        TestCase.assertEqual(prim.date.type, 'date');
-        TestCase.assertEqual(prim.decimal128.type, 'decimal');
-        TestCase.assertEqual(prim.objectId.type, 'object id');
+        TestCase.assertEqual(prim.bool.type, "bool");
+        TestCase.assertEqual(prim.int.type, "int");
+        TestCase.assertEqual(prim.float.type, "float");
+        TestCase.assertEqual(prim.double.type, "double");
+        TestCase.assertEqual(prim.string.type, "string");
+        TestCase.assertEqual(prim.date.type, "date");
+        TestCase.assertEqual(prim.decimal128.type, "decimal128");
+        TestCase.assertEqual(prim.objectId.type, "objectId");
 
-        TestCase.assertEqual(prim.optBool.type, 'bool');
-        TestCase.assertEqual(prim.optInt.type, 'int');
-        TestCase.assertEqual(prim.optFloat.type, 'float');
-        TestCase.assertEqual(prim.optDouble.type, 'double');
-        TestCase.assertEqual(prim.optString.type, 'string');
-        TestCase.assertEqual(prim.optDate.type, 'date');
-        TestCase.assertEqual(prim.optDecimal128.type, 'decimal');
-        TestCase.assertEqual(prim.optObjectId.type, 'object id');
+        TestCase.assertEqual(prim.optBool.type, "bool");
+        TestCase.assertEqual(prim.optInt.type, "int");
+        TestCase.assertEqual(prim.optFloat.type, "float");
+        TestCase.assertEqual(prim.optDouble.type, "double");
+        TestCase.assertEqual(prim.optString.type, "string");
+        TestCase.assertEqual(prim.optDate.type, "date");
+        TestCase.assertEqual(prim.optDecimal128.type, "decimal128");
+        TestCase.assertEqual(prim.optObjectId.type, "objectId");
 
         TestCase.assertFalse(prim.bool.optional);
         TestCase.assertFalse(prim.int.optional);


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #2948

We have an inconsistency between schema and `.type` on properties. `objectId` vs `object id` and `decimal128` vs `decimal`. 

This fix requires https://github.com/realm/realm-object-store/pull/1039 to be approved and merged.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
