### PR TITLE
use correct JS type name for Decimal128 and ObjectID

### DIFF
--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -106,7 +106,7 @@ std::string TypeErrorException::type_string(Property const& prop)
             ret = "decimal128";
             break;
         case PropertyType::ObjectId:
-            ret = "ObjectId";
+            ret = "objectId";
             break;
         case PropertyType::LinkingObjects:
         case PropertyType::Object:

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -405,10 +405,10 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
     else {
         std::string propertyType = string_for_property_type(property.type);
         if (property.type == realm::PropertyType::Decimal) {
-            propertyType = "Decimal128";
+            propertyType = "decimal128";
         }
         else if (property.type == realm::PropertyType::ObjectId) {
-            propertyType = "ObjectId";
+            propertyType = "objectId";
         }
 
         Object::set_property(ctx, object, type_string, Value::from_string(ctx, propertyType));

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -403,7 +403,15 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         }
     }
     else {
-        Object::set_property(ctx, object, type_string, Value::from_string(ctx, string_for_property_type(property.type)));
+        std::string propertyType = string_for_property_type(property.type);
+        if (property.type == realm::PropertyType::Decimal) {
+            propertyType = "Decimal128";
+        }
+        else if (property.type == realm::PropertyType::ObjectId) {
+            propertyType = "ObjectId";
+        }
+
+        Object::set_property(ctx, object, type_string, Value::from_string(ctx, propertyType));
     }
 
     static const String object_type_string = "objectType";

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1905,6 +1905,9 @@ module.exports = {
         let objects = realm.objects(schemas.Decimal128Object.name);
         TestCase.assertEqual(objects.length, numbers.length);
 
+        var d128Col = objects[0].objectSchema().properties.decimal128Col;
+        TestCase.assertEqual(d128Col.type, "Decimal128");
+
         for (let i = 0; i < numbers.length; i++) {
             let d128 = objects[i]["decimal128Col"];
             TestCase.assertTrue(d128 instanceof Decimal128);
@@ -1953,6 +1956,9 @@ module.exports = {
 
         let objects = realm.objects(schemas.ObjectIdObject.name);
         TestCase.assertEqual(objects.length, values.length);
+
+        var idCol = objects[0].objectSchema().properties.id;
+        TestCase.assertEqual(idCol.type, "ObjectId");
 
         for (let i = 0; i < values.length; i++) {
             let oid2 = objects[i]["id"];


### PR DESCRIPTION
use correct JS type name for Decimal128 and ObjectID