### PR TITLE
add object schema as possible value for property for embedded objects

### DIFF
--- a/docs/realm.js
+++ b/docs/realm.js
@@ -404,7 +404,7 @@ class Realm {
  *   that must be unique across all objects of this type within the same Realm.
  * @property {boolean} [embedded] - True if the object type is embedded. An embedded object
  *   can be linked to by at most one parent object. Default value: false.
- * @property {Object<string, (Realm~PropertyType|Realm~ObjectSchemaProperty)>} properties -
+ * @property {Object<string, (Realm~PropertyType|Realm~ObjectSchemaProperty|Realm~ObjectSchema)>} properties -
  *   An object where the keys are property names and the values represent the property type.
  *
  * @example

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,7 +61,7 @@ declare namespace Realm {
 
     // properties types
     interface PropertiesTypes {
-        [keys: string]: PropertyType | ObjectSchemaProperty;
+        [keys: string]: PropertyType | ObjectSchemaProperty | ObjectSchema;
     }
 
     enum UpdateMode {


### PR DESCRIPTION
<!-- Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you. -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
My understanding is that schemas for embedded objects are embedded within the schema so ts should allow a full ObjectSchema as a property. I did this locally to run tests on embedded objects 

This closes # ??? Let me know if you want me to file a ticket 

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
