### PR TITLE
Missing toJSON TS declaration added for Realm.Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Missing `toJSON` TS declaration added for `Realm.Object` ([2903](https://github.com/realm/realm-js/issues/2903))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -155,6 +155,11 @@ declare namespace Realm {
         entries(): [string, any][];
 
         /**
+         * @returns An object for JSON serialization.
+         */
+        toJSON(): object;
+
+        /**
          * @returns boolean
          */
         isValid(): boolean;


### PR DESCRIPTION
## What, How & Why?
Missing `toJSON` TS declaration added for `Realm.Object`.

This closes #2903

* [x] typescript definitions file is updated
