### PR TITLE
Adds missing syncconfig.error typescript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Added missing `SyncConfiguration.error` field in the typescript definitions.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -35,7 +35,7 @@
  */
 
 /**
- * This describes the different options used to create a {@link Realm} instance with Realm Platform synchronization.
+ * This describes the different options used to create a {@link Realm} instance with Realm Cloud synchronization.
  * @typedef {Object} Realm.Sync~SyncConfiguration
  * @property {Realm.User} user - A {@link Realm.User} object obtained by calling `Realm.App.logIn`.
  * @property {string|number|BSON.ObjectId} partitionValue - The value of the partition key.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -110,6 +110,7 @@ declare namespace Realm {
         newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
         existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
         _sessionStopPolicy?: SessionStopPolicy;
+        error?: (session: Sync.Session, error: SyncError) => void;
     }
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -110,7 +110,7 @@ declare namespace Realm {
         newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
         existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
         _sessionStopPolicy?: SessionStopPolicy;
-        error?: (session: Sync.Session, error: SyncError) => void;
+        error?: ErrorCallback;
     }
 
     /**
@@ -409,6 +409,8 @@ declare namespace Realm {
         category?: string;
         code: number;
     }
+
+    type ErrorCallback = (session: Session, error: SyncError) => void;
 
     const enum SessionStopPolicy {
         AfterUpload = "after-upload",


### PR DESCRIPTION
## What, How & Why?
Noticed that error was missing on the sync configuration typings.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
