### PR TITLE
Realm Web: Persist and retrieve users

### DIFF
--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -20,12 +20,22 @@ import { expect } from "chai";
 
 import { App, Credentials } from "realm-web";
 
-import { createApp } from "./utils";
+import { createApp, clearStorage } from "./utils";
+
+async function logOutAllUsers(app: App<object>) {
+    for (const user of app.allUsers) {
+        await user.logOut();
+    }
+}
 
 describe("App#constructor", () => {
     it("constructs", () => {
         const app = new App("default-app-id");
         expect(app).to.be.instanceOf(App);
+    });
+
+    afterEach(() => {
+        clearStorage();
     });
 
     it("can login a user", async () => {

--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -18,9 +18,11 @@
 
 import { expect } from "chai";
 
-import { App, Credentials, User } from "realm-web";
+import { App, Credentials, User, createDefaultStorage } from "realm-web";
 
-import { createApp, clearStorage } from "./utils";
+import { createApp } from "./utils";
+
+const storage = createDefaultStorage();
 
 describe("App#constructor", () => {
     it("constructs", () => {
@@ -29,7 +31,7 @@ describe("App#constructor", () => {
     });
 
     afterEach(() => {
-        clearStorage();
+        storage.clear();
     });
 
     it("can login a user", async () => {
@@ -79,7 +81,6 @@ describe("App#constructor", () => {
             const credentials = Credentials.anonymous();
             user = await app.logIn(credentials);
             expect(typeof user.id).equals("string");
-            console.log(window.localStorage);
         }
         // Recreate the app and expect the user to be restored
         {

--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -18,15 +18,9 @@
 
 import { expect } from "chai";
 
-import { App, Credentials } from "realm-web";
+import { App, Credentials, User } from "realm-web";
 
 import { createApp, clearStorage } from "./utils";
-
-async function logOutAllUsers(app: App<object>) {
-    for (const user of app.allUsers) {
-        await user.logOut();
-    }
-}
 
 describe("App#constructor", () => {
     it("constructs", () => {
@@ -76,5 +70,28 @@ describe("App#constructor", () => {
         expect(app.allUsers).deep.equals([user2, user1]);
         await app.removeUser(user1);
         expect(app.allUsers).deep.equals([user2]);
+    });
+
+    it("restores a user", async () => {
+        let user: User<object>;
+        {
+            const app = createApp();
+            const credentials = Credentials.anonymous();
+            user = await app.logIn(credentials);
+            expect(typeof user.id).equals("string");
+            console.log(window.localStorage);
+        }
+        // Recreate the app and expect the user to be restored
+        {
+            const app = createApp();
+            expect(app.allUsers.length).equals(1);
+            expect(app.currentUser).instanceOf(User);
+            expect(app.currentUser?.id).equals(user.id);
+            expect(app.currentUser?.profile).deep.equals(user.profile);
+            expect(app.currentUser?.accessToken).equals(user.accessToken);
+            expect(app.currentUser?.refreshToken).deep.equals(
+                user.refreshToken,
+            );
+        }
     });
 });

--- a/packages/realm-web-integration-tests/src/utils.ts
+++ b/packages/realm-web-integration-tests/src/utils.ts
@@ -22,7 +22,9 @@ import { App } from "realm-web";
 declare const APP_ID: string;
 declare const BASE_URL: string;
 
-export function createApp<FunctionsFactoryType extends object>() {
+export function createApp<
+    FunctionsFactoryType extends object = Realm.DefaultFunctionsFactory
+>() {
     if (typeof APP_ID !== "string") {
         throw new Error("Expected a global APP_ID");
     }

--- a/packages/realm-web-integration-tests/src/utils.ts
+++ b/packages/realm-web-integration-tests/src/utils.ts
@@ -34,3 +34,9 @@ export function createApp<FunctionsFactoryType extends object>() {
         baseUrl: BASE_URL,
     });
 }
+
+export function clearStorage() {
+    if (window.localStorage) {
+        localStorage.clear();
+    }
+}

--- a/packages/realm-web-integration-tests/src/utils.ts
+++ b/packages/realm-web-integration-tests/src/utils.ts
@@ -36,9 +36,3 @@ export function createApp<
         baseUrl: BASE_URL,
     });
 }
-
-export function clearStorage() {
-    if (window.localStorage) {
-        localStorage.clear();
-    }
-}

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,15 @@
+?.?.? Release notes (2020-??-??)
+=============================================================
+
+### Enhancements
+* Users are now persisted across refreshes and browser tabs (using the browsers local-storage). ([#2990](https://github.com/realm/realm-js/pull/2990))
+
+### Fixed
+* None.
+
+### Internal
+* None
+
 0.4.0 Release notes (2020-6-11)
 =============================================================
 

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -2,7 +2,7 @@
 =============================================================
 
 ### Enhancements
-* Users are now persisted across refreshes and browser tabs (using the browsers local-storage). ([#2990](https://github.com/realm/realm-js/pull/2990))
+* Users are now persisted across refreshes and browser tabs (using the browser's local-storage). ([#2990](https://github.com/realm/realm-js/pull/2990))
 
 ### Fixed
 * None.

--- a/packages/realm-web/README.md
+++ b/packages/realm-web/README.md
@@ -25,7 +25,6 @@ As this is a beta release, it comes with a few caveats:
 
 Some parts of the legacy Stitch SDK is still missing, most notably:
 - The ability to link a user to another identity.
-- Persistance of the users tokens in the browsers local storage (user must reauthenticate after a page reload).
 - The types for the `Realm.Credentials` namespace is not fully implemented.
 - No device information is sent to the service when authenticating a user.
 

--- a/packages/realm-web/src/App.test.ts
+++ b/packages/realm-web/src/App.test.ts
@@ -22,6 +22,8 @@ import { App } from "./App";
 import { User, UserState } from "./User";
 import { MockNetworkTransport } from "./test/MockNetworkTransport";
 import { Credentials } from "./Credentials";
+import { MemoryStorage } from "./storage";
+import { app } from ".";
 
 const DEFAULT_HEADERS = {
     Accept: "application/json",
@@ -334,5 +336,156 @@ describe("App", () => {
         });
         expect(app.services).keys(["mongodb", "http"]);
         expect(typeof app.services.mongodb).equals("function");
+    });
+
+    it("hydrates users from storage", () => {
+        const storage = new MemoryStorage();
+        const transport = new MockNetworkTransport([]);
+
+        // Fill data into the storage that can be hydrated
+        const appStorage = storage.prefix("app(default-app-id)");
+        appStorage.set("userIds", JSON.stringify(["alices-id", "bobs-id"]));
+
+        const alicesStorage = appStorage.prefix("user(alices-id)");
+        alicesStorage.set("accessToken", "alices-access-token");
+        alicesStorage.set("refreshToken", "alices-refresh-token");
+
+        const bobsStorage = appStorage.prefix("user(bobs-id)");
+        bobsStorage.set("accessToken", "bobs-access-token");
+        bobsStorage.set("refreshToken", "bobs-refresh-token");
+
+        const app = new App({
+            id: "default-app-id",
+            storage,
+            transport,
+            baseUrl: "http://localhost:1337",
+        });
+
+        expect(app.allUsers.length).equals(2);
+
+        const alice = app.allUsers[0];
+        expect(alice.id).equals("alices-id");
+        expect(alice.accessToken).equals("alices-access-token");
+        expect(alice.refreshToken).equals("alices-refresh-token");
+
+        const bob = app.allUsers[1];
+        expect(bob.id).equals("bobs-id");
+        expect(bob.accessToken).equals("bobs-access-token");
+        expect(bob.refreshToken).equals("bobs-refresh-token");
+    });
+
+    it("saves users to storage when logging in", async () => {
+        const storage = new MemoryStorage();
+        const transport = new MockNetworkTransport([
+            {
+                user_id: "totally-valid-user-id",
+                access_token: "deadbeef",
+                refresh_token: "very-refreshing",
+            },
+        ]);
+        const app = new App({
+            id: "default-app-id",
+            storage,
+            transport,
+            baseUrl: "http://localhost:1337",
+        });
+
+        const credentials = App.Credentials.anonymous();
+        const user = await app.logIn(credentials, false);
+
+        expect(user.id).equals("totally-valid-user-id");
+        const appStorage = storage.prefix("app(default-app-id)");
+        expect(appStorage.get("userIds")).equals(
+            JSON.stringify(["totally-valid-user-id"]),
+        );
+        const userStorage = appStorage.prefix("user(totally-valid-user-id)");
+        expect(userStorage.get("accessToken")).equals("deadbeef");
+        expect(userStorage.get("refreshToken")).equals("very-refreshing");
+    });
+
+    it("merges logins and logouts of multiple apps with the same storage", async () => {
+        const storage = new MemoryStorage();
+
+        const app1 = new App({
+            id: "default-app-id",
+            storage,
+            transport: new MockNetworkTransport([
+                {
+                    user_id: "alices-id",
+                    access_token: "alices-access-token",
+                    refresh_token: "alices-refresh-token",
+                },
+                {
+                    user_id: "bobs-id",
+                    access_token: "bobs-access-token",
+                    refresh_token: "bobs-refresh-token",
+                },
+                {
+                    data: {
+                        first_name: "Bobby",
+                    },
+                    identities: [],
+                    type: "normal",
+                },
+                {},
+            ]),
+            baseUrl: "http://localhost:1337",
+        });
+
+        const app2 = new App({
+            id: "default-app-id",
+            storage,
+            transport: new MockNetworkTransport([
+                {
+                    user_id: "charlies-id",
+                    access_token: "charlies-access-token",
+                    refresh_token: "charlies-refresh-token",
+                },
+            ]),
+            baseUrl: "http://localhost:1337",
+        });
+
+        const credentials = App.Credentials.anonymous();
+        const alice = await app1.logIn(credentials, false);
+        const charlie = await app2.logIn(credentials, false);
+        const bob = await app1.logIn(credentials, true);
+
+        const appStorage = storage.prefix("app(default-app-id)");
+        expect(appStorage.get("userIds")).equals(
+            // We expect Charlies id to be last, because the last login was in app1
+            // We expect bobs-id to be first because he was the last login
+            JSON.stringify(["bobs-id", "alices-id", "charlies-id"]),
+        );
+
+        // Logging out bob, we expect:
+        // - The tokens to be removed from storage
+        // - The profile to remain in storage
+        // - The id to remain in the list of ids
+        const bobsStorage = appStorage.prefix("user(bobs-id)");
+        expect(bobsStorage.get("accessToken")).equals("bobs-access-token");
+        expect(bobsStorage.get("refreshToken")).equals("bobs-refresh-token");
+        const bobsProfileBefore = JSON.parse(bobsStorage.get("profile") || "");
+        expect(bobsProfileBefore).deep.equals({
+            type: "normal",
+            identities: [],
+            firstName: "Bobby",
+        });
+
+        await bob.logOut();
+        expect(bobsStorage.get("accessToken")).equals(null);
+        expect(bobsStorage.get("refreshToken")).equals(null);
+        const bobsProfileAfter = JSON.parse(bobsStorage.get("profile") || "");
+        expect(bobsProfileAfter).deep.equals(bobsProfileBefore);
+        expect(appStorage.get("userIds")).equals(
+            JSON.stringify(["bobs-id", "alices-id", "charlies-id"]),
+        );
+
+        // Removing Bob from the app, removes his id from apps storage
+        await app1.removeUser(bob);
+        expect(bobsStorage.get("profile")).equals(null);
+        expect(appStorage.get("userIds")).equals(
+            JSON.stringify(["alices-id", "charlies-id"]),
+        );
+        console.log((storage as any).storage);
     });
 });

--- a/packages/realm-web/src/App.test.ts
+++ b/packages/realm-web/src/App.test.ts
@@ -81,6 +81,7 @@ describe("App", () => {
     });
 
     it("can log in a user", async () => {
+        const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([
             {
                 user_id: "totally-valid-user-id",
@@ -106,6 +107,7 @@ describe("App", () => {
         ]);
         const app = new App({
             id: "default-app-id",
+            storage,
             transport,
             baseUrl: "http://localhost:1337",
         });
@@ -147,6 +149,7 @@ describe("App", () => {
     });
 
     it("can log out a user", async () => {
+        const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([
             {
                 user_id: "totally-valid-user-id",
@@ -158,6 +161,7 @@ describe("App", () => {
         const app = new App({
             id: "default-app-id",
             transport,
+            storage,
             baseUrl: "http://localhost:1337",
         });
         const credentials = Credentials.anonymous();
@@ -191,6 +195,7 @@ describe("App", () => {
     });
 
     it("can remove an active user", async () => {
+        const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([
             {
                 user_id: "totally-valid-user-id",
@@ -201,6 +206,7 @@ describe("App", () => {
         ]);
         const app = new App({
             id: "default-app-id",
+            storage,
             transport,
             baseUrl: "http://localhost:1337",
         });
@@ -288,6 +294,7 @@ describe("App", () => {
     });
 
     it("expose a callable functions factory", async () => {
+        const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([
             {
                 user_id: "totally-valid-user-id",
@@ -298,6 +305,7 @@ describe("App", () => {
         ]);
         const app = new App({
             id: "default-app-id",
+            storage,
             transport,
             baseUrl: "http://localhost:1337",
         });
@@ -349,6 +357,14 @@ describe("App", () => {
         const alicesStorage = appStorage.prefix("user(alices-id)");
         alicesStorage.set("accessToken", "alices-access-token");
         alicesStorage.set("refreshToken", "alices-refresh-token");
+        alicesStorage.set(
+            "profile",
+            JSON.stringify({
+                type: "normal",
+                identities: [],
+                firstName: "Alice",
+            }),
+        );
 
         const bobsStorage = appStorage.prefix("user(bobs-id)");
         bobsStorage.set("accessToken", "bobs-access-token");
@@ -367,6 +383,7 @@ describe("App", () => {
         expect(alice.id).equals("alices-id");
         expect(alice.accessToken).equals("alices-access-token");
         expect(alice.refreshToken).equals("alices-refresh-token");
+        expect(alice.profile.firstName).equals("Alice");
 
         const bob = app.allUsers[1];
         expect(bob.id).equals("bobs-id");
@@ -480,12 +497,11 @@ describe("App", () => {
             JSON.stringify(["bobs-id", "alices-id", "charlies-id"]),
         );
 
-        // Removing Bob from the app, removes his id from apps storage
+        // Removing Bob from the app, removes his profile and id from the app's storage
         await app1.removeUser(bob);
         expect(bobsStorage.get("profile")).equals(null);
         expect(appStorage.get("userIds")).equals(
             JSON.stringify(["alices-id", "charlies-id"]),
         );
-        console.log((storage as any).storage);
     });
 });

--- a/packages/realm-web/src/App.test.ts
+++ b/packages/realm-web/src/App.test.ts
@@ -23,7 +23,6 @@ import { User, UserState } from "./User";
 import { MockNetworkTransport } from "./test/MockNetworkTransport";
 import { Credentials } from "./Credentials";
 import { MemoryStorage } from "./storage";
-import { app } from ".";
 
 const DEFAULT_HEADERS = {
     Accept: "application/json",

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -24,6 +24,8 @@ import { AuthenticatedTransport, Transport, BaseTransport } from "./transports";
 import { Credentials } from "./Credentials";
 import { create as createServicesFactory } from "./services";
 import { EmailPasswordAuth } from "./auth-providers";
+import { Storage, createDefaultStorage } from "./storage";
+import { AppStorage } from "./AppStorage";
 
 /**
  * Configuration to pass as an argument when constructing an app.
@@ -31,6 +33,8 @@ import { EmailPasswordAuth } from "./auth-providers";
 export interface AppConfiguration extends Realm.AppConfiguration {
     /** Transport to use when fetching resources */
     transport?: NetworkTransport;
+    /** Used when persisting app state, such as tokens of authenticated users */
+    storage?: Storage;
 }
 
 /**
@@ -74,15 +78,20 @@ export class App<
     public readonly emailPasswordAuth: EmailPasswordAuth;
 
     /**
+     * Storage available for the app
+     */
+    public readonly storage: AppStorage;
+
+    /**
      * This base route will be prefixed requests issued through by the base transport
      */
     private static readonly BASE_ROUTE = "/api/client/v2.0";
 
     /**
-     * A (reversed) stack of active and logged-out users.
+     * An array of active and logged-out users.
      * Elements in the beginning of the array is considered more recent than the later elements.
      */
-    private readonly users: User<FunctionsFactoryType, CustomDataType>[] = [];
+    private users: User<FunctionsFactoryType, CustomDataType>[] = [];
 
     /**
      * Construct a Realm App, either from the Realm App id visible from the MongoDB Realm UI or a configuration.
@@ -125,6 +134,11 @@ export class App<
         this.services = createServicesFactory(authTransport);
         // Construct the auth providers
         this.emailPasswordAuth = new EmailPasswordAuth(authTransport);
+        // Construct the storage
+        const baseStorage = configuration.storage || createDefaultStorage();
+        this.storage = new AppStorage(baseStorage, this.id);
+        // Hydrate the app state from storage
+        this.hydrate();
     }
 
     /**
@@ -156,6 +170,12 @@ export class App<
         > = await User.logIn(this, credentials, fetchProfile);
         // Add the user at the top of the stack
         this.users.unshift(user);
+        // Persist the user id in the storage,
+        // merging to avoid overriding logins from other apps using the same underlying storage
+        this.storage.setUserIds(
+            this.users.map(u => u.id),
+            true,
+        );
         // Return the user
         return user;
     }
@@ -170,9 +190,12 @@ export class App<
             throw new Error("The user was never logged into this app");
         }
         this.users.splice(index, 1);
-        // Log out the user
+        // Log out the user - this removes access and refresh tokens from storage
         await user.logOut();
-        // TODO: Delete any data / tokens which were persisted
+        // Remove the users profile from storage
+        this.storage.remove(`user(${user.id}):profile`);
+        // Remove the user from the storage
+        this.storage.removeUserId(user.id);
     }
 
     /**
@@ -217,19 +240,10 @@ export class App<
     }
 
     /**
-     * Get the (user and it's controller) handle of a user
-     *
-     * @param userOrId A user object or user id
-     * @returns A handle containing the user and it's controller.
+     * Restores the state of the app (active and logged-out users) from the storage
      */
-    private getUser(userOrId: Realm.User | string | null) {
-        const user = this.users.find(u =>
-            typeof userOrId === "string" ? u.id === userOrId : u === userOrId,
-        );
-        if (user) {
-            return user;
-        } else {
-            throw new Error("Invalid user or user id");
-        }
+    private hydrate() {
+        const userIds = this.storage.getUserIds();
+        this.users = userIds.map(id => User.hydrate(this, id));
     }
 }

--- a/packages/realm-web/src/AppStorage.test.ts
+++ b/packages/realm-web/src/AppStorage.test.ts
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import { AppStorage } from "./AppStorage";
+import { MemoryStorage } from "./storage";
+
+describe("AppStorage", () => {
+    describe("user ids", () => {
+        it("can be set with merging, retrieved, removed and set without merging", () => {
+            const baseStorage = new MemoryStorage();
+            // Add two existing user ids
+            baseStorage.set(
+                "app(default-app-id):userIds",
+                JSON.stringify(["a", "b", "c"]),
+            );
+            const storage = new AppStorage(baseStorage, "default-app-id");
+
+            // Inserting updating by adding two new users (d and e)
+            storage.setUserIds(["c", "d", "e"], true);
+            // We expect the three newly updated ids to be stored and any existing to be at the end of the array
+            expect(storage.getUserIds()).deep.equals(["c", "d", "e", "a", "b"]);
+            // Remove a single user
+            storage.removeUserId("e");
+            expect(storage.getUserIds()).deep.equals(["c", "d", "a", "b"]);
+            // Empty the list of users
+            storage.setUserIds([], false);
+            expect(storage.getUserIds()).deep.equals([]);
+        });
+    });
+});

--- a/packages/realm-web/src/AppStorage.ts
+++ b/packages/realm-web/src/AppStorage.ts
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { PrefixedStorage, Storage } from "./storage";
+
+const USER_IDS_STORAGE_KEY = "userIds";
+
+/**
+ * Storage specific to the app.
+ */
+export class AppStorage extends PrefixedStorage {
+    /**
+     * Construct a storage for an `App`
+     *
+     * @param storage The underlying storage to wrap.
+     * @param appId The id of the app.
+     */
+    constructor(storage: Storage, appId: string) {
+        super(storage, `app(${appId})`);
+    }
+
+    /**
+     * Reads out the list of user ids from storage.
+     *
+     * @returns A list of user ids.
+     */
+    public getUserIds() {
+        try {
+            const userIdsString = this.get(USER_IDS_STORAGE_KEY);
+            const userIds = userIdsString ? JSON.parse(userIdsString) : [];
+            if (Array.isArray(userIds)) {
+                return userIds;
+            } else {
+                throw new Error("Expected an array");
+            }
+        } catch (err) {
+            // The storage was corrupted
+            this.remove(USER_IDS_STORAGE_KEY);
+            throw err;
+        }
+    }
+
+    /**
+     * Sets the list of ids in storage.
+     * Optionally merging with existing ids stored in the storage, by prepending these while voiding duplicates.
+     *
+     * @param userIds The list of ids to store.
+     * @param mergeWithExisting Prepend existing ids to avoid data-races with other apps using this storage.
+     */
+    public setUserIds(userIds: string[], mergeWithExisting: boolean) {
+        if (mergeWithExisting) {
+            // Add any existing user id to the end of this list, avoiding duplicates
+            const existingIds = this.getUserIds();
+            for (const id of existingIds) {
+                if (userIds.indexOf(id) === -1) {
+                    userIds.push(id);
+                }
+            }
+        }
+        // Store the list of ids
+        this.set(USER_IDS_STORAGE_KEY, JSON.stringify(userIds));
+    }
+
+    /**
+     * Remove an id from the list of ids.
+     *
+     * @param userId The id of a User to be removed.
+     */
+    public removeUserId(userId: string) {
+        const existingIds = this.getUserIds();
+        const userIds = existingIds.filter(id => id !== userId);
+        // Store the list of ids
+        this.setUserIds(userIds, false);
+    }
+}

--- a/packages/realm-web/src/User.test.ts
+++ b/packages/realm-web/src/User.test.ts
@@ -113,9 +113,9 @@ describe("User", () => {
         const userStorage = user.app.storage.prefix("user(some-user-id)");
         expect(userStorage.get("accessToken")).equals("deadbeef");
         expect(userStorage.get("refreshToken")).equals("very-refreshing");
-        const profile = JSON.parse(userStorage.get("profile") || "");
+        const profileBefore = JSON.parse(userStorage.get("profile") || "");
 
-        expect(profile).deep.equals({
+        expect(profileBefore).deep.equals({
             firstName: "John",
             identities: [],
             type: "normal",
@@ -125,8 +125,8 @@ describe("User", () => {
         expect(userStorage.get("accessToken")).equals(null);
         expect(userStorage.get("refreshToken")).equals(null);
         // Logging out shouldn't delete information about the profile
-        expect(user.profile).deep.equals(profile);
-        const profile2 = JSON.parse(userStorage.get("profile") || "");
-        expect(profile2).deep.equals(profile);
+        expect(user.profile).deep.equals(profileBefore);
+        const profileAfter = JSON.parse(userStorage.get("profile") || "");
+        expect(profileAfter).deep.equals(profileBefore);
     });
 });

--- a/packages/realm-web/src/User.test.ts
+++ b/packages/realm-web/src/User.test.ts
@@ -125,6 +125,7 @@ describe("User", () => {
         expect(userStorage.get("accessToken")).equals(null);
         expect(userStorage.get("refreshToken")).equals(null);
         // Logging out shouldn't delete information about the profile
+        expect(user.profile).deep.equals(profile);
         const profile2 = JSON.parse(userStorage.get("profile") || "");
         expect(profile2).deep.equals(profile);
     });

--- a/packages/realm-web/src/User.test.ts
+++ b/packages/realm-web/src/User.test.ts
@@ -20,6 +20,7 @@ import { expect } from "chai";
 
 import { MockApp } from "./test/MockApp";
 import { UserType, User, UserState } from "./User";
+import { MemoryStorage } from "./storage";
 
 // Since responses from the server uses underscores in field names:
 /* eslint @typescript-eslint/camelcase: "warn" */
@@ -88,5 +89,43 @@ describe("User", () => {
             type: UserType.Normal,
             firstName: "John",
         });
+    });
+
+    it("sets tokens and profile on storage when constructed, removes them on log out", async () => {
+        const user = new User({
+            app: new MockApp("my-mocked-app", [
+                {
+                    data: {
+                        first_name: "John",
+                    },
+                    identities: [],
+                    type: "normal",
+                },
+                {},
+            ]),
+            id: "some-user-id",
+            accessToken: "deadbeef",
+            refreshToken: "very-refreshing",
+        });
+        // Fetch the profile
+        await user.refreshProfile();
+
+        const userStorage = user.app.storage.prefix("user(some-user-id)");
+        expect(userStorage.get("accessToken")).equals("deadbeef");
+        expect(userStorage.get("refreshToken")).equals("very-refreshing");
+        const profile = JSON.parse(userStorage.get("profile") || "");
+
+        expect(profile).deep.equals({
+            firstName: "John",
+            identities: [],
+            type: "normal",
+        });
+
+        await user.logOut();
+        expect(userStorage.get("accessToken")).equals(null);
+        expect(userStorage.get("refreshToken")).equals(null);
+        // Logging out shouldn't delete information about the profile
+        const profile2 = JSON.parse(userStorage.get("profile") || "");
+        expect(profile2).deep.equals(profile);
     });
 });

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -19,6 +19,8 @@
 import type { App } from "./App";
 import { AuthenticatedTransport } from "./transports";
 import { UserProfile } from "./UserProfile";
+import { UserStorage } from "./UserStorage";
+import { Storage } from "./storage";
 
 // Disabling requiring JSDoc for now - as the User class is exported as the Realm.User interface, which is already documented.
 /* eslint-disable jsdoc/require-jsdoc */
@@ -26,8 +28,8 @@ import { UserProfile } from "./UserProfile";
 interface UserParameters {
     app: App<any>;
     id: string;
-    accessToken: string;
-    refreshToken: string;
+    accessToken: string | null;
+    refreshToken: string | null;
 }
 
 export enum UserState {
@@ -107,26 +109,54 @@ export class User<
         return user;
     }
 
+    /**
+     * Creates a user from the data stored in the storage of an `App` instance.
+     *
+     * @param app The app that the user was logged into.
+     * @param userId The id of the user to restore.
+     * @returns The user created from values retrieved from storage.
+     */
+    public static hydrate<
+        FunctionsFactoryType extends object,
+        CustomDataType extends object
+    >(app: App<FunctionsFactoryType, CustomDataType>, userId: string) {
+        const user = new User<FunctionsFactoryType, CustomDataType>({
+            app,
+            id: userId,
+            accessToken: null,
+            refreshToken: null,
+        });
+        user.hydrate();
+        return user;
+    }
+
     private _id: string;
     private _accessToken: string | null;
     private _refreshToken: string | null;
-    private _profile: Realm.UserProfile | undefined;
-    private _state: Realm.UserState;
+    private _profile: UserProfile | undefined;
     private transport: AuthenticatedTransport;
+    private storage: UserStorage;
 
     public constructor({ app, id, accessToken, refreshToken }: UserParameters) {
         this.app = app;
         this._id = id;
         this._accessToken = accessToken;
         this._refreshToken = refreshToken;
-        this._state = UserState.Active;
         this.transport = new AuthenticatedTransport(app.baseTransport, {
             currentUser: this,
         });
+        this.storage = new UserStorage(app.storage, id);
+        // Store tokens in storage for later hydration
+        if (accessToken) {
+            this.storage.accessToken = accessToken;
+        }
+        if (refreshToken) {
+            this.storage.refreshToken = refreshToken;
+        }
     }
 
     /**
-     * The automatically-generated internal ID of the user.
+     * The automatically-generated internal id of the user.
      *
      * @returns The id of the user in the MongoDB Realm database.
      */
@@ -197,6 +227,8 @@ export class User<
         });
         // Create a profile instance
         this._profile = new UserProfile(response);
+        // Store this for later hydration
+        this.storage.profile = this._profile;
     }
 
     public async logOut() {
@@ -209,12 +241,13 @@ export class User<
                     Authorization: `Bearer ${this._refreshToken}`,
                 },
             });
-            // Forget the tokens
-            this._accessToken = null;
-            this._refreshToken = null;
         }
-        // Update the state
-        this._state = UserState.LoggedOut;
+        // Forget the access token
+        this._accessToken = null;
+        this.storage.accessToken = null;
+        // Forget the refresh token
+        this._refreshToken = null;
+        this.storage.refreshToken = null;
     }
 
     /** @inheritdoc */
@@ -231,7 +264,32 @@ export class User<
         return this.functions.callFunction(name, ...args);
     }
 
+    /**
+     * Restore a user from the data stored in the storage of an `App` instance.
+     */
+    public hydrate() {
+        const accessToken = this.storage.accessToken;
+        const refreshToken = this.storage.refreshToken;
+        if (
+            typeof accessToken === "string" &&
+            typeof refreshToken === "string"
+        ) {
+            this._accessToken = accessToken;
+            this._refreshToken = refreshToken;
+        } else {
+            throw new Error(
+                `Failed hydrating user (${this.id}), missing access or refresh token`,
+            );
+        }
+
+        const profile = this.storage.profile;
+        if (profile) {
+            this._profile = profile;
+        }
+    }
+
     private async refreshAccessToken() {
+        // TODO: this.storage.set(User.ACCESS_TOKEN_STORAGE_KEY, accessToken);
         throw new Error("Not yet implemented");
     }
 

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -268,6 +268,7 @@ export class User<
      * Restore a user from the data stored in the storage of an `App` instance.
      */
     public hydrate() {
+        // Hydrate tokens
         const accessToken = this.storage.accessToken;
         const refreshToken = this.storage.refreshToken;
         if (
@@ -281,11 +282,8 @@ export class User<
                 `Failed hydrating user (${this.id}), missing access or refresh token`,
             );
         }
-
-        const profile = this.storage.profile;
-        if (profile) {
-            this._profile = profile;
-        }
+        // Hydrate any profile
+        this._profile = this.storage.profile;
     }
 
     private async refreshAccessToken() {

--- a/packages/realm-web/src/UserProfile.ts
+++ b/packages/realm-web/src/UserProfile.ts
@@ -16,6 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+/**
+ * The type of a user.
+ */
+enum UserType {
+    /** A normal end-user created this user */
+    Normal = "normal",
+    /** The user was created by the server */
+    Server = "server",
+}
+
 /** @ignore */
 enum DataKey {
     /** @ignore */
@@ -80,7 +90,7 @@ export class UserProfile implements Realm.UserProfile {
     public readonly maxAge?: string;
 
     /** @inheritdoc */
-    public readonly type: Realm.UserType;
+    public readonly type: Realm.UserType = UserType.Normal;
 
     /** @inheritdoc */
     public readonly identities: Realm.UserIdentity[];
@@ -90,20 +100,7 @@ export class UserProfile implements Realm.UserProfile {
      *
      * @param response The response of a call fetching the users profile
      */
-    constructor(response: any) {
-        /**
-      -  "data": {}
-      -  "domain_id": "5ed10debc085000e2c0097ac"
-      -  "identities": [
-      -    {
-      -      "id": "5ed10e0dc085000e2c0099f2-fufttusvpmojykvacvhijoaq"
-      -      "provider_id": "5ed10dedc085000e2c0097c5"
-      -      "provider_type": "anon-user"
-      -    }
-      -  ]
-      -  "type": "normal"
-      -  "user_id": "5ed10e0dc085000e2c0099f3"
-         */
+    constructor(response?: any) {
         if (typeof response.type === "string") {
             this.type = response.type;
         } else {
@@ -139,4 +136,6 @@ export class UserProfile implements Realm.UserProfile {
             throw new Error("Expected 'data' in the response body");
         }
     }
+
+    // public hydrateFromResponse() {}
 }

--- a/packages/realm-web/src/UserProfile.ts
+++ b/packages/realm-web/src/UserProfile.ts
@@ -93,7 +93,7 @@ export class UserProfile implements Realm.UserProfile {
     public readonly type: Realm.UserType = UserType.Normal;
 
     /** @inheritdoc */
-    public readonly identities: Realm.UserIdentity[];
+    public readonly identities: Realm.UserIdentity[] = [];
 
     /**
      * Construct a user profile from the body of a response
@@ -101,41 +101,41 @@ export class UserProfile implements Realm.UserProfile {
      * @param response The response of a call fetching the users profile
      */
     constructor(response?: any) {
-        if (typeof response.type === "string") {
-            this.type = response.type;
-        } else {
-            throw new Error("Expected 'type' in the response body");
-        }
-
-        if (Array.isArray(response.identities)) {
-            this.identities = response.identities.map((identity: any) => {
-                return {
-                    id: identity.id,
-                    providerId: identity["provider_id"],
-                    providerType: identity["provider_type"],
-                };
-            });
-        } else {
-            throw new Error("Expected 'identities' in the response body");
-        }
-
-        const { data } = response;
-        if (typeof data === "object") {
-            for (const key in DATA_MAPPING) {
-                const value = data[key];
-                const propertyName = DATA_MAPPING[key as DataKey];
-                if (
-                    typeof value === "string" &&
-                    propertyName !== "identities" &&
-                    propertyName !== "type"
-                ) {
-                    this[propertyName] = value;
-                }
+        if (response) {
+            if (typeof response.type === "string") {
+                this.type = response.type;
+            } else {
+                throw new Error("Expected 'type' in the response body");
             }
-        } else {
-            throw new Error("Expected 'data' in the response body");
+
+            if (Array.isArray(response.identities)) {
+                this.identities = response.identities.map((identity: any) => {
+                    return {
+                        id: identity.id,
+                        providerId: identity["provider_id"],
+                        providerType: identity["provider_type"],
+                    };
+                });
+            } else {
+                throw new Error("Expected 'identities' in the response body");
+            }
+
+            const { data } = response;
+            if (typeof data === "object") {
+                for (const key in DATA_MAPPING) {
+                    const value = data[key];
+                    const propertyName = DATA_MAPPING[key as DataKey];
+                    if (
+                        typeof value === "string" &&
+                        propertyName !== "identities" &&
+                        propertyName !== "type"
+                    ) {
+                        this[propertyName] = value;
+                    }
+                }
+            } else {
+                throw new Error("Expected 'data' in the response body");
+            }
         }
     }
-
-    // public hydrateFromResponse() {}
 }

--- a/packages/realm-web/src/UserStorage.ts
+++ b/packages/realm-web/src/UserStorage.ts
@@ -102,7 +102,7 @@ export class UserStorage extends PrefixedStorage {
      * @param value User profile (undefined if its unknown).
      */
     set profile(value: UserProfile | undefined) {
-        if (value === null) {
+        if (!value) {
             this.remove(PROFILE_STORAGE_KEY);
         } else {
             this.set(PROFILE_STORAGE_KEY, JSON.stringify(value));

--- a/packages/realm-web/src/UserStorage.ts
+++ b/packages/realm-web/src/UserStorage.ts
@@ -40,7 +40,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Get the access token from storage
      *
-     * @returns Access token.
+     * @returns Access token (null if unknown).
      */
     get accessToken() {
         return this.get(ACCESS_TOKEN_STORAGE_KEY);
@@ -49,7 +49,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Set the access token in storage.
      *
-     * @param value Access token.
+     * @param value Access token (null if unknown).
      */
     set accessToken(value: string | null) {
         if (value === null) {
@@ -62,7 +62,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Get the refresh token from storage
      *
-     * @returns Refresh token.
+     * @returns Refresh token (null if unknown and user is logged out).
      */
     get refreshToken() {
         return this.get(REFRESH_TOKEN_STORAGE_KEY);
@@ -71,7 +71,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Set the refresh token in storage.
      *
-     * @param value Refresh token.
+     * @param value Refresh token (null if unknown and user is logged out).
      */
     set refreshToken(value: string | null) {
         if (value === null) {
@@ -84,7 +84,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Get the user profile from storage.
      *
-     * @returns User profile.
+     * @returns User profile (undefined if its unknown).
      */
     get profile() {
         const value = this.get(PROFILE_STORAGE_KEY);
@@ -99,7 +99,7 @@ export class UserStorage extends PrefixedStorage {
     /**
      * Set the user profile in storage.
      *
-     * @param value User profile.
+     * @param value User profile (undefined if its unknown).
      */
     set profile(value: UserProfile | undefined) {
         if (value === null) {

--- a/packages/realm-web/src/UserStorage.ts
+++ b/packages/realm-web/src/UserStorage.ts
@@ -108,13 +108,4 @@ export class UserStorage extends PrefixedStorage {
             this.set(PROFILE_STORAGE_KEY, JSON.stringify(value));
         }
     }
-
-    /**
-     * Clears all values saved in the store
-     */
-    public removeAll() {
-        this.remove(ACCESS_TOKEN_STORAGE_KEY);
-        this.remove(REFRESH_TOKEN_STORAGE_KEY);
-        this.remove(PROFILE_STORAGE_KEY);
-    }
 }

--- a/packages/realm-web/src/UserStorage.ts
+++ b/packages/realm-web/src/UserStorage.ts
@@ -1,0 +1,120 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { PrefixedStorage, Storage } from "./storage";
+import { UserProfile } from "./UserProfile";
+
+const ACCESS_TOKEN_STORAGE_KEY = "accessToken";
+const REFRESH_TOKEN_STORAGE_KEY = "refreshToken";
+const PROFILE_STORAGE_KEY = "profile";
+
+/**
+ * Storage specific to the app.
+ */
+export class UserStorage extends PrefixedStorage {
+    /**
+     * Construct a storage for a `User`
+     *
+     * @param storage The underlying storage to wrap.
+     * @param userId The id of the user.
+     */
+    constructor(storage: Storage, userId: string) {
+        super(storage, `user(${userId})`);
+    }
+
+    /**
+     * Get the access token from storage
+     *
+     * @returns Access token.
+     */
+    get accessToken() {
+        return this.get(ACCESS_TOKEN_STORAGE_KEY);
+    }
+
+    /**
+     * Set the access token in storage.
+     *
+     * @param value Access token.
+     */
+    set accessToken(value: string | null) {
+        if (value === null) {
+            this.remove(ACCESS_TOKEN_STORAGE_KEY);
+        } else {
+            this.set(ACCESS_TOKEN_STORAGE_KEY, value);
+        }
+    }
+
+    /**
+     * Get the refresh token from storage
+     *
+     * @returns Refresh token.
+     */
+    get refreshToken() {
+        return this.get(REFRESH_TOKEN_STORAGE_KEY);
+    }
+
+    /**
+     * Set the refresh token in storage.
+     *
+     * @param value Refresh token.
+     */
+    set refreshToken(value: string | null) {
+        if (value === null) {
+            this.remove(REFRESH_TOKEN_STORAGE_KEY);
+        } else {
+            this.set(REFRESH_TOKEN_STORAGE_KEY, value);
+        }
+    }
+
+    /**
+     * Get the user profile from storage.
+     *
+     * @returns User profile.
+     */
+    get profile() {
+        const value = this.get(PROFILE_STORAGE_KEY);
+        if (value) {
+            const profile = new UserProfile();
+            // Patch in the values
+            Object.assign(profile, JSON.parse(value));
+            return profile;
+        }
+    }
+
+    /**
+     * Set the user profile in storage.
+     *
+     * @param value User profile.
+     */
+    set profile(value: UserProfile | undefined) {
+        if (value === null) {
+            this.remove(PROFILE_STORAGE_KEY);
+        } else {
+            this.set(PROFILE_STORAGE_KEY, JSON.stringify(value));
+        }
+    }
+
+    /**
+     * Clears all values saved in the store
+     */
+    public removeAll() {
+        this.remove(ACCESS_TOKEN_STORAGE_KEY);
+        this.remove(REFRESH_TOKEN_STORAGE_KEY);
+        this.remove(PROFILE_STORAGE_KEY);
+    }
+}

--- a/packages/realm-web/src/index.ts
+++ b/packages/realm-web/src/index.ts
@@ -39,3 +39,4 @@ export function app(id: string) {
 export { App };
 export { Credentials } from "./Credentials";
 export { User, UserState } from "./User";
+export { createDefaultStorage } from "./storage";

--- a/packages/realm-web/src/storage/LocalStorage.ts
+++ b/packages/realm-web/src/storage/LocalStorage.ts
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Storage } from "./Storage";
+import { PrefixedStorage } from "./PrefixedStorage";
+
+/**
+ * In-memory storage that will not be persisted.
+ */
+export class LocalStorage implements Storage {
+    /**
+     * Internal state of the storage
+     */
+    private readonly window: WindowLocalStorage;
+
+    /**
+     * Constructs a LocalStorage using the global window
+     */
+    constructor() {
+        if (typeof window === "object") {
+            this.window = window;
+        } else {
+            throw new Error(
+                "Cannot use LocalStorage without a global window object",
+            );
+        }
+    }
+
+    /** @inheritdoc */
+    public get(key: string): string | null {
+        return this.window.localStorage.getItem(key);
+    }
+
+    /** @inheritdoc */
+    public set(key: string, value: string) {
+        return this.window.localStorage.setItem(key, value);
+    }
+
+    /** @inheritdoc */
+    public remove(key: string) {
+        return this.window.localStorage.removeItem(key);
+    }
+
+    /** @inheritdoc */
+    public prefix(keyPart: string): Storage {
+        return new PrefixedStorage(this, keyPart);
+    }
+}

--- a/packages/realm-web/src/storage/LocalStorage.ts
+++ b/packages/realm-web/src/storage/LocalStorage.ts
@@ -60,4 +60,15 @@ export class LocalStorage implements Storage {
     public prefix(keyPart: string): Storage {
         return new PrefixedStorage(this, keyPart);
     }
+
+    /** @inheritdoc */
+    public clear(prefix?: string) {
+        // Iterate all keys and delete their values if they have a matching prefix
+        for (let i = 0; i < this.window.localStorage.length; i++) {
+            const key = this.window.localStorage.key(i);
+            if (key && (!prefix || key.startsWith(prefix))) {
+                this.window.localStorage.removeItem(key);
+            }
+        }
+    }
 }

--- a/packages/realm-web/src/storage/LocalStorage.ts
+++ b/packages/realm-web/src/storage/LocalStorage.ts
@@ -63,12 +63,17 @@ export class LocalStorage implements Storage {
 
     /** @inheritdoc */
     public clear(prefix?: string) {
-        // Iterate all keys and delete their values if they have a matching prefix
+        const keys = [];
+        // Iterate all keys to find the once have a matching prefix
         for (let i = 0; i < this.window.localStorage.length; i++) {
             const key = this.window.localStorage.key(i);
             if (key && (!prefix || key.startsWith(prefix))) {
-                this.window.localStorage.removeItem(key);
+                keys.push(key);
             }
+        }
+        // Remove the items in a seperate loop to avoid updating while iterating
+        for (const key of keys) {
+            this.window.localStorage.removeItem(key);
         }
     }
 }

--- a/packages/realm-web/src/storage/MemoryStorage.ts
+++ b/packages/realm-web/src/storage/MemoryStorage.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Storage } from "./Storage";
+import { PrefixedStorage } from "./PrefixedStorage";
+
+/**
+ * In-memory storage that will not be persisted.
+ */
+export class MemoryStorage implements Storage {
+    /**
+     * Internal state of the storage
+     */
+    private readonly storage: { [key: string]: string } = {};
+
+    /** @inheritdoc */
+    public get(key: string): string | null {
+        if (key in this.storage) {
+            return this.storage[key];
+        } else {
+            return null;
+        }
+    }
+
+    /** @inheritdoc */
+    public set(key: string, value: string) {
+        this.storage[key] = value;
+    }
+
+    /** @inheritdoc */
+    public remove(key: string) {
+        delete this.storage[key];
+    }
+
+    /** @inheritdoc */
+    public prefix(keyPart: string): Storage {
+        return new PrefixedStorage(this, keyPart);
+    }
+}

--- a/packages/realm-web/src/storage/MemoryStorage.ts
+++ b/packages/realm-web/src/storage/MemoryStorage.ts
@@ -51,4 +51,14 @@ export class MemoryStorage implements Storage {
     public prefix(keyPart: string): Storage {
         return new PrefixedStorage(this, keyPart);
     }
+
+    /** @inheritdoc */
+    public clear(prefix?: string) {
+        // Iterate all keys and delete their values if they have a matching prefix
+        for (const key of Object.keys(this.storage)) {
+            if (!prefix || key.startsWith(prefix)) {
+                delete this.storage[key];
+            }
+        }
+    }
 }

--- a/packages/realm-web/src/storage/PrefixedStorage.ts
+++ b/packages/realm-web/src/storage/PrefixedStorage.ts
@@ -23,6 +23,11 @@ import { Storage } from "./Storage";
  */
 export class PrefixedStorage implements Storage {
     /**
+     * The string separating two parts
+     */
+    private static PART_SEPARATOR = ":";
+
+    /**
      * The underlying storage to use for operations.
      */
     private storage: Storage;
@@ -45,21 +50,35 @@ export class PrefixedStorage implements Storage {
 
     /** @inheritdoc */
     public get(key: string) {
-        return this.storage.get(this.keyPart + ":" + key);
+        return this.storage.get(
+            this.keyPart + PrefixedStorage.PART_SEPARATOR + key,
+        );
     }
 
     /** @inheritdoc */
     public set(key: string, value: string) {
-        return this.storage.set(this.keyPart + ":" + key, value);
+        return this.storage.set(
+            this.keyPart + PrefixedStorage.PART_SEPARATOR + key,
+            value,
+        );
     }
 
     /** @inheritdoc */
     public remove(key: string) {
-        return this.storage.remove(this.keyPart + ":" + key);
+        return this.storage.remove(
+            this.keyPart + PrefixedStorage.PART_SEPARATOR + key,
+        );
     }
 
     /** @inheritdoc */
     public prefix(keyPart: string): Storage {
         return new PrefixedStorage(this, keyPart);
+    }
+
+    /** @inheritdoc */
+    public clear(prefix = "") {
+        return this.storage.clear(
+            this.keyPart + PrefixedStorage.PART_SEPARATOR + prefix,
+        );
     }
 }

--- a/packages/realm-web/src/storage/PrefixedStorage.ts
+++ b/packages/realm-web/src/storage/PrefixedStorage.ts
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Storage } from "./Storage";
+
+/**
+ * A `Storage` which will prefix a key part to every operation.
+ */
+export class PrefixedStorage implements Storage {
+    /**
+     * The underlying storage to use for operations.
+     */
+    private storage: Storage;
+
+    /**
+     * The part of the key to prefix when performing operations.
+     */
+    private keyPart: string;
+
+    /**
+     * Construct a `Storage` which will prefix a key part to every operation.
+     *
+     * @param storage The underlying storage to use for operations.
+     * @param keyPart The part of the key to prefix when performing operations.
+     */
+    constructor(storage: Storage, keyPart: string) {
+        this.storage = storage;
+        this.keyPart = keyPart;
+    }
+
+    /** @inheritdoc */
+    public get(key: string) {
+        return this.storage.get(this.keyPart + ":" + key);
+    }
+
+    /** @inheritdoc */
+    public set(key: string, value: string) {
+        return this.storage.set(this.keyPart + ":" + key, value);
+    }
+
+    /** @inheritdoc */
+    public remove(key: string) {
+        return this.storage.remove(this.keyPart + ":" + key);
+    }
+
+    /** @inheritdoc */
+    public prefix(keyPart: string): Storage {
+        return new PrefixedStorage(this, keyPart);
+    }
+}

--- a/packages/realm-web/src/storage/Storage.ts
+++ b/packages/realm-web/src/storage/Storage.ts
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Implementors of this provide a simple key-value store
+ */
+export interface Storage {
+    /**
+     * Get the value of a particular key in the storage.
+     */
+    get(key: string): string | null;
+
+    /**
+     * Set the value of a particular key in the storage.
+     */
+    set(key: string, value: string): void;
+
+    /**
+     * Remove the entry for a particular key from the storage.
+     */
+    remove(key: string): void;
+
+    /**
+     * Create a new store prefixed with a part of the key.
+     */
+    prefix(keyPart: string): Storage;
+}

--- a/packages/realm-web/src/storage/Storage.ts
+++ b/packages/realm-web/src/storage/Storage.ts
@@ -39,4 +39,11 @@ export interface Storage {
      * Create a new store prefixed with a part of the key.
      */
     prefix(keyPart: string): Storage;
+
+    /**
+     * Clears all values stored in the storage.
+     *
+     * @param prefix Clear only values starting with this prefix.
+     */
+    clear(prefix?: string): void;
 }

--- a/packages/realm-web/src/storage/index.test.ts
+++ b/packages/realm-web/src/storage/index.test.ts
@@ -50,6 +50,13 @@ describe("Storage", () => {
             expect(storage.get("something")).equals(null);
             expect(storage.get("something else")).equals("is still there");
         });
+
+        it("clears the right values", () => {
+            storage.clear("nothing");
+            expect(storage.get("something else")).equals("is still there");
+            storage.clear("something");
+            expect(storage.get("something else")).equals(null);
+        });
     });
 
     describe("PrefixedStorage", () => {
@@ -58,6 +65,7 @@ describe("Storage", () => {
 
         before(() => {
             parentStorage = new MemoryStorage();
+            parentStorage.set("unremovable", "remains!");
             storage = new PrefixedStorage(parentStorage, "key-prefix");
         });
 
@@ -83,6 +91,19 @@ describe("Storage", () => {
             expect(parentStorage.get("key-prefix:something else")).equals(
                 "is still there",
             );
+        });
+
+        it("clears the right values", () => {
+            storage.set("another", "value");
+            storage.clear("nothing");
+            expect(storage.get("something else")).equals("is still there");
+            storage.clear("something");
+            expect(storage.get("something else")).equals(null);
+            expect(parentStorage.get("key-prefix:something else")).equals(null);
+            expect(storage.get("another")).equals("value");
+            storage.clear();
+            expect(storage.get("another")).equals(null);
+            expect(parentStorage.get("unremovable")).equals("remains!");
         });
     });
 

--- a/packages/realm-web/src/storage/index.test.ts
+++ b/packages/realm-web/src/storage/index.test.ts
@@ -1,0 +1,96 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import { Storage } from "./Storage";
+import { MemoryStorage } from "./MemoryStorage";
+import { LocalStorage } from "./LocalStorage";
+import { Suite } from "mocha";
+import { PrefixedStorage } from "./PrefixedStorage";
+
+const skipIfBrowser = typeof window === "object" ? it.skip : it;
+
+describe("Storage", () => {
+    describe("MemoryStorage", function () {
+        let storage: Storage;
+
+        before(() => {
+            storage = new MemoryStorage();
+        });
+
+        it("returns null before a value is set", () => {
+            expect(storage.get("something")).equals(null);
+        });
+
+        it("sets and gets the correct value", () => {
+            storage.set("something", "good");
+            expect(storage.get("something")).equals("good");
+        });
+
+        it("removes the correct value", () => {
+            storage.set("something else", "is still there");
+            expect(storage.get("something")).equals("good");
+            storage.remove("something");
+            expect(storage.get("something")).equals(null);
+            expect(storage.get("something else")).equals("is still there");
+        });
+    });
+
+    describe("PrefixedStorage", () => {
+        let parentStorage: Storage;
+        let storage: Storage;
+
+        before(() => {
+            parentStorage = new MemoryStorage();
+            storage = new PrefixedStorage(parentStorage, "key-prefix");
+        });
+
+        it("returns null before a value is set", () => {
+            expect(storage.get("something")).equals(null);
+            expect(parentStorage.get("key-prefix:something")).equals(null);
+        });
+
+        it("sets and gets the correct value", () => {
+            storage.set("something", "good");
+            expect(storage.get("something")).equals("good");
+            expect(parentStorage.get("key-prefix:something")).equals("good");
+        });
+
+        it("removes the correct value", () => {
+            storage.set("something else", "is still there");
+            expect(storage.get("something")).equals("good");
+            expect(parentStorage.get("key-prefix:something")).equals("good");
+            storage.remove("something");
+            expect(storage.get("something")).equals(null);
+            expect(parentStorage.get("key-prefix:something")).equals(null);
+            expect(storage.get("something else")).equals("is still there");
+            expect(parentStorage.get("key-prefix:something else")).equals(
+                "is still there",
+            );
+        });
+    });
+
+    describe("LocalStorage", () => {
+        skipIfBrowser("throws when constructed outside of a browser", () => {
+            expect(() => {
+                new LocalStorage();
+            }).throws("Cannot use LocalStorage without a global window object");
+        });
+    });
+});

--- a/packages/realm-web/src/storage/index.ts
+++ b/packages/realm-web/src/storage/index.ts
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+export { LocalStorage } from "./LocalStorage";
+export { MemoryStorage } from "./MemoryStorage";
+export { PrefixedStorage } from "./PrefixedStorage";
+export { Storage } from "./Storage";
+
+import { LocalStorage } from "./LocalStorage";
+import { MemoryStorage } from "./MemoryStorage";
+
+/**
+ * Create a `Storage` instance, default to the current environment
+ *
+ * @returns A LocalStorage instance if the window global is an object, MemoryStorage otherwise.
+ *          Both will prefix keys with "realm-web".
+ */
+export function createDefaultStorage() {
+    const storage =
+        typeof window === "object" ? new LocalStorage() : new MemoryStorage();
+    return storage.prefix("realm-web");
+}

--- a/packages/realm-web/src/storage/index.ts
+++ b/packages/realm-web/src/storage/index.ts
@@ -24,7 +24,7 @@ export { Storage } from "./Storage";
 import { LocalStorage } from "./LocalStorage";
 import { MemoryStorage } from "./MemoryStorage";
 
-/** We're reusing a singleton to simulate the persistance of the localstorage */
+/** We're reusing a singleton to simulate the persistance of the browsers `localStorage` */
 const memoryStorageSingleton = new MemoryStorage();
 
 /**

--- a/packages/realm-web/src/storage/index.ts
+++ b/packages/realm-web/src/storage/index.ts
@@ -24,6 +24,9 @@ export { Storage } from "./Storage";
 import { LocalStorage } from "./LocalStorage";
 import { MemoryStorage } from "./MemoryStorage";
 
+/** We're reusing a singleton to simulate the persistance of the localstorage */
+const memoryStorageSingleton = new MemoryStorage();
+
 /**
  * Create a `Storage` instance, default to the current environment
  *
@@ -32,6 +35,8 @@ import { MemoryStorage } from "./MemoryStorage";
  */
 export function createDefaultStorage() {
     const storage =
-        typeof window === "object" ? new LocalStorage() : new MemoryStorage();
+        typeof window === "object"
+            ? new LocalStorage()
+            : memoryStorageSingleton;
     return storage.prefix("realm-web");
 }

--- a/packages/realm-web/src/test/MockApp.ts
+++ b/packages/realm-web/src/test/MockApp.ts
@@ -18,6 +18,7 @@
 
 import { App } from "../App";
 import { MockNetworkTransport } from "./MockNetworkTransport";
+import { MemoryStorage } from "../storage";
 
 /**
  * An App using the MockTransport
@@ -31,14 +32,16 @@ export class MockApp extends App<any> {
     /**
      * Create mocked App, useful when testing.
      *
-     * @param id The ID of the app.
+     * @param id The id of the app.
      * @param requests An array of requests returned by the underlying mocked network transport.
      */
     constructor(id: string, requests: object[] = []) {
         const transport = new MockNetworkTransport(requests);
+        const storage = new MemoryStorage();
         super({
             id,
             baseUrl: "http://localhost:1337",
+            storage,
             transport,
         });
         this.mockTransport = transport;


### PR DESCRIPTION
## What, How & Why?

This closes #2964 by adding:
- A storage abstraction and three specializations:
  - `LocalStorage` the browsers local storage.
  - `MemoryStorage` ephemeral storage used when running from Node.js (during unit tests).
  - `PrefixedStorage` wrapping another `Storage`, adding a prefix to the key before getting or setting values, helps keep storage local and avoid repeating the prefixed key in code.
- Storing a users access & refresh tokens after successful log in.
- Storing a users profile after successful refresh.
- Restoring the list of users and their data (id, access & refresh tokens and profile) when an instance of `App` gets constructed.

Since localStorage is shared across tabs of the same origin and the current implementation allows for multiple `App` instances with the same `id` a couple of considerations had to be made when adding this feature.

### Merge users when logged in across multiple tabs
Consider the following activity from two app instances with the same ID:
1. App-1 logs in "Alice"
2. App-2 logs in "Bob" (in a different tab)
3. App-1 logs in "Charlie"
4. All tabs are closed and the user returns the next day
5. App-3 restores users.

In this case both "Alice", "Bob" and "Charlie" must be logged in, "Charlie" being the most recent (and therefore current user).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
