### PR TITLE
Realm Web: Refactored `AuthenticatedTransport`

### DIFF
--- a/packages/realm-web/src/Credentials.test.ts
+++ b/packages/realm-web/src/Credentials.test.ts
@@ -31,12 +31,12 @@ describe("Credentials", () => {
     it("expose the email/password credentials", () => {
         expect(typeof Credentials.emailPassword).equals("function");
         const credentials = Credentials.emailPassword(
-            "gilfoil@testing.mongodb.com",
+            "gilfoyle@testing.mongodb.com",
             "s3cr3t",
         );
         expect(credentials).to.be.instanceOf(Credentials);
         expect(credentials.payload).deep.equals({
-            username: "gilfoil@testing.mongodb.com",
+            username: "gilfoyle@testing.mongodb.com",
             password: "s3cr3t",
         });
     });

--- a/packages/realm-web/src/User.test.ts
+++ b/packages/realm-web/src/User.test.ts
@@ -19,8 +19,7 @@
 import { expect } from "chai";
 
 import { MockApp } from "./test/MockApp";
-import { UserType, User, UserState } from "./User";
-import { MemoryStorage } from "./storage";
+import { UserType, User } from "./User";
 
 // Since responses from the server uses underscores in field names:
 /* eslint @typescript-eslint/camelcase: "warn" */

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -77,7 +77,6 @@ export class User<
                 path: `/auth/providers/${credentials.providerName}/login`,
                 body: credentials.payload,
             },
-            null,
         );
         // Spread out values from the response and ensure they're valid
         const {

--- a/packages/realm-web/src/transports/AuthenticatedTransport.test.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.test.ts
@@ -84,4 +84,30 @@ describe("AuthenticatedTransport", () => {
             },
         ]);
     });
+
+    it("returns an AuthenticatedTransport when prefixed", async () => {
+        const baseTransport = new MockTransport([{}]);
+        const transport = new AuthenticatedTransport(baseTransport, {
+            currentUser: { accessToken: "my-access-token" } as Realm.User,
+        });
+        const prefixedTransport = transport.prefix("/prefixed-path");
+        expect(prefixedTransport).to.be.instanceOf(AuthenticatedTransport);
+        // Send a request
+        await prefixedTransport.fetch({
+            method: "GET",
+            path: "/w00t",
+        });
+        // Expect something of the request
+        expect(baseTransport.requests).deep.equals([
+            {
+                method: "GET",
+                url: "http://localhost:1337/prefixed-path/w00t",
+                headers: {
+                    Authorization: "Bearer my-access-token",
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                },
+            },
+        ]);
+    });
 });

--- a/packages/realm-web/src/transports/AuthenticatedTransport.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.ts
@@ -54,7 +54,13 @@ export class AuthenticatedTransport implements Transport {
         this.userContext = userContext;
     }
 
-    /** @inheritdoc */
+    /**
+     * Fetch a network resource as an authenticated user.
+     *
+     * @param request The request to issue towards the server
+     * @param user The user used when fetching, defaults to the `app.currentUser`.
+     *             If `null`, the fetch will be unauthenticated.
+     */
     public fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,
         user: Realm.User | null = this.userContext.currentUser,
@@ -69,8 +75,9 @@ export class AuthenticatedTransport implements Transport {
     }
 
     /** @inheritdoc */
-    public prefix(pathPrefix: string): Transport {
-        return new PrefixedTransport(this, pathPrefix);
+    public prefix(pathPrefix: string): AuthenticatedTransport {
+        const prefixedTransport = this.transport.prefix(pathPrefix);
+        return new AuthenticatedTransport(prefixedTransport, this.userContext);
     }
 
     /**

--- a/packages/realm-web/src/transports/AuthenticatedTransport.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.ts
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { Transport, Request } from "./Transport";
-import { PrefixedTransport } from "./PrefixedTransport";
 
 /**
  * Used to control which user is currently active - this would most likely be the {App} instance.
@@ -60,6 +59,7 @@ export class AuthenticatedTransport implements Transport {
      * @param request The request to issue towards the server
      * @param user The user used when fetching, defaults to the `app.currentUser`.
      *             If `null`, the fetch will be unauthenticated.
+     * @returns A response from requesting with authentication.
      */
     public fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,

--- a/packages/realm-web/src/transports/BaseTransport.ts
+++ b/packages/realm-web/src/transports/BaseTransport.ts
@@ -65,13 +65,7 @@ export class BaseTransport implements Transport {
     /** @inheritdoc */
     public fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,
-        user: any,
     ): Promise<ResponseBody> {
-        if (user) {
-            throw new Error(
-                "BaseTransport doesn't support fetching as a particular user",
-            );
-        }
         const { path, headers, ...restOfRequest } = request;
         return this.networkTransport.fetchAndParse({
             ...restOfRequest,

--- a/packages/realm-web/src/transports/PrefixedTransport.ts
+++ b/packages/realm-web/src/transports/PrefixedTransport.ts
@@ -46,13 +46,12 @@ export class PrefixedTransport implements Transport {
     /** @inheritdoc */
     fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,
-        user?: Realm.User | null,
     ): Promise<ResponseBody> {
         const prefixedRequest = {
             ...request,
             path: `${this.pathPrefix}${request.path || ""}`,
         };
-        return this.transport.fetch(prefixedRequest, user);
+        return this.transport.fetch(prefixedRequest);
     }
 
     /** @inheritdoc */

--- a/packages/realm-web/src/transports/Transport.ts
+++ b/packages/realm-web/src/transports/Transport.ts
@@ -41,12 +41,9 @@ export interface Transport {
      * Fetch a network resource.
      *
      * @param request The request to issue towards the server
-     * @param user The user used when fetching, defaults to the `app.currentUser`.
-     *             If `null`, the fetch will be unauthenticated.
      */
     fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,
-        user?: Realm.User | null,
     ): Promise<ResponseBody>;
 
     /**


### PR DESCRIPTION
## What, How & Why?

This simplifies the `Transport` interface, by removing the optional `user` argument and instead returning an `AuthenticatedTransport` when prefixing a `AuthenticatedTransport`. This change is purely internal and has no effects on the API users are consuming.

Note: This PR should be rebased onto `v10` once the parent branch (`kh/web/persist-users`) gets merged.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
