### PR TITLE
Pass use frameworks environment variable. Fixes (#2830)

### DIFF
--- a/RealmJS.podspec
+++ b/RealmJS.podspec
@@ -8,11 +8,16 @@ app_path = File.expand_path('../..', __dir__)
 # The "React" framework is only available and should be used if the Podfile calls use_frameworks!
 # Therefore we make an assumption on the location of the Podfile and check if it contains "use_frameworks!" ...
 podfile_path = File.expand_path('ios/Podfile', app_path)
-begin
-  podfile = File.read(podfile_path)
-  uses_frameworks = podfile.scan(/\n\s*use_frameworks!\n/).any?
-rescue
-  uses_frameworks = false
+
+if !ENV['REALM_USE_FRAMEWORKS'].present?
+  begin
+    podfile = File.read(podfile_path)
+    uses_frameworks = podfile.scan(/\n\s*use_frameworks!\n/).any?
+  rescue
+    uses_frameworks = false
+  end
+else
+  uses_frameworks = ENV['REALM_USE_FRAMEWORKS'] == 'true' ? true : false
 end
 
 if ENV['DEBUG_REALM_JS_PODSPEC'].present?
@@ -57,7 +62,7 @@ Pod::Spec.new do |s|
                              'src/object-store/src/util/apple/*.cpp',
                              'react-native/ios/RealmReact/*.mm',
                              'vendor/*.cpp'
-  
+
   s.frameworks             = uses_frameworks ? ['JavaScriptCore', 'React'] : ['JavaScriptCore']
 
   s.library                = 'c++', 'z'
@@ -87,7 +92,7 @@ Pod::Spec.new do |s|
                                  # "'#{app_path}/ios/Pods/Headers/Public/React-Core'" # Use this line instead of 👆 while linting
                                ].join(' ')
                              }
-  
+
   # TODO: Consider providing an option to build with the -dbg binaries instead
   s.ios.vendored_libraries = 'vendor/realm-ios/librealm-ios.a', 'vendor/realm-ios/librealm-parser-ios.a'
   # s.watchos.vendored_libraries = 'vendor/realm-ios/librealm-watchos.a', 'vendor/realm-ios/librealm-parser-watchos.a'


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
This change allows user to pass environment variable `REALM_USE_FRAMEWORKS`.
This overrides Realm's own detection of `use_frameworks!`.
The issue with Realm's detection is that it just scans the whole file, not specific target.
For example, one target may contain `use_frameworks!`, but there is no Realm dependency there and we build another target, with Realm dependency.
Nevertheless, the target we _do_ build for will be marked as using frameworks, which will lead to error described in #2830.

Passing environment variable like it is done in this PR allows developer to override detection and avoid Realm's detection.

Example of project where issue is reproduced: https://github.com/alexeykomov/RealmUseFrameworksIssue
Example of project where issue is fixed: https://github.com/alexeykomov/RealmUseFrameworksIssueFixed

This closes #2830

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
