### PR TITLE
Fix RemoteMongoClient test

### DIFF
--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -661,7 +661,7 @@ inline bson::Bson Value<T>::to_bson(typename T::Context ctx, ValueType value) {
         value,
         Object<T>::create_obj(ctx, {{"relaxed", Value::from_boolean(ctx, false)}}),
     });
-    return bson::parse(Value::to_string(ctx, call_args_json));
+    return bson::parse(std::string(Value::to_string(ctx, call_args_json)));
 }
 } // js
 } // realm

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -228,7 +228,7 @@ module.exports = {
     let user = await app.logIn(credentials);
 
     let mongo = user.remoteMongoClient('BackingDB');
-    let collection = mongo.db('test').collection('testRemoteMongoClient');
+    let collection = mongo.db('test_data').collection('testRemoteMongoClient');
 
     await collection.deleteMany({});
     await collection.insertOne({hello: "world"});


### PR DESCRIPTION
## What, How & Why?

Pulls in https://github.com/realm/realm-object-store/pull/1050 to fix the "no such rule" error when running the RemoteMongoClient test.


## ☑️ ToDos
<!-- Add your own todos here -->
* ~[ ] 📝 Changelog entry~
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
