### PR TITLE
Realm Web: Refresh access token

### DIFF
--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -256,7 +256,7 @@
       "dev": true
     },
     "eslint": {
-      "version": "file:../../node_modules/eslint",
+      "version": "file:https:/registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -1716,7 +1716,7 @@
       "dev": true
     },
     "typescript": {
-      "version": "file:../../node_modules/typescript",
+      "version": "file:https:/registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },

--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -599,7 +599,7 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.2.0",
+          "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
           "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
           "dev": true
@@ -945,7 +945,7 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.0",
+          "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,

--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -256,7 +256,7 @@
       "dev": true
     },
     "eslint": {
-      "version": "file:https:/registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "version": "file:../../node_modules/eslint",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -309,9 +309,9 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.9.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-          "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
           "dev": true
         },
         "@babel/highlight": {
@@ -328,8 +328,7 @@
         "@types/color-name": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-          "dev": true
+          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "acorn": {
           "version": "7.2.0",
@@ -344,9 +343,9 @@
           "dev": true
         },
         "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -379,11 +378,12 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "argparse": {
@@ -497,17 +497,17 @@
           "dev": true
         },
         "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "concat-map": {
           "version": "0.0.1",
@@ -561,9 +561,9 @@
           }
         },
         "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -572,9 +572,9 @@
           "dev": true
         },
         "eslint-scope": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -599,9 +599,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+          "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
           "dev": true
         },
         "espree": {
@@ -768,9 +768,9 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "iconv-lite": {
           "version": "0.4.24",
@@ -914,9 +914,9 @@
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "is-glob": {
           "version": "4.0.1",
@@ -945,9 +945,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -1304,11 +1304,11 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         },
         "table": {
@@ -1716,7 +1716,7 @@
       "dev": true
     },
     "typescript": {
-      "version": "file:https:/registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "version": "file:../../node_modules/typescript",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Implements cross-platform fetching used by Realm JS",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Implements cross-platform fetching used by Realm JS",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/packages/realm-network-transport/src/MongoDBRealmError.ts
+++ b/packages/realm-network-transport/src/MongoDBRealmError.ts
@@ -16,17 +16,27 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { Method } from "./types";
+
 /**
  * TODO: Determine if the shape of an error response is specific to each service or widely used
  */
 
 export class MongoDBRealmError extends Error {
+    public readonly method: Method;
+    public readonly url: string;
     public readonly statusCode: number;
     public readonly statusText: string;
     public readonly errorCode: string | undefined;
     public readonly link: string | undefined;
 
-    constructor(statusCode: number, statusText: string, response: any) {
+    constructor(
+        method: Method,
+        url: string,
+        statusCode: number,
+        statusText: string,
+        response: any,
+    ) {
         if (
             typeof response === "object" &&
             typeof response.error === "string"
@@ -34,7 +44,11 @@ export class MongoDBRealmError extends Error {
             const statusSummary = statusText
                 ? `status ${statusCode} ${statusText}`
                 : `status ${statusCode}`;
-            super(`${response.error} (${statusSummary})`);
+            super(
+                `Request failed (${method} ${url}): ${response.error} (${statusSummary})`,
+            );
+            this.method = method;
+            this.url = url;
             this.statusText = statusText;
             this.statusCode = statusCode;
             this.errorCode = response.error_code;

--- a/packages/realm-network-transport/src/index.ts
+++ b/packages/realm-network-transport/src/index.ts
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 export {
-    DefaultNetworkTransport,
     NetworkTransport,
     Request,
     Response,
@@ -25,6 +24,6 @@ export {
     SuccessCallback,
     ErrorCallback,
     ResponseHandler,
-} from "./NetworkTransport";
-
+} from "./types";
+export { DefaultNetworkTransport } from "./NetworkTransport";
 export { MongoDBRealmError } from "./MongoDBRealmError";

--- a/packages/realm-network-transport/src/types.ts
+++ b/packages/realm-network-transport/src/types.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+export type Method = "GET" | "POST" | "DELETE" | "PUT";
+
+export type Headers = { [name: string]: string };
+
+export interface Request<RequestBody> {
+    method: Method;
+    url: string;
+    timeoutMs?: number;
+    headers?: Headers;
+    body?: RequestBody | string;
+}
+
+export interface Response {
+    statusCode: number;
+    headers: Headers;
+    body: string;
+}
+
+export type SuccessCallback = (response: Response) => void;
+
+export type ErrorCallback = (err: Error) => void;
+
+export interface ResponseHandler {
+    onSuccess: SuccessCallback;
+    onError: ErrorCallback;
+}
+
+export interface NetworkTransport {
+    fetchAndParse<RequestBody extends any, ResponseBody extends any>(
+        request: Request<RequestBody>,
+    ): Promise<ResponseBody>;
+    fetchWithCallbacks<RequestBody extends any>(
+        request: Request<RequestBody>,
+        handler: ResponseHandler,
+    ): void;
+}

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -20,7 +20,7 @@ import { expect } from "chai";
 
 import { Credentials, UserState } from "realm-web";
 
-import { createApp } from "./utils";
+import { createApp, INVALID_TOKEN } from "./utils";
 
 describe("User", () => {
     it("can login a user", async () => {
@@ -36,5 +36,19 @@ describe("User", () => {
         // TODO: expect(user.profile.identities.length).equals(1);
         expect(user.profile.name).equals(undefined);
         expect(user.customData).deep.equals({});
+    });
+
+    it("refresh invalid access tokens", async () => {
+        const app = createApp();
+        const credentials = Credentials.anonymous();
+        const user = await app.logIn(credentials, false);
+        // Invalidate the token
+        (user as any)._accessToken = INVALID_TOKEN;
+        expect(user.accessToken).equals(INVALID_TOKEN);
+        // Try using the broken access token
+        const response = await user.functions.translate("hello", "en_fr");
+        expect(response).to.equal("bonjour");
+        // Expect the user to have a diffent token now
+        expect(user.accessToken).not.equals(INVALID_TOKEN);
     });
 });

--- a/packages/realm-web-integration-tests/src/utils.ts
+++ b/packages/realm-web-integration-tests/src/utils.ts
@@ -48,3 +48,6 @@ export function describeIf(
         describe.skip(title, fn);
     }
 }
+
+export const INVALID_TOKEN =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MDAwMDAwMDAsImlhdCI6MTUwMDAwMDAwMCwic3ViIjoiMTIzNDU2Nzg5MCJ9.x3-ZWVJGjEltXWWa1uaBaN4oo7dOjPbgA46STVD5KKY";

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -2,6 +2,18 @@
 =============================================================
 
 ### Enhancements
+* None
+
+### Fixed
+* None
+
+### Internal
+* None
+
+0.6.0 Release notes (2020-07-01)
+=============================================================
+
+### Enhancements
 * Added more credentials enabling logins via additional authentication providers: Custom Functions, Custom JWT, Google, Facebook & Apple ID. ([#3019](https://github.com/realm/realm-js/pull/3019))
 * Custom data can now be retrieved from an active User. ([#3019](https://github.com/realm/realm-js/pull/3019))
 

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Fixed an error "Cannot use 'in' operator to search for 'node' in undefined", which could occur when bundling the package without Node.js stubs available. ([#3001](https://github.com/realm/realm-js/pull/3001))
+* Fixed refreshing of access tokens upon 401 responses from the server. ([#3020](https://github.com/realm/realm-js/pull/3020))
 
 ### Internal
 * None

--- a/packages/realm-web/README.md
+++ b/packages/realm-web/README.md
@@ -13,17 +13,12 @@ npm install realm-web
 As this is a beta release, it comes with a few caveats:
 
 - Most importantly, the Realm Web project *will not* include a Realm Sync client in any foreseeable future.
-- A limited selection of types of [credentials for authentication providers](https://docs.mongodb.com/stitch/authentication/providers/) are implemented at the moment:
-  - Anonymous.
-  - API key.
-  - Email & password.
 - A limited selection of [services](https://docs.mongodb.com/stitch/services/) are implemented at the moment:
   - MongoDB (watching a collection is not yet implemented).
-  - HTTP (send requests using the MongoDB service as a proxy).
+  - HTTP: Send requests using the MongoDB service as a proxy.
 
 Some parts of the legacy Stitch SDK is still missing, most notably:
 - The ability to link a user to another identity.
-- The types for the `Realm.Credentials` namespace is not fully implemented.
 - No device information is sent to the service when authenticating a user.
 
 ## Using Realm Web from Node.js

--- a/packages/realm-web/package-lock.json
+++ b/packages/realm-web/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "realm-web",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Authenticate and communicate with the MongoDB Realm platform, from your web-browser",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -56,7 +56,7 @@
     "eslint": "file:../../node_modules/eslint",
     "mocha": "^5.2.0",
     "node-fetch": "^2.6.0",
-    "realm-network-transport": "^0.4.0",
+    "realm-network-transport": "^0.5.0",
     "rollup": "^2.6.1",
     "rollup-plugin-dts": "^1.4.0",
     "ts-node": "^8.8.2",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -56,7 +56,7 @@
     "eslint": "file:../../node_modules/eslint",
     "mocha": "^5.2.0",
     "node-fetch": "^2.6.0",
-    "realm-network-transport": "^0.5.0",
+    "realm-network-transport": "^0.6.0",
     "rollup": "^2.6.1",
     "rollup-plugin-dts": "^1.4.0",
     "ts-node": "^8.8.2",

--- a/packages/realm-web/src/App.test.ts
+++ b/packages/realm-web/src/App.test.ts
@@ -368,6 +368,7 @@ describe("App", () => {
     });
 
     it("throws if asked to switch to or remove an unknown user", async () => {
+        const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([
             {
                 user_id: "totally-valid-user-id",
@@ -377,8 +378,10 @@ describe("App", () => {
         ]);
         const app = new App({
             id: "default-app-id",
+            storage,
             transport,
             baseUrl: "http://localhost:1337",
+            fetchLocation: false,
         });
         const credentials = Credentials.anonymous();
         const user = await app.logIn(credentials, false);

--- a/packages/realm-web/src/App.test.ts
+++ b/packages/realm-web/src/App.test.ts
@@ -449,7 +449,7 @@ describe("App", () => {
             },
             { bar: "baz" },
         ]);
-        // Login with an aanonymous user
+        // Login with an anonymous user
         const credentials = Credentials.anonymous();
         await app.logIn(credentials, false);
         // Send a request (which will fail)

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import type { App } from "./App";
-import { AuthenticatedTransport } from "./transports";
+import { AuthenticatedTransport, AppTransport } from "./transports";
 import { UserProfile } from "./UserProfile";
 import { UserStorage } from "./UserStorage";
 import { FunctionsFactory } from "./FunctionsFactory";
@@ -152,7 +152,8 @@ export class User<
         this.transport = new AuthenticatedTransport(app.baseTransport, {
             currentUser: this,
         });
-        this.functions = FunctionsFactory.create(this.transport);
+        const appTransport = new AppTransport(this.transport, app.id);
+        this.functions = FunctionsFactory.create(appTransport);
         this.storage = new UserStorage(app.storage, id);
         // Store tokens in storage for later hydration
         if (accessToken) {

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -264,6 +264,23 @@ export class User<
         throw new Error("Not yet implemented");
     }
 
+    public async refreshAccessToken() {
+        const response = await this.app.baseTransport.fetch({
+            method: "POST",
+            path: "/auth/session",
+            headers: {
+                Authorization: `Bearer ${this._refreshToken}`,
+            },
+        });
+        const { access_token: accessToken } = response;
+        if (typeof accessToken === "string") {
+            this._accessToken = accessToken;
+            this.storage.accessToken = accessToken;
+        } else {
+            throw new Error("Expected a 'access_token' in the response");
+        }
+    }
+
     public async refreshCustomData() {
         await this.refreshAccessToken();
         return this.customData;

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -310,11 +310,6 @@ export class User<
         }
     }
 
-    private async refreshAccessToken() {
-        // TODO: this.storage.set(User.ACCESS_TOKEN_STORAGE_KEY, accessToken);
-        throw new Error("Not yet implemented");
-    }
-
     push(serviceName = ""): Realm.Services.Push {
         throw new Error("Not yet implemented");
     }

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -278,7 +278,7 @@ export class User<
             this._accessToken = accessToken;
             this.storage.accessToken = accessToken;
         } else {
-            throw new Error("Expected a 'access_token' in the response");
+            throw new Error("Expected an 'access_token' in the response");
         }
     }
 

--- a/packages/realm-web/src/test/MockNetworkTransport.ts
+++ b/packages/realm-web/src/test/MockNetworkTransport.ts
@@ -20,6 +20,7 @@ import {
     NetworkTransport,
     Request,
     ResponseHandler,
+    MongoDBRealmError,
 } from "realm-network-transport";
 
 /**
@@ -58,7 +59,11 @@ export class MockNetworkTransport implements NetworkTransport {
         this.requests.push(request);
         if (this.responses.length > 0) {
             const [response] = this.responses.splice(0, 1);
-            return Promise.resolve(response);
+            if (response instanceof MongoDBRealmError) {
+                return Promise.reject(response);
+            } else {
+                return Promise.resolve(response);
+            }
         } else {
             throw new Error(
                 `Unexpected request (method = ${request.method}, url = ${

--- a/packages/realm-web/src/test/index.ts
+++ b/packages/realm-web/src/test/index.ts
@@ -16,15 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export {
-    DefaultNetworkTransport,
-    NetworkTransport,
-    Request,
-    Response,
-    Method,
-    SuccessCallback,
-    ErrorCallback,
-    ResponseHandler,
-} from "./NetworkTransport";
+export const DEFAULT_HEADERS = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+};
 
-export { MongoDBRealmError } from "./MongoDBRealmError";
+export { MockApp } from "./MockApp";
+export { MockNetworkTransport } from "./MockNetworkTransport";
+export { MockTransport } from "./MockTransport";

--- a/packages/realm-web/src/transports/AppTransport.ts
+++ b/packages/realm-web/src/transports/AppTransport.ts
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { BaseTransport } from "./BaseTransport";
 import { PrefixedTransport } from "./PrefixedTransport";
 import { Transport, Request } from "./Transport";
 
@@ -27,7 +26,7 @@ export class AppTransport implements Transport {
     /**
      * The underlying transport used to issue requests.
      */
-    private readonly transport: BaseTransport;
+    private readonly transport: Transport;
 
     /**
      * The id of the app.
@@ -40,7 +39,7 @@ export class AppTransport implements Transport {
      * @param transport The base transport used to issue requests.
      * @param appId The id of the app.
      */
-    constructor(transport: BaseTransport, appId: string) {
+    constructor(transport: Transport, appId: string) {
         this.transport = transport;
         this.appId = appId;
     }

--- a/packages/realm-web/src/transports/AuthenticatedTransport.test.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.test.ts
@@ -19,7 +19,8 @@
 import { expect } from "chai";
 
 import { AuthenticatedTransport } from "./AuthenticatedTransport";
-import { MockTransport } from "../test/MockTransport";
+import { MockTransport } from "../test";
+import { User } from "../User";
 
 describe("AuthenticatedTransport", () => {
     it("constructs", () => {
@@ -32,7 +33,7 @@ describe("AuthenticatedTransport", () => {
     it("sends access token when requesting", async () => {
         const baseTransport = new MockTransport([{ foo: "bar" }]);
         const transport = new AuthenticatedTransport(baseTransport, {
-            currentUser: { accessToken: "my-access-token" } as Realm.User,
+            currentUser: { accessToken: "my-access-token" } as User,
         });
         // Send a request
         const response = await transport.fetch({
@@ -61,7 +62,7 @@ describe("AuthenticatedTransport", () => {
     it("allows overwriting headers", async () => {
         const baseTransport = new MockTransport([{}]);
         const transport = new AuthenticatedTransport(baseTransport, {
-            currentUser: { accessToken: "my-access-token" } as Realm.User,
+            currentUser: { accessToken: "my-access-token" } as User,
         });
         // Send a request
         await transport.fetch({
@@ -88,7 +89,7 @@ describe("AuthenticatedTransport", () => {
     it("returns an AuthenticatedTransport when prefixed", async () => {
         const baseTransport = new MockTransport([{}]);
         const transport = new AuthenticatedTransport(baseTransport, {
-            currentUser: { accessToken: "my-access-token" } as Realm.User,
+            currentUser: { accessToken: "my-access-token" } as User,
         });
         const prefixedTransport = transport.prefix("/prefixed-path");
         expect(prefixedTransport).to.be.instanceOf(AuthenticatedTransport);

--- a/packages/realm-web/src/transports/AuthenticatedTransport.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.ts
@@ -82,8 +82,7 @@ export class AuthenticatedTransport implements Transport {
                 user &&
                 retries === 0 &&
                 err instanceof MongoDBRealmError &&
-                err.statusCode === 401 &&
-                err.message.startsWith("invalid session")
+                err.statusCode === 401
             ) {
                 // Refresh the access token
                 await user.refreshAccessToken();

--- a/packages/realm-web/src/transports/AuthenticatedTransport.ts
+++ b/packages/realm-web/src/transports/AuthenticatedTransport.ts
@@ -16,7 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Transport, Request } from "./Transport";
+import { Transport, Request, MongoDBRealmError } from "./Transport";
+import { User } from "../User";
 
 /**
  * Used to control which user is currently active - this would most likely be the {App} instance.
@@ -25,7 +26,7 @@ interface UserContext {
     /**
      * The currently active user.
      */
-    currentUser: Realm.User<any, any> | null;
+    currentUser: User<any, any> | null;
 }
 
 /**
@@ -59,19 +60,38 @@ export class AuthenticatedTransport implements Transport {
      * @param request The request to issue towards the server.
      * @param user The user used when fetching, defaults to the `app.currentUser`.
      *             If `null`, the fetch will be unauthenticated.
+     * @param retries How many times was this request retried?
      * @returns A response from requesting with authentication.
      */
-    public fetch<RequestBody extends any, ResponseBody extends any>(
+    public async fetch<RequestBody extends any, ResponseBody extends any>(
         request: Request<RequestBody>,
-        user: Realm.User | null = this.userContext.currentUser,
+        user: User | null = this.userContext.currentUser,
+        retries = 0,
     ): Promise<ResponseBody> {
-        return this.transport.fetch({
-            ...request,
-            headers: {
-                ...this.buildAuthorizationHeader(user),
-                ...request.headers,
-            },
-        });
+        try {
+            // Awaiting to intercept errors being thrown
+            return await this.transport.fetch({
+                ...request,
+                headers: {
+                    ...this.buildAuthorizationHeader(user),
+                    ...request.headers,
+                },
+            });
+        } catch (err) {
+            if (
+                user &&
+                retries === 0 &&
+                err instanceof MongoDBRealmError &&
+                err.statusCode === 401 &&
+                err.message.startsWith("invalid session")
+            ) {
+                // Refresh the access token
+                await user.refreshAccessToken();
+                // Retry
+                return this.fetch(request, user, retries + 1);
+            }
+            throw err;
+        }
     }
 
     /** @inheritdoc */
@@ -86,7 +106,7 @@ export class AuthenticatedTransport implements Transport {
      * @param user An optional user to generate the header for
      * @returns An object containing with the users access token as authorization header or undefined if no user is given.
      */
-    private buildAuthorizationHeader(user: Realm.User | null) {
+    private buildAuthorizationHeader(user: User | null) {
         if (user) {
             // TODO: Ensure the access token is valid
             return {

--- a/packages/realm-web/src/transports/BaseTransport.ts
+++ b/packages/realm-web/src/transports/BaseTransport.ts
@@ -92,9 +92,10 @@ export class BaseTransport implements Transport {
     }
 
     /** @inheritdoc */
-    public async fetch<RequestBody extends any, ResponseBody extends any>(
-        request: BaseRequest<RequestBody>,
-    ): Promise<ResponseBody> {
+    public async fetch<
+        RequestBody extends any = any,
+        ResponseBody extends any = any
+    >(request: BaseRequest<RequestBody>): Promise<ResponseBody> {
         const {
             path,
             headers,

--- a/packages/realm-web/src/transports/Transport.ts
+++ b/packages/realm-web/src/transports/Transport.ts
@@ -16,7 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Method } from "realm-network-transport";
+import { Method, MongoDBRealmError } from "realm-network-transport";
+
+export { MongoDBRealmError };
 
 /**
  * A request to be sent via the transport.


### PR DESCRIPTION
## What, How & Why?

This fixes the first part of #2965 (refreshing tokens upon the first 401 response.

Note: This should be rebased on `v10` once the current base has been merged.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
