### PR TITLE
Correction to TS declaration for Realm.Object.toJSON

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Realm {
         /**
          * @returns An object for JSON serialization.
          */
-        toJSON(): object;
+        toJSON(): any;
 
         /**
          * @returns boolean


### PR DESCRIPTION
Correction to https://github.com/realm/realm-js/pull/2985.
Return type of `Realm.Object.toJSON` changed from `object` to `any`.