### PR TITLE
sendResetPasswordEmail() must parse arguments correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Failed to parse arguments correctly, causing the error `callback must be of type 'function', got (undefined)` when calling `Realm.App.emailPassword.sendResetPasswordEmail()` and `Realm.App.emailPassword.resendConfirmationEmail()`. ([#3037](https://github.com/realm/realm-js/issues/3037), since v10.0.0-beta.1)
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v11 (reads and upgrades file format v5 or later).
+
+### Internal
+* None.
+
 10.0.0-beta.8 Release notes (2020-7-07)
 =============================================================
 NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.

--- a/src/js_email_password_provider.hpp
+++ b/src/js_email_password_provider.hpp
@@ -108,7 +108,7 @@ void EmailPasswordProviderClientClass<T>::resend_confirmation_email(ContextType 
     auto& client = *get_internal<T, EmailPasswordProviderClientClass<T>>(ctx, this_object);
 
     auto email = Value::validated_to_string(ctx, args[0], "email");
-    auto callback = Value::validated_to_function(ctx, args[2], "callback");
+    auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
     client.resend_confirmation_email(email, make_callback_handler<T>(ctx, this_object, callback));
 }
@@ -120,7 +120,7 @@ void EmailPasswordProviderClientClass<T>::send_reset_password_email(ContextType 
     auto& client = *get_internal<T, EmailPasswordProviderClientClass<T>>(ctx, this_object);
 
     auto email = Value::validated_to_string(ctx, args[0], "email");
-    auto callback = Value::validated_to_function(ctx, args[2], "callback");
+    auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
     client.send_reset_password_email(email, make_callback_handler<T>(ctx, this_object, callback));
 }


### PR DESCRIPTION
## What, How & Why?

This closes #3037

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [ ] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
