### PR TITLE
JSON serialization of Realm.Object & Realm.Collection (incl. polished TS declarations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 
 ### Enhancements
 * Adding the possibility of passing a string argument when constructing an App. ([#3082](https://github.com/realm/realm-js/pull/3082))
+* `toJSON()` implemented for `Realm.Collection`, to return a nicer serializable Array. ([#3044](https://github.com/realm/realm-js/pull/3044))
+* `Realm.JsonSerializationReplacer` exposed as a replacer (for usage with `JSON.stringify`) to handle circular structures.([#3044](https://github.com/realm/realm-js/pull/3044))
+* TS: Stricter model validation for `create<T>(...)`. ([#3044](https://github.com/realm/realm-js/pull/3044))
 
 ### Fixed
 * Fixed a crash when calling `user.apiKeys.fetchAll()`. ([#3067](https://github.com/realm/realm-js/pull/3067))
@@ -14,6 +17,9 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * Fixed `Realm.Object` TS declaration to allow inheritance. ([#1226](https://github.com/realm/realm-js/issues/1226))
 * Fixed TS declaration for `CollectionChangeSet` in `CollectionChangeCallback` when adding a change listener to a collection ([#3093](https://github.com/realm/realm-js/pull/3093)).
 * Fixed an error Error: `Invalid arguments: 2 expected, but 1 supplied.` when calling `app.removeUser` [#3091](https://github.com/realm/realm-js/issues/3091)
+* `toJSON()` no longer throws `"RangeError: Maximum call stack size exceeded"` when a circular structure is encountered (applies for both `Realm.Object` & `Realm.Collection`). ([#3044](https://github.com/realm/realm-js/pull/3044))
+* TS: `objects<T>(...)` now sets return types reflecting underlying implementation. ([#3044](https://github.com/realm/realm-js/pull/3044))
+* TS: `_objectId()` added to TS declaration for `Realm.Object`. ([#3044](https://github.com/realm/realm-js/pull/3044))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/integration-tests/tests/src/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/dynamic-schema-updates.ts
@@ -18,11 +18,11 @@
 
 import { expect } from "chai";
 
-import { PersonAndDogSchema } from "./schemas/person-and-dogs";
+import { PersonSchema, DogSchema } from "./schemas/person-and-dogs";
 
 describe("realm._updateSchema", () => {
     it("is a function", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         expect(realm.schema).to.be.an("array");
         // There is a function defined on the Realm
         expect(realm._updateSchema).to.be.a("function");
@@ -33,7 +33,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("creates a class schema from a name", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         realm.write(() => {
             realm._updateSchema([
                 ...realm.schema,
@@ -45,7 +45,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("creates a class schema from a name and properties", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         realm.write(() => {
             realm._updateSchema([
                 ...realm.schema,
@@ -69,7 +69,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("creates a property on an existing class", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         // Copy the schema
         const updatedSchema = [...realm.schema];
         // Locate the Dog schema
@@ -121,7 +121,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("can use a newly added class", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         realm.write(() => {
             realm._updateSchema([
                 ...realm.schema,
@@ -135,7 +135,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("fires the schema change event", done => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         realm.addListener("schema", () => {
             expect(realm.schema).to.have.length(3);
             const objectSchemaNames = realm.schema.map(s => s.name);
@@ -152,7 +152,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("throws if creating a class schema outside of a transaction", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         expect(() => {
             realm._updateSchema([
                 ...realm.schema,
@@ -162,7 +162,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("throws if asked to create a class that already exists", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         expect(() => {
             realm.write(() => {
                 realm._updateSchema([
@@ -174,7 +174,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("throws if called without a schema object", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         expect(() => {
             realm.write(() => {
                 (realm as any)._updateSchema();
@@ -183,7 +183,7 @@ describe("realm._updateSchema", () => {
     });
 
     it("throws if called with an unexpected type", () => {
-        const realm = new Realm({ schema: PersonAndDogSchema });
+        const realm = new Realm({ schema: [PersonSchema, DogSchema] });
         expect(() => {
             realm.write(() => {
                 (realm as any)._updateSchema("w00t");

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -42,6 +42,7 @@ global.it.skipIf = skipIf;
 
 describe(global.title, () => {
     require("./realm-constructor");
+    require("./serialization");
     require("./objects");
     require("./iterators");
     require("./dynamic-schema-updates");

--- a/integration-tests/tests/src/iterators.ts
+++ b/integration-tests/tests/src/iterators.ts
@@ -19,18 +19,16 @@
 import { expect } from "chai";
 
 import {
-    Dog,
     DogSchema,
     IDog,
     IPerson,
-    Person,
     PersonSchema
 } from "./schemas/person-and-dogs";
 
 describe("Iterating", () => {
     let realm: Realm;
-    let dogs: { [name: string]: Dog };
-    let persons: { [name: string]: Person };
+    let dogs: { [name: string]: IDog };
+    let persons: { [name: string]: IPerson };
 
     beforeEach(() => {
         // Add linkingObjects to the PersonAndDogs schema
@@ -51,32 +49,32 @@ describe("Iterating", () => {
                 alice: realm.create<IPerson>("Person", {
                     name: "Alice",
                     age: 16
-                }) as Person,
+                }),
                 bob: realm.create<IPerson>("Person", {
                     name: "Bob",
                     age: 42
-                }) as Person,
+                }),
                 charlie: realm.create<IPerson>("Person", {
                     name: "Charlie",
                     age: 62
-                }) as Person
+                })
             };
             dogs = {
                 max: realm.create<IDog>("Dog", {
                     age: 1,
                     name: "Max",
                     owner: persons.alice
-                }) as Dog,
+                }),
                 rex: realm.create<IDog>("Dog", {
                     age: 3,
                     name: "Rex",
                     owner: persons.alice
-                }) as Dog,
+                }),
                 bobby: realm.create<IDog>("Dog", {
                     age: 5,
                     name: "Bobby",
                     owner: persons.bob
-                }) as Dog
+                })
             };
             // Make Bob and Charlie frieds
             persons.bob.friends.push(persons.charlie);

--- a/integration-tests/tests/src/realm-constructor.ts
+++ b/integration-tests/tests/src/realm-constructor.ts
@@ -18,7 +18,7 @@
 
 import { expect } from "chai";
 
-import { IPerson, PersonAndDogSchema } from "./schemas/person-and-dogs";
+import { IPerson, PersonSchema, DogSchema } from "./schemas/person-and-dogs";
 
 const RealmAsAny = Realm as any;
 
@@ -118,7 +118,7 @@ describe("Realm#constructor", () => {
             realm1.close();
             // Re-open with a different version
             const realm2 = new Realm({
-                schema: PersonAndDogSchema,
+                schema: [PersonSchema, DogSchema],
                 schemaVersion: 2
             });
             expect(realm2.schemaVersion).to.equal(2);
@@ -148,7 +148,7 @@ describe("Realm#constructor", () => {
     describe("re-opening without a schema", () => {
         it("has the same schema as before", () => {
             // Open the Realm with a schema
-            const realm = new Realm({ schema: PersonAndDogSchema });
+            const realm = new Realm({ schema: [PersonSchema, DogSchema] });
             realm.close();
             // Re-open it without a schema
             const reopenedRealm = new Realm();
@@ -297,7 +297,7 @@ describe("Realm#constructor", () => {
 describe("#deleteFile", () => {
     function expectDeletion(path?: string) {
         // Create the Realm with a schema
-        const realm = new Realm({ path, schema: PersonAndDogSchema });
+        const realm = new Realm({ path, schema: [PersonSchema, DogSchema] });
         realm.close();
         // Delete the Realm
         Realm.deleteFile({ path });

--- a/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
+++ b/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as Realm from "realm";
+import { ObjectId } from 'bson'
+
+export interface IPerson {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    friends: Realm.List<IPerson>;
+    dogs: Realm.Collection<IDog>;
+}
+
+export const PersonSchema: Realm.ObjectSchema = {
+    name: "Person",
+    primaryKey: "_id",
+    properties: {
+        _id: "objectId",
+        age: "int",
+        name: "string",
+        friends: "Person[]"
+    }
+};
+
+export class Person extends Realm.Object {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    friends: Realm.List<Person>;
+    dogs: Realm.Collection<Dog>;
+
+    static schema: Realm.ObjectSchema = PersonSchema;
+}
+
+export interface IDog {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    owner: IPerson;
+}
+
+export const DogSchema: Realm.ObjectSchema = {
+    name: "Dog",
+    primaryKey: "_id",
+    properties: {
+        _id: "objectId",
+        age: "int",
+        name: "string",
+        owner: "Person"
+    }
+};
+
+export class Dog extends Realm.Object {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    owner: Person;
+
+    static schema: Realm.ObjectSchema = DogSchema;
+}

--- a/integration-tests/tests/src/schemas/person-and-dogs.ts
+++ b/integration-tests/tests/src/schemas/person-and-dogs.ts
@@ -21,13 +21,9 @@ import * as Realm from "realm";
 export interface IPerson {
     name: string;
     age: number;
+    friends: Realm.List<IPerson>;
+    dogs: Realm.Collection<IDog>;
 }
-
-export type Person = {
-    friends: Realm.List<Person>;
-    dogs: Realm.Collection<Dog>;
-} & IPerson &
-    Realm.Object;
 
 export const PersonSchema: Realm.ObjectSchema = {
     name: "Person",
@@ -43,11 +39,6 @@ export interface IDog {
     age: number;
     owner: IPerson;
 }
-
-export type Dog = {
-    owner: Person;
-} & IDog &
-    Realm.Object;
 
 export const DogSchema: Realm.ObjectSchema = {
     name: "Dog",

--- a/integration-tests/tests/src/schemas/person-and-dogs.ts
+++ b/integration-tests/tests/src/schemas/person-and-dogs.ts
@@ -34,6 +34,22 @@ export const PersonSchema: Realm.ObjectSchema = {
     }
 };
 
+export class Person extends Realm.Object {
+    name: string;
+    age: number;
+    friends: Realm.List<Person>;
+    dogs: Realm.Collection<Dog>;
+
+    constructor(name: string, age: number) {
+      super();
+
+      this.name = name;
+      this.age = age;
+    }
+
+    static schema: Realm.ObjectSchema = PersonSchema;
+}
+
 export interface IDog {
     name: string;
     age: number;
@@ -49,4 +65,18 @@ export const DogSchema: Realm.ObjectSchema = {
     }
 };
 
-export const PersonAndDogSchema = [PersonSchema, DogSchema];
+export class Dog extends Realm.Object {
+    name: string;
+    age: number;
+    owner: Person;
+
+    constructor(name: string, age: number, owner: Person) {
+      super();
+
+      this.name = name;
+      this.age = age;
+      this.owner = owner;
+    }
+
+    static schema: Realm.ObjectSchema = DogSchema;
+}

--- a/integration-tests/tests/src/serialization.ts
+++ b/integration-tests/tests/src/serialization.ts
@@ -1,0 +1,89 @@
+import { expect } from "chai";
+
+import { IPerson, PersonSchema } from "./schemas/person-and-dogs";
+import * as expectedCircularStructure from "./structures/circular-result.json"
+
+describe("Serialization", () => {
+    it("JsonSerializationReplacer is exposed on the Realm constructor", () => {
+        expect(typeof Realm.JsonSerializationReplacer).equal('function');
+        expect(Realm.JsonSerializationReplacer.length).equal(2);
+    })
+
+    it("Realm.Object has 'toJSON' implemented", () => {
+        const realm = new Realm({ schema: [PersonSchema] });
+
+        let john!: IPerson & Realm.Object;
+
+        realm.write(() => {
+            john = realm.create<IPerson>("Person", {
+                name: "John Doe",
+                age: 42
+            });
+
+            john.friends.push(john)
+        });
+
+        expect(typeof john.toJSON).equals('function');
+        expect(john.toJSON().objectSchema).equals(undefined);
+        expect(john.toJSON().friends).instanceOf(Array);
+    });
+
+    it("Realm.Results (Collection) has 'toJSON' implemented", () => {
+        const realm = new Realm({ schema: [PersonSchema] });
+
+        let john!: IPerson & Realm.Object;
+
+        realm.write(() => {
+            john = realm.create<IPerson>("Person", {
+                name: "John Doe",
+                age: 42
+            });
+        });
+
+        const persons = realm.objects<IPerson>("Person");
+
+        expect(typeof persons.toJSON).equals('function');
+        expect(persons.toJSON()).instanceOf(Array);
+
+        const first = persons.toJSON()[0];
+        expect(first.objectSchema).equals(undefined);
+        expect(first.friends).instanceOf(Array);
+    });
+
+    it("Realm.Results can be serialized with circular references", () => {
+        const realm = new Realm({ schema: [PersonSchema] });
+
+        let john!: IPerson & Realm.Object;
+        let jane!: IPerson & Realm.Object;
+        let tony!: IPerson & Realm.Object;
+
+        realm.write(() => {
+            john = realm.create<IPerson>("Person", {
+                name: "John Doe",
+                age: 42
+            });
+            jane = realm.create<IPerson>("Person", {
+                name: "Jane Doe",
+                age: 40
+            });
+            tony = realm.create<IPerson>("Person", {
+                name: "Tony Doe",
+                age: 35
+            });
+
+            // ensure circular references
+            john.friends.push(jane);
+            john.friends.push(tony);
+
+            jane.friends.push(tony);
+            jane.friends.push(john);
+            
+            tony.friends.push(jane);
+        });
+
+        const persons = realm.objects<IPerson>("Person");
+
+        expect(JSON.stringify(persons, Realm.JsonSerializationReplacer))
+            .equal(JSON.stringify(expectedCircularStructure));
+    });
+});

--- a/integration-tests/tests/src/serialization.ts
+++ b/integration-tests/tests/src/serialization.ts
@@ -117,8 +117,8 @@ describe("JSON serialization", () => {
                 });
             
                 it("throws correct error on serialization", () => {
-                    expect(() => JSON.stringify(john)).throws(TypeError)
-                        .property("message", "Converting circular structure to JSON");
+                    expect(() => JSON.stringify(john))
+                        .throws(TypeError, /^Converting circular structure to JSON/);
                 });
         
                 it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
@@ -147,8 +147,8 @@ describe("JSON serialization", () => {
                 });
         
                 it("throws correct error on serialization", () => {
-                    expect(() => JSON.stringify(persons)).throws(TypeError)
-                        .property("message", "Converting circular structure to JSON");
+                    expect(() => JSON.stringify(persons))
+                        .throws(TypeError, /^Converting circular structure to JSON/);
                 });
         
                 it("serializes to expected output using Realm.JsonSerializationReplacer", () => {

--- a/integration-tests/tests/src/serialization.ts
+++ b/integration-tests/tests/src/serialization.ts
@@ -1,38 +1,91 @@
 import { expect } from "chai";
 
-import { IPerson, PersonSchema } from "./schemas/person-and-dogs";
+import { IPerson, PersonSchema, DogSchema, Person, Dog } from "./schemas/person-and-dogs";
 import * as circularCollectionResult from "./structures/circular-collection-result.json"
 
-const createRealmWithCircularStructure = () => {
-    const realm = new Realm({ schema: [PersonSchema] });
-
-    realm.write(() => {
-        const john = realm.create<IPerson>(PersonSchema.name, {
-            name: "John Doe",
-            age: 42,
-        });
-        const jane = realm.create<IPerson>(PersonSchema.name, {
-            name: "Jane Doe",
-            age: 40
-        });
-        const tony = realm.create<IPerson>(PersonSchema.name, {
-            name: "Tony Doe",
-            age: 35
-        });
-
-        // ensure circular references
-        john.friends.push(john);
-        john.friends.push(jane);
-        john.friends.push(tony);
-
-        jane.friends.push(tony);
-        jane.friends.push(john);
-        
-        tony.friends.push(jane);
-    });
-
-    return realm;
+type testSetup = {
+    name: string,
+    testData: () => { john: any, persons: Realm.Results<any> }
 };
+
+const testSetups: testSetup[] = [
+    {
+        name: "Object literal",
+        testData: () => {
+            const realm = new Realm({ schema: [PersonSchema, DogSchema] });
+        
+            realm.write(() => {
+                const john = realm.create<IPerson>(PersonSchema.name, {
+                    name: "John Doe",
+                    age: 42,
+                });
+                const jane = realm.create<IPerson>(PersonSchema.name, {
+                    name: "Jane Doe",
+                    age: 40
+                });
+                const tony = realm.create<IPerson>(PersonSchema.name, {
+                    name: "Tony Doe",
+                    age: 35
+                });
+        
+                // ensure circular references
+                john.friends.push(john);
+                john.friends.push(jane);
+                john.friends.push(tony);
+        
+                jane.friends.push(tony);
+                jane.friends.push(john);
+                
+                tony.friends.push(jane);
+            });
+        
+            const persons = realm.objects<IPerson>(PersonSchema.name);
+
+            return {
+                john: persons[0],
+                persons
+            };
+        },
+    },
+    {
+        name: "Class models",
+        testData: () => {
+            const realm = new Realm({ schema: [Person, Dog] });
+        
+            realm.write(() => {
+                const john = realm.create(Person, {
+                    name: "John Doe",
+                    age: 42
+                });
+                const jane = realm.create(Person, {
+                    name: "Jane Doe",
+                    age: 40,
+                });
+                const tony = realm.create(Person, {
+                    name: "Tony Doe",
+                    age: 35
+                });
+        
+                // ensure circular references
+                john.friends.push(john);
+                john.friends.push(jane);
+                john.friends.push(tony);
+        
+                jane.friends.push(tony);
+                jane.friends.push(john);
+                
+                tony.friends.push(jane);
+            });
+        
+            const persons = realm.objects(Person);
+
+            return {
+                john: persons[0],
+                persons
+            };
+        }
+    }
+];
 
 describe("JSON serialization", () => {
 
@@ -41,65 +94,68 @@ describe("JSON serialization", () => {
         expect(Realm.JsonSerializationReplacer.length).equal(2);
     });
 
-    describe("Realm.Object", () => {
-        let john!: IPerson & Realm.Object;
+    testSetups.forEach((testSetup) => {
+        describe(`Repeated test for "${testSetup.name}":`, () => {
 
-        beforeEach(() => {
-            const realm = createRealmWithCircularStructure();
-            john = realm.objects<IPerson>(PersonSchema.name)[0];
-        })
-
-        it("implements toJSON", () => {
-            expect(typeof john.toJSON).equals('function');
+            describe("Realm.Object", () => {
+                let john: any;
+        
+                beforeEach(() => {
+                    john = testSetup.testData().john;
+                })
+        
+                it("implements toJSON", () => {
+                    expect(typeof john.toJSON).equals('function');
+                });
+        
+                it("toJSON returns a circular structure", () => {
+                    const serializable = john.toJSON();
+        
+                    expect(serializable.objectSchema).equals(undefined);
+                    expect(serializable.friends).instanceOf(Array);
+                    expect(serializable).equal(serializable.friends[0]);
+                });
+            
+                it("throws correct error on serialization", () => {
+                    expect(() => JSON.stringify(john)).throws(TypeError)
+                        .property("message", "Converting circular structure to JSON");
+                });
+        
+                it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
+                    expect(JSON.stringify(john, Realm.JsonSerializationReplacer))
+                        .equals(JSON.stringify(circularCollectionResult[0]));
+                })
+            });
+        
+            describe("Realm.Results", () => {
+                let persons!: Realm.Results<any>;
+        
+                beforeEach(() => {
+                    persons = testSetup.testData().persons;
+                })
+        
+                it("implements toJSON", () => {
+                    expect(typeof persons.toJSON).equals('function');
+                });
+        
+                it("toJSON returns a circular structure", () => {
+                    const serializable = persons.toJSON();
+        
+                    expect(serializable).instanceOf(Array);
+                    expect(serializable[0].friends).instanceOf(Array);
+                    expect(serializable[0]).equal(serializable[0].friends[0]);
+                });
+        
+                it("throws correct error on serialization", () => {
+                    expect(() => JSON.stringify(persons)).throws(TypeError)
+                        .property("message", "Converting circular structure to JSON");
+                });
+        
+                it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
+                    expect(JSON.stringify(persons, Realm.JsonSerializationReplacer))
+                        .equal(JSON.stringify(circularCollectionResult));
+                })
+            });
         });
-
-        it("toJSON returns a circular structure", () => {
-            const serializable = john.toJSON();
-
-            expect(serializable.objectSchema).equals(undefined);
-            expect(serializable.friends).instanceOf(Array);
-            expect(serializable).equal(serializable.friends[0]);
-        });
-    
-        it("throws correct error on serialization", () => {
-            expect(() => JSON.stringify(john)).throws(TypeError)
-                .property("message", "Converting circular structure to JSON");
-        });
-
-        it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
-            expect(JSON.stringify(john, Realm.JsonSerializationReplacer))
-                .equals(JSON.stringify(circularCollectionResult[0]));
-        })
-    });
-
-    describe("Realm.Results", () => {
-        let persons!: Realm.Results<IPerson & Realm.Object>;
-
-        beforeEach(() => {
-            const realm = createRealmWithCircularStructure();
-            persons = realm.objects<IPerson>(PersonSchema.name);
-        })
-
-        it("implements toJSON", () => {
-            expect(typeof persons.toJSON).equals('function');
-        });
-
-        it("toJSON returns a circular structure", () => {
-            const serializable = persons.toJSON();
-
-            expect(serializable).instanceOf(Array);
-            expect(serializable[0].friends).instanceOf(Array);
-            expect(serializable[0]).equal(serializable[0].friends[0]);
-        });
-
-        it("throws correct error on serialization", () => {
-            expect(() => JSON.stringify(persons)).throws(TypeError)
-                .property("message", "Converting circular structure to JSON");
-        });
-
-        it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
-            expect(JSON.stringify(persons, Realm.JsonSerializationReplacer))
-                .equal(JSON.stringify(circularCollectionResult));
-        })
     });
 });

--- a/integration-tests/tests/src/structures/circular-collection-result-with-object-ids.json
+++ b/integration-tests/tests/src/structures/circular-collection-result-with-object-ids.json
@@ -1,0 +1,125 @@
+[
+  {
+    "_id": "5f086d00ddf69c48082eb63b",
+    "age": 42,
+    "name": "John Doe",
+    "friends": [
+      {
+        "$ref": "5f086d00ddf69c48082eb63b"
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63d",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "_id": "5f086d00ddf69c48082eb63f",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              }
+            ]
+          },
+          {
+            "$ref": "5f086d00ddf69c48082eb63b"
+          }
+        ]
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63f",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "_id": "5f086d00ddf69c48082eb63d",
+            "age": 40,
+            "name": "Jane Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63f"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63b"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "5f086d00ddf69c48082eb63d",
+    "age": 40,
+    "name": "Jane Doe",
+    "friends": [
+      {
+        "_id": "5f086d00ddf69c48082eb63f",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63d"
+          }
+        ]
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63b",
+        "age": 42,
+        "name": "John Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63b"
+          },
+          {
+            "$ref": "5f086d00ddf69c48082eb63d"
+          },
+          {
+            "_id": "5f086d00ddf69c48082eb63f",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "5f086d00ddf69c48082eb63f",
+    "age": 35,
+    "name": "Tony Doe",
+    "friends": [
+      {
+        "_id": "5f086d00ddf69c48082eb63d",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63f"
+          },
+          {
+            "_id": "5f086d00ddf69c48082eb63b",
+            "age": 42,
+            "name": "John Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63b"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63f"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/integration-tests/tests/src/structures/circular-collection-result.json
+++ b/integration-tests/tests/src/structures/circular-collection-result.json
@@ -5,6 +5,9 @@
     "name": "John Doe",
     "friends": [
       {
+        "$ref": "Person{0000-0000}"
+      },
+      {
         "$refId": "Person{0000-0001}",
         "age": 40,
         "name": "Jane Doe",
@@ -67,6 +70,9 @@
         "name": "John Doe",
         "friends": [
           {
+            "$ref": "Person{0000-0000}"
+          },
+          {
             "$ref": "Person{0000-0001}"
           },
           {
@@ -101,6 +107,9 @@
             "age": 42,
             "name": "John Doe",
             "friends": [
+              {
+                "$ref": "Person{0000-0000}"
+              },
               {
                 "$ref": "Person{0000-0001}"
               },

--- a/integration-tests/tests/src/structures/circular-result.json
+++ b/integration-tests/tests/src/structures/circular-result.json
@@ -1,44 +1,44 @@
 [
   {
-    "$refId": "{0000-0000}",
+    "$refId": "Person{0000-0000}",
     "age": 42,
     "name": "John Doe",
     "friends": [
       {
-        "$refId": "{0000-0001}",
+        "$refId": "Person{0000-0001}",
         "age": 40,
         "name": "Jane Doe",
         "friends": [
           {
-            "$refId": "{0000-0002}",
+            "$refId": "Person{0000-0002}",
             "age": 35,
             "name": "Tony Doe",
             "friends": [
               {
-                "$ref": "{0000-0001}"
+                "$ref": "Person{0000-0001}"
               }
             ]
           },
           {
-            "$ref": "{0000-0000}"
+            "$ref": "Person{0000-0000}"
           }
         ]
       },
       {
-        "$refId": "{0000-0002}",
+        "$refId": "Person{0000-0002}",
         "age": 35,
         "name": "Tony Doe",
         "friends": [
           {
-            "$refId": "{0000-0001}",
+            "$refId": "Person{0000-0001}",
             "age": 40,
             "name": "Jane Doe",
             "friends": [
               {
-                "$ref": "{0000-0002}"
+                "$ref": "Person{0000-0002}"
               },
               {
-                "$ref": "{0000-0000}"
+                "$ref": "Person{0000-0000}"
               }
             ]
           }
@@ -47,35 +47,35 @@
     ]
   },
   {
-    "$refId": "{0000-0001}",
+    "$refId": "Person{0000-0001}",
     "age": 40,
     "name": "Jane Doe",
     "friends": [
       {
-        "$refId": "{0000-0002}",
+        "$refId": "Person{0000-0002}",
         "age": 35,
         "name": "Tony Doe",
         "friends": [
           {
-            "$ref": "{0000-0001}"
+            "$ref": "Person{0000-0001}"
           }
         ]
       },
       {
-        "$refId": "{0000-0000}",
+        "$refId": "Person{0000-0000}",
         "age": 42,
         "name": "John Doe",
         "friends": [
           {
-            "$ref": "{0000-0001}"
+            "$ref": "Person{0000-0001}"
           },
           {
-            "$refId": "{0000-0002}",
+            "$refId": "Person{0000-0002}",
             "age": 35,
             "name": "Tony Doe",
             "friends": [
               {
-                "$ref": "{0000-0001}"
+                "$ref": "Person{0000-0001}"
               }
             ]
           }
@@ -84,28 +84,28 @@
     ]
   },
   {
-    "$refId": "{0000-0002}",
+    "$refId": "Person{0000-0002}",
     "age": 35,
     "name": "Tony Doe",
     "friends": [
       {
-        "$refId": "{0000-0001}",
+        "$refId": "Person{0000-0001}",
         "age": 40,
         "name": "Jane Doe",
         "friends": [
           {
-            "$ref": "{0000-0002}"
+            "$ref": "Person{0000-0002}"
           },
           {
-            "$refId": "{0000-0000}",
+            "$refId": "Person{0000-0000}",
             "age": 42,
             "name": "John Doe",
             "friends": [
               {
-                "$ref": "{0000-0001}"
+                "$ref": "Person{0000-0001}"
               },
               {
-                "$ref": "{0000-0002}"
+                "$ref": "Person{0000-0002}"
               }
             ]
           }

--- a/integration-tests/tests/src/structures/circular-result.json
+++ b/integration-tests/tests/src/structures/circular-result.json
@@ -1,0 +1,116 @@
+[
+  {
+    "$realmId": "{0000-0000}",
+    "age": 42,
+    "name": "John Doe",
+    "friends": [
+      {
+        "$realmId": "{0000-0001}",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "$realmId": "{0000-0002}",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "{0000-0001}"
+              }
+            ]
+          },
+          {
+            "$ref": "{0000-0000}"
+          }
+        ]
+      },
+      {
+        "$realmId": "{0000-0002}",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "$realmId": "{0000-0001}",
+            "age": 40,
+            "name": "Jane Doe",
+            "friends": [
+              {
+                "$ref": "{0000-0002}"
+              },
+              {
+                "$ref": "{0000-0000}"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "$realmId": "{0000-0001}",
+    "age": 40,
+    "name": "Jane Doe",
+    "friends": [
+      {
+        "$realmId": "{0000-0002}",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "$ref": "{0000-0001}"
+          }
+        ]
+      },
+      {
+        "$realmId": "{0000-0000}",
+        "age": 42,
+        "name": "John Doe",
+        "friends": [
+          {
+            "$ref": "{0000-0001}"
+          },
+          {
+            "$realmId": "{0000-0002}",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "{0000-0001}"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "$realmId": "{0000-0002}",
+    "age": 35,
+    "name": "Tony Doe",
+    "friends": [
+      {
+        "$realmId": "{0000-0001}",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "$ref": "{0000-0002}"
+          },
+          {
+            "$realmId": "{0000-0000}",
+            "age": 42,
+            "name": "John Doe",
+            "friends": [
+              {
+                "$ref": "{0000-0001}"
+              },
+              {
+                "$ref": "{0000-0002}"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/integration-tests/tests/src/structures/circular-result.json
+++ b/integration-tests/tests/src/structures/circular-result.json
@@ -1,16 +1,16 @@
 [
   {
-    "$realmId": "{0000-0000}",
+    "$refId": "{0000-0000}",
     "age": 42,
     "name": "John Doe",
     "friends": [
       {
-        "$realmId": "{0000-0001}",
+        "$refId": "{0000-0001}",
         "age": 40,
         "name": "Jane Doe",
         "friends": [
           {
-            "$realmId": "{0000-0002}",
+            "$refId": "{0000-0002}",
             "age": 35,
             "name": "Tony Doe",
             "friends": [
@@ -25,12 +25,12 @@
         ]
       },
       {
-        "$realmId": "{0000-0002}",
+        "$refId": "{0000-0002}",
         "age": 35,
         "name": "Tony Doe",
         "friends": [
           {
-            "$realmId": "{0000-0001}",
+            "$refId": "{0000-0001}",
             "age": 40,
             "name": "Jane Doe",
             "friends": [
@@ -47,12 +47,12 @@
     ]
   },
   {
-    "$realmId": "{0000-0001}",
+    "$refId": "{0000-0001}",
     "age": 40,
     "name": "Jane Doe",
     "friends": [
       {
-        "$realmId": "{0000-0002}",
+        "$refId": "{0000-0002}",
         "age": 35,
         "name": "Tony Doe",
         "friends": [
@@ -62,7 +62,7 @@
         ]
       },
       {
-        "$realmId": "{0000-0000}",
+        "$refId": "{0000-0000}",
         "age": 42,
         "name": "John Doe",
         "friends": [
@@ -70,7 +70,7 @@
             "$ref": "{0000-0001}"
           },
           {
-            "$realmId": "{0000-0002}",
+            "$refId": "{0000-0002}",
             "age": 35,
             "name": "Tony Doe",
             "friends": [
@@ -84,12 +84,12 @@
     ]
   },
   {
-    "$realmId": "{0000-0002}",
+    "$refId": "{0000-0002}",
     "age": 35,
     "name": "Tony Doe",
     "friends": [
       {
-        "$realmId": "{0000-0001}",
+        "$refId": "{0000-0001}",
         "age": 40,
         "name": "Jane Doe",
         "friends": [
@@ -97,7 +97,7 @@
             "$ref": "{0000-0002}"
           },
           {
-            "$realmId": "{0000-0000}",
+            "$refId": "{0000-0000}",
             "age": 42,
             "name": "John Doe",
             "friends": [

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -33,10 +33,14 @@ declare namespace Mocha {
     }
 }
 
-
 interface Console {
     error(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
 }
 
 declare var console: Console;
+// allow import of json files
+declare module "*.json" {
+  const value: any;
+  export = value;
+}

--- a/integration-tests/tests/tsconfig.json
+++ b/integration-tests/tests/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "es2018",
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"resolveJsonModule": true,
 		"outDir": "dist",
 		"types": [
 			"node",

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -493,16 +493,16 @@ module.exports = function(realmConstructor, context) {
                 if (seen.length > 0) {
                     const pos = seen.indexOf(parent);
                     if (pos !== -1) {
-                        seen.splice(pos + 1)
+                        seen.splice(pos + 1);
                     } else {
-                        seen.push(parent)
+                        seen.push(parent);
                     }
 
                     if (seen.includes(value)) {
                         return value.$realmId ? { $ref: value.$realmId } : "[Circular reference]";
                     }
                 } else {
-                    seen.push(value)
+                    seen.push(value);
                 }
 
                 return value;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -100,17 +100,17 @@ module.exports = function(realmConstructor, context) {
                 return existing;
             }
 
-            // create new result, and store in cache
-            const result = { $realmId: id };
+            const result = {};
             cache.set(id, result);
 
-            const moveAsSerializable = (cache, key, from, to) => {
-                // TODO: check that we're dealing with a Realm type, before passing in cache?
-                to[key] = from[key].toJSON ? from[key].toJSON(undefined, cache) : this[key];
-            };
+            Object.defineProperty(result, "$refId", { value: id, configurable: true });
 
-            Object.keys(this).forEach(k => moveAsSerializable(cache, k, this, result));
-            Object.keys(Object.getPrototypeOf(this)).forEach(k => moveAsSerializable(cache, k, this, result));
+            Object.keys(this)
+                .concat(Object.keys(Object.getPrototypeOf(this)))
+                .forEach(k => {
+                    // TODO: check that we're dealing with a Realm type, before passing in cache?
+                    result[k] = this[k].toJSON ? this[k].toJSON(undefined, cache) : this[k];
+                });
 
             return result;
         },
@@ -485,12 +485,19 @@ module.exports = function(realmConstructor, context) {
             const seen = [];
 
             return function(_, value) {
-                if (typeof value !== "object") {
+                if (value === null || typeof value !== "object") {
                     return value;
                 }
 
                 const parent = this;
-                if (seen.length > 0) {
+
+                if (value.$refId) {
+                    Object.defineProperty(value, "$refId", { enumerable: true })
+                }
+
+                if (!seen.length) {
+                    seen.push(value);
+                } else {
                     const pos = seen.indexOf(parent);
                     if (pos !== -1) {
                         seen.splice(pos + 1);
@@ -499,14 +506,12 @@ module.exports = function(realmConstructor, context) {
                     }
 
                     if (seen.includes(value)) {
-                        return value.$realmId ? { $ref: value.$realmId } : "[Circular reference]";
+                        return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
                     }
-                } else {
-                    seen.push(value);
                 }
 
                 return value;
-            }
+            };
         }
-    })
-}
+    });
+};

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -91,7 +91,7 @@ module.exports = function(realmConstructor, context) {
     });
 
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
-        value: function (key, cache = new Map()) {
+        value: function (_, cache = new Map()) {
             // Construct a reference-id of table-name & objectId
             const id = this.constructor.name + this._objectId();
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -94,17 +94,20 @@ module.exports = function(realmConstructor, context) {
         value: function (key, cache = new Map()) {
             const id = this._objectId();
 
-            // check if currect objectId has already matched
+            // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);
             if (existing) {
                 return existing;
             }
 
+            // Create new result, and store in cache.
             const result = {};
             cache.set(id, result);
 
+            // Add '_objectId' as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
             Object.defineProperty(result, "$refId", { value: id, configurable: true });
 
+            // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
             Object.keys(this)
                 .concat(Object.keys(Object.getPrototypeOf(this)))
                 .forEach(k => {
@@ -485,27 +488,36 @@ module.exports = function(realmConstructor, context) {
             const seen = [];
 
             return function(_, value) {
+                // Only check for circular references when dealing with objects & arrays.
                 if (value === null || typeof value !== "object") {
                     return value;
                 }
 
+                // 'this' refers to the object or array containing the the current key/value.
                 const parent = this;
 
+                // Expose the non-enumerable prop $refId for circular serialization, if it exists.
                 if (value.$refId) {
                     Object.defineProperty(value, "$refId", { enumerable: true })
                 }
 
                 if (!seen.length) {
+                    // If we haven't seen anything yet, we push the current value (root element/array).
                     seen.push(value);
                 } else {
                     const pos = seen.indexOf(parent);
                     if (pos !== -1) {
+                        // If we have seen the parent before, we have already traversed a sibling in the array.
+                        // We then discard information gathered for the sibling (zero back to the current array).
                         seen.splice(pos + 1);
                     } else {
+                        // If we haven't seen the parent before, we add it to the seen-path.
+                        // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
                         seen.push(parent);
                     }
 
                     if (seen.includes(value)) {
+                        // If we have seen the current value before, return a reference-structure if possible.
                         return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
                     }
                 }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -497,30 +497,31 @@ module.exports = function(realmConstructor, context) {
                 // 'this' refers to the object or array containing the the current key/value.
                 const parent = this;
 
-                // Expose the non-enumerable prop $refId for circular serialization, if it exists.
                 if (value.$refId) {
+                    // Expose the non-enumerable prop $refId for circular serialization, if it exists.
                     Object.defineProperty(value, "$refId", { enumerable: true })
                 }
 
                 if (!seen.length) {
-                    // If we haven't seen anything yet, we push the current value (root element/array).
+                    // If we haven't seen anything yet, we only push the current value (root element/array).
                     seen.push(value);
-                } else {
-                    const pos = seen.indexOf(parent);
-                    if (pos !== -1) {
-                        // If we have seen the parent before, we have already traversed a sibling in the array.
-                        // We then discard information gathered for the sibling (zero back to the current array).
-                        seen.splice(pos + 1);
-                    } else {
-                        // If we haven't seen the parent before, we add it to the seen-path.
-                        // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
-                        seen.push(parent);
-                    }
+                    return value;
+                }
 
-                    if (seen.includes(value)) {
-                        // If we have seen the current value before, return a reference-structure if possible.
-                        return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
-                    }
+                const pos = seen.indexOf(parent);
+                if (pos !== -1) {
+                    // If we have seen the parent before, we have already traversed a sibling in the array.
+                    // We then discard information gathered for the sibling (zero back to the current array).
+                    seen.splice(pos + 1);
+                } else {
+                    // If we haven't seen the parent before, we add it to the seen-path.
+                    // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
+                    seen.push(parent);
+                }
+
+                if (seen.includes(value)) {
+                    // If we have seen the current value before, return a reference-structure if possible.
+                    return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
                 }
 
                 return value;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -82,7 +82,8 @@ module.exports = function(realmConstructor, context) {
 
     Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
-            return this.map((item, index) => item.toJSON ? item.toJSON(index.toString(), cache) : item);
+            return this.map((item, index) =>
+                item instanceof realmConstructor.Object ? item.toJSON(index.toString(), cache) : item);
         },
 
         writable: true,
@@ -112,8 +113,10 @@ module.exports = function(realmConstructor, context) {
             Object.keys(this)
                 .concat(Object.keys(Object.getPrototypeOf(this)))
                 .forEach(key => {
-                    // TODO: check that we're dealing with a Realm type, before passing in cache?
-                    result[key] = this[key].toJSON ? this[key].toJSON(key, cache) : this[key];
+                    const value = this[key];
+                    result[key] = value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection
+                        ? value.toJSON(key, cache)
+                        : value;
                 });
 
             return result;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -91,10 +91,23 @@ module.exports = function(realmConstructor, context) {
         enumerable: false
     });
 
+    const serializedPrimaryKeyValue = (value) => {
+        if (value.toJSON) {
+          return value.toJSON();
+        }
+        if (value.toString) {
+          return value.toString();
+        }
+        return value;
+    }
+
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
-            // Construct a reference-id of table-name & objectId
-            const id = this.constructor.name + this._objectId();
+            // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
+            const primaryKey = this.objectSchema().primaryKey;
+            const id = primaryKey 
+                ? serializedPrimaryKeyValue(this[primaryKey])
+                 : this.constructor.name + this._objectId();
 
             // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);
@@ -106,8 +119,13 @@ module.exports = function(realmConstructor, context) {
             const result = {};
             cache.set(id, result);
 
-            // Add the generated reference-id as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
-            Object.defineProperty(result, "$refId", { value: id, configurable: true });
+            if (primaryKey) {
+                // Expose the key holding the primaryKey, as a non-enumerable prop, checkable at serialization.
+                Object.defineProperty(result, "_primaryKeyProp", { value: primaryKey });
+            } else {
+                // Add the generated reference-id, as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
+                Object.defineProperty(result, "$refId", { value: id, configurable: true });
+            }
 
             // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
             Object.keys(this)
@@ -524,7 +542,13 @@ module.exports = function(realmConstructor, context) {
 
                 if (seen.includes(value)) {
                     // If we have seen the current value before, return a reference-structure if possible.
-                    return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
+                    if (value._primaryKeyProp) {
+                      return { $ref: value[value._primaryKeyProp] };
+                    }
+                    if (value.$refId) {
+                      return { $ref: value.$refId };
+                    }
+                    return "[Circular reference]";
                 }
 
                 return value;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -479,4 +479,28 @@ module.exports = function(realmConstructor, context) {
         },
         configurable: true
     });
+
+    Object.defineProperty(realmConstructor, "JsonSerializationReplacer", {
+        get: function () {
+            const seen = [];
+
+            return function(_, value) {
+                if (seen.length > 0) {
+                    const pos = seen.indexOf(this);
+                    if (pos !== -1) {
+                        seen.splice(pos + 1)
+                    } else {
+                        seen.push(this)
+                    }
+                    if (seen.includes(value)) {
+                        return value.$realmId ? { $ref: value.$realmId } : "[Circular reference]";
+                    }
+                } else {
+                    seen.push(value)
+                }
+
+                return value;
+            }
+        }
+    })
 }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -80,37 +80,39 @@ module.exports = function(realmConstructor, context) {
     const { DefaultNetworkTransport } = require('realm-network-transport');
     realmConstructor._networkTransport = new DefaultNetworkTransport();
 
+    Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
+        value: function (key, cache = new Map()) {
+            return this.map(item => item.toJSON(key, cache));
+        },
+
+        writable: true,
+        configurable: true,
+        enumerable: false
+    });
+
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
-        value: function () {
-            const result = {}
-            Object.keys(this).forEach(p => result[p] = this[p]);
-            Object.keys(Object.getPrototypeOf(this)).forEach(p => result[p] = this[p]);
-            return result;
-        },
+        value: function (key, cache = new Map()) {
+            const id = this._objectId();
 
-        writable: true,
-        configurable: true,
-        enumerable: false
-    });
-
-    Object.defineProperty(realmConstructor.Object.prototype, "keys", {
-        value: function () {
-            return Object.keys(this).concat(Object.keys(Object.getPrototypeOf(this)));
-        },
-
-        writable: true,
-        configurable: true,
-        enumerable: false
-    });
-
-    Object.defineProperty(realmConstructor.Object.prototype, "entries", {
-        value: function () {
-            let result = {};
-            for (const key in this) {
-                result[key] = this[key];
+            // check if currect objectId has already matched
+            const existing = cache.get(id);
+            if (existing) {
+                return existing;
             }
 
-            return Object.entries(result);
+            // create new result, and store in cache
+            const result = { $realmId: id };
+            cache.set(id, result);
+
+            const moveAsSerializable = (cache, key, from, to) => {
+                // TODO: check that we're dealing with a Realm type, before passing in cache?
+                to[key] = from[key].toJSON ? from[key].toJSON(undefined, cache) : this[key];
+            };
+
+            Object.keys(this).forEach(k => moveAsSerializable(cache, k, this, result));
+            Object.keys(Object.getPrototypeOf(this)).forEach(k => moveAsSerializable(cache, k, this, result));
+
+            return result;
         },
 
         writable: true,

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -92,7 +92,8 @@ module.exports = function(realmConstructor, context) {
 
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
         value: function (key, cache = new Map()) {
-            const id = this._objectId();
+            // Construct a reference-id of table-name & objectId
+            const id = this.constructor.name + this._objectId();
 
             // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);
@@ -104,7 +105,7 @@ module.exports = function(realmConstructor, context) {
             const result = {};
             cache.set(id, result);
 
-            // Add '_objectId' as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
+            // Add the generated reference-id as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
             Object.defineProperty(result, "$refId", { value: id, configurable: true });
 
             // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -485,13 +485,19 @@ module.exports = function(realmConstructor, context) {
             const seen = [];
 
             return function(_, value) {
+                if (typeof value !== "object") {
+                    return value;
+                }
+
+                const parent = this;
                 if (seen.length > 0) {
-                    const pos = seen.indexOf(this);
+                    const pos = seen.indexOf(parent);
                     if (pos !== -1) {
                         seen.splice(pos + 1)
                     } else {
-                        seen.push(this)
+                        seen.push(parent)
                     }
+
                     if (seen.includes(value)) {
                         return value.$realmId ? { $ref: value.$realmId } : "[Circular reference]";
                     }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -82,7 +82,7 @@ module.exports = function(realmConstructor, context) {
 
     Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
-            return this.map((item, index) => item.toJSON(index.toString(), cache));
+            return this.map((item, index) => item.toJSON ? item.toJSON(index.toString(), cache) : item);
         },
 
         writable: true,

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -81,8 +81,8 @@ module.exports = function(realmConstructor, context) {
     realmConstructor._networkTransport = new DefaultNetworkTransport();
 
     Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
-        value: function (key, cache = new Map()) {
-            return this.map(item => item.toJSON(key, cache));
+        value: function (_, cache = new Map()) {
+            return this.map((item, index) => item.toJSON(index.toString(), cache));
         },
 
         writable: true,
@@ -111,9 +111,9 @@ module.exports = function(realmConstructor, context) {
             // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
             Object.keys(this)
                 .concat(Object.keys(Object.getPrototypeOf(this)))
-                .forEach(k => {
+                .forEach(key => {
                     // TODO: check that we're dealing with a Realm type, before passing in cache?
-                    result[k] = this[k].toJSON ? this[k].toJSON(undefined, cache) : this[k];
+                    result[key] = this[key].toJSON ? this[key].toJSON(key, cache) : this[key];
                 });
 
             return result;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -201,6 +201,12 @@ declare namespace Realm {
     }
 
     /**
+     * RealmJsonSerializeReplacer solves circular structures when serializing Realm entities
+     * @example JSON.stringify(realm.objects("Person"), Realm.RealmJsonSerializeReplacer)
+     */
+    const JsonSerializationReplacer: (key: string, val: any) => any;
+
+    /**
      * SortDescriptor
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Collection.html#~SortDescriptor }
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -185,6 +185,11 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
+<<<<<<< HEAD
+=======
+        _objectId(): string;
+
+>>>>>>> a2aadfa3... Realm.Object TS declaration for objectId() changed to _objectId().
         /**
          * @returns void
          */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -430,6 +430,14 @@ interface ProgressPromise extends Promise<Realm> {
     progress(callback: Realm.ProgressNotificationCallback): Promise<Realm>;
 }
 
+type ExtractPropertyNamesOfType<T, S> = {
+    [K in keyof T]: T[K] extends S ? K : never
+}[keyof T];
+
+type RealmPartialModel<T> =
+    Omit<T, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>
+    & Partial<Pick<T, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>>
+
 declare class Realm {
     static defaultPath: string;
 
@@ -508,7 +516,7 @@ declare class Realm {
      *
      * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
      */
-    create<T>(type: string | Realm.ObjectClass | Function, properties: T | Realm.ObjectPropsType, update?: boolean): T;
+    create<T>(type: string | Realm.ObjectClass | Function, properties: RealmPartialModel<T>, update?: boolean): T & Realm.Object
 
     /**
      * @param  {string|Realm.ObjectClass|Function} type
@@ -516,7 +524,7 @@ declare class Realm {
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T
      */
-    create<T>(type: string | Realm.ObjectClass | Function, properties: T | Realm.ObjectPropsType, mode?: Realm.UpdateMode): T;
+    create<T>(type: string | Realm.ObjectClass | Function, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -451,7 +451,7 @@ type ExtractPropertyNamesOfType<T, S> = {
 }[keyof T];
 
 type RealmPartialModel<T> =
-    Omit<T, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>
+    Omit<Omit<T, keyof Realm.Object>, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>
     & Partial<Pick<T, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>>
 
 declare class Realm {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -185,11 +185,8 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
-<<<<<<< HEAD
-=======
         _objectId(): string;
 
->>>>>>> a2aadfa3... Realm.Object TS declaration for objectId() changed to _objectId().
         /**
          * @returns void
          */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -525,22 +525,40 @@ declare class Realm {
     close(): void;
 
     /**
-     * @param  {string|Realm.ObjectClass|Function} type
-     * @param  {T&Realm.ObjectPropsType} properties
+     * @param  {string} type
+     * @param  {T} properties
+     * @param  {boolean} update?
+     * @returns T & Realm.Object
+     *
+     * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
+     */
+    create<T>(type: string, properties: RealmPartialModel<T>, update?: boolean): T & Realm.Object
+
+    /**
+     * @param  {Class} type
+     * @param  {T} properties
      * @param  {boolean} update?
      * @returns T
      *
      * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
      */
-    create<T>(type: string | Realm.ObjectClass | Function, properties: RealmPartialModel<T>, update?: boolean): T & Realm.Object
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmPartialModel<T>, update?: boolean): T
 
     /**
-     * @param  {string|Realm.ObjectClass|Function} type
-     * @param  {T&Realm.ObjectPropsType} properties
+     * @param  {string} type
+     * @param  {T} properties
+     * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
+     * @returns T & Realm.Object
+     */
+    create<T>(type: string, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
+
+    /**
+     * @param  {Class} type
+     * @param  {T} properties
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T
      */
-    create<T>(type: string | Realm.ObjectClass | Function, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object
@@ -566,10 +584,16 @@ declare class Realm {
     objectForPrimaryKey<T>(type: string | Realm.ObjectType | Function, key: number | string | Realm.ObjectId): T & Realm.Object | undefined;
 
     /**
-     * @param  {string|Realm.ObjectType|Function} type
-     * @returns Realm
+     * @param  {string} type
+     * @returns Realm.Results<T & Realm.Object>
      */
-    objects<T>(type: string | Realm.ObjectType | Function): Realm.Results<T & Realm.Object>;
+    objects<T>(type: string): Realm.Results<T & Realm.Object>;
+
+    /**
+     * @param  {Class} type
+     * @returns Realm.Results<T>
+     */
+    objects<T extends Realm.Object>(type: {new(...arg: any[]): T; }): Realm.Results<T>;
 
     /**
      * @param  {string} name

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -214,6 +214,11 @@ declare namespace Realm {
         readonly type: PropertyType;
         readonly optional: boolean;
 
+        /**
+         * @returns An object for JSON serialization.
+         */
+        toJSON(): Array<any>;
+
         description(): string;
 
         /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -442,14 +442,28 @@ interface ProgressPromise extends Promise<Realm> {
     cancel(): void;
     progress(callback: Realm.ProgressNotificationCallback): Promise<Realm>;
 }
-
-type ExtractPropertyNamesOfType<T, S> = {
-    [K in keyof T]: T[K] extends S ? K : never
+/**
+ * Extracts an intersection of keys from T, where the value extends the given PropType.
+ */
+type ExtractPropertyNamesOfType<T, PropType> = {
+    [K in keyof T]: T[K] extends PropType ? K : never
 }[keyof T];
 
-type RealmPartialModel<T> =
+/**
+ * Exchanges properties defined as Realm.List<Model> with an optional Array<Model | RealmInsertionModel<Model>>.
+ */
+type RealmOptionalParMappedModel<T> = {
+    [K in keyof T]?: T[K] extends Realm.List<infer GT> ? Array<GT | RealmInsertionModel<GT>> : never
+}
+
+/**
+ * Joins T stripped of all keys which value extends Realm.Collection and all inherited from Realm.Object,
+ * with only the keys which value extends Realm.List, remapped as Arrays.
+ */
+//
+type RealmInsertionModel<T> =
     Omit<Omit<T, keyof Realm.Object>, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>
-    & Partial<Pick<T, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>>
+    & RealmOptionalParMappedModel<Pick<T, ExtractPropertyNamesOfType<T, Realm.List<any>>>>
 
 declare class Realm {
     static defaultPath: string;
@@ -529,7 +543,7 @@ declare class Realm {
      *
      * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
      */
-    create<T>(type: string, properties: RealmPartialModel<T>, update?: boolean): T & Realm.Object
+    create<T>(type: string, properties: RealmInsertionModel<T>, update?: boolean): T & Realm.Object
 
     /**
      * @param  {Class} type
@@ -539,7 +553,7 @@ declare class Realm {
      *
      * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
      */
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmPartialModel<T>, update?: boolean): T
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, update?: boolean): T
 
     /**
      * @param  {string} type
@@ -547,7 +561,7 @@ declare class Realm {
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T & Realm.Object
      */
-    create<T>(type: string, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
+    create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
 
     /**
      * @param  {Class} type
@@ -555,7 +569,7 @@ declare class Realm {
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T
      */
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmPartialModel<T>, mode?: Realm.UpdateMode): T
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object


### PR DESCRIPTION
## JSON serialization of `Realm.Object` & `Realm.Collection` & a rework of TS declarations

This PR is a port of https://github.com/realm/realm-js/pull/3013 to the `v10` branch.

These changes fixes #2997 & drastically simplifies https://github.com/realm/realm-studio/issues/1312

## Progress (subject to change)

#### TS declarations (used in integration-tests)
- [x] Limit input in `create<T>(...)` to match a model (using @nirinchev's `ExtractPropertyNamesOfType`©) **notion of any implications this could introduce, is welcome!**.
- [x] Allow input to contain `Array<T>` in `RealmPartialModel<T>` instead of a defined `Realm.Collection<T>` in `create<T>(...)`.
- [x] Update `objects<T>(...)` to accommodate the underlying logic & different responses.
- [x] Allow extending `Realm.Object` for class models.

#### `toJSON` on `Realm.Object` & `Realm.Collection` (this includes `Realm.List` & `Realm.Results`)
- [x] Implement solution with object references (this introduces a cache to not return new objects).
- [x] Ensure `TypeError: Converting circular structure to JSON` is thrown for circular structures, not `RangeError: Maximum call stack size exceeded`.
- [x] Implement & expose replacer for circular structures. \*

\* _I've included a combined key of the table-type & `_objectId()` as unique `$refId` in `Realm.JsonSerializationReplacer`, for a (visual) reference in serialized JSON. This is only used in case a `primaryKey` is not defined._

#### Integration Tests
- [x] Write test covering `toJSON` implementations for both interface/schema & class model usage.

#### Changelog
- [x] Update `CHANGELOG.md`