### PR TITLE
Using realm-network-transport v0.6.0 fixing "process.versions is not an Object"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.
+
+NOTE: This version bumps the Realm file format to version 11. It is not possible to downgrade to earlier versions. Older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v1.0.0, might not be upgradeable. Only [Realm Studio 10.0.0](https://github.com/realm/realm-studio/releases/tag/v10.0.0-beta.1) or later will be able to open the new file format.
+
+### Enhancements
+* None.
+
+### Fixed
+* Fixed `TypeError: process.versions is not an Object` error being thrown when requiring the package from React Native. ([#3045](https://github.com/realm/realm-js/issues/3045), since v10.0.0-beta.8)
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v11 (reads and upgrades file format v5 or later).
+
+### Internal
+* None.
+
 10.0.0-beta.8 Release notes (2020-7-07)
 =============================================================
 NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5427,7 +5427,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -7730,9 +7730,9 @@
       }
     },
     "realm-network-transport": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.4.0.tgz",
-      "integrity": "sha512-cdfu9KU+KDcLVZ4BF8U4v8n2gfJZ+64invqH+6N9yHh7pCaDpXWWryveX8CE/bW68QSlDXs73CFsTZCDf3lMfA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.6.0.tgz",
+      "integrity": "sha512-QCwyjdvJVkIcJ69CbGSoJuXzhremeyBm7HW5M4yqtf8JE7LvySQLQyIigvNWOYFcYG4yfcn7VgE5aRtdZed9/Q==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "node-pre-gyp": "^0.15.0",
     "progress": "^2.0.3",
     "prop-types": "^15.6.2",
-    "realm-network-transport": "^0.4.0",
+    "realm-network-transport": "^0.6.0",
     "request": "^2.88.0",
     "stream-counter": "^1.0.0",
     "sync-request": "^3.0.1",


### PR DESCRIPTION
## What, How & Why?

This closes #3045 by upgrading to a version of realm-network-transport released off https://github.com/realm/realm-js/pull/3020.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (I tested with the fixed integration tests with this change rebased off https://github.com/realm/realm-js/pull/3041)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
