### PR TITLE
JSON serialization: Use primary key as reference-id when possible.

### DIFF
--- a/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
+++ b/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as Realm from "realm";
+import { ObjectId } from 'bson'
+
+export interface IPerson {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    friends: Realm.List<IPerson>;
+    dogs: Realm.Collection<IDog>;
+}
+
+export const PersonSchema: Realm.ObjectSchema = {
+    name: "Person",
+    primaryKey: "_id",
+    properties: {
+        _id: "objectId",
+        age: "int",
+        name: "string",
+        friends: "Person[]"
+    }
+};
+
+export class Person extends Realm.Object {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    friends: Realm.List<Person>;
+    dogs: Realm.Collection<Dog>;
+
+    static schema: Realm.ObjectSchema = PersonSchema;
+}
+
+export interface IDog {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    owner: IPerson;
+}
+
+export const DogSchema: Realm.ObjectSchema = {
+    name: "Dog",
+    primaryKey: "_id",
+    properties: {
+        _id: "objectId",
+        age: "int",
+        name: "string",
+        owner: "Person"
+    }
+};
+
+export class Dog extends Realm.Object {
+    _id: ObjectId;
+    name: string;
+    age: number;
+    owner: Person;
+
+    static schema: Realm.ObjectSchema = DogSchema;
+}

--- a/integration-tests/tests/src/structures/circular-collection-result-with-object-ids.json
+++ b/integration-tests/tests/src/structures/circular-collection-result-with-object-ids.json
@@ -1,0 +1,125 @@
+[
+  {
+    "_id": "5f086d00ddf69c48082eb63b",
+    "age": 42,
+    "name": "John Doe",
+    "friends": [
+      {
+        "$ref": "5f086d00ddf69c48082eb63b"
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63d",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "_id": "5f086d00ddf69c48082eb63f",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              }
+            ]
+          },
+          {
+            "$ref": "5f086d00ddf69c48082eb63b"
+          }
+        ]
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63f",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "_id": "5f086d00ddf69c48082eb63d",
+            "age": 40,
+            "name": "Jane Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63f"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63b"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "5f086d00ddf69c48082eb63d",
+    "age": 40,
+    "name": "Jane Doe",
+    "friends": [
+      {
+        "_id": "5f086d00ddf69c48082eb63f",
+        "age": 35,
+        "name": "Tony Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63d"
+          }
+        ]
+      },
+      {
+        "_id": "5f086d00ddf69c48082eb63b",
+        "age": 42,
+        "name": "John Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63b"
+          },
+          {
+            "$ref": "5f086d00ddf69c48082eb63d"
+          },
+          {
+            "_id": "5f086d00ddf69c48082eb63f",
+            "age": 35,
+            "name": "Tony Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "5f086d00ddf69c48082eb63f",
+    "age": 35,
+    "name": "Tony Doe",
+    "friends": [
+      {
+        "_id": "5f086d00ddf69c48082eb63d",
+        "age": 40,
+        "name": "Jane Doe",
+        "friends": [
+          {
+            "$ref": "5f086d00ddf69c48082eb63f"
+          },
+          {
+            "_id": "5f086d00ddf69c48082eb63b",
+            "age": 42,
+            "name": "John Doe",
+            "friends": [
+              {
+                "$ref": "5f086d00ddf69c48082eb63b"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63d"
+              },
+              {
+                "$ref": "5f086d00ddf69c48082eb63f"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -91,10 +91,23 @@ module.exports = function(realmConstructor, context) {
         enumerable: false
     });
 
+    const serializedPrimaryKeyValue = (value) => {
+        if (value.toJSON) {
+          return value.toJSON();
+        }
+        if (value.toString) {
+          return value.toString();
+        }
+        return value;
+    }
+
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
-            // Construct a reference-id of table-name & objectId
-            const id = this.constructor.name + this._objectId();
+            // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
+            const primaryKey = this.objectSchema().primaryKey;
+            const id = primaryKey 
+                ? serializedPrimaryKeyValue(this[primaryKey])
+                 : this.constructor.name + this._objectId();
 
             // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);
@@ -106,8 +119,13 @@ module.exports = function(realmConstructor, context) {
             const result = {};
             cache.set(id, result);
 
-            // Add the generated reference-id as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
-            Object.defineProperty(result, "$refId", { value: id, configurable: true });
+            if (primaryKey) {
+                // Expose the key holding the primaryKey, as a non-enumerable prop, checkable at serialization.
+                Object.defineProperty(result, "_primaryKeyProp", { value: primaryKey });
+            } else {
+                // Add the generated reference-id, as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
+                Object.defineProperty(result, "$refId", { value: id, configurable: true });
+            }
 
             // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
             Object.keys(this)
@@ -524,7 +542,13 @@ module.exports = function(realmConstructor, context) {
 
                 if (seen.includes(value)) {
                     // If we have seen the current value before, return a reference-structure if possible.
-                    return value.$refId ? { $ref: value.$refId } : "[Circular reference]";
+                    if (value._primaryKeyProp) {
+                      return { $ref: value[value._primaryKeyProp] };
+                    }
+                    if (value.$refId) {
+                      return { $ref: value.$refId };
+                    }
+                    return "[Circular reference]";
                 }
 
                 return value;


### PR DESCRIPTION
- Use primary key as reference-id when possible.
- Added integration-tests for Person/Dog structure with added `ObjectId` as primary keys.