### PR TITLE
Realm Web: Reject login when window closes

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 * Added an export of the `ObjectId` BSON type on the package namespace. ([#3071](https://github.com/realm/realm-js/pull/3071))
 * Added an IIFE bundle enabling users to consume the package from a script-tag. ([#3071](https://github.com/realm/realm-js/pull/3071))
+* Upon authenticating with an OAuth 2.0 authentication provider (Google, Facebook or Apple), the promise returned by `logIn` will get rejected with an error, messaged "Window closed". ([#3064](https://github.com/realm/realm-js/pull/3064))
 
 ### Fixed
 * None

--- a/packages/realm-web/src/OAuth2Helper.ts
+++ b/packages/realm-web/src/OAuth2Helper.ts
@@ -191,7 +191,7 @@ export class OAuth2Helper {
         // Return a promise that resolves when the  gets known
         return new Promise((resolve, reject) => {
             let redirectWindow: Window | null = null;
-            let windowClosedInterval = 0;
+            let windowClosedInterval: TimerHandle = 0;
 
             const handleStorageUpdate = () => {
                 // Trying to get the secret from storage

--- a/packages/realm-web/src/OAuth2Helper.ts
+++ b/packages/realm-web/src/OAuth2Helper.ts
@@ -27,6 +27,8 @@ import {
 } from "./utils/string";
 import { getEnvironment } from "./environment";
 
+const CLOSE_CHECK_INTERVAL = 100; // 10 times per second
+
 type DetermineAppUrl = () => Promise<string>;
 
 export type Window = {
@@ -187,8 +189,10 @@ export class OAuth2Helper {
         const stateStorage = this.getStateStorage(state);
         const url = await this.generateOAuth2Url(credentials, state);
         // Return a promise that resolves when the  gets known
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             let redirectWindow: Window | null = null;
+            let windowClosedInterval = 0;
+
             const handleStorageUpdate = () => {
                 // Trying to get the secret from storage
                 const result = stateStorage.get("result");
@@ -201,6 +205,8 @@ export class OAuth2Helper {
                     // Try closing the newly created window
                     try {
                         if (redirectWindow) {
+                            // Stop checking if the window closed
+                            clearInterval(windowClosedInterval);
                             redirectWindow.close();
                         }
                     } catch (err) {
@@ -210,10 +216,22 @@ export class OAuth2Helper {
                     }
                 }
             };
+
             // Add a listener to the state storage, awaiting an update to the secret
             stateStorage.addListener(handleStorageUpdate);
             // Open up a window
             redirectWindow = this.openWindow(url);
+            // No using a const, because we need the two listeners to reference each other when removing the other.
+            windowClosedInterval = setInterval(() => {
+                if (redirectWindow && redirectWindow.closed) {
+                    clearInterval(windowClosedInterval);
+                    // Stop listening for changes to the storage
+                    stateStorage.removeListener(handleStorageUpdate);
+                    // Reject the promise
+                    const err = new Error("Window closed");
+                    reject(err);
+                }
+            }, CLOSE_CHECK_INTERVAL);
         });
     }
 

--- a/packages/realm-web/types/environment.d.ts
+++ b/packages/realm-web/types/environment.d.ts
@@ -40,16 +40,17 @@ interface Console {
 declare const console: Console;
 
 // Timer related stuff
+type TimerHandle = any;
 type TimerHandler = string | Function;
 declare function setTimeout(
     handler: TimerHandler,
     timeout?: number,
     ...arguments: any[]
-): number;
+): TimerHandle;
 declare function setInterval(
     handler: TimerHandler,
     timeout?: number,
     ...arguments: any[]
-): number;
-declare function clearInterval(handle?: number): void;
-declare function clearTimeout(handle?: number): void;
+): TimerHandle;
+declare function clearInterval(handle?: TimerHandle): void;
+declare function clearTimeout(handle?: TimerHandle): void;


### PR DESCRIPTION
## What, How & Why?

This adds an enhancement of rejecting the promised returned by `logIn` if the user closes the window before the OAuth flow completes.

This is based off `kh/realm-web-iife`, it should be rebased onto `v10` once that PR merges.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually in an app)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
