### PR TITLE
Fix resetPassword and callResetPasswordFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * None.
 
 ### Fixed
-* A crash when calling `user.apiKeys.fetchAll()`
+* Fixed a crash when calling `user.apiKeys.fetchAll()`. ([#3067](https://github.com/realm/realm-js/pull/3067))
+* Fixed calling `app.emailPasswordAuth.resetPassword` and `app.emailPasswordAuth.callResetPasswordFunction`, which would throw an error of mismatch in count of arguments. ([#3079](https://github.com/realm/realm-js/pull/3079))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -415,10 +415,10 @@ class EmailPasswordAuth {
      *
      * @param {string} email - The email address of the user.
      * @param {string} password - The desired new password.
-     * @param {Array<BSON>} args - A bson array of arguments.
+     * @param {Array<BSON>} args - Arguments passed onto the function.
      * @return {Promose<void>}
      */
-    callResetPasswordFunction(email, password, args) { }
+    callResetPasswordFunction(email, password, ...args) { }
 }
 
 /**

--- a/lib/email-password-auth-methods.js
+++ b/lib/email-password-auth-methods.js
@@ -37,11 +37,11 @@ const instanceMethods = {
     },
 
     resetPassword(password, token, token_id) {
-        return promisify(cb => this._resetPassword(password, token, token_id));
+        return promisify(cb => this._resetPassword(password, token, token_id, cb));
     },
 
     callResetPasswordFunction(email, password, bsonArgs) {
-        return promisify(cb => this._callResetPasswordFunction(email, password, bsonArgs));
+        return promisify(cb => this._callResetPasswordFunction(email, password, bsonArgs, cb));
     },
 };
 

--- a/lib/email-password-auth-methods.js
+++ b/lib/email-password-auth-methods.js
@@ -40,7 +40,7 @@ const instanceMethods = {
         return promisify(cb => this._resetPassword(password, token, token_id, cb));
     },
 
-    callResetPasswordFunction(email, password, bsonArgs) {
+    callResetPasswordFunction(email, password, ...bsonArgs) {
         return promisify(cb => this._callResetPasswordFunction(email, password, bsonArgs, cb));
     },
 };

--- a/packages/realm-web/src/auth-providers/EmailPasswordAuth.ts
+++ b/packages/realm-web/src/auth-providers/EmailPasswordAuth.ts
@@ -88,7 +88,7 @@ export class EmailPasswordAuth implements Realm.Auth.EmailPasswordAuth {
     callResetPasswordFunction(
         email: string,
         password: string,
-        args: any[],
+        ...args: any[]
     ): Promise<void> {
         return this.transport.fetch({
             method: "POST",

--- a/src/js_email_password_auth.hpp
+++ b/src/js_email_password_auth.hpp
@@ -150,7 +150,7 @@ void EmailPasswordAuthClass<T>::call_reset_password_function(ContextType ctx, Ob
 
     auto email = Value::validated_to_string(ctx, args[0], "email");
     auto password = Value::validated_to_string(ctx, args[1], "password");
-    auto call_args_js = Value::validated_to_array(ctx, args[1], "args");
+    auto call_args_js = Value::validated_to_array(ctx, args[2], "args");
     auto callback = Value::validated_to_function(ctx, args[3], "callback");
 
     bson::BsonArray call_args_bson;

--- a/types/auth-providers.d.ts
+++ b/types/auth-providers.d.ts
@@ -85,7 +85,7 @@ declare namespace Realm {
             callResetPasswordFunction(
                 email: string,
                 password: string,
-                args: any[],
+                ...args: any[],
             ): Promise<void>;
         }
 


### PR DESCRIPTION
## What, How & Why?

This closes #3080, an issue with the `app.emailPasswordAuth.resetPassword` and `app.emailPasswordAuth.callResetPasswordFunction` methods.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
