### PR TITLE
Allow a string argument when constructing an App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has bee
 NOTE: This version bumps the Realm file format to version 11. It is not possible to downgrade to earlier versions. Older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v1.0.0, might not be upgradeable. Only [Realm Studio 10.0.0](https://github.com/realm/realm-studio/releases/tag/v10.0.0-beta.1) or later will be able to open the new file format.
 
 ### Enhancements
-* None.
+* Adding the possibility of passing a string argument when constructing an App. ([#3082](https://github.com/realm/realm-js/pull/3082))
 
 ### Fixed
 * A crash when calling `user.apiKeys.fetchAll()`

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -89,10 +89,10 @@
     /**
      * Creates a new app and connects to a MongoDB Realm instance.
      *
-     * @param {Realm.App~AppConfiguration} config - The configuration of the app.
+     * @param {(Realm.App~AppConfiguration|string)} configOrId - The configuration of the app or a string app id.
      * @throws If no app id is provided.
      */
-    constructor(config) { }
+    constructor(configOrId) { }
 
     /**
      * Logs in a user.

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -139,6 +139,10 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
                 config.local_app_version = util::Optional<std::string>(Value::validated_to_string(ctx, config_app_version_value, "version"));
             }
         }
+    } else if (Value::is_string(ctx, args[0])) {
+        config.app_id = Value::validated_to_string(ctx, args[0]);
+    } else {
+        throw std::runtime_error("Expected either a configuration object or an app id string.");
     }
 
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -53,6 +53,28 @@ module.exports = {
         TestCase.assertInstanceOf(app, Realm.App);
     },
 
+    testNewAppFromString() {
+        let app = new Realm.App(config.id);
+        TestCase.assertInstanceOf(app, Realm.App);
+        TestCase.assertEqual(app.id, config.id);
+    },
+
+    testNewAppFromUndefined() {
+        const error = TestCase.assertThrows(() =>  new Realm.App());
+        TestCase.assertEqual(
+            error.message,
+            'Invalid arguments: 1 expected, but 0 supplied.',
+        );
+    },
+
+    testNewAppFromOther() {
+        const error = TestCase.assertThrows(() => new Realm.App(1234));
+        TestCase.assertEqual(
+            error.message,
+            'Expected either a configuration object or an app id string.',
+        );
+    },
+
     async testInvalidServer() {
         const conf = {
             id: 'smurf',


### PR DESCRIPTION
## What, How & Why?

This closes #3081 by adding a branch to the check if the argument is a string.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
