### PR TITLE
Allow realm object inheritance from Realm.Object in TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * realm.delete throws an exception `Argument to 'delete' must be a Realm object or a collection of Realm objects.` for schema objects defined with JS class syntax and not inheriting from RealmObject [2848](https://github.com/realm/realm-js/issues/2848).
+* Fixed `Realm.Object` TS declaration to allow inheritance. ([#1226](https://github.com/realm/realm-js/issues/1226))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -143,7 +143,7 @@ declare namespace Realm {
      * Object
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Object.html }
      */
-    interface Object {
+    abstract class Object {
         /**
          * @returns An array of the names of the object's properties.
          */
@@ -189,10 +189,6 @@ declare namespace Realm {
         removeListener(callback: ObjectChangeCallback): void;
 
         removeAllListeners(): void;
-    }
-
-    const Object: {
-        readonly prototype: Object;
     }
 
     /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -179,7 +179,7 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
-        objectId(): string;
+        _objectId(): string;
 
         /**
          * @returns void


### PR DESCRIPTION
Currently extending `Realm.Object` like so:
```ts
class Foo extends Realm.Object {}
```

Results in this TS compile error:
```zsh
Type '{ readonly prototype: Object; }' is not a constructor function type.
```

(Even with `"allowSyntheticDefaultImports": true` in tsconfig.json, which previously has fixed the problem, see: https://github.com/realm/realm-js/issues/1226)

This closes #1226 - again.

* [x] typescript definitions file is updated