### PR TITLE
Allow realm object inheritance from Realm.Object in TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * Fixed a crash when calling `user.apiKeys.fetchAll()`. ([#3067](https://github.com/realm/realm-js/pull/3067))
 * Fixed calling `app.emailPasswordAuth.resetPassword` and `app.emailPasswordAuth.callResetPasswordFunction`, which would throw an error of mismatch in count of arguments. ([#3079](https://github.com/realm/realm-js/pull/3079))
 * realm.delete throws an exception `Argument to 'delete' must be a Realm object or a collection of Realm objects.` for schema objects defined with JS class syntax and not inheriting from RealmObject [2848](https://github.com/realm/realm-js/issues/2848).
+* Fixed `Realm.Object` TS declaration to allow inheritance. ([#1226](https://github.com/realm/realm-js/issues/1226))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Realm {
      * Object
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Object.html }
      */
-    interface Object {
+    abstract class Object {
         /**
          * @returns An array of the names of the object's properties.
          */
@@ -201,10 +201,6 @@ declare namespace Realm {
         removeListener(callback: ObjectChangeCallback): void;
 
         removeAllListeners(): void;
-    }
-
-    const Object: {
-        readonly prototype: Object;
     }
 
     /**


### PR DESCRIPTION
Currently extending `Realm.Object` like so:
```ts
class Foo extends Realm.Object {}
```

Results in this TS compile error:
```zsh
Type '{ readonly prototype: Object; }' is not a constructor function type.
```

(Even with `"allowSyntheticDefaultImports": true` in tsconfig.json, which previously has fixed the problem, see: https://github.com/realm/realm-js/issues/1226)

This closes #1226 - again.

* [x] typescript definitions file is updated