### PR TITLE
Use a bash script for building (fixes Xcode builds), detect and use n…

### DIFF
--- a/RealmJS.podspec
+++ b/RealmJS.podspec
@@ -39,9 +39,9 @@ Pod::Spec.new do |s|
   # 1) As "prepare_command" (executed when running `pod install`), to have the files available when  to modify the XCode project correctly.
   # 2) As "script_phase" (executed by XCode when building), to allow developers to commit their `ios/Pods` directory to their repository (and not run `pod install` after cloning it).
   # Note: It leaves a lock file, ensuring it will only download the archive once.
-  s.prepare_command        = 'node ./scripts/download-realm.js ios --sync'
+  s.prepare_command        = './scripts/xcode-download-realm.sh'
   s.script_phase           = { :name => 'Download Realm Core & Sync',
-                               :script => 'echo "Using Node.js $(node --version)" && node ${PODS_TARGET_SRCROOT}/scripts/download-realm.js ios --sync',
+                               :script => '${PODS_TARGET_SRCROOT}/scripts/xcode-download-realm.sh',
                                :execution_position => :before_compile }
 
   s.source_files           = 'src/*.cpp',

--- a/RealmJS.podspec
+++ b/RealmJS.podspec
@@ -39,9 +39,9 @@ Pod::Spec.new do |s|
   # 1) As "prepare_command" (executed when running `pod install`), to have the files available when  to modify the XCode project correctly.
   # 2) As "script_phase" (executed by XCode when building), to allow developers to commit their `ios/Pods` directory to their repository (and not run `pod install` after cloning it).
   # Note: It leaves a lock file, ensuring it will only download the archive once.
-  s.prepare_command        = './scripts/xcode-download-realm.sh'
+  s.prepare_command        = './scripts/xcode-download-realm.sh ./scripts'
   s.script_phase           = { :name => 'Download Realm Core & Sync',
-                               :script => '${PODS_TARGET_SRCROOT}/scripts/xcode-download-realm.sh',
+                               :script => '${PODS_TARGET_SRCROOT}/scripts/xcode-download-realm.sh ${PODS_TARGET_SRCROOT}/scripts',
                                :execution_position => :before_compile }
 
   s.source_files           = 'src/*.cpp',

--- a/scripts/xcode-download-realm.sh
+++ b/scripts/xcode-download-realm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+#enable for debugging
+# set -x
+
+export NODE_COMMAND="node"
+
+if ! which node > /dev/null; then
+  echo "warning: node is not found in PATH. Looking for nvm in $HOME/.nvm"
+  [ ! -d "$HOME/.nvm" ] && echo "error: node or nvm not found." && exit 1;
+ 
+  #do not print nvm output. comment set +x if output is needed for debugging 
+  # set +x
+  [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  export NODE_CURRENT_VERSION=$(nvm current);  
+  echo "warning: nvm found. Using node version: $NODE_CURRENT_VERSION"
+  # set -x
+  
+  #use nvm to invoke the current node
+  export NODE_COMMAND="nvm run $NODE_CURRENT_VERSION"
+fi
+
+$NODE_COMMAND ${PODS_TARGET_SRCROOT}/scripts/download-realm.js ios --sync
+
+exit 0

--- a/scripts/xcode-download-realm.sh
+++ b/scripts/xcode-download-realm.sh
@@ -4,6 +4,13 @@ set -e
 #enable for debugging
 # set -x
 
+SCRIPTS_DIR=$1
+if test -z "$SCRIPTS_DIR"
+then
+    echo "error: This script requires a first argument to be the directory path where download-realm.js is located";
+    exit 1;
+fi
+
 export NODE_COMMAND="node"
 
 if ! which node > /dev/null; then
@@ -22,6 +29,6 @@ if ! which node > /dev/null; then
   export NODE_COMMAND="nvm run $NODE_CURRENT_VERSION"
 fi
 
-$NODE_COMMAND ${PODS_TARGET_SRCROOT}/scripts/download-realm.js ios --sync
+$NODE_COMMAND ${SCRIPTS_DIR}/scripts/download-realm.js ios --sync
 
 exit 0

--- a/scripts/xcode-download-realm.sh
+++ b/scripts/xcode-download-realm.sh
@@ -29,6 +29,6 @@ if ! which node > /dev/null; then
   export NODE_COMMAND="nvm run $NODE_CURRENT_VERSION"
 fi
 
-$NODE_COMMAND ${SCRIPTS_DIR}/scripts/download-realm.js ios --sync
+$NODE_COMMAND "${SCRIPTS_DIR}/scripts/download-realm.js" ios --sync
 
 exit 0


### PR DESCRIPTION
Use a bash script for RN on iOS instead of commands directly.
Detect nvm when node is not available at the current $PATH. Required for building from inside XCode where the shell used is not interactive.