### PR TITLE
Bugfix: integration-tests TS build error

### DIFF
--- a/integration-tests/tests/tsconfig.json
+++ b/integration-tests/tests/tsconfig.json
@@ -14,14 +14,7 @@
 			"types",
 			"node_modules/@types"
 		],
-		"noImplicitAny": true,
-		"lib": [
-			"es5",
-			"es2015",
-			"es2015.promise",
-			"es2015.symbol",
-			"es2015.iterable"
-		]
+		"noImplicitAny": true
 	},
 	"include": [
 		"src/**/typings.d.ts",


### PR DESCRIPTION
Removed "lib" specification for integration-tests/tests, as it was (now) lower than its "target" & realm-web utilizes newer features.