### PR TITLE
proxy fix for internal calls

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,6 +1,18 @@
 ?.?.? Release notes (2020-??-??)
 =============================================================
 
+### Enhancements
+* None
+
+### Fixed
+* Fixed error `"function not found: 'argsTransformation'"` when calling `user.functions.callFunction('functionName', args)` [#3134](https://github.com/realm/realm-js/pull/3134)
+
+### Internal
+* None
+
+0.8.0 Release notes (2020-07-31)
+=============================================================
+
 ### Breaking changes
 * Renamed `Realm.app` to `Realm.getApp` to make it less conflicting with a local `app` variable.
 

--- a/packages/realm-web/src/FunctionsFactory.ts
+++ b/packages/realm-web/src/FunctionsFactory.ts
@@ -113,13 +113,16 @@ export class FunctionsFactory {
             transport,
             config,
         );
-        // Wrap the factory in a promise that calls the internal call method
+        // Wrap the factory in a proxy that calls the internal call method
         return new Proxy<any>(factory, {
             get(target, p, receiver) {
                 if (typeof p === "string" && RESERVED_NAMES.indexOf(p) === -1) {
                     return target.callFunction.bind(target, p);
                 } else {
-                    return Reflect.get(target, p, receiver);
+                    const prop = Reflect.get(target, p, receiver);
+                    return typeof prop === "function"
+                        ? prop.bind(target)
+                        : prop;
                 }
             },
         });

--- a/packages/realm-web/src/tests/FunctionsFactory.test.ts
+++ b/packages/realm-web/src/tests/FunctionsFactory.test.ts
@@ -43,7 +43,32 @@ describe("FunctionsFactory", () => {
         expect(typeof factory.anyFunction).equals("function");
     });
 
-    it("calls the network transport correctly", async () => {
+    it("calls the network transport correctly through callFunction", async () => {
+        const transport = new MockTransport([
+            { message: `hello friendly world!` },
+        ]);
+        const factory = FunctionsFactory.create(transport, {
+            serviceName: "custom-service",
+        });
+        const response = factory.callFunction("hello", "friendly");
+        expect(response).to.be.instanceOf(Promise);
+        const { message } = await response;
+        expect(message).equals("hello friendly world!");
+        expect(transport.requests).deep.equals([
+            {
+                url: "http://localhost:1337/functions/call",
+                method: "POST",
+                body: {
+                    name: "hello",
+                    service: "custom-service",
+                    arguments: ["friendly"],
+                },
+                headers: DEFAULT_HEADERS,
+            },
+        ]);
+    });
+
+    it("calls the network transport correctly via proxy", async () => {
         const transport = new MockTransport([
             { message: `hello friendly world!` },
         ]);


### PR DESCRIPTION
This fix binds `callFunction` to `FunctionsFactory`.

A different approach would be to define `callFunction` as a property containing an arrow-function:
```ts
callFunction = async (name, ...args) => {
  // ...
}
```