### PR TITLE
fix: build without sync

### DIFF
--- a/react-native/android/src/main/jni/Android.mk
+++ b/react-native/android/src/main/jni/Android.mk
@@ -72,6 +72,8 @@ LOCAL_SRC_FILES += src/object-store/src/schema.cpp
 LOCAL_SRC_FILES += src/object-store/src/shared_realm.cpp
 LOCAL_SRC_FILES += src/object-store/src/thread_safe_reference.cpp
 LOCAL_SRC_FILES += src/object-store/src/util/scheduler.cpp
+LOCAL_SRC_FILES += src/object-store/src/util/bson/bson.cpp
+LOCAL_SRC_FILES += src/object-store/src/util/bson/regular_expression.cpp
 ifeq ($(strip $(BUILD_TYPE_SYNC)),1)
 LOCAL_SRC_FILES += src/object-store/src/sync/async_open_task.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/sync_manager.cpp
@@ -85,8 +87,6 @@ LOCAL_SRC_FILES += src/object-store/src/sync/remote_mongo_client.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/remote_mongo_collection.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/remote_mongo_database.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/generic_network_transport.cpp
-LOCAL_SRC_FILES += src/object-store/src/util/bson/bson.cpp
-LOCAL_SRC_FILES += src/object-store/src/util/bson/regular_expression.cpp
 LOCAL_SRC_FILES += src/object-store/src/sync/push_client.cpp
 endif
 

--- a/realm.gypi
+++ b/realm.gypi
@@ -109,6 +109,8 @@
         "src/object-store/src/util/apple/scheduler.hpp",
         "src/object-store/src/util/generic/scheduler.hpp",
         "src/object-store/src/util/uv/scheduler.hpp",
+        "src/object-store/src/util/bson/bson.cpp",
+        "src/object-store/src/util/bson/regular_expression.cpp",
       ],
       "conditions": [
         ["OS=='win'", {
@@ -145,8 +147,6 @@
             "src/object-store/src/sync/remote_mongo_database.cpp",
             "src/object-store/src/sync/generic_network_transport.cpp",
             "src/object-store/src/sync/push_client.cpp",
-            "src/object-store/src/util/bson/bson.cpp",
-            "src/object-store/src/util/bson/regular_expression.cpp",
           ],
         }, {
           "dependencies": [ "realm-core" ]


### PR DESCRIPTION
bson references moved out of sync specific build config.

**Warning:** Android build not tested, I'm having an issue with the ndk atm.