### PR TITLE
Fix segfault on push() to list of embedded objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * Rare crash when a schema was updated ([#6680](https://github.com/realm/realm-cocoa/issues/6680))
 * Bug in memory mapping management. This bug could result in multiple different asserts as well as segfaults. In many cases stack backtraces would include members of the EncyptedFileMapping near the top - even if encryption was not used at all. In other cases asserts or crashes would be in methods reading an array header or array element. In all cases the application would terminate immediately. (Realm Core PR #3838, since 7.0.0)
 * Fixed the error `expected either accessToken, id_token or authCode in payload` when using Facebook Auth ([#3109])(https://github.com/realm/realm-js/issues/3109)
+* Fixed segfault when `push()`ing onto a list of embedded objects ([RJS-732](https://jira.mongodb.org/browse/RJS-732))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -375,7 +375,10 @@ struct Unbox<JSEngine, Obj> {
             if (!updating && !policy.create) {
                 throw std::runtime_error("Realm object is from another Realm");
             }
+        }
 
+        if (!policy.create) {
+            return Obj();
         }
 
         if (Value::is_array(ctx->m_ctx, object)) {

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -1521,8 +1521,11 @@ module.exports = {
 
         realm.write(() => {
             TestCase.assertThrows(() => {
-                ib.addresses.push({ street: "Njalsgade", city: "Islands Brygge" });
+                realm.create(schemas.AddressSchema.name, { street: "Njalsgade", city: "Islands Brygge" });
             });
+
+            ib.addresses.push({ street: "Njalsgade", city: "Islands Brygge" });
+            TestCase.assertEqual(3, ib.addresses.length);
         });
 
         realm.close();

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -1470,6 +1470,21 @@ module.exports = {
             addresses[0]["street"] = "Strandvejen";
         });
 
+        // insert an extra address into Ib's list (add embedded object)
+        let ibs_addrs = owners[0].addresses;
+        realm.write(() => {
+            ibs_addrs.push({ street: "Njalsgade", city: "Islands Brygge" });
+        });
+
+        streets = ["Algade", "Njalsgade", "Skolevej", "Strandvejen"];
+        for (let i = 0; i < streets.length; i++) {
+            TestCase.assertEqual(addresses[i]["street"], streets[i]);
+        }
+
+        // remove the last of Ib's addresses
+        realm.write(() => {
+            ibs_addrs.pop();
+        });
         streets = ["Algade", "Skolevej", "Strandvejen"];
         for (let i = 0; i < streets.length; i++) {
             TestCase.assertEqual(addresses[i]["street"], streets[i]);

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -1493,6 +1493,55 @@ module.exports = {
         realm.close();
     },
 
+    testCreateNestedEmbeddedObjects: function() {
+        const realm = new Realm({schema: [schemas.ScoutDivisionSchema, schemas.ScoutGroupSchema, schemas.ScoutBranchSchema]});
+
+        realm.write(() => {
+            realm.create(schemas.ScoutDivisionSchema.name, {
+                name: "Oeresund Division", 
+                groups: [
+                    {
+                        name: "RungstedSpejderne",
+                        branches: [ { name: "Micro" }, { name: "Mini" }, { name: "Junior" }, {name: "Trop" } ]
+                    },
+                    {
+                        name: "Bent Byg",
+                        branches: [ { name: "Mini" }, { name: "Junior" }, { name: "Trop" }, { name: "Klan" } ]
+                    }
+                ]
+            });
+            realm.create(schemas.ScoutDivisionSchema.name, {
+                name: "Bernstorff Division",
+                groups: [
+                    {
+                        name: 'HellerupSpejderne',
+                        branches: [ { name: 'Mini' }, { name: 'Flok' }, { name: 'Klan' } ]
+                    }
+                ]
+            });
+        });
+
+        let divisions = realm.objects(schemas.ScoutDivisionSchema.name).sorted("name");
+        let groups = realm.objects(schemas.ScoutGroupSchema.name).sorted("name");
+        TestCase.assertEqual(divisions.length, 2);
+        TestCase.assertEqual(groups.length, 3);
+
+        let bernstorff_groups = divisions[0].groups;
+        TestCase.assertEqual(bernstorff_groups.length, 1);
+
+        // add a Group to Bernstorff Division
+        realm.write(() => {
+            bernstorff_groups.push({
+                name: "1. Ordrup",
+                branches: [ { name: 'FamilieSpejd' }, { name: 'Mikro' }, { name: 'Ulve' }, { name: 'Hvalpe' }, { name: 'Trop' }, { name: 'Klan' } ]
+            });
+        });
+
+        // check that we have successfully added a Group
+        TestCase.assertEqual(groups.length, 4);
+        realm.close();
+    },
+
     testCreateFreeFloatingEmbeddedObject: function() {
         const realm = new Realm({schema: [schemas.HouseOwnerSchema, schemas.AddressSchema]});
 

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -462,3 +462,29 @@ exports.AddressSchema = {
         city: 'string'
     }
 };
+
+exports.ScoutDivisionSchema = {
+    name: 'ScoutDivision',
+    primaryKey: 'name',
+    properties: {
+        name: 'string',
+        groups: { type: 'list', objectType: 'ScoutGroup' }
+    }
+};
+
+exports.ScoutGroupSchema = {
+    name: 'ScoutGroup',
+    embedded: true,
+    properties: {
+        name: 'string',
+        branches: { type: 'list', objectType: 'ScoutBranch' }
+    }
+};
+
+exports.ScoutBranchSchema = {
+    name: 'ScoutBranch',
+    embedded: true,
+    properties: {
+        name: 'string'
+    }
+};


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
Fix incorrect handling of embedded objects being pushed onto a list of embedded objects.  The new object is now created as an unmanaged object before bring linked up in Core.

Added tests for push()/pop() of embedded objects in `testCreateMultipleEmbeddedObjects`.
Fixed `testAddEmbeddedObject`, as it is no longer expected to throw.

This closes [Realm JavaScript SDK / RJS-732](https://jira.mongodb.org/browse/RJS-732) (private ticket).

Note:  Node.js tests pass on MacOS and Linux.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~