### PR TITLE
Realm Network Transport v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * Realm Object Store updated to commit 9c80160881f2af76d99c356a9d6017c88c9b7e52
 * Upgraded Realm Core from v10.0.0-beta.1 to v10.0.0-beta.4
 * Upgraded Realm Sync from v10.0.0-beta.3 to v10.0.0-beta.6
+* Upgraded Realm Network Transport from v0.6.0 to v0.7.0
 
 10.0.0-beta.9 Release notes (2020-7-15)
 =============================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -7730,9 +7730,9 @@
       }
     },
     "realm-network-transport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.6.0.tgz",
-      "integrity": "sha512-QCwyjdvJVkIcJ69CbGSoJuXzhremeyBm7HW5M4yqtf8JE7LvySQLQyIigvNWOYFcYG4yfcn7VgE5aRtdZed9/Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.0.tgz",
+      "integrity": "sha512-w81+N+YrFBkWZWFlspDPrpot50xCkfr+AB+NCQjsTI6OfVF0igqhLfl3frwrSS61fQiL5XrZrFYFV6BWU0F+iA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "node-pre-gyp": "^0.15.0",
     "progress": "^2.0.3",
     "prop-types": "^15.6.2",
-    "realm-network-transport": "^0.6.0",
+    "realm-network-transport": "^0.7.0",
     "request": "^2.88.0",
     "stream-counter": "^1.0.0",
     "sync-request": "^3.0.1",

--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -645,14 +645,6 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-              "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-              "dev": true
-            }
           }
         },
         "eslint-visitor-keys": {
@@ -946,11 +938,6 @@
             "is-extglob": "^2.1.1"
           }
         },
-        "is-promise": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-        },
         "isexe": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1107,11 +1094,6 @@
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "path-key": {
           "version": "2.0.1",
@@ -1331,12 +1313,6 @@
             "string-width": "^3.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            },
             "emoji-regex": {
               "version": "7.0.3",
               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1358,15 +1334,6 @@
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
               }
             }
           }

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Implements cross-platform fetching used by Realm JS",
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.es.js",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -63,7 +63,7 @@
     "eslint": "file:../../node_modules/eslint",
     "mocha": "^5.2.0",
     "node-fetch": "^2.6.0",
-    "realm-network-transport": "^0.6.0",
+    "realm-network-transport": "^0.7.0",
     "rollup": "^2.6.1",
     "rollup-plugin-dts": "^1.4.0",
     "rollup-plugin-node-builtins": "^2.1.2",


### PR DESCRIPTION
## What, How & Why?

This bumps the version of the Realm Network Transport package and updates dependencies on it.
This makes Realm JS use a refactoring of the `realm-network-transport` package, which relies on "main" fields in the package.json (which can be used when statically analyzing the package) over runtime checks of the environment (which as proven error prone and allegedly is breaking the use of the library as-is).

Note: `realm-network-transport@0.7.0` has already been published on NPM.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually in a test app running RN@0.61.2)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
