### PR TITLE
Remove extra scripts/ in path to download-realm.js

### DIFF
--- a/scripts/xcode-download-realm.sh
+++ b/scripts/xcode-download-realm.sh
@@ -29,6 +29,6 @@ if ! which node > /dev/null; then
   export NODE_COMMAND="nvm run $NODE_CURRENT_VERSION"
 fi
 
-$NODE_COMMAND "${SCRIPTS_DIR}/scripts/download-realm.js" ios --sync
+$NODE_COMMAND "${SCRIPTS_DIR}/download-realm.js" ios --sync
 
 exit 0


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Removed an extra `scripts/` directory in the path to `download-realm.js`. The args passed in from the Podspec [already include `scripts/`](https://github.com/realm/realm-js/commit/c09abf0ce7393c7ef62d443d271766e7b15566a9) so including it again here causes pod install to fail.

This closes #3168.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary