### PR TITLE
fix non sync build on windows

### DIFF
--- a/src/node/node_init.cpp
+++ b/src/node/node_init.cpp
@@ -21,6 +21,7 @@
 
 #if !REALM_ENABLE_SYNC
 #pragma comment( lib, "ws2_32.lib")
+#pragma comment (lib, "crypt32");
 #endif
 
 #include "js_realm.hpp"


### PR DESCRIPTION
fixes linker errors
libcrypto.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertOpenStore referenced in function capi_list_certs
and the like