### PR TITLE
fixed JsonSerializationReplacer ts-jsdoc-annotation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -198,8 +198,8 @@ declare namespace Realm {
     }
 
     /**
-     * RealmJsonSerializeReplacer solves circular structures when serializing Realm entities
-     * @example JSON.stringify(realm.objects("Person"), Realm.RealmJsonSerializeReplacer)
+     * JsonSerializationReplacer solves circular structures when serializing Realm entities
+     * @example JSON.stringify(realm.objects("Person"), Realm.JsonSerializationReplacer)
      */
     const JsonSerializationReplacer: (key: string, val: any) => any;
 


### PR DESCRIPTION
Fixing incorrect naming in jsdoc-annotation for v10, (as highlighted in https://github.com/realm/realm-js/pull/3174 for v6)