### PR TITLE
fix createSession import

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -31,7 +31,7 @@ import Credentials, { createCredentials } from './credentials';
 import * as rpc from './rpc';
 import * as util from './util';
 import { static as staticUserMethods } from '../user';
-import { createSession } './session';
+import { createSession } from './session';
 
 const {debugHosts, debugPort} = NativeModules.Realm;
 


### PR DESCRIPTION
## What, How & Why?
After I upgraded realm from 10.0.0-beta.9 to 10.0.0-beta.11, my app gets an error on startup 


```
error: SyntaxError: /Users/euzebe/dev/myApp/node_modules/realm/lib/browser/index.js: Unexpected token (34:25)

  32 | import * as util from './util';
  33 | import { static as staticUserMethods } from '../user';
> 34 | import { createSession } './session';
     |                          ^
  35 | 
  36 | const {debugHosts, debugPort} = NativeModules.Realm;
  37 | 
```

`from` keyword is missing.
The problem comes from commit https://github.com/realm/realm-js/commit/2a1877afabdbad9d70960dd62f59a4e26783dc72

This closes https://github.com/realm/realm-js/issues/3181

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

