### PR TITLE
repopulate partitionValue on syncSession (v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Added descriptive errors for `partitionValue` of unsupported formats & ranges.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed missing `partitionValue` on `syncSession`. ([#3205](https://github.com/realm/realm-js/pull/3205), since v10.0.0-beta.1)
+* Fixed a bug where an integer could prematurely be converted & returned as a `Long` instead of a `number`. ([#3205](https://github.com/realm/realm-js/pull/3205), since v10.0.0-beta.1)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -62,11 +62,18 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         bson::Bson partition_bson;
         if (Value<T>::is_string(ctx, partition_value_value)) {
             std::string pv = Value<T>::validated_to_string(ctx, partition_value_value);
+            if (pv.length() == 0) {
+                throw std::runtime_error("partitionValue of type 'string' cannot be an empty string.");
+            }
             partition_bson = bson::Bson(pv);
         }
         else if (Value<T>::is_number(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
-            partition_bson = bson::Bson(static_cast<int64_t>(pv));
+            auto pvi = static_cast<int64_t>(pv);
+            if (pv != pvi || pvi < 0) {
+                throw std::runtime_error("partitionValue of type 'number' must be a whole positive number.");
+            }
+            partition_bson = bson::Bson(pvi);
         }
         else if (Value<T>::is_object_id(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_object_id(ctx, partition_value_value);
@@ -88,6 +95,7 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
 
 
 using WeakSession = std::weak_ptr<realm::SyncSession>;
+using bson::Bson;
 
 template<typename T>
 class SessionClass : public ClassDefinition<T, WeakSession> {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -321,6 +321,8 @@ void SessionClass<T>::get_config(ContextType ctx, ObjectType object, ReturnValue
         ObjectType config = Object::create_empty(ctx);
         Object::set_property(ctx, config, "user", create_object<T, UserClass<T>>(ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
         // TODO: add app id
+        bson::Bson partition_value_bson = bson::parse(session->config().partition_value);
+        Object::set_property(ctx, config, "partitionValue", Value::from_bson(ctx, partition_value_bson));
         if (auto dispatcher = session->config().error_handler.template target<util::EventLoopDispatcher<SyncSessionErrorHandler>>()) {
             if (auto handler = dispatcher->func().template target<SyncSessionErrorHandlerFunctor<T>>()) {
                 Object::set_property(ctx, config, "error", handler->func());

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <math.h>
+
 #include "js_class.hpp"
 #include "js_collection.hpp"
 #include "js_app.hpp"
@@ -69,10 +71,10 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         }
         else if (Value<T>::is_number(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
-            auto pvi = static_cast<int64_t>(pv);
-            if (pv != pvi || pvi < 0 || pvi > JS_MAX_SAFE_INTEGER) {
-                throw std::runtime_error("partitionValue of type 'number' must be a whole number > 0 and <= Number.MAX_SAFE_INTEGER.");
+            if (pv < 0 || pv > JS_MAX_SAFE_INTEGER || fmod(pv, 1) != 0) {
+                throw std::runtime_error("partitionValue of type 'number' must be a whole number >= 0 and <= Number.MAX_SAFE_INTEGER.");
             }
+            auto pvi = static_cast<int64_t>(pv);
             partition_bson = bson::Bson(pvi);
         }
         else if (Value<T>::is_object_id(ctx, partition_value_value)) {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -70,12 +70,13 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
             partition_bson = bson::Bson(pv);
         }
         else if (Value<T>::is_number(ctx, partition_value_value)) {
-            auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
-            if (pv < 0.0 || pv > JS_MAX_SAFE_INTEGER || fmod(pv, 1.0) > 0.0) {
+            double pv = Value<T>::validated_to_number(ctx, partition_value_value);
+            double integerPart;
+            double fractionalPart = modf(pv, &integerPart);
+            if (fractionalPart > 0.0 || pv < 0.0 || pv > JS_MAX_SAFE_INTEGER) {
                 throw std::runtime_error("partitionValue of type 'number' must be a non-negative integer <= Number.MAX_SAFE_INTEGER.");
             }
-            auto pvi = static_cast<int64_t>(pv);
-            partition_bson = bson::Bson(pvi);
+            partition_bson = bson::Bson(static_cast<int64_t>(integerPart));
         }
         else if (Value<T>::is_object_id(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_object_id(ctx, partition_value_value);

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -73,8 +73,8 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
             double pv = Value<T>::validated_to_number(ctx, partition_value_value);
             double integerPart;
             double fractionalPart = modf(pv, &integerPart);
-            if (fractionalPart > 0.0 || pv < 0.0 || pv > JS_MAX_SAFE_INTEGER) {
-                throw std::runtime_error("partitionValue of type 'number' must be a non-negative integer <= Number.MAX_SAFE_INTEGER.");
+            if (pv > JS_MAX_SAFE_INTEGER  || pv < -JS_MAX_SAFE_INTEGER || fabs(fractionalPart) > 0.0) {
+                throw std::runtime_error("partitionValue of type 'number' must be an integer in the range: Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER.");
             }
             partition_bson = bson::Bson(static_cast<int64_t>(integerPart));
         }

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -65,14 +65,14 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         if (Value<T>::is_string(ctx, partition_value_value)) {
             std::string pv = Value<T>::validated_to_string(ctx, partition_value_value);
             if (pv.length() == 0) {
-                throw std::runtime_error("partitionValue of type 'string' cannot be an empty string.");
+                throw std::runtime_error("partitionValue of type 'string' may not be an empty string.");
             }
             partition_bson = bson::Bson(pv);
         }
         else if (Value<T>::is_number(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
             if (pv < 0 || pv > JS_MAX_SAFE_INTEGER || fmod(pv, 1) != 0) {
-                throw std::runtime_error("partitionValue of type 'number' must be a whole number >= 0 and <= Number.MAX_SAFE_INTEGER.");
+                throw std::runtime_error("partitionValue of type 'number' must be a non-negative integer <= Number.MAX_SAFE_INTEGER.");
             }
             auto pvi = static_cast<int64_t>(pv);
             partition_bson = bson::Bson(pvi);

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -97,7 +97,6 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
 
 
 using WeakSession = std::weak_ptr<realm::SyncSession>;
-using bson::Bson;
 
 template<typename T>
 class SessionClass : public ClassDefinition<T, WeakSession> {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -70,8 +70,8 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         else if (Value<T>::is_number(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
             auto pvi = static_cast<int64_t>(pv);
-            if (pv != pvi || pvi < 0) {
-                throw std::runtime_error("partitionValue of type 'number' must be a whole positive number.");
+            if (pv != pvi || pvi < 0 || pvi > JS_MAX_SAFE_INTEGER) {
+                throw std::runtime_error("partitionValue of type 'number' must be > 0 and <= Number.MAX_SAFE_INTEGER.");
             }
             partition_bson = bson::Bson(pvi);
         }

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -71,7 +71,7 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
             auto pvi = static_cast<int64_t>(pv);
             if (pv != pvi || pvi < 0 || pvi > JS_MAX_SAFE_INTEGER) {
-                throw std::runtime_error("partitionValue of type 'number' must be > 0 and <= Number.MAX_SAFE_INTEGER.");
+                throw std::runtime_error("partitionValue of type 'number' must be a whole number > 0 and <= Number.MAX_SAFE_INTEGER.");
             }
             partition_bson = bson::Bson(pvi);
         }

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -71,7 +71,7 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         }
         else if (Value<T>::is_number(ctx, partition_value_value)) {
             auto pv = Value<T>::validated_to_number(ctx, partition_value_value);
-            if (pv < 0 || pv > JS_MAX_SAFE_INTEGER || fmod(pv, 1) != 0) {
+            if (pv < 0.0 || pv > JS_MAX_SAFE_INTEGER || fmod(pv, 1.0) > 0.0) {
                 throw std::runtime_error("partitionValue of type 'number' must be a non-negative integer <= Number.MAX_SAFE_INTEGER.");
             }
             auto pvi = static_cast<int64_t>(pv);

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -63,6 +63,9 @@ enum PropertyAttributes : unsigned {
     DontDelete = 1 << 2
 };
 
+// JS: Number.MAX_SAFE_INTEGER === Math.pow(2, 53)-1;
+constexpr static int64_t JS_MAX_SAFE_INTEGER = (1ll << 53) - 1;
+
 inline PropertyAttributes operator|(PropertyAttributes a, PropertyAttributes b) {
     return PropertyAttributes(static_cast<unsigned>(a) | static_cast<unsigned>(b));
 }
@@ -616,8 +619,7 @@ inline typename T::Value Value<T>::from_bson(typename T::Context ctx, const bson
         // it to a plain js number if it is in the range where it can be done precisely, otherwise
         // we map to the bson.Long type which preserves the value, but is harder to use.
         const auto i64_val = value.operator int64_t();
-        constexpr static int64_t max_precise_double = 1ll << 52; // 52 bits mantissa + implicit leading 1 bit.
-        if (-max_precise_double <= i64_val && i64_val <= max_precise_double)
+        if (-JS_MAX_SAFE_INTEGER <= i64_val && i64_val <= JS_MAX_SAFE_INTEGER)
             return Value<T>::from_number(ctx, double(i64_val));
 
         return Object<T>::create_bson_type(ctx, "Long", {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -871,6 +871,7 @@ module.exports = {
 
     async testNonAcceptedPartitionValueTypes() {
         const testPartitionValues = [
+            undefined,
             "",
             Number.MAX_SAFE_INTEGER + 1,
             1.2,

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -833,15 +833,19 @@ module.exports = {
     async testAcceptedPartitionValueTypes() {
         const testPartitionValues = [
             Utils.genPartition(), // string
-            0,
-            26123582,
-            6837697641419457,
             Number.MAX_SAFE_INTEGER,
+            6837697641419457,
+            26123582,
+            0,
+            -12342908,
+            -7482937500235834,
+            -Number.MAX_SAFE_INTEGER,
             new ObjectId(),
             null
         ];
 
         for (const partitionValue of testPartitionValues) {
+            console.log('>partitionValue', partitionValue)
             const app = new Realm.App(appConfig);
 
             const user = await app.logIn(Realm.Credentials.anonymous())
@@ -868,12 +872,12 @@ module.exports = {
     async testNonAcceptedPartitionValueTypes() {
         const testPartitionValues = [
             "",
+            Number.MAX_SAFE_INTEGER + 1,
             1.2,
             0.0000000000000001,
             -0.0000000000000001,
-            -1,
-            -7134289827705675,
-            Number.MAX_SAFE_INTEGER + 1
+            -1.3,
+            -Number.MAX_SAFE_INTEGER - 1
         ];
 
         for (const partitionValue of testPartitionValues) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -833,6 +833,7 @@ module.exports = {
     async testAcceptedPartitionValueTypes() {
         const testPartitionValues = [
             Utils.genPartition(), // string
+            0,
             Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
             Number.MAX_SAFE_INTEGER,
             new ObjectId(),
@@ -852,7 +853,7 @@ module.exports = {
 
             const spv = realm.syncSession.config.partitionValue;
 
-            // BSON types have their own 'equals' comparrer
+            // BSON types have their own 'equals' comparer
             if (spv instanceof ObjectId) {
                 TestCase.assertTrue(spv.equals(partitionValue));
             } else {
@@ -867,6 +868,7 @@ module.exports = {
         const testPartitionValues = [
             "",
             1.2,
+            0.0000000000000001,
             Math.floor(Math.random() * Number.MIN_SAFE_INTEGER),
             Number.MAX_SAFE_INTEGER + 1
         ];

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -26,7 +26,7 @@
 
 const debug = require('debug')('tests:session');
 const Realm = require('realm');
-const { ObjectId, Long } = require("bson");
+const { ObjectId } = require("bson");
 
 const TestCase = require('./asserts');
 const Utils = require('./test-utils');
@@ -831,13 +831,12 @@ module.exports = {
     },
 
     async testAcceptedPartitionValueTypes() {
-        const lowRndNumber =Math.floor(Math.random() * Math.floor(100000));
         const testPartitionValues = [
             Utils.genPartition(), // string
-            lowRndNumber, // low random number
-            Number.MAX_SAFE_INTEGER - lowRndNumber, // high random number
-            new ObjectId(), // ObjectId
-            null // null...
+            Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+            Number.MAX_SAFE_INTEGER,
+            new ObjectId(),
+            null
         ];
 
         for (const partitionValue of testPartitionValues) {
@@ -853,8 +852,8 @@ module.exports = {
 
             const spv = realm.syncSession.config.partitionValue;
 
-            // ObjectId & Long have their own 'equals' comparrer
-            if (spv instanceof ObjectId || spv instanceof Long) {
+            // BSON types have their own 'equals' comparrer
+            if (spv instanceof ObjectId) {
                 TestCase.assertTrue(spv.equals(partitionValue));
             } else {
                 TestCase.assertEqual(spv, partitionValue);
@@ -865,7 +864,12 @@ module.exports = {
     },
 
     async testNonAcceptedPartitionValueTypes() {
-        const testPartitionValues = ["", 1.2];
+        const testPartitionValues = [
+            "",
+            1.2,
+            Math.floor(Math.random() * Number.MIN_SAFE_INTEGER),
+            Number.MAX_SAFE_INTEGER + 1
+        ];
 
         for (const partitionValue of testPartitionValues) {
             const app = new Realm.App(appConfig);

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -834,7 +834,8 @@ module.exports = {
         const testPartitionValues = [
             Utils.genPartition(), // string
             0,
-            Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+            26123582,
+            6837697641419457,
             Number.MAX_SAFE_INTEGER,
             new ObjectId(),
             null
@@ -869,7 +870,9 @@ module.exports = {
             "",
             1.2,
             0.0000000000000001,
-            Math.floor(Math.random() * Number.MIN_SAFE_INTEGER),
+            -0.0000000000000001,
+            -1,
+            -7134289827705675,
             Number.MAX_SAFE_INTEGER + 1
         ];
 


### PR DESCRIPTION
This closes #3155

Besides _"repopulate partitionValue on syncSession"_, this PR adds checks for `partitionValue`:
- string: must not be empty.
- number: must be a whole number `>= Number.MIN_SAFE_INTEGER` and `<= Number.MAX_SAFE_INTEGER`.

In particular I'm worried I've overlooked something in regards to changes to: src/js_types.hpp:
When converting from Int64 to a number, we switch to Long. Doing so we have a `max_precise_double`, but this doesn't align with `Number.MAX_SAFE_INTEGER`, which is defined as `Math.pow(2, 53) - 1`.
```c++
constexpr static int64_t max_precise_double = 1ll << 52;
```

### NOTE: Missing CHANGELOG entry.