### PR TITLE
Realm Web: Adding User.toJSON

### DIFF
--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -42,10 +42,8 @@ describe("User", () => {
         const app = createApp();
         const credentials = Credentials.anonymous();
         const user = await app.logIn(credentials);
-
-        console.log(user);
-        const json = JSON.stringify(user);
-        console.log(json);
+        const output = JSON.stringify(user);
+        expect(typeof output).equals("string");
     });
 
     it("refresh invalid access tokens", async () => {

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -38,6 +38,16 @@ describe("User", () => {
         expect(user.customData).deep.equals({});
     });
 
+    it("can be stringified", async () => {
+        const app = createApp();
+        const credentials = Credentials.anonymous();
+        const user = await app.logIn(credentials);
+
+        console.log(user);
+        const json = JSON.stringify(user);
+        console.log(json);
+    });
+
     it("refresh invalid access tokens", async () => {
         const app = createApp();
         const credentials = Credentials.anonymous();

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -2,7 +2,8 @@
 =============================================================
 
 ### Enhancements
-* Added support for linking credentials to an existing user. [#3088](https://github.com/realm/realm-js/pull/3088).
+* Added support for linking credentials to an existing user. [#3088](https://github.com/realm/realm-js/pull/3088)
+* Added a better toJSON() implementation on User objects. [#3221](https://github.com/realm/realm-js/pull/3221)
 
 ### Fixed
 * If the payload for `callFunction` included certain types the request would fail with `"invalid function call request (status 400)"`. All `EJSON` serialization is now done in canonical mode [#3157](https://github.com/realm/realm-js/pull/3157)

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -298,6 +298,20 @@ export class User<
         }
     }
 
+    /**
+     * @returns A plain ol' JavaScript object representation of the user.
+     */
+    public toJSON() {
+        return {
+            id: this.id,
+            accessToken: this.accessToken,
+            refreshToken: this.refreshToken,
+            profile: this._profile,
+            state: this.state,
+            customData: this.customData,
+        };
+    }
+
     /** @inheritdoc */
     push(serviceName = ""): Realm.Services.Push {
         throw new Error("Not yet implemented");
@@ -308,7 +322,7 @@ export class User<
             // Decode and spread the token
             const parts = this.accessToken.split(".");
             if (parts.length !== 3) {
-                throw new Error("Expected three parts");
+                throw new Error("Expected an access token with three parts");
             }
             // Decode the payload
             const encodedPayload = parts[1];

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
+import { inspect } from "util";
 
 import { UserType, User, Credentials } from "..";
 
@@ -42,6 +43,26 @@ describe("User", () => {
         });
         // Assume that the user has an access token
         expect(user.accessToken).equals("deadbeef");
+    });
+
+    it("can be inspected and stringified", () => {
+        const app = new MockApp("my-mocked-app");
+        const user = new User({
+            app,
+            id: "some-user-id",
+            accessToken: "deadbeef.eyJleHAiOjAsImlhdCI6MH0=.e30=",
+            refreshToken: "very-refreshing",
+        });
+        {
+            const output = inspect(user);
+            expect(typeof output).equals("string");
+            expect(output.length).not.equals(0);
+        }
+        {
+            const output = JSON.stringify(user);
+            expect(typeof output).equals("string");
+            expect(output.length).not.equals(0);
+        }
     });
 
     it("deletes session when logging out", async () => {


### PR DESCRIPTION
## What, How & Why?

This implements a `toJSON` method on users to prevent circular references when calling `console.log` on a user.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

