### PR TITLE
Fix type/objectType for lists of ObjectId/Decimal128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NOTE: This version bumps the Realm file format to version 11. It is not possible
 * Reapplied fix for the error `expected either accessToken, id_token or authCode in payload` when using Facebook Auth. ([#3109])(https://github.com/realm/realm-js/issues/3109)
 * Fixed linking issue (error message: `ld: symbol(s) not found for architecture x86_64`) on iOS. ([#3189](https://github.com/realm/realm-js/issues/3189), since v10.0.0-beta.12)
 * It is not allowed to query embedded objects directly. An expection will be thrown. ([RJS-763](https://jira.mongodb.org/browse/RJS-763), since v10.0.0-beta.1)
+* Fixed a bug where .type is incorrect for some property types. ([#3235](https://github.com/realm/realm-js/pull/3235))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -130,7 +130,7 @@ void ListClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue &r
 template<typename T>
 void ListClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     auto list = get_internal<T, ListClass<T>>(ctx, object);
-    return_value.set(string_for_property_type(list->get_type() & ~realm::PropertyType::Flags));
+    return_value.set(local_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags));
 }
 
 template<typename T>
@@ -315,7 +315,7 @@ void ListClass<T>::validate_value(ContextType ctx, realm::List& list, ValueType 
         object_type = list.get_object_schema().name;
     }
     if (!Value::is_valid_for_property_type(ctx, value, type, object_type)) {
-        throw TypeErrorException("Property", object_type ? object_type : string_for_property_type(type), Value::to_string(ctx, value));
+        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type), Value::to_string(ctx, value));
     }
 }
 

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -225,7 +225,7 @@ void ResultsClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue
 template<typename T>
 void ResultsClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
     auto results = get_internal<T, ResultsClass<T>>(ctx, object);
-    return_value.set(string_for_property_type(results->get_type() & ~realm::PropertyType::Flags));
+    return_value.set(local_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags));
 }
 
 template<typename T>

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -145,7 +145,7 @@ static inline void parse_property_type(StringData object_name, Property& prop, S
             prop.object_type = "";
         }
         else if (prop.object_type == "objectId") {
-            prop.type |= PropertyType::Decimal | PropertyType::Array;
+            prop.type |= PropertyType::ObjectId | PropertyType::Array;
             prop.object_type = "";
         }
         else {
@@ -418,15 +418,7 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         }
     }
     else {
-        std::string propertyType = string_for_property_type(property.type);
-        if (property.type == realm::PropertyType::Decimal) {
-            propertyType = "decimal128";
-        }
-        else if (property.type == realm::PropertyType::ObjectId) {
-            propertyType = "objectId";
-        }
-
-        Object::set_property(ctx, object, type_string, Value::from_string(ctx, propertyType));
+        Object::set_property(ctx, object, type_string, Value::from_string(ctx, local_string_for_property_type(property.type)));
     }
 
     static const String object_type_string = "objectType";
@@ -434,7 +426,7 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, property.object_type));
     }
     else if (is_array(property.type)) {
-        Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, string_for_property_type(property.type & ~realm::PropertyType::Flags)));
+        Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, local_string_for_property_type(property.type & ~realm::PropertyType::Flags)));
     }
 
     static const String property_string = "property";

--- a/src/js_util.hpp
+++ b/src/js_util.hpp
@@ -43,6 +43,17 @@ static inline RealmDelegate<T> *get_delegate(realm::Realm *realm) {
     return static_cast<RealmDelegate<T> *>(realm->m_binding_context.get());
 }
 
+static const char *local_string_for_property_type(realm::PropertyType type)
+{
+    switch (type & ~realm::PropertyType::Flags) {
+        // Override naming given by ObjectStore
+        case realm::PropertyType::ObjectId: return "objectId";
+        case realm::PropertyType::Decimal: return "decimal128";
+
+        default: return string_for_property_type(type);
+    }
+}
+
 template<typename T>
 static inline T stot(const std::string &s) {
     std::istringstream iss(s);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -72,7 +72,7 @@ json get_type(Container const& c) {
         return serialize_object_schema(c.get_object_schema());
     }
     return {
-        {"type", string_for_property_type(type)},
+        {"type", local_string_for_property_type(type)},
         {"optional", is_nullable(type)}
     };
 }
@@ -721,7 +721,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesList},
             {"id", store_object(js_object)},
-            {"dataType", string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", local_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(list->get_type())},
          };
     }
@@ -730,7 +730,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesResults},
             {"id", store_object(js_object)},
-            {"dataType", string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", local_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(results->get_type())},
         };
     }

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -72,7 +72,7 @@ json get_type(Container const& c) {
         return serialize_object_schema(c.get_object_schema());
     }
     return {
-        {"type", local_string_for_property_type(type)},
+        {"type", js::local_string_for_property_type(type)},
         {"optional", is_nullable(type)}
     };
 }
@@ -721,7 +721,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesList},
             {"id", store_object(js_object)},
-            {"dataType", local_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", js::local_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(list->get_type())},
          };
     }
@@ -730,7 +730,7 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
         return {
             {"type", RealmObjectTypesResults},
             {"id", store_object(js_object)},
-            {"dataType", local_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
+            {"dataType", js::local_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags)},
             {"optional", is_nullable(results->get_type())},
         };
     }

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -54,6 +54,7 @@ module.exports = {
             prim = realm.create('PrimitiveArrays', {});
         });
 
+        // Check instance type
         TestCase.assertEqual(obj.arrayCol.type, 'object');
         TestCase.assertEqual(obj.arrayCol1.type, 'object');
 
@@ -63,8 +64,8 @@ module.exports = {
         TestCase.assertEqual(prim.double.type, 'double');
         TestCase.assertEqual(prim.string.type, 'string');
         TestCase.assertEqual(prim.date.type, 'date');
-        TestCase.assertEqual(prim.decimal128.type, 'decimal');
-        TestCase.assertEqual(prim.objectId.type, 'object id');
+        TestCase.assertEqual(prim.decimal128.type, 'decimal128');
+        TestCase.assertEqual(prim.objectId.type, 'objectId');
 
         TestCase.assertEqual(prim.optBool.type, 'bool');
         TestCase.assertEqual(prim.optInt.type, 'int');
@@ -72,9 +73,31 @@ module.exports = {
         TestCase.assertEqual(prim.optDouble.type, 'double');
         TestCase.assertEqual(prim.optString.type, 'string');
         TestCase.assertEqual(prim.optDate.type, 'date');
-        TestCase.assertEqual(prim.optDecimal128.type, 'decimal');
-        TestCase.assertEqual(prim.optObjectId.type, 'object id');
+        TestCase.assertEqual(prim.optDecimal128.type, 'decimal128');
+        TestCase.assertEqual(prim.optObjectId.type, 'objectId');
 
+        // Check schema objectType
+        const pa = realm.schema.find((s) => s.name === schemas.PrimitiveArrays.name);
+
+        TestCase.assertEqual(pa.properties.bool.objectType, "bool");
+        TestCase.assertEqual(pa.properties.int.objectType, "int");
+        TestCase.assertEqual(pa.properties.float.objectType, "float");
+        TestCase.assertEqual(pa.properties.double.objectType, "double");
+        TestCase.assertEqual(pa.properties.string.objectType, "string");
+        TestCase.assertEqual(pa.properties.date.objectType, "date");
+        TestCase.assertEqual(pa.properties.decimal128.objectType, "decimal128");
+        TestCase.assertEqual(pa.properties.objectId.objectType, "objectId");
+
+        TestCase.assertEqual(pa.properties.optBool.objectType, "bool");
+        TestCase.assertEqual(pa.properties.optInt.objectType, "int");
+        TestCase.assertEqual(pa.properties.optFloat.objectType, "float");
+        TestCase.assertEqual(pa.properties.optDouble.objectType, "double");
+        TestCase.assertEqual(pa.properties.optString.objectType, "string");
+        TestCase.assertEqual(pa.properties.optDate.objectType, "date");
+        TestCase.assertEqual(pa.properties.optDecimal128.objectType, "decimal128");
+        TestCase.assertEqual(pa.properties.optObjectId.objectType, "objectId");
+
+        // Check optional
         TestCase.assertFalse(prim.bool.optional);
         TestCase.assertFalse(prim.int.optional);
         TestCase.assertFalse(prim.float.optional);


### PR DESCRIPTION
*Issue:*
Lists of `ObjectId` or `Decimal128` still returns `'object id'` & `'decimal'` instead of `'objectId'` & `'decimal128'`, when checking `type`/`objectType`.

*Solution:*
A util method `local_string_for_property_type` has been introduced, wrapping OS `string_for_property_type` - this is now used instead of `string_for_property_type`.
Tests expanded to include checks for `objectType`.
