### PR TITLE
Fix: premature TS deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fixed `create<T>(...)` deprecation warning. ([#3243](https://github.com/realm/realm-js/pull/3243))
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
+
+### Internal
+* None.
+
 10.0.0 Release notes (2020-9-18)
 =============================================================
 NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -539,6 +539,22 @@ declare class Realm {
     /**
      * @param  {string} type
      * @param  {T} properties
+     * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
+     * @returns T & Realm.Object
+     */
+    create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
+
+    /**
+     * @param  {Class} type
+     * @param  {T} properties
+     * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
+     * @returns T
+     */
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T
+
+    /**
+     * @param  {string} type
+     * @param  {T} properties
      * @param  {boolean} update?
      * @returns T & Realm.Object
      *
@@ -555,22 +571,6 @@ declare class Realm {
      * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
      */
     create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, update?: boolean): T
-
-    /**
-     * @param  {string} type
-     * @param  {T} properties
-     * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
-     * @returns T & Realm.Object
-     */
-    create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
-
-    /**
-     * @param  {Class} type
-     * @param  {T} properties
-     * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
-     * @returns T
-     */
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object


### PR DESCRIPTION
## What, How & Why?
When using `create<T>(...)` without the 3rd optional argument, the deprecation warning for `create<T>(..., update?: boolean)` currently triggers.
This change just reorders the TS declarations for create<T>(...), to not trigger the deprecation warning prematurely.

Quite visual in the lastest vscode:
<img src="https://user-images.githubusercontent.com/5254755/93754490-1e7f1300-fc02-11ea-9c56-435adfcd998e.png" width="600" />


*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
