### PR TITLE
bugfix: toJSON internal cache ids resulting in wrong data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed an issue with `toJSON` where data from a different object could be serialized. ([#3254](https://github.com/realm/realm-js/issues/3254), since v6.1.0)
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -135,10 +135,10 @@ module.exports = function(realmConstructor, context) {
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
             // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
-            const primaryKey = this.objectSchema().primaryKey;
-            const id = primaryKey 
+            const { name: schemaName, primaryKey } = this.objectSchema();
+            const id = primaryKey
                 ? serializedPrimaryKeyValue(this[primaryKey])
-                 : this.constructor.name + this._objectId();
+                 : schemaName + this._objectId();
 
             // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);


### PR DESCRIPTION
Relying on `this.constructor.name` was a bad idea. This fix switches to using `objectSchema.name` instead.

This fixes #3254 