### PR TITLE
bugfix: toJSON internal cache ids resulting in wrong data (v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
+* Fixed an issue with `toJSON` where data from a different object could be serialized. ([#3254](https://github.com/realm/realm-js/issues/3254), since v10.0.0-beta.10)
 * Fixed `create<T>(...)` deprecation warning. ([#3243](https://github.com/realm/realm-js/pull/3243))
 
 ### Compatibility

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -104,10 +104,10 @@ module.exports = function(realmConstructor, context) {
     Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
         value: function (_, cache = new Map()) {
             // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
-            const primaryKey = this.objectSchema().primaryKey;
+            const { name: schemaName, primaryKey } = this.objectSchema();
             const id = primaryKey
                 ? serializedPrimaryKeyValue(this[primaryKey])
-                 : this.constructor.name + this._objectId();
+                 : schemaName + this._objectId();
 
             // Check if current objectId has already processed, to keep object references the same.
             const existing = cache.get(id);


### PR DESCRIPTION
Relying on `this.constructor.name` was a bad idea. This fix switches to using `objectSchema.name` instead.

Related issue #3254 