### PR TITLE
Fix for TS create declarations when updating (v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* TS declaration for `objectForPrimaryKey<T>(...)` now mimics behavior of `objects<T>(...)`. ([#3266](https://github.com/realm/realm-js/pull/3266))
 
 ### Fixed
 * Fixed an issue with `toJSON` where data from a different object could be serialized. ([#3254](https://github.com/realm/realm-js/issues/3254), since v10.0.0-beta.10)
@@ -9,6 +9,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Throw error when `deleteRealmIfMigrationNeeded` is requested on a synced realm (incompatible options) ([#3245](https://github.com/realm/realm-js/pull/3245))
 * Fixed inheritance when transpiling with Babel which results in TypeError: Reflect.construct requires the first argument to be a constructor ([#3110](https://github.com/realm/realm-js/issues/3110))
 * `-fno-aligned-new` added to podspec as C++ flag for for armv7. This could lead to error messages like Aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on iOS 11 or newer when archiving an app. ([#3076](https://github.com/realm/realm-js/issues/3076), since v10.0.0-beta.1)
+* TS declaration for `create<T>(...)` has been relaxed when `Realm.UpdateMode` `All` or `Modified` is given. ([#3266](https://github.com/realm/realm-js/pull/3266))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/integration-tests/tests/src/objects.ts
+++ b/integration-tests/tests/src/objects.ts
@@ -111,6 +111,7 @@ describe("Realm objects", () => {
             expect(persons.length).equals(1);
             const [firstPerson] = persons;
             expect(firstPerson).deep.equals(john);
+            expect(firstPerson).instanceOf(Person);
         });
 
         it("can have it's properties read", () => {

--- a/integration-tests/tests/src/objects.ts
+++ b/integration-tests/tests/src/objects.ts
@@ -1,33 +1,179 @@
 import { expect } from "chai";
 
-import { IPerson, PersonSchema } from "./schemas/person-and-dogs";
+import { IPerson, Person, PersonSchema } from "./schemas/person-and-dogs";
+import {
+    IPerson as IPersonWithId,
+    Person as PersonWithId,
+    PersonSchema as PersonSchemaWithId,
+} from "./schemas/person-and-dog-with-object-ids";
+import { ObjectId } from "bson";
 
 describe("Realm objects", () => {
-    it("can be created", () => {
-        const realm = new Realm({ schema: [PersonSchema] });
-        let john: IPerson;
-        realm.write(() => {
-            john = realm.create<IPerson>("Person", {
-                name: "John Doe",
-                age: 42
-            });
-        });
-        // Expect John to be the one and only result
-        const persons = realm.objects("Person");
-        expect(persons.length).equals(1);
-        const [firstPerson] = persons;
-        expect(firstPerson).deep.equals(john);
-    });
+    describe("Interface & object literal", () => {
+        it("can be created", () => {
+            const realm = new Realm({ schema: [PersonSchema] });
+            let john: IPerson;
 
-    it("can have it's properties read", () => {
-        const realm = new Realm({ schema: [PersonSchema] });
-        realm.write(() => {
-            const john = realm.create<IPerson>("Person", {
-                name: "John Doe",
-                age: 42
+            realm.write(() => {
+                john = realm.create<IPerson>(PersonSchema.name, {
+                    name: "John Doe",
+                    age: 42,
+                });
             });
+
+            // Expect John to be the one and only result
+            const persons = realm.objects(PersonSchema.name);
+            expect(persons.length).equals(1);
+            const [firstPerson] = persons;
+            expect(firstPerson).deep.equals(john);
+        });
+
+        it("can have it's properties read", () => {
+            const realm = new Realm({ schema: [PersonSchema] });
+            let john: IPerson;
+
+            realm.write(() => {
+                john = realm.create<IPerson>(PersonSchema.name, {
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
             expect(john.name).equals("John Doe");
             expect(john.age).equals(42);
+        });
+
+        it("can be updated", () => {
+            const realm = new Realm({ schema: [PersonSchemaWithId] });
+            let john: IPersonWithId;
+            const _id = new ObjectId();
+
+            realm.write(() => {
+                john = realm.create<IPersonWithId>(PersonSchemaWithId.name, {
+                    _id,
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(42);
+
+            realm.write(() => {
+                realm.create<IPersonWithId>(
+                    PersonSchemaWithId.name,
+                    { _id, age: 43 },
+                    Realm.UpdateMode.All
+                );
+            });
+
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(43);
+
+            realm.write(() => {
+                realm.create<IPersonWithId>(
+                    PersonSchemaWithId.name,
+                    { _id, name: "Mr. John Doe" },
+                    Realm.UpdateMode.Modified
+                );
+            });
+
+            expect(john.name).equals("Mr. John Doe");
+            expect(john.age).equals(43);
+
+            expect(() =>
+                realm.write(() => {
+                    realm.create<IPersonWithId>(
+                        PersonSchemaWithId.name,
+                        { _id, name: "John Doe", age: 42 },
+                        Realm.UpdateMode.Never
+                    );
+                })
+            ).throws(
+                `Attempting to create an object of type '${PersonSchemaWithId.name}' with an existing primary key value '${_id}'.`
+            );
+        });
+    });
+
+    describe("Class Model", () => {
+        it("can be created", () => {
+            const realm = new Realm({ schema: [Person] });
+            let john: Person;
+
+            realm.write(() => {
+                john = realm.create(Person, {
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+            // Expect John to be the one and only result
+            const persons = realm.objects(Person);
+            expect(persons.length).equals(1);
+            const [firstPerson] = persons;
+            expect(firstPerson).deep.equals(john);
+        });
+
+        it("can have it's properties read", () => {
+            const realm = new Realm({ schema: [Person] });
+            realm.write(() => {
+                const john = realm.create(Person, {
+                    name: "John Doe",
+                    age: 42,
+                });
+                expect(john.name).equals("John Doe");
+                expect(john.age).equals(42);
+            });
+        });
+
+        it("can be updated", () => {
+            const realm = new Realm({ schema: [PersonWithId] });
+            let john: PersonWithId;
+            const _id = new ObjectId();
+
+            realm.write(() => {
+                john = realm.create(PersonWithId, {
+                    _id,
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(42);
+
+            realm.write(() => {
+                realm.create(
+                    PersonWithId,
+                    { _id, age: 43 },
+                    Realm.UpdateMode.All
+                );
+            });
+
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(43);
+
+            realm.write(() => {
+                realm.create(
+                    PersonWithId,
+                    { _id, name: "Mr. John Doe" },
+                    Realm.UpdateMode.Modified
+                );
+            });
+
+            expect(john.name).equals("Mr. John Doe");
+            expect(john.age).equals(43);
+
+            expect(() =>
+                realm.write(() => {
+                    realm.create(
+                        PersonWithId,
+                        { _id, name: "John Doe", age: 42 },
+                        Realm.UpdateMode.Never
+                    );
+                })
+            ).throws(
+                `Attempting to create an object of type '${PersonWithId.schema.name}' with an existing primary key value '${_id}'.`
+            );
         });
     });
 });

--- a/integration-tests/tests/src/objects.ts
+++ b/integration-tests/tests/src/objects.ts
@@ -43,6 +43,29 @@ describe("Realm objects", () => {
             expect(john.age).equals(42);
         });
 
+        it("can be fetched with objectForPrimaryKey", () => {
+            const realm = new Realm({ schema: [PersonSchemaWithId] });
+            const _id = new ObjectId();
+
+            realm.write(() => {
+                realm.create<PersonWithId>(PersonSchemaWithId.name, {
+                    _id,
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
+            const john = realm.objectForPrimaryKey<IPersonWithId>(
+                PersonSchemaWithId.name,
+                _id
+            );
+
+            expect(john).instanceOf(Realm.Object);
+            expect(john._id.equals(_id)).equals(true);
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(42);
+        });
+
         it("can be updated", () => {
             const realm = new Realm({ schema: [PersonSchemaWithId] });
             let john: IPersonWithId;
@@ -56,6 +79,7 @@ describe("Realm objects", () => {
                 });
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("John Doe");
             expect(john.age).equals(42);
 
@@ -67,6 +91,7 @@ describe("Realm objects", () => {
                 );
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("John Doe");
             expect(john.age).equals(43);
 
@@ -83,6 +108,7 @@ describe("Realm objects", () => {
                 );
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("Mr. John Doe");
             expect(john.age).equals(43);
 
@@ -97,6 +123,10 @@ describe("Realm objects", () => {
             ).throws(
                 `Attempting to create an object of type '${PersonSchemaWithId.name}' with an existing primary key value '${_id}'.`
             );
+
+            // Excpect only one instance of 'PersonSchemaWithId' in db after all updates
+            const persons = realm.objects(PersonSchemaWithId.name);
+            expect(persons.length).equals(1);
         });
     });
 
@@ -126,9 +156,30 @@ describe("Realm objects", () => {
                     name: "John Doe",
                     age: 42,
                 });
+
                 expect(john.name).equals("John Doe");
                 expect(john.age).equals(42);
             });
+        });
+
+        it("can be fetched with objectForPrimaryKey", () => {
+            const realm = new Realm({ schema: [PersonWithId] });
+            const _id = new ObjectId();
+
+            realm.write(() => {
+                realm.create(PersonWithId, {
+                    _id,
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
+            const john = realm.objectForPrimaryKey(PersonWithId, _id);
+
+            expect(john).instanceOf(PersonWithId);
+            expect(john._id.equals(_id)).equals(true);
+            expect(john.name).equals("John Doe");
+            expect(john.age).equals(42);
         });
 
         it("can be updated", () => {
@@ -144,6 +195,7 @@ describe("Realm objects", () => {
                 });
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("John Doe");
             expect(john.age).equals(42);
 
@@ -155,6 +207,7 @@ describe("Realm objects", () => {
                 );
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("John Doe");
             expect(john.age).equals(43);
 
@@ -167,6 +220,7 @@ describe("Realm objects", () => {
                 realm.create(PersonWithId, update, Realm.UpdateMode.Modified);
             });
 
+            expect(john._id.equals(_id)).equals(true);
             expect(john.name).equals("Mr. John Doe");
             expect(john.age).equals(43);
 
@@ -181,6 +235,10 @@ describe("Realm objects", () => {
             ).throws(
                 `Attempting to create an object of type '${PersonWithId.schema.name}' with an existing primary key value '${_id}'.`
             );
+
+            // Excpect only one instance of 'PersonWithId' in db after all updates
+            const persons = realm.objects(PersonWithId);
+            expect(persons.length).equals(1);
         });
     });
 });

--- a/integration-tests/tests/src/objects.ts
+++ b/integration-tests/tests/src/objects.ts
@@ -70,10 +70,15 @@ describe("Realm objects", () => {
             expect(john.name).equals("John Doe");
             expect(john.age).equals(43);
 
+            const update: Partial<IPersonWithId> = {
+                _id,
+                name: "Mr. John Doe",
+            };
+
             realm.write(() => {
                 realm.create<IPersonWithId>(
                     PersonSchemaWithId.name,
-                    { _id, name: "Mr. John Doe" },
+                    update,
                     Realm.UpdateMode.Modified
                 );
             });
@@ -153,12 +158,13 @@ describe("Realm objects", () => {
             expect(john.name).equals("John Doe");
             expect(john.age).equals(43);
 
+            const update: Partial<PersonWithId> = {
+                _id,
+                name: "Mr. John Doe",
+            };
+
             realm.write(() => {
-                realm.create(
-                    PersonWithId,
-                    { _id, name: "Mr. John Doe" },
-                    Realm.UpdateMode.Modified
-                );
+                realm.create(PersonWithId, update, Realm.UpdateMode.Modified);
             });
 
             expect(john.name).equals("Mr. John Doe");

--- a/integration-tests/tests/src/serialization.ts
+++ b/integration-tests/tests/src/serialization.ts
@@ -18,39 +18,47 @@
 
 import { expect } from "chai";
 
-import { IPerson, PersonSchema, DogSchema, Person, Dog } from "./schemas/person-and-dogs";
-import { 
+import {
+    IPerson,
+    PersonSchema,
+    DogSchema,
+    Person,
+    Dog,
+} from "./schemas/person-and-dogs";
+import {
     IPerson as IPersonWithId,
     PersonSchema as PersonSchemaWithId,
     DogSchema as DogSchemaWithId,
     Person as PersonWithId,
-    Dog as DogWithId
+    Dog as DogWithId,
 } from "./schemas/person-and-dog-with-object-ids";
-import * as circularCollectionResult from "./structures/circular-collection-result.json"
-import * as circularCollectionResultWithIds from "./structures/circular-collection-result-with-object-ids.json"
-import { ObjectId } from 'bson'
+import * as circularCollectionResult from "./structures/circular-collection-result.json";
+import * as circularCollectionResultWithIds from "./structures/circular-collection-result-with-object-ids.json";
+import { ObjectId } from "bson";
 
 describe("JSON serialization (exposed properties)", () => {
     it("JsonSerializationReplacer is exposed on the Realm constructor", () => {
-        expect(typeof Realm.JsonSerializationReplacer).equals('function');
+        expect(typeof Realm.JsonSerializationReplacer).equals("function");
         expect(Realm.JsonSerializationReplacer.length).equals(2);
     });
-})
+});
 
 type TestSetup = {
-    name: string,
+    name: string;
     testData: () => {
-        realm: Realm,
-        predefinedStructure: any,
-    },
+        realm: Realm;
+        predefinedStructure: any;
+    };
 };
 
 const testSetups: TestSetup[] = [
     {
         name: "Object literal",
         testData: () => {
-            const realm = new Realm({ schema: [PersonSchema, DogSchema], inMemory: true });
-            console.log('path', realm.path)
+            const realm = new Realm({
+                schema: [PersonSchema, DogSchema],
+                inMemory: true,
+            });
 
             realm.write(() => {
                 const john = realm.create<IPerson>(PersonSchema.name, {
@@ -59,24 +67,24 @@ const testSetups: TestSetup[] = [
                 });
                 const jane = realm.create<IPerson>(PersonSchema.name, {
                     name: "Jane Doe",
-                    age: 40
+                    age: 40,
                 });
                 const tony = realm.create<IPerson>(PersonSchema.name, {
                     name: "Tony Doe",
-                    age: 35
+                    age: 35,
                 });
-        
+
                 // ensure circular references
                 john.friends.push(john);
                 john.friends.push(jane);
                 john.friends.push(tony);
-        
+
                 jane.friends.push(tony);
                 jane.friends.push(john);
-                
+
                 tony.friends.push(jane);
             });
-        
+
             return {
                 realm,
                 predefinedStructure: circularCollectionResult,
@@ -87,11 +95,11 @@ const testSetups: TestSetup[] = [
         name: "Class models",
         testData: () => {
             const realm = new Realm({ schema: [Person, Dog], inMemory: true });
-        
+
             realm.write(() => {
                 const john = realm.create(Person, {
                     name: "John Doe",
-                    age: 42
+                    age: 42,
                 });
                 const jane = realm.create(Person, {
                     name: "Jane Doe",
@@ -99,76 +107,90 @@ const testSetups: TestSetup[] = [
                 });
                 const tony = realm.create(Person, {
                     name: "Tony Doe",
-                    age: 35
+                    age: 35,
                 });
-        
+
                 // ensure circular references
                 john.friends.push(john);
                 john.friends.push(jane);
                 john.friends.push(tony);
-        
+
                 jane.friends.push(tony);
                 jane.friends.push(john);
-                
+
                 tony.friends.push(jane);
             });
 
             return {
                 realm,
-                predefinedStructure: circularCollectionResult
+                predefinedStructure: circularCollectionResult,
             };
-        }
+        },
     },
     {
         name: "Object literal with primary ObjectId",
         testData: () => {
-            const realm = new Realm({ schema: [PersonSchemaWithId, DogSchemaWithId], inMemory: true });
-        
+            const realm = new Realm({
+                schema: [PersonSchemaWithId, DogSchemaWithId],
+                inMemory: true,
+            });
+
             realm.write(() => {
-                const john = realm.create<IPersonWithId>(PersonSchemaWithId.name, {
-                    _id: new ObjectId("5f086d00ddf69c48082eb63b"),
-                    name: "John Doe",
-                    age: 42,
-                });
-                const jane = realm.create<IPersonWithId>(PersonSchemaWithId.name, {
-                    _id: new ObjectId("5f086d00ddf69c48082eb63d"),
-                    name: "Jane Doe",
-                    age: 40
-                });
-                const tony = realm.create<IPersonWithId>(PersonSchemaWithId.name, {
-                    _id: new ObjectId("5f086d00ddf69c48082eb63f"),
-                    name: "Tony Doe",
-                    age: 35
-                });
-        
+                const john = realm.create<IPersonWithId>(
+                    PersonSchemaWithId.name,
+                    {
+                        _id: new ObjectId("5f086d00ddf69c48082eb63b"),
+                        name: "John Doe",
+                        age: 42,
+                    }
+                );
+                const jane = realm.create<IPersonWithId>(
+                    PersonSchemaWithId.name,
+                    {
+                        _id: new ObjectId("5f086d00ddf69c48082eb63d"),
+                        name: "Jane Doe",
+                        age: 40,
+                    }
+                );
+                const tony = realm.create<IPersonWithId>(
+                    PersonSchemaWithId.name,
+                    {
+                        _id: new ObjectId("5f086d00ddf69c48082eb63f"),
+                        name: "Tony Doe",
+                        age: 35,
+                    }
+                );
+
                 // ensure circular references
                 john.friends.push(john);
                 john.friends.push(jane);
                 john.friends.push(tony);
-        
+
                 jane.friends.push(tony);
                 jane.friends.push(john);
-                
+
                 tony.friends.push(jane);
             });
-        
 
             return {
                 realm,
-                predefinedStructure: circularCollectionResultWithIds
+                predefinedStructure: circularCollectionResultWithIds,
             };
         },
     },
     {
         name: "Class models with primary ObjectId",
         testData: () => {
-            const realm = new Realm({ schema: [PersonWithId, DogWithId], inMemory: true });
-        
+            const realm = new Realm({
+                schema: [PersonWithId, DogWithId],
+                inMemory: true,
+            });
+
             realm.write(() => {
                 const john = realm.create(PersonWithId, {
                     _id: new ObjectId("5f086d00ddf69c48082eb63b"),
                     name: "John Doe",
-                    age: 42
+                    age: 42,
                 });
                 const jane = realm.create(PersonWithId, {
                     _id: new ObjectId("5f086d00ddf69c48082eb63d"),
@@ -178,30 +200,29 @@ const testSetups: TestSetup[] = [
                 const tony = realm.create(PersonWithId, {
                     _id: new ObjectId("5f086d00ddf69c48082eb63f"),
                     name: "Tony Doe",
-                    age: 35
+                    age: 35,
                 });
-        
+
                 // ensure circular references
                 john.friends.push(john);
                 john.friends.push(jane);
                 john.friends.push(tony);
-        
+
                 jane.friends.push(tony);
                 jane.friends.push(john);
-                
+
                 tony.friends.push(jane);
             });
-        
+
             return {
                 realm,
-                predefinedStructure: circularCollectionResultWithIds
+                predefinedStructure: circularCollectionResultWithIds,
             };
-        }
-    }
+        },
+    },
 ];
 
 describe("JSON serialization", () => {
-
     let testSetup: TestSetup;
     let realm: Realm | null;
     let predefinedStructure: any;
@@ -216,7 +237,7 @@ describe("JSON serialization", () => {
         if (realm) {
             realm.write(() => {
                 realm.deleteAll();
-            })
+            });
             realm.close();
             realm = null;
         }
@@ -224,58 +245,64 @@ describe("JSON serialization", () => {
 
     testSetups.forEach((ts) => {
         // expose testSetup to predefined before/after hooks
-        testSetup = ts
+        testSetup = ts;
 
         describe(`Repeated test for "${testSetup.name}":`, () => {
-
             describe("Realm.Object", () => {
-        
                 it("implements toJSON", () => {
-                    expect(typeof persons[0].toJSON).equals('function');
+                    expect(typeof persons[0].toJSON).equals("function");
                 });
-        
+
                 it("toJSON returns a circular structure", () => {
                     const serializable = persons[0].toJSON();
-        
+
                     expect(serializable.objectSchema).equals(undefined);
                     expect(serializable.friends).instanceOf(Array);
                     expect(serializable).equals(serializable.friends[0]);
                 });
-            
-                it("throws correct error on serialization", () => {
-                    expect(() => JSON.stringify(persons[0]))
-                        .throws(TypeError, /^Converting circular structure to JSON/);
-                });
-        
-                it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
-                    expect(JSON.stringify(persons[0], Realm.JsonSerializationReplacer))
-                        .equals(JSON.stringify(predefinedStructure[0]));
-                })
-            });
-        
-            describe("Realm.Results", () => {
 
-                it("implements toJSON", () => {
-                    expect(typeof persons.toJSON).equals('function');
+                it("throws correct error on serialization", () => {
+                    expect(() => JSON.stringify(persons[0])).throws(
+                        TypeError,
+                        /circular|cyclic/i
+                    );
                 });
-        
+
+                it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
+                    expect(
+                        JSON.stringify(
+                            persons[0],
+                            Realm.JsonSerializationReplacer
+                        )
+                    ).equals(JSON.stringify(predefinedStructure[0]));
+                });
+            });
+
+            describe("Realm.Results", () => {
+                it("implements toJSON", () => {
+                    expect(typeof persons.toJSON).equals("function");
+                });
+
                 it("toJSON returns a circular structure", () => {
                     const serializable = persons.toJSON();
-        
+
                     expect(serializable).instanceOf(Array);
                     expect(serializable[0].friends).instanceOf(Array);
                     expect(serializable[0]).equals(serializable[0].friends[0]);
                 });
-        
+
                 it("throws correct error on serialization", () => {
-                    expect(() => JSON.stringify(persons))
-                        .throws(TypeError, /^Converting circular structure to JSON/);
+                    expect(() => JSON.stringify(persons)).throws(
+                        TypeError,
+                        /circular|cyclic/i
+                    );
                 });
-        
+
                 it("serializes to expected output using Realm.JsonSerializationReplacer", () => {
-                    expect(JSON.stringify(persons, Realm.JsonSerializationReplacer))
-                        .equals(JSON.stringify(predefinedStructure));
-                })
+                    expect(
+                        JSON.stringify(persons, Realm.JsonSerializationReplacer)
+                    ).equals(JSON.stringify(predefinedStructure));
+                });
             });
         });
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -571,11 +571,18 @@ declare class Realm {
     deleteAll(): void;
 
     /**
-     * @param  {string|Realm.ObjectType|Function} type
+     * @param  {string} type
      * @param  {number|string|ObjectId} key
      * @returns {T | undefined}
      */
-    objectForPrimaryKey<T>(type: string | Realm.ObjectType | Function, key: number | string | Realm.ObjectId): T & Realm.Object | undefined;
+    objectForPrimaryKey<T>(type: string, key: number | string | Realm.ObjectId): (T & Realm.Object) | undefined;
+
+    /**
+     * @param  {Class} type
+     * @param  {number|string|ObjectId} key
+     * @returns {T | undefined}
+     */
+    objectForPrimaryKey<T extends Realm.Object>(type: {new(...arg: any[]): T; }, key: number | string | Realm.ObjectId): T | undefined;
 
     /**
      * @param  {string} type

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -542,7 +542,8 @@ declare class Realm {
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T & Realm.Object
      */
-    create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T & Realm.Object
+    create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T & Realm.Object;
+    create<T>(type: string, properties: Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T & Realm.Object;
 
     /**
      * @param  {Class} type
@@ -550,27 +551,8 @@ declare class Realm {
      * @param  {Realm.UpdateMode} mode? If not provided, `Realm.UpdateMode.Never` is used.
      * @returns T
      */
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode): T
-
-    /**
-     * @param  {string} type
-     * @param  {T} properties
-     * @param  {boolean} update?
-     * @returns T & Realm.Object
-     *
-     * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
-     */
-    create<T>(type: string, properties: RealmInsertionModel<T>, update?: boolean): T & Realm.Object
-
-    /**
-     * @param  {Class} type
-     * @param  {T} properties
-     * @param  {boolean} update?
-     * @returns T
-     *
-     * @deprecated, to be removed in future versions. Use `create(type, properties, UpdateMode)` instead.
-     */
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, update?: boolean): T
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T;
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T;
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -543,7 +543,7 @@ declare class Realm {
      * @returns T & Realm.Object
      */
     create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T & Realm.Object;
-    create<T>(type: string, properties: Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T & Realm.Object;
+    create<T>(type: string, properties: Partial<T> | Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T & Realm.Object;
 
     /**
      * @param  {Class} type
@@ -552,7 +552,7 @@ declare class Realm {
      * @returns T
      */
     create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T;
-    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T;
+    create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: Partial<T> | Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T;
 
     /**
      * @param  {Realm.Object|Realm.Object[]|Realm.List<any>|Realm.Results<any>|any} object


### PR DESCRIPTION
### Main goal
Initiated based on this comment: https://github.com/realm/realm-js/pull/3044#issuecomment-698617303 - v6 PR can be found here: https://github.com/realm/realm-js/pull/3271

Allow for partial models when using `Realm.UpdateMode.All` or `Realm.UpdateMode.Modified`

**Create declarations has been updated to:**
```ts
/** ... */
create<T>(type: string, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T & Realm.Object;
create<T>(type: string, properties: Partial<T> | Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T & Realm.Object;

/** ... */
create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: RealmInsertionModel<T>, mode?: Realm.UpdateMode.Never): T;
create<T extends Realm.Object>(type: {new(...arg: any[]): T; }, properties: Partial<T> | Partial<RealmInsertionModel<T>>, mode: Realm.UpdateMode.All | Realm.UpdateMode.Modified): T;
```
Deprecated declarations has been removed after agreement with @kneth 
Any better way of achieving the above?

### Additional changes

I extended integration-tests for object creation/reading to include update-tests & test for Class Models (these additions only works in combination with https://github.com/realm/realm-js/pull/3262 - now rebased on `v10` efter merge).

And fixed an issue with serialization tests (so it now works in different environments - the previous error message check was a bit too specific, as described [here (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value)).

### Update

**objectForPrimaryKey<T> updated to:**
(to align with the existing declarations for `objects<T>(...)` - tests for this added)
```ts
/** ... */
objectForPrimaryKey<T>(type: string, key: number | string | Realm.ObjectId): (T & Realm.Object) | undefined;

/** ... */
objectForPrimaryKey<T extends Realm.Object>(type: {new(...arg: any[]): T; }, key: number | string | Realm.ObjectId): T | undefined;
```

The above change limits the use of `realm.objectForPrimaryKey(Person)` to only accept Class Model which extends `Realm.Object` (just like `objects<T>(...)` is currently declared).

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 🚦 Tests

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
