### PR TITLE
Realm Web: Making session refresh and deletion more robust

### DIFF
--- a/packages/realm-app-importer/package.json
+++ b/packages/realm-app-importer/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint --ext .js,.ts .",
-    "prepack": "rm -rf dist && npm run build",
+    "prepare": "rm -rf dist && npm run build",
     "start": "ts-node src/cli.ts"
   },
   "files": [

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -15,7 +15,7 @@
     "build": "npm run generate-types && rollup --config",
     "lint": "eslint --ext .js,.ts .",
     "test": "mocha 'src/**/*.test.ts'",
-    "prepack": "rm -rf dist && npm run build"
+    "prepare": "rm -rf dist && npm run build"
   },
   "files": [
     "dist"

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -2,10 +2,10 @@
 =============================================================
 
 ### Enhancements
-* None
+* Changing the behaviour when refreshing an access token fails. With this change, if the refresh token cannot be used to refresh an access token, the user is logged out. ([#3269](https://github.com/realm/realm-js/pull/3269))
 
 ### Fixed
-* None
+* Fixed forgetting the users access and refresh tokens, even if the request to delete the session fails. ([#3269](https://github.com/realm/realm-js/pull/3269))
 
 ### Internal
 * None
@@ -14,14 +14,14 @@
 =============================================================
 
 ### Enhancements
-* Added support for linking credentials to an existing user. [#3088](https://github.com/realm/realm-js/pull/3088), [#3239](https://github.com/realm/realm-js/pull/3239) and [#3240](https://github.com/realm/realm-js/pull/3240)
-* Added a better toJSON() implementation on User objects. [#3221](https://github.com/realm/realm-js/pull/3221)
-* Added `watch` support to MongoDB Collections. [#3247](https://github.com/realm/realm-js/pull/3247)
+* Added support for linking credentials to an existing user. ([#3088](https://github.com/realm/realm-js/pull/3088), [#3239](https://github.com/realm/realm-js/pull/3239) and [#3240](https://github.com/realm/realm-js/pull/3240))
+* Added a better toJSON() implementation on User objects. ([#3221](https://github.com/realm/realm-js/pull/3221))
+* Added `watch` support to MongoDB Collections. ([#3247](https://github.com/realm/realm-js/pull/3247))
 
 ### Fixed
-* If the payload for `callFunction` included certain types the request would fail with `"invalid function call request (status 400)"`. All `EJSON` serialization is now done in canonical mode [#3157](https://github.com/realm/realm-js/pull/3157)
-* Fixed sending device information when authenticating a user. [#3220](https://github.com/realm/realm-js/pull/3220)
-* Fixed an issue where logging an `app` instance could result in a MongoDB Realm function being called. [#3223](https://github.com/realm/realm-js/pull/3223)
+* If the payload for `callFunction` included certain types the request would fail with `"invalid function call request (status 400)"`. All `EJSON` serialization is now done in canonical mode. ([#3157](https://github.com/realm/realm-js/pull/3157))
+* Fixed sending device information when authenticating a user. ([#3220](https://github.com/realm/realm-js/pull/3220))
+* Fixed an issue where logging an `app` instance could result in a MongoDB Realm function being called. ([#3223](https://github.com/realm/realm-js/pull/3223))
 
 ### Internal
 * None
@@ -33,7 +33,7 @@
 * None
 
 ### Fixed
-* Fixed error `"function not found: 'argsTransformation'"` when calling `user.functions.callFunction('functionName', args)` [#3134](https://github.com/realm/realm-js/pull/3134)
+* Fixed error `"function not found: 'argsTransformation'"` when calling `user.functions.callFunction('functionName', args)`. ([#3134](https://github.com/realm/realm-js/pull/3134))
 
 ### Internal
 * None

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changing the behaviour when refreshing an access token fails. With this change, if the refresh token cannot be used to refresh an access token, the user is logged out. ([#3269](https://github.com/realm/realm-js/pull/3269))
 
 ### Fixed
-* Fixed forgetting the users access and refresh tokens, even if the request to delete the session fails. ([#3269](https://github.com/realm/realm-js/pull/3269))
+* Fixed forgetting the user's access and refresh tokens, even if the request to delete the session fails. ([#3269](https://github.com/realm/realm-js/pull/3269))
 
 ### Internal
 * None

--- a/packages/realm-web/src/Fetcher.ts
+++ b/packages/realm-web/src/Fetcher.ts
@@ -273,7 +273,13 @@ export class Fetcher implements LocationUrlContext {
                 attempts === 0
             ) {
                 // Refresh the access token
-                await user.refreshAccessToken();
+                try {
+                    await user.refreshAccessToken();
+                } catch (err) {
+                    await user.logOut();
+                    // Rethrow
+                    throw err;
+                }
                 // Retry with the specific user, since the currentUser might have changed.
                 return this.fetch({ ...request, user }, attempts + 1);
             } else {

--- a/packages/realm-web/src/Fetcher.ts
+++ b/packages/realm-web/src/Fetcher.ts
@@ -233,12 +233,10 @@ export class Fetcher implements LocationUrlContext {
      * Fetch a network resource as an authenticated user.
      *
      * @param request The request which should be sent to the server.
-     * @param attempts Number of times this request has been attempted. Used when retrying, callers don't need to pass a value.
      * @returns The response from the server.
      */
     public async fetch<RequestBody = unknown>(
         request: AuthenticatedRequest<RequestBody>,
-        attempts = 0,
     ): Promise<FetchResponse> {
         const {
             path,
@@ -269,19 +267,25 @@ export class Fetcher implements LocationUrlContext {
             } else if (
                 user &&
                 response.status === 401 &&
-                tokenType === "access" &&
-                attempts === 0
+                tokenType === "access"
             ) {
-                // Refresh the access token
                 try {
+                    // If the access token has expired, it would help refreshing it
                     await user.refreshAccessToken();
+                    // Retry with the specific user, since the currentUser might have changed.
+                    return this.fetch({ ...request, user });
                 } catch (err) {
-                    await user.logOut();
+                    if (
+                        err instanceof MongoDBRealmError &&
+                        err.statusCode === 401
+                    ) {
+                        // A 401 error while refreshing the access token indicates the refresh token has an issue too
+                        // Log out the user to prevent a live lock.
+                        await user.logOut();
+                    }
                     // Rethrow
                     throw err;
                 }
-                // Retry with the specific user, since the currentUser might have changed.
-                return this.fetch({ ...request, user }, attempts + 1);
             } else {
                 // Throw an error with a message extracted from the body
                 throw await MongoDBRealmError.fromRequestAndResponse(

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -252,16 +252,19 @@ export class User<
      */
     public async logOut() {
         // Invalidate the refresh token
-        if (this._refreshToken !== null) {
-            await this.fetcher.fetchJSON({
-                method: "DELETE",
-                path: routes.api().auth().session().path,
-                tokenType: "refresh",
-            });
+        try {
+            if (this._refreshToken !== null) {
+                await this.fetcher.fetchJSON({
+                    method: "DELETE",
+                    path: routes.api().auth().session().path,
+                    tokenType: "refresh",
+                });
+            }
+        } finally {
+            // Forget the access and refresh token
+            this.accessToken = null;
+            this.refreshToken = null;
         }
-        // Forget the access and refresh token
-        this.accessToken = null;
-        this.refreshToken = null;
     }
 
     /** @inheritdoc */

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -446,7 +446,7 @@ describe("App", () => {
         ]);
         // Login with an anonymous user
         const credentials = Credentials.anonymous();
-        await app.logIn(credentials, false);
+        const user = await app.logIn(credentials, false);
         // Send a request (which will fail)
         try {
             await app.functions.foo({ bar: "baz" });
@@ -455,10 +455,14 @@ describe("App", () => {
             expect(err).instanceOf(MongoDBRealmError);
             if (err instanceof MongoDBRealmError) {
                 expect(err.message).equals(
-                    "Request failed (POST http://localhost:1337/api/client/v2.0/auth/session): invalid session (status 401)",
+                    // Trying this if the request from
+                    "Request failed (DELETE http://localhost:1337/api/client/v2.0/auth/session): invalid session (status 401)",
                 );
             }
         }
+        // Expect the tokens to be forgotten
+        expect(user.accessToken).equals(null);
+        expect(user.refreshToken).equals(null);
         // Manually try again - this time refreshing the access token correctly
         const response = await app.functions.foo({ bar: "baz" });
         expect(response).deep.equals({ bar: "baz" });

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -90,9 +90,12 @@ describe("User", () => {
                 },
             },
         ]);
+        // Expect the user to forget tokens anyway
+        expect(user.accessToken).equals(null);
+        expect(user.refreshToken).equals(null);
     });
 
-    it("won't throw if session delete fails", async () => {
+    it("will forget tokens if session delete fails", async () => {
         const app = new MockApp("my-mocked-app", [
             LOCATION_RESPONSE,
             new MongoDBRealmError(

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -113,11 +113,12 @@ describe("User", () => {
             refreshToken: "very-refreshing",
         });
         // Log out the user
-        let errorThrown;
-        await user.logOut().then(null, err => {
-            errorThrown = err;
-        });
-        expect(errorThrown).instanceOf(MongoDBRealmError);
+        try {
+            await user.logOut();
+            assert.fail("Logout should fail");
+        } catch (err) {
+            expect(err).instanceOf(MongoDBRealmError);
+        }
         // Expect the user to forget tokens anyway
         expect(user.accessToken).equals(null);
         expect(user.refreshToken).equals(null);

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -20,6 +20,7 @@ import { expect } from "chai";
 import { inspect } from "util";
 
 import { UserType, User, Credentials } from "..";
+import { MongoDBRealmError } from "../MongoDBRealmError";
 
 import {
     MockApp,
@@ -89,6 +90,34 @@ describe("User", () => {
                 },
             },
         ]);
+    });
+
+    it("won't throw if session delete fails", async () => {
+        const app = new MockApp("my-mocked-app", [
+            LOCATION_RESPONSE,
+            new MongoDBRealmError(
+                "POST",
+                "http://localhost:1337/some-path",
+                401,
+                "",
+                "invalid session",
+            ),
+        ]);
+        const user = new User({
+            app,
+            id: "some-user-id",
+            accessToken: "deadbeef",
+            refreshToken: "very-refreshing",
+        });
+        // Log out the user
+        let errorThrown;
+        await user.logOut().then(null, err => {
+            errorThrown = err;
+        });
+        expect(errorThrown).instanceOf(MongoDBRealmError);
+        // Expect the user to forget tokens anyway
+        expect(user.accessToken).equals(null);
+        expect(user.refreshToken).equals(null);
     });
 
     it("can refresh the user profile", async () => {

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -115,7 +115,7 @@ describe("User", () => {
         // Log out the user
         try {
             await user.logOut();
-            assert.fail("Logout should fail");
+            expect.fail("Log out should fail");
         } catch (err) {
             expect(err).instanceOf(MongoDBRealmError);
         }


### PR DESCRIPTION
## What, How & Why?

**As is**: Failure during access token / session refresh (which could happen due to the session or user already being deleted from the server), would fail an authenticated request with the failure from refreshing the token.
**To be**: Merging this PR, if the request refreshing the access token fails with a 401 HTTP status code, we expect the refresh token to have been invalidated and we therefore don't expect a retry of the request to solve anything - the only thing we can do to make progress is logging out the user.

This also fixes an issue where session deletion upon logging out a user wouldn't make the user forget their token.

The semantics of logging out or removing a user might change in the future, but this is an attempt to make the current implementation a bit more robust and usable.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
