### PR TITLE
Realm Web: Send device information in body (fixing tests)

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None
 
 ### Internal
-* None
+* Sending device information in request body instead of a query parameter. ([#3295](https://github.com/realm/realm-js/pull/3295))
 
 0.9.0 Release notes (2020-09-24)
 =============================================================

--- a/packages/realm-web/src/Authenticator.ts
+++ b/packages/realm-web/src/Authenticator.ts
@@ -96,7 +96,7 @@ export class Authenticator {
                 // Ensure redirects are communicated in a header different from "Location" and status remains 200 OK
                 providerRedirectHeader: isLinking ? true : undefined,
                 // Add the device information, only if we're not linking - since that request won't have a body of its own.
-                device: deviceInformation.encode(),
+                device: !isLinking ? deviceInformation.encode() : undefined,
             });
 
             // If we're linking, we need to send the users access token in the request

--- a/packages/realm-web/src/Authenticator.ts
+++ b/packages/realm-web/src/Authenticator.ts
@@ -82,6 +82,7 @@ export class Authenticator {
         credentials: Realm.Credentials<any>,
         linkingUser?: User<object, object>,
     ): Promise<AuthResponse> {
+        const deviceInformation = this.getDeviceInformation();
         const isLinking = typeof linkingUser === "object";
         if (
             credentials.providerType.startsWith("oauth2") &&
@@ -94,6 +95,8 @@ export class Authenticator {
                 redirect: credentials.payload.redirectUrl,
                 // Ensure redirects are communicated in a header different from "Location" and status remains 200 OK
                 providerRedirectHeader: isLinking ? true : undefined,
+                // Add the device information, only if we're not linking - since that request won't have a body of its own.
+                device: deviceInformation.encode(),
             });
 
             // If we're linking, we need to send the users access token in the request
@@ -132,7 +135,12 @@ export class Authenticator {
             const response = await this.fetcher.fetchJSON({
                 method: "POST",
                 url: logInUrl,
-                body: credentials.payload,
+                body: {
+                    ...credentials.payload,
+                    options: {
+                        device: deviceInformation.toJSON(),
+                    },
+                },
                 tokenType: isLinking ? "access" : "none",
                 user: linkingUser,
             });
@@ -168,10 +176,8 @@ export class Authenticator {
         const loginRoute = appRoute
             .authProvider(credentials.providerName)
             .login();
-        const deviceInformation = this.getDeviceInformation();
         const qs = encodeQueryString({
             link: link ? "true" : undefined,
-            device: deviceInformation.encode(),
             ...extraQueryParams,
         });
         const locationUrl = await this.fetcher.locationUrl;

--- a/packages/realm-web/src/DeviceInformation.ts
+++ b/packages/realm-web/src/DeviceInformation.ts
@@ -111,4 +111,11 @@ export class DeviceInformation implements DeviceInformationValues {
         const obj = removeKeysWithUndefinedValues(this);
         return Base64.encode(JSON.stringify(obj));
     }
+
+    /**
+     * @returns The defaults
+     */
+    public toJSON() {
+        return removeKeysWithUndefinedValues(this);
+    }
 }

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -26,7 +26,7 @@ import {
     SENDING_JSON_HEADERS,
     LOCATION_RESPONSE,
     LOCATION_REQUEST,
-    DEFAULT_DEVICE,
+    DEFAULT_AUTH_OPTIONS,
     MockApp,
     MockNetworkTransport,
 } from "./utils";
@@ -105,8 +105,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
         ]);
@@ -163,10 +165,11 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login?device=${DEFAULT_DEVICE}`,
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login`,
                 body: {
                     username: "gilfoyle@testing.mongodb.com",
                     password: "v3ry-s3cret",
+                    options: DEFAULT_AUTH_OPTIONS,
                 },
                 headers: SENDING_JSON_HEADERS,
             },
@@ -213,8 +216,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
             {
@@ -281,10 +286,11 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login?device=${DEFAULT_DEVICE}`,
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login`,
                 body: {
                     username: "gilfoyle@testing.mongodb.com",
                     password: "v3ry-s3cret-1",
+                    options: DEFAULT_AUTH_OPTIONS,
                 },
                 headers: SENDING_JSON_HEADERS,
             },
@@ -298,10 +304,11 @@ describe("App", () => {
             },
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login?device=${DEFAULT_DEVICE}`,
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login`,
                 body: {
                     username: "dinesh@testing.mongodb.com",
                     password: "v3ry-s3cret-2",
+                    options: DEFAULT_AUTH_OPTIONS,
                 },
                 headers: SENDING_JSON_HEADERS,
             },
@@ -348,8 +355,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
             {
@@ -412,8 +421,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
         ]);
@@ -467,8 +478,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
             {
@@ -546,8 +559,10 @@ describe("App", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login?device=${DEFAULT_DEVICE}`,
-                body: {},
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
                 headers: SENDING_JSON_HEADERS,
             },
             {

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -27,7 +27,7 @@ import {
     LOCATION_REQUEST,
     ACCEPT_JSON_HEADERS,
     SENDING_JSON_HEADERS,
-    DEFAULT_DEVICE,
+    DEFAULT_AUTH_OPTIONS,
 } from "./utils";
 
 // Since responses from the server uses underscores in field names:
@@ -253,7 +253,7 @@ describe("User", () => {
             LOCATION_REQUEST,
             {
                 method: "POST",
-                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login?link=true&device=${DEFAULT_DEVICE}`,
+                url: `http://localhost:1337/api/client/v2.0/app/my-mocked-app/auth/providers/local-userpass/login?link=true`,
                 headers: {
                     ...SENDING_JSON_HEADERS,
                     Authorization: "Bearer deadbeef",
@@ -261,6 +261,7 @@ describe("User", () => {
                 body: {
                     username: "gilfoyle@testing.mongodb.com",
                     password: "s3cr3t",
+                    options: DEFAULT_AUTH_OPTIONS,
                 },
             },
             {

--- a/packages/realm-web/src/tests/utils/index.ts
+++ b/packages/realm-web/src/tests/utils/index.ts
@@ -50,10 +50,16 @@ export const LOCATION_RESPONSE = Object.freeze({
 });
 
 /**
- * Default information about the device.
+ * Default options sent when authenticating.
  */
-export const DEFAULT_DEVICE =
-    "eyJzZGtWZXJzaW9uIjoiMC4wLjAtdGVzdCIsInBsYXRmb3JtIjoibm9kZSIsInBsYXRmb3JtVmVyc2lvbiI6IjEyLjE0LjEifQ%3D%3D";
+export const DEFAULT_AUTH_OPTIONS = {
+    device: {
+        platform: "node",
+        platformVersion: process.versions.node,
+        // As defined in /test/env.js
+        sdkVersion: "0.0.0-test",
+    },
+};
 
 export * from "./MockApp";
 export * from "./MockFetcher";


### PR DESCRIPTION
## What, How & Why?

This close https://github.com/realm/realm-js/issues/3282 and an issue with tests failing if run on a different Node.js version than the authors.

This also change over to attaching device information in the request body for regular auth requests: https://github.com/realm/realm-object-store/blob/v10/src/sync/app.cpp#L649-L663

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
