### PR TITLE
Realm Web: Move the getApp method

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Enhancements
 * Changing the behaviour when refreshing an access token fails. With this change, if the refresh token cannot be used to refresh an access token, the user is logged out. ([#3269](https://github.com/realm/realm-js/pull/3269))
+* Moved the `getApp` function exported by the package onto the `App` class as a static method. This can be used to get or create an instance from an app-id. ([#3297](https://github.com/realm/realm-js/pull/3297))
 
 ### Fixed
 * Fixed forgetting the user's access and refresh tokens, even if the request to delete the session fails. ([#3269](https://github.com/realm/realm-js/pull/3269))

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -61,6 +61,28 @@ export class App<
     FunctionsFactoryType extends object = Realm.DefaultFunctionsFactory,
     CustomDataType extends object = any
 > implements Realm.App<FunctionsFactoryType, CustomDataType> {
+    /**
+     * A map of app instances returned from calling getApp.
+     */
+    private static appCache: { [id: string]: Realm.App } = {};
+
+    /**
+     * Get or create a singleton Realm App from an id.
+     * Calling this function multiple times with the same id will return the same instance.
+     *
+     * @param id The Realm App id visible from the MongoDB Realm UI or a configuration.
+     * @returns The Realm App instance.
+     */
+    static getApp(id: string) {
+        if (id in App.appCache) {
+            return App.appCache[id];
+        } else {
+            const instance = new App(id);
+            App.appCache[id] = instance;
+            return instance;
+        }
+    }
+
     /** @inheritdoc */
     public readonly functions: FunctionsFactoryType &
         Realm.BaseFunctionsFactory;

--- a/packages/realm-web/src/index.ts
+++ b/packages/realm-web/src/index.ts
@@ -18,22 +18,15 @@
 
 import { App } from "./App";
 
-const appCache: { [id: string]: Realm.App } = {};
-
 /**
  * Get or create a singleton Realm App from an id.
+ * Calling this function multiple times with the same id will return the same instance.
  *
  * @param id The Realm App id visible from the MongoDB Realm UI or a configuration.
- * @returns The Realm App instance. Calling this function multiple times with the same id will return the same instance.
+ * @returns The Realm App instance.
  */
 export function getApp(id: string) {
-    if (id in appCache) {
-        return appCache[id];
-    } else {
-        const instance = new App(id);
-        appCache[id] = instance;
-        return instance;
-    }
+    return App.getApp(id);
 }
 
 export * from "./App";

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -39,6 +39,17 @@ describe("App", () => {
         expect(app).to.be.instanceOf(App);
     });
 
+    describe("static getApp function", () => {
+        it("return the same App instance only if ids match", () => {
+            const app1 = App.getApp("default-app-id");
+            expect(app1).to.be.instanceOf(App);
+            const app2 = App.getApp("default-app-id");
+            expect(app2).equals(app1);
+            const app3 = App.getApp("another-app-id");
+            expect(app2).to.not.equal(app3);
+        });
+    });
+
     it("can call the App as a constructor with options", () => {
         const app = new App({
             id: "default-app-id",

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -273,7 +273,11 @@ declare namespace Realm {
         >;
 
         /**
-         * Get an app instance.
+         * Get or create a singleton Realm App from an id.
+         * Calling this function multiple times with the same id will return the same instance.
+         *
+         * @param id The Realm App id visible from the MongoDB Realm UI or a configuration.
+         * @returns The Realm App instance.
          */
         static getApp(appId: string): App;
 


### PR DESCRIPTION
## What, How & Why?

This closes a part of #3256 by moving the `getApp` method from the package to a static member of the `App` class.

```javascript
import { App } from "realm-web";
const app = App.getApp("my-awesome-app");
```

Since I expect this to be such a common method to use (and to avoid this being a breaking change), I decided to leave in the named exported function too (which calls `App.getApp` internally) for now, which enables:

```javascript
import { getApp } from "realm-web";
const app = getApp("my-awesome-app");
```

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
