### PR TITLE
Realm Web: App "services" and "functions" removed

### DIFF
--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -18,13 +18,7 @@
 
 import { expect } from "chai";
 
-import {
-    App,
-    Credentials,
-    User,
-    LocalStorage,
-    getEnvironment,
-} from "realm-web";
+import { App, Credentials, User, getEnvironment } from "realm-web";
 
 import { createApp } from "./utils";
 

--- a/packages/realm-web-integration-tests/src/functions.test.ts
+++ b/packages/realm-web-integration-tests/src/functions.test.ts
@@ -31,9 +31,9 @@ describe("Realm.FunctionsFactory", () => {
         const app = createApp<TranslateFunctions>();
         // Login a user
         const credentials = Credentials.anonymous();
-        await app.logIn(credentials);
+        const user = await app.logIn(credentials);
         // Call a function
-        const response = await app.functions.translate("hello", "en_fr");
+        const response = await user.functions.translate("hello", "en_fr");
         expect(response).to.equal("bonjour");
     });
 });

--- a/packages/realm-web-integration-tests/src/http-service.test.ts
+++ b/packages/realm-web-integration-tests/src/http-service.test.ts
@@ -16,6 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+// TODO: Re-enable if the HTTP service gets reintroduced to the API.
+
+/*
 import { expect } from "chai";
 import { Credentials } from "realm-web";
 
@@ -43,3 +46,4 @@ describe("HTTP", () => {
         expect(body.name).equals("realm-js");
     });
 });
+*/

--- a/packages/realm-web-integration-tests/src/iife.test.ts
+++ b/packages/realm-web-integration-tests/src/iife.test.ts
@@ -77,9 +77,9 @@ describeIf(typeof window === "object", "IIFE bundle", () => {
         const app = new Realm.App({ id: APP_ID, baseUrl: BASE_URL });
         // Authenticate
         const credentials = Realm.Credentials.anonymous();
-        await app.logIn(credentials);
+        const user = await app.logIn(credentials);
         // Call a function
-        const response = await app.functions.translate("hello", "en_fr");
+        const response = await user.functions.translate("hello", "en_fr");
         expect(response).to.equal("bonjour");
     });
 });

--- a/packages/realm-web-integration-tests/src/remote-mongodb-service.test.ts
+++ b/packages/realm-web-integration-tests/src/remote-mongodb-service.test.ts
@@ -39,10 +39,14 @@ describe("Remote MongoDB", () => {
         await app.logIn(credentials);
     });
 
-    function getCollection() {
-        const mongodb = app.services.mongodb("local-mongodb");
-        const db = mongodb.db("test-database");
-        return db.collection<TestDocument>("test-collection");
+    function getCollection<T extends Realm.Services.MongoDB.Document>() {
+        if (app.currentUser) {
+            const mongodb = app.currentUser.mongoClient("local-mongodb");
+            const db = mongodb.db("test-database");
+            return db.collection<T>("test-collection");
+        } else {
+            throw new Error("Expected an authenticated user");
+        }
     }
 
     let runId: number;
@@ -50,7 +54,7 @@ describe("Remote MongoDB", () => {
         // Genereate a collection
         runId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
         // Insert a couple of documents
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         await collection.insertMany([
             {
                 runId,
@@ -71,7 +75,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can find documents", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.find(
             { name: { $exists: true } },
             { limit: 10 },
@@ -84,7 +88,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("returns null when finding no document", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.findOne({
             whatever: "non-existent",
         });
@@ -92,7 +96,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can find a single documents, with projection", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.findOne(
             { runId, name: "Bob" },
             { projection: { name: 1 } },
@@ -108,7 +112,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can upsert a document if no one is found", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.findOneAndUpdate(
             { runId, name: "Nobody" },
             { name: "Dennis", hiddenField: "a hidden value" },
@@ -125,7 +129,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can find and update a document, with projection", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.findOneAndUpdate(
             { runId, name: "Bob" },
             { name: "Bobby" },
@@ -142,7 +146,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can find and replace a document, with projection", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.findOneAndReplace(
             { runId, name: "Alice" },
             { runId, name: "Alison" },
@@ -163,7 +167,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can find and delete a document", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const countBefore = await collection.count({ runId });
         // Delete the document with the last name (Charlie)
         const result = await collection.findOneAndDelete(
@@ -185,7 +189,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can aggregate", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const result = await collection.aggregate([
             { $match: { runId } },
             { $group: { _id: null, names: { $push: "$name" } } },
@@ -195,7 +199,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can count documents, insert a document and count & retrieve it again", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Determine the number of documents before insertion
         const countBefore = await collection.count();
         // Insert a document
@@ -221,7 +225,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can insert many documents", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Determine the number of documents before insertion
         const countBefore = await collection.count();
         // Insert a document
@@ -240,7 +244,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can delete a document", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const countBefore = await collection.count({ runId });
         // Delete the document with the last name (Charlie)
         const result = await collection.deleteOne({ runId });
@@ -253,7 +257,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can delete many documents", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         const countBefore = await collection.count({ runId });
         expect(countBefore).equals(3);
         // Delete all documents in this run
@@ -267,7 +271,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can update a document", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Delete the document with the last name (Charlie)
         const result = await collection.updateOne(
             { runId, name: "Alice" },
@@ -281,7 +285,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("upserts a document when updating and the query match nothing", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Delete the document with the last name (Charlie)
         const result = await collection.updateOne(
             { runId, name: "Dennis" },
@@ -296,7 +300,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("can update many documents", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Delete the document with the last name (Charlie)
         const result = await collection.updateMany(
             { runId },
@@ -309,7 +313,7 @@ describe("Remote MongoDB", () => {
     });
 
     it("upserts when updating many non-existing documents", async () => {
-        const collection = getCollection();
+        const collection = getCollection<TestDocument>();
         // Delete the document with the last name (Charlie)
         const result = await collection.updateMany(
             { runId, name: "Dennis" },
@@ -327,10 +331,9 @@ describe("Remote MongoDB", () => {
         this.timeout(10_000);
         this.slow(2_000);
 
-        const mongodb = app.services.mongodb("local-mongodb");
-        const db = mongodb.db("test-database");
-        const collection = db.collection("test-collection");
+        const collection = getCollection<any>();
 
+        // Delete all documents in the collection
         await collection.deleteMany({});
 
         const sleep = async (time: number) =>

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,6 +1,9 @@
 ?.?.? Release notes (2020-??-??)
 =============================================================
 
+### Breaking Changes
+* Removed the `functions` and `services` properties from `App`, use the `functions` property and `mongoClient` method on `User` instances instead. ([#3298](https://github.com/realm/realm-js/pull/3298))
+
 ### Enhancements
 * Changing the behaviour when refreshing an access token fails. With this change, if the refresh token cannot be used to refresh an access token, the user is logged out. ([#3269](https://github.com/realm/realm-js/pull/3269))
 

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -22,10 +22,8 @@ import {
 } from "realm-network-transport";
 import { ObjectId } from "bson";
 
-import { FunctionsFactory } from "./FunctionsFactory";
 import { User, UserState } from "./User";
 import { Credentials } from "./Credentials";
-import { create as createServicesFactory } from "./services";
 import { EmailPasswordAuth } from "./auth-providers";
 import { Storage } from "./storage";
 import { AppStorage } from "./AppStorage";
@@ -61,13 +59,6 @@ export class App<
     FunctionsFactoryType extends object = Realm.DefaultFunctionsFactory,
     CustomDataType extends object = any
 > implements Realm.App<FunctionsFactoryType, CustomDataType> {
-    /** @inheritdoc */
-    public readonly functions: FunctionsFactoryType &
-        Realm.BaseFunctionsFactory;
-
-    /** @inheritdoc */
-    public readonly services: Realm.Services;
-
     /** @inheritdoc */
     public readonly id: string;
 
@@ -149,12 +140,6 @@ export class App<
             locationUrlContext: this,
             transport,
         });
-        // Construct the functions factory
-        this.functions = FunctionsFactory.create<FunctionsFactoryType>(
-            this.fetcher,
-        );
-        // Construct the services factory
-        this.services = createServicesFactory(this.fetcher);
         // Construct the auth providers
         this.emailPasswordAuth = new EmailPasswordAuth(this.fetcher);
         // Construct the storage

--- a/packages/realm-web/src/services/HTTPService.ts
+++ b/packages/realm-web/src/services/HTTPService.ts
@@ -30,7 +30,7 @@ type Response = Realm.Services.HTTP.Response;
  *
  * @see https://docs.mongodb.com/stitch/services/http/
  */
-class HTTPService implements HTTP {
+export class HTTPService implements HTTP {
     /**
      * The functions factory interface to use when sending requests.
      */

--- a/packages/realm-web/src/services/MongoDBService/index.ts
+++ b/packages/realm-web/src/services/MongoDBService/index.ts
@@ -31,9 +31,7 @@ export { MongoDBCollection };
  * @param collectionName A collection name.
  * @returns The collection.
  */
-export function createCollection<
-    T extends Realm.Services.MongoDB.Document = any
->(
+function createCollection<T extends Realm.Services.MongoDB.Document = any>(
     fetcher: Fetcher,
     serviceName: string,
     databaseName: string,
@@ -56,7 +54,7 @@ export function createCollection<
  * @param databaseName A database name
  * @returns The database.
  */
-export function createDatabase(
+function createDatabase(
     fetcher: Fetcher,
     serviceName: string,
     databaseName: string,

--- a/packages/realm-web/src/services/index.ts
+++ b/packages/realm-web/src/services/index.ts
@@ -16,20 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Fetcher } from "../Fetcher";
+export {
+    MongoDBCollection,
+    createService as createMongoDBService,
+} from "./MongoDBService";
 
-import { createService as createMongoDBRemoteService } from "./MongoDBService";
-import { createService as createHttpService } from "./HTTPService";
-
-/**
- * Create all services for a particular app.
- *
- * @param fetcher The fetcher to use when senting requests to the services.
- * @returns An object containing functions that create the individual services.
- */
-export function create(fetcher: Fetcher): Realm.Services {
-    return {
-        mongodb: createMongoDBRemoteService.bind(null, fetcher),
-        http: createHttpService.bind(null, fetcher),
-    };
-}
+export { HTTPService, createService as createHTTPService } from "./HTTPService";

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -64,16 +64,6 @@ describe("App", () => {
         expect(app.id).equals("default-app-id");
     });
 
-    it("expose a functions factory", () => {
-        const app = new App("default-app-id");
-        expect(typeof app.functions).equals("object");
-    });
-
-    it("expose a callable functions factory", () => {
-        const app = new App("default-app-id");
-        expect(typeof app.functions.hello).equals("function");
-    });
-
     it("expose a static Credentials factory", () => {
         expect(typeof App.Credentials).not.equals("undefined");
         expect(typeof App.Credentials.anonymous).equals("function");
@@ -454,7 +444,7 @@ describe("App", () => {
         expect(user.accessToken).not.equals(null);
         expect(user.refreshToken).not.equals(null);
         // Manually try again - this time refreshing the access token correctly
-        const response = await app.functions.foo({ bar: "baz" });
+        const response = await user.functions.foo({ bar: "baz" });
         expect(response).deep.equals({ bar: "baz" });
         // Expect something of the request and response
         expect(app.requests).deep.equals([
@@ -520,7 +510,7 @@ describe("App", () => {
         const user = await app.logIn(credentials, false);
         // Send a request (which will fail)
         try {
-            await app.functions.foo({ bar: "baz" });
+            await user.functions.foo({ bar: "baz" });
             throw new Error("Expected the request to fail");
         } catch (err) {
             expect(err).instanceOf(MongoDBRealmError);
@@ -590,9 +580,9 @@ describe("App", () => {
             baseUrl: "http://localhost:1234",
         });
         const credentials = Credentials.anonymous();
-        await app.logIn(credentials, false);
+        const user = await app.logIn(credentials, false);
         // Call the function
-        const response = await app.functions.hello();
+        const response = await user.functions.hello();
         expect(response).to.deep.equal({ msg: "hi there!" });
         expect(transport.requests).to.deep.equal([
             LOCATION_REQUEST,
@@ -613,17 +603,6 @@ describe("App", () => {
                 },
             },
         ]);
-    });
-
-    it("expose a collection of service factories", () => {
-        const transport = new MockNetworkTransport([]);
-        const app = new App({
-            id: "my-mocked-app",
-            transport,
-            baseUrl: "http://localhost:1337",
-        });
-        expect(app.services).keys(["mongodb", "http"]);
-        expect(typeof app.services.mongodb).equals("function");
     });
 
     it("hydrates users from storage", () => {


### PR DESCRIPTION
## What, How & Why?

This closes a part of #3256 by removing the `services` and `functions` members from instances of `App`, to align with Realm JS and other SDKs.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
