### PR TITLE
Aborting CI when changes only happen to /packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
 
 ### Internal
-* None.
+* Changed CI to abort if changes are exclusively made to the /packages directory. ([#3298](https://github.com/realm/realm-js/pull/3298))
 
 10.0.0-rc.1 Release notes (2020-10-1)
 =============================================================


### PR DESCRIPTION
## What, How & Why?

Since the /packages are not relying on Jenkins, I suggest aborting the job if changes are made only to these files to allow an clean migration to another CI platform.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually on this PR)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
