### PR TITLE
Realm Web: Add custom JWT metadata to UserProfile data property

### DIFF
--- a/packages/realm-web/src/UserProfile.ts
+++ b/packages/realm-web/src/UserProfile.ts
@@ -94,6 +94,9 @@ export class UserProfile implements Realm.UserProfile {
     public readonly maxAge?: string;
 
     /** @inheritdoc */
+    public readonly data?: any;
+
+    /** @inheritdoc */
     public readonly type: Realm.UserType = UserType.Normal;
 
     /** @inheritdoc */
@@ -134,6 +137,17 @@ export class UserProfile implements Realm.UserProfile {
                     ) {
                         this[propertyName] = value;
                     }
+                }
+                // Add remaining data to `data` property
+                const metadata = Object.entries(data).reduce((acc, entry) => {
+                    if (DATA_MAPPING[entry[0] as DataKey]) {
+                        return acc;
+                    }
+                    acc[entry[0]] = entry[1];
+                    return acc;
+                }, {} as Record<string, unknown>);
+                if (Object.keys(metadata).length > 0) {
+                    this.data = metadata;
                 }
             } else {
                 throw new Error("Expected 'data' in the response body");

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -131,6 +131,7 @@ describe("User", () => {
                 {
                     data: {
                         first_name: "John",
+                        metadata: "JWT metadata",
                     },
                     identities: [],
                     type: "normal",
@@ -150,6 +151,9 @@ describe("User", () => {
             identities: [],
             type: UserType.Normal,
             firstName: "John",
+            data: {
+                metadata: "JWT metadata",
+            },
         });
     });
 


### PR DESCRIPTION
## What, How & Why?
Fixes realm/realm-js#3268
Any properties from the `data` property on the `/profile` HTTP response which are not specified in the `DATA_MAPPING` keys, will be added to the `UserProfile.data` property. This results in the same behaviour as the old Stitch browser SDK.


## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
