### PR TITLE
open-behaviour-tests (v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: This version uses the Realm file format to version 20. It is not possible 
 * TS declaration for `isLoggedIn` added to `User`. ([#3294](https://github.com/realm/realm-js/pull/3294))
 * Fixed error `Attempted import error: 'invalidateCache' is not exported from './util' (imported as 'util').` ([#3314](https://github.com/realm/realm-js/issues/3314))
 * Fixed a bug preventing caching of Realm instances. In certain cases, the Realm file would grow without any new objects added.
+* TS declarations for `OpenRealmBehaviorConfiguration` presets `openLocalRealmBehavior` & `downloadBeforeOpenBehavior` moved to namespace `Realm.App.Sync`, to reflect the implementation. ([#3307](https://github.com/realm/realm-js/pull/3307), since v10.0.0-beta.1)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -10,6 +10,7 @@ const Realm = require('realm');
 const TestCase = require('./asserts');
 const AppConfig = require('./support/testConfig')
 const Utils = require('./test-utils');
+const schemas = require('./schemas');
 
 const config = AppConfig.integrationAppConfig;
 
@@ -148,16 +149,7 @@ module.exports = {
         let user = await app.logIn(credentials);
         const partition = Utils.genPartition();
         const realmConfig = {
-            schema: [{
-                name: 'Dog',
-                primaryKey: '_id',
-                properties: {
-                  _id: 'objectId?',
-                  breed: 'string?',
-                  name: 'string',
-                  realm_id: 'string?',
-                }
-              }],
+            schema: [schemas.DogForSync],
             sync: {
                 user: user,
                 partitionValue: partition,

--- a/tests/js/asserts.js
+++ b/tests/js/asserts.js
@@ -201,6 +201,22 @@ module.exports = {
             throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown`, depth);
         }
     },
+    assertThrowsAsyncContaining: async function(func, expectedMessage, depth) {
+        let caught = false;
+        try {
+            await func();
+        }
+        catch (e) {
+            caught = true;
+            if (!e.message.includes(expectedMessage)) {
+                throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown - instead caught: "${e}"`, depth);
+            }
+        }
+
+        if (!caught) {
+            throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown`, depth);
+        }
+    },
 
     assertTrue: function(condition, errorMessage, depth) {
         if (!condition) {

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -16,57 +16,57 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
-const Realm = require('realm');
+const Realm = require("realm");
 
-if (typeof Realm.App !== 'undefined' && Realm.App !== null) {
+if (typeof Realm.App !== "undefined" && Realm.App !== null) {
     global.WARNING = "global is not available in React Native. Use it only in tests";
     global.enableSyncTests = process.env.REALM_DISABLE_SYNC_TESTS ? false : true;
 }
 
-const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';
-const isElectronProcess = typeof process === 'object' && process.versions && process.versions.electron;
+const isNodeProcess = typeof process === "object" && process + "" === "[object process]";
+const isElectronProcess = typeof process === "object" && process.versions && process.versions.electron;
 const require_method = require;
 function node_require(module) { return require_method(module); }
 
-if (isNodeProcess && process.platform === 'win32') {
+if (isNodeProcess && process.platform === "win32") {
     global.enableSyncTests = false;
 }
 
 var TESTS = {
-    ListTests: require('./list-tests'),
-    LinkingObjectsTests: require('./linkingobjects-tests'),
-    ObjectTests: require('./object-tests'),
-    RealmTests: require('./realm-tests'),
-    ResultsTests: require('./results-tests'),
-    QueryTests: require('./query-tests'),
-    MigrationTests: require('./migration-tests'),
-    EncryptionTests: require('./encryption-tests'),
-    AliasTests: require('./alias-tests'),
-    BsonTests: require('./bson-tests'),
+    ListTests: require("./list-tests"),
+    LinkingObjectsTests: require("./linkingobjects-tests"),
+    ObjectTests: require("./object-tests"),
+    RealmTests: require("./realm-tests"),
+    ResultsTests: require("./results-tests"),
+    QueryTests: require("./query-tests"),
+    MigrationTests: require("./migration-tests"),
+    EncryptionTests: require("./encryption-tests"),
+    AliasTests: require("./alias-tests"),
+    BsonTests: require("./bson-tests"),
     // Garbagecollectiontests: require('./garbage-collection'),
 };
 
 //TODO: remove when MongoDB Realm test server can be hosted on Mac or other options exists
 if (isNodeProcess) {
-    TESTS.ObjectIDTests = require('./object-id-tests');
+    TESTS.ObjectIDTests = require("./object-id-tests");
 }
 
 // If sync is enabled, run the sync tests
 if (global.enableSyncTests) {
     //TODO: remove when MongoDB Realm test server can be hosted on Mac or other options exists
     if (isNodeProcess) {
-        TESTS.AppTests = require('./app-tests');
-    // TESTS.OpenBehaviorTests = require('./open-behavior-tests'); // FIXME: figure out how to enable them
-        TESTS.UserTests = require('./user-tests');
-        TESTS.SessionTests = require('./session-tests');
+        TESTS.AppTests = require("./app-tests");
+        TESTS.OpenBehaviorTests = require("./open-behavior-tests"); // FIXME: figure out how to enable them
+        TESTS.UserTests = require("./user-tests");
+        TESTS.SessionTests = require("./session-tests");
     }
 }
 
 // If on node, run the async tests
-if (isNodeProcess && process.platform !== 'win32') {
-    TESTS.AsyncTests = node_require('./async-tests');
+if (isNodeProcess && process.platform !== "win32") {
+    TESTS.AsyncTests = node_require("./async-tests");
 }
 
 var SPECIAL_METHODS = {
@@ -81,7 +81,7 @@ exports.getTestNames = function() {
         var testSuite = TESTS[suiteName];
 
         testNames[suiteName] = Object.keys(testSuite).filter(function(testName) {
-            return !(testName in SPECIAL_METHODS) && typeof testSuite[testName] == 'function';
+            return !(testName in SPECIAL_METHODS) && typeof testSuite[testName] == "function";
         });
     }
 

--- a/tests/js/index.js
+++ b/tests/js/index.js
@@ -58,7 +58,7 @@ if (global.enableSyncTests) {
     //TODO: remove when MongoDB Realm test server can be hosted on Mac or other options exists
     if (isNodeProcess) {
         TESTS.AppTests = require("./app-tests");
-        TESTS.OpenBehaviorTests = require("./open-behavior-tests"); // FIXME: figure out how to enable them
+        TESTS.OpenBehaviorTests = require("./open-behavior-tests");
         TESTS.UserTests = require("./user-tests");
         TESTS.SessionTests = require("./session-tests");
     }

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -140,7 +140,7 @@ module.exports = {
 
         const realm = await Realm.open(config);
 
-        // TODO: Not quite sure what we're testing here?
+        // NOTE: Not quite sure what we're testing here?
         TestCase.assertTrue(realm.empty);
 
         realm.close();
@@ -522,7 +522,7 @@ module.exports = {
 
         const openPromise = new Promise((resolve, reject) => {
             const promise = Realm.open(config);
-            // TODO: could this potentially trigger before canceling?
+            // NOTE: could this potentially trigger before canceling?
             promise.progress(() => {
                 reject("Progress listener called");
             });

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -38,6 +38,17 @@ class TestError extends Error {
 // NOTE: these tests can be simplified once we can create multiple anonymous users.
 
 module.exports = {
+    static_references_defined: function() {
+        TestCase.assertDefined(
+            Realm.App.Sync.openLocalRealmBehavior,
+            "static Realm.App.Sync.openLocalRealmBehavior is missing"
+        );
+        TestCase.assertDefined(
+            Realm.App.Sync.downloadBeforeOpenBehavior,
+            "static Realm.App.Sync.downloadBeforeOpenBehavior is missing"
+        );
+    },
+
     testNewFile_openLocal: async function() {
         // NOTE: this test no longer runs with a logged out user.
         // Reason: Error: User is no longer valid.

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -16,463 +16,527 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
 /* global navigator, WorkerNavigator */
 
-const Realm = require('realm');
-const TestCase = require('./asserts');
-const schemas = require('./schemas');
-const Utils = require('./test-utils');
+const Realm = require("realm");
+const { ObjectId } = require("bson");
+const TestCase = require("./asserts");
+const schemas = require("./schemas");
+const Utils = require("./test-utils");
+const AppConfig = require("./support/testConfig");
+const user = require("../../lib/user");
 
-// Returns a user that looks valid but isn't able to establish a connection to the server
-function getLoggedOutUser() {
-    return Realm.App.Sync.User.login('http://127.0.0.1:9080', Realm.App.Sync.Credentials.nickname("admin", true))
-        .then(user => {
-            const serializedUser = user.serialize();
-            return user.logout().then(() => {
-                return Realm.App.Sync.User.deserialize(serializedUser);
-            });
-        });
+const APP_CONFIG = AppConfig.integrationAppConfig;
+
+class TestError extends Error {
+    constructor(message) {
+        super(message)
+    }
 }
 
-function getLoggedInUser(userName) {
-    const userId = userName || 'admin';
-    return Realm.App.Sync.User.login('http://127.0.0.1:9080', Realm.App.Sync.Credentials.nickname(userId, true))
+const createSyncConfig = (sync, clearLocalFile = true) => {
+    const config = { schema: [schemas.DogForSync], sync };
+    if (clearLocalFile) {
+        // By default clean any previous test file.
+        Realm.deleteFile(config);
+    }
+    return config;
 }
 
 module.exports = {
-    testNewFile_openLocal: function() {
-        // When opening a local Realm, the user doesn't have to be valid.
-        // If we attempted to sync this Realm with the server this test
-        // would time out.
-        return getLoggedOutUser()
-            .then(user => {
-                let config = user.createConfiguration({
-                    sync: {
-                        url: 'http://127.0.0.1/new_file_local_' + Utils.uuid(),
-                        newRealmFileBehavior: Realm.App.Sync.openLocalRealmBehavior,
-                        error: () => {},
-                    }
-                });
-                TestCase.assertFalse(Realm.exists(config));
-                return Realm.open(config);
-            })
-            .then(realm => {
-                TestCase.assertDefined(realm.path);
-                realm.close();
-            })
+    testNewFile_openLocal: async function() {
+        // NOTE: this test no longer runs with a logged out user.
+        // Reason: Error: User is no longer valid.
+
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
+
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            newRealmFileBehavior: Realm.App.Sync.openLocalRealmBehavior
+        });
+
+        console.log("testNewFile_openLocal", config);
+
+        TestCase.assertFalse(Realm.exists(config));
+        const realm = await Realm.open(config);
+
+        TestCase.assertDefined(realm.path);
+
+        realm.close();
+        await user.logOut();
     },
 
-    testExistingFile_openLocal: function() {
-        return getLoggedOutUser()
-            .then(user => {
-                const url = 'http://127.0.0.1/existing_file_local_' + Utils.uuid();
-                let config = user.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        url,
-                        newRealmFileBehavior: Realm.App.Sync.openLocalRealmBehavior,
-                        error: () => {},
-                    }
-                });
-                TestCase.assertFalse(Realm.exists(config));
-                const realm = new Realm(config);
-                realm.write(() => {
-                    realm.create(schemas.TestObject.name, {'doubleCol': 42.123});
-                });
-                realm.close();
+    testExistingFile_openLocal: async function() {
+        // NOTE: this test no longer runs with a logged out user.
+        // Reason: Error: User is no longer valid.
 
-                // Re-open the Realm
-                config = user.createConfiguration({
-                    sync: {
-                        url,
-                        existingRealmFileBehavior: {
-                            type: 'openImmediately'
-                        }
-                    }
-                });
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
 
-                return Realm.open(config);
-            })
-            .then(realm => {
-                TestCase.assertTrue(realm.objects(schemas.TestObject.name).length == 1);
-                realm.close();
+        {
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                newRealmFileBehavior: Realm.App.Sync.openLocalRealmBehavior
             });
-    },
 
-    testNewFile_downloadBeforeOpen: function() {
-        return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        newRealmFileBehavior: {
-                            type: 'downloadBeforeOpen'
-                        },
-                        url: 'realm://127.0.0.1:9080/new_realm_' + Utils.uuid()
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                TestCase.assertTrue(realm.empty)
-                realm.close();
+            TestCase.assertFalse(Realm.exists(config));
+
+            const realm = new Realm(config);
+            realm.write(() => {
+                realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Bella" });
             });
+            realm.close();
+        }
+
+        {
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                existingRealmFileBehavior: { type: "openImmediately" }
+            }, false);
+
+            const realm = await Realm.open(config);
+
+            TestCase.assertEqual(realm.objects(schemas.DogForSync.name).length, 1);
+
+            realm.close();
+        }
+
+        await user.logOut();
     },
 
-    testExistingFile_downloadBeforeOpen: function() {
+    testNewFile_downloadBeforeOpen: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
+
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "downloadBeforeOpen" }
+        });
+
+        const realm = await Realm.open(config);
+
+        // TODO: Not quite sure what we're testing here?
+        TestCase.assertTrue(realm.empty);
+
+        realm.close();
+        await user.logOut();
+    },
+
+    testExistingFile_downloadBeforeOpen: async function() {
         // 1. Open empty Realm
         // 2. Close Realm
         // 3. Let other user upload changes to the Realm on the server.
         // 4. Re-open empty Realm with `existingRealmFileBehavior = syncWhenOpen`
-        const realmName = 'existing_realm_' + Utils.uuid();
-        return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        url: 'realm://127.0.0.1:9080/' + realmName
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(userRealm => {
-                userRealm.close();
-                return getLoggedInUser('other_admin');
-            })
-            .then(otherUser => {
-                const config = otherUser.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        url: 'realm://127.0.0.1:9080/' + realmName
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(otherUserRealm => {
-                otherUserRealm.write(() => {
-                    otherUserRealm.create(schemas.TestObject.name, { doubleCol: 42.133 });
-                });
-                return otherUserRealm.syncSession.uploadAllLocalChanges().then(() => {
-                    otherUserRealm.close();
-                });
-            })
-            .then(() => {
-                return getLoggedInUser();
-            })
-            .then(user => {
-                const config = user.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        existingRealmBehavior: {
-                            type: 'downloadBeforeOpen'
-                        },
-                        url: 'realm://127.0.0.1:9080/' + realmName
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(userRealm => {
-                TestCase.assertTrue(userRealm.objects(schemas.TestObject.name).length === 1);
-            })
-    },
 
-    testNewFile_downloadBeforeOpen_throwOnTimeOut: function() {
-        return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        newRealmFileBehavior: {
-                            type: 'downloadBeforeOpen',
-                            timeOut: 0,
-                            timeOutBehavior: 'throwException'
-                        },
-                        url: 'realm://127.0.0.1:9080/sync_before_open_' + Utils.uuid()
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                realm.close();
-                throw new Error("It shouldn't be posssible to open the Realm");
-            })
-            .catch(e => {
-                TestCase.assertTrue(e.message.includes('could not be downloaded in the allocated time'));
+        const app = new Realm.App(APP_CONFIG);
+        const partitionValue = Utils.genPartition();
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
             });
-    },
 
-    testExistingFile_downloadBeforeOpen_throwOnTimeOut: function() {
-        const realmName = 'sync_timeout_throw_' + Utils.uuid();
-        return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        url: 'realm://127.0.0.1:9080/' + realmName
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                realm.close();
-                const config = Realm.App.Sync.User.current.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        existingRealmFileBehavior: {
-                            type: 'downloadBeforeOpen',
-                            timeOut: 0,
-                            timeOutBehavior: 'throwException'
-                        },
-                        url: 'realm://127.0.0.1:9080/' + realmName
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                throw Error("Realm should fail to open.");
-            })
-            .catch(e => {
-                TestCase.assertTrue(e.message.includes('could not be downloaded in the allocated time'));
+            const realm = await Realm.open(config);
+
+            realm.close();
+            await user.logOut();
+        }
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
             });
+
+            const realm = await Realm.open(config);
+
+            realm.write(() => {
+                realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Milo" });
+            });
+
+            await realm.syncSession.uploadAllLocalChanges();
+
+            realm.close();
+            await user.logOut();
+        }
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately",
+                existingRealmBehavior: { type: "downloadBeforeOpen" }
+            });
+
+            const realm = await Realm.open(config);
+
+            TestCase.assertEqual(realm.objects(schemas.DogForSync.name).length, 1);
+
+            realm.close();
+            await user.logOut();
+        }
     },
 
-    testNewFile_downloadBeforeOpen_openLocalOnTimeOut: function() {
+    testNewFile_downloadBeforeOpen_throwOnTimeOut: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
+
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: {
+                type: "downloadBeforeOpen",
+                timeOut: 0,
+                timeOutBehavior: "throwException"
+            }
+        });
+
+        await TestCase.assertThrowsAsyncContaining(
+            async () => {
+                const realm = await Realm.open(config);
+                realm.close();
+            },
+            "could not be downloaded in the allocated time"
+        );
+
+        await user.logOut();
+        // try {
+        //     const realm = await Realm.open(config)
+        //     realm.close();
+        //     throw new TestError("Realm did not fail to open.");
+        // } catch (err) {
+        //     TestCase.assertTrue(err.message.includes("could not be downloaded in the allocated time"));
+        // } finally {
+        // }
+    },
+
+    testExistingFile_downloadBeforeOpen_throwOnTimeOut: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
+
+        {
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
+            });
+
+            const realm = await Realm.open(config);
+            realm.close();
+        }
+
+        {
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately",
+                existingRealmFileBehavior: {
+                    type: "downloadBeforeOpen",
+                    timeOut: 0,
+                    timeOutBehavior: "throwException"
+                }
+            });
+
+            // ERROR: This currently does NOT throw.
+            // NOTE: Are "timeOut"/"timeOutBehavior" ignored?
+            await TestCase.assertThrowsAsyncContaining(
+                async () => {
+                    const realm = await Realm.open(config);
+                    realm.close();
+                },
+                "could not be downloaded in the allocated time"
+            );
+
+            // try {
+            //     const realm = await Realm.open(config);
+            //     realm.close();
+            //     throw new TestError("Realm did not fail to open.");
+            // } catch (err) {
+            //     console.log("testExistingFile_downloadBeforeOpen_throwOnTimeOut err", err);
+            //     TestCase.assertTrue(err.message.includes("could not be downloaded in the allocated time"));
+            // }
+        }
+
+        await user.logOut();
+    },
+
+    testNewFile_downloadBeforeOpen_openLocalOnTimeOut: async function() {
         // 1. Add data to server Realm from User 1
         // 2. Open Realm with User 2
         // 3. Timeout and check that the returned Realm is empty.
-        const realmName = 'sync_timeout_open_' + Utils.uuid();
-        const syncConfig = {
-            _sessionStopPolicy: 'immediately',
-            url: 'realm://127.0.0.1:9080/' + realmName,
-        };
-        return getLoggedInUser("User1")
-            .then(user1 => {
-                const config = user1.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: syncConfig,
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                realm.write(() => {
-                    realm.create(schemas.TestObject.name, { doubleCol: 42.123 });
-                });
-                return realm.syncSession.uploadAllLocalChanges().then(() => {
-                    realm.close();
-                });
-            })
-            .then(() => {
-                return getLoggedInUser("User2");
-            })
-            .then(user2 => {
-                const config = user2.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        ...syncConfig,
-                        newRealmFileBehavior: {
-                            type: 'downloadBeforeOpen',
-                            timeOut: 0,
-                            timeOutBehavior: 'openLocal'
-                        },
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(realm => {
-                const user = Realm.App.SyncSession.user;
-                TestCase.assertEqual(0, realm.objects(schemas.TestObject.name).length);
-                realm.close();
-                // Wait for the download to complete so that we don't call
-                // clearTestState() while a download is in progress
-                return Realm.open(user.createConfiguration({sync: syncConfig}));
-            })
-            .then(r => r.close());
+
+        const app = new Realm.App(APP_CONFIG);
+        const partitionValue = Utils.genPartition();
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
+            });
+
+            const realm = await Realm.open(config);
+
+            realm.write(() => {
+                realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Lola" });
+            });
+
+            await realm.syncSession.uploadAllLocalChanges();
+
+            realm.close();
+            await user.logOut();
+        }
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately",
+                newRealmFileBehavior: {
+                    type: "downloadBeforeOpen",
+                    timeOut: 0,
+                    timeOutBehavior: "openLocal"
+                }
+            });
+
+            const realm = await Realm.open(config);
+
+            TestCase.assertEqual(realm.objects(schemas.DogForSync.name).length, 0);
+
+            realm.close();
+
+            // Wait for the download to complete so that we don't call
+            // clearTestState() while a download is in progress
+            const cleanUpRealm = await Realm.open({
+                schema: [schemas.DogForSync],
+                sync: {
+                    user,
+                    partitionValue,
+                    _sessionStopPolicy: "immediately"
+                }
+            });
+            cleanUpRealm.close();
+
+            await user.logOut();
+        }
     },
 
-    testExistingFile_downloadBeforeOpen_openLocalOnTimeOut: function () {
+    testExistingFile_downloadBeforeOpen_openLocalOnTimeOut: async function () {
         // 1. Open empty Realm
         // 2. Close Realm
         // 3. Let other user upload changes to the Realm on the server.
         // 4. Re-open empty Realm with timeOut and localOpen, Realm should still be empty.
-        const realmName = 'existing_realm_' + Utils.uuid();
-        const syncConfig = {
-            _sessionStopPolicy: 'immediately',
-            url: 'realm://127.0.0.1:9080/' + realmName,
-        };
-        return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: syncConfig,
-                });
-                return Realm.open(config);
-            })
-            .then(userRealm => {
-                userRealm.close();
-                return getLoggedInUser('other_admin');
-            })
-            .then(otherUser => {
-                const config = otherUser.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: syncConfig,
-                });
-                return Realm.open(config);
-            })
-            .then(otherUserRealm => {
-                otherUserRealm.write(() => {
-                    otherUserRealm.create(schemas.TestObject.name, { doubleCol: 42.133 });
-                });
-                return otherUserRealm.syncSession.uploadAllLocalChanges().then(() => {
-                    otherUserRealm.close();
-                });
-            })
-            .then(() => {
-                return getLoggedInUser();
-            })
-            .then(user => {
-                const config = user.createConfiguration({
-                    schema: [schemas.TestObject],
-                    sync: {
-                        ...syncConfig,
-                        existingRealmFileBehavior: {
-                            type: 'downloadBeforeOpen',
-                            timeOut: 0,
-                            timeOutBehavior: 'openLocal'
-                        },
-                    }
-                });
-                return Realm.open(config);
-            })
-            .then(userRealm => {
-                const user = userRealm.App.SyncSession.user;
-                TestCase.assertTrue(userRealm.objects(schemas.TestObject.name).length === 0);
-                // Wait for the download to complete so that we don't call
-                // clearTestState() while a download is in progress
-                return Realm.open(user.createConfiguration({sync: syncConfig}));
-            })
-            .then(r => r.close());
+
+        const app = new Realm.App(APP_CONFIG);
+        const partitionValue = Utils.genPartition();
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
+            });
+
+            const realm = await Realm.open(config);
+
+            realm.close();
+            await user.logOut();
+        }
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately"
+            });
+
+            const realm = await Realm.open(config);
+
+            realm.write(() => {
+                realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Molly" });
+            });
+
+            await realm.syncSession.uploadAllLocalChanges();
+
+            realm.close();
+            await user.logOut();
+        }
+
+        {
+            const user = await app.logIn(Realm.Credentials.anonymous());
+            const config = createSyncConfig({
+                user,
+                partitionValue,
+                _sessionStopPolicy: "immediately",
+                existingRealmFileBehavior: {
+                    type: "downloadBeforeOpen",
+                    timeOut: 0,
+                    timeOutBehavior: "openLocal"
+                }
+            });
+            const realm = await Realm.open(config);
+
+            // ERROR: This currently fails... Error: '1' does not equal expected value '0'
+            // NOTE: Are "timeOut"/"timeOutBehavior" ignored?
+            TestCase.assertEqual(realm.objects(schemas.DogForSync.name).length, 0);
+
+            realm.close();
+
+            // Wait for the download to complete so that we don't call
+            // clearTestState() while a download is in progress
+            const cleanUpRealm = await Realm.open({
+                schema: [schemas.DogForSync],
+                sync: {
+                    user,
+                    partitionValue,
+                    _sessionStopPolicy: "immediately"
+                }
+            });
+            cleanUpRealm.close();
+
+            await user.logOut();
+        }
     },
 
-    testCancel: function() {
-        let openPromise = new Promise((resolve, reject) => {
-            return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        newRealmFileBehavior: {
-                            type: 'downloadBeforeOpen'
-                        },
-                        url: 'realm://127.0.0.1:9080/new_realm_' + Utils.uuid()
-                    }
-                });
+    testCancel: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
 
-                let promise = Realm.open(config);
-                promise.cancel();
-                return promise;
-            })
-            .then(realm => {
-                reject("Realm was opened after being canceled");
-            })
-            .catch(e => {
-                reject("An error was thrown after open was canceled: " + e.message);
-            });
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "downloadBeforeOpen" }
         });
+
+        const openPromise = new Promise((resolve, reject) => {
+            const promise = Realm.open(config);
+            promise.cancel();
+            return promise;
+        });
+
+        openPromise
+            .then(() => { throw new TestError("Realm was opened after being canceled."); })
+            .catch(err => { throw new TestError("An error was thrown after open was canceled: " + err.message); });
 
         // Wait for 1 second after canceling. The open promise should not emit any events in that period.
-        let timeOutPromise = new Promise(resolve => setTimeout(resolve, 1000));
-        return Promise.race([openPromise, timeOutPromise]);
+        const timeOutPromise = new Promise(resolve => setTimeout(resolve, 1000));
+
+        const any = Promise.race([openPromise, timeOutPromise]);
+
+        return any.finally(() => user.logOut());
     },
 
-    testCancel_multipleOpenCalls: function() {
-        // Due to us sharing the same session for each URL, canceling a download will cancel all current
-        // calls to the same URL. This is probably acceptable for this use case.
-        return getLoggedInUser()
-        .then(user => {
-            const config = user.createConfiguration({
-                sync: {
-                    _sessionStopPolicy: 'immediately',
-                    newRealmFileBehavior: {
-                        type: 'downloadBeforeOpen'
-                    },
-                    url: 'realm://127.0.0.1:9080/new_realm_' + Utils.uuid()
-                }
-            });
+    testCancel_multipleOpenCalls: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
 
-            let openPromise1 = Realm.open(config);
-            let openPromise2 = Realm.open(config);
-            openPromise1.cancel(); // Will cancel both promise 1 and 2 at the native level.
-
-            return openPromise2.catch(e => {
-                TestCase.assertEqual(e.message, "Operation canceled");
-            })
-        })
-    },
-
-    testDownloadListener_whenCanceled: function() {
-        let openPromise = new Promise((resolve, reject) => {
-            return getLoggedInUser()
-            .then(user => {
-                const config = user.createConfiguration({
-                    sync: {
-                        _sessionStopPolicy: 'immediately',
-                        newRealmFileBehavior: {
-                            type: 'downloadBeforeOpen',
-                        },
-                        url: 'realm://127.0.0.1:9080/downloadlistener_cancel_' + Utils.uuid()
-                    }
-                });
-                let promise = Realm.open(config);
-                promise.progress((transferred, transferable) => {
-                    reject("Progress listener called");
-                });
-                promise.cancel();
-                return promise;
-            })
-            .then(() => {
-                reject("Realm was opened after being canceled");
-            })
-            .catch(e => {
-                reject("An error was thrown after open was canceled: " + e.message);
-            });
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "downloadBeforeOpen" }
         });
+
+        const openPromise1 = Realm.open(config);
+        const openPromise2 = Realm.open(config);
+
+        openPromise1.cancel(); // Will cancel both promise 1 and 2 at the native level.
+
+        try {
+            await openPromise2;
+            throw new TestError("openPromise2 should have been rejected..");
+        } catch (err) {
+            TestCase.assertEqual(err.message, "Operation canceled");
+        }
+    },
+
+    testDownloadListener_whenCanceled: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
+
+        const config = createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "downloadBeforeOpen" }
+        });
+
+        const openPromise = new Promise((resolve, reject) => {
+            const promise = Realm.open(config);
+            // TODO: could this potentially trigger before canceling?
+            promise.progress(() => {
+                reject("Progress listener called");
+            });
+            promise.cancel();
+            return promise;
+        });
+
+        openPromise
+            .then(() => { throw new TestError("Realm was opened after being canceled."); })
+            .catch(err => { throw new TestError("An error was thrown after open was canceled: " + err.message); });
 
         // Wait for 1 second after canceling. The open promise should not emit any events in that period.
-        let timeOutPromise = new Promise(resolve => setTimeout(resolve, 1000));
-        return Promise.race([timeOutPromise, openPromise]);
+        const timeOutPromise = new Promise(resolve => setTimeout(resolve, 1000));
+
+        const any = Promise.race([timeOutPromise, openPromise]);
+
+        return any.finally(() => user.logOut());
     },
 
-    testBehavior_invalidOptions: function() {
-        return getLoggedInUser().then(user => {
+    testBehavior_invalidOptions: async function() {
+        const app = new Realm.App(APP_CONFIG);
+        const user = await app.logIn(Realm.Credentials.anonymous());
+        const partitionValue = Utils.genPartition();
 
-            // New file behavior tests
-            let config = user.createConfiguration({ sync: { newRealmFileBehavior: { type: 'foo' } } });
-            TestCase.assertThrows(() => Realm.open(config));
+        await TestCase.assertThrowsAsync(() => Realm.open(createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "foo" } // this should fail
+        })));
 
-            config = user.createConfiguration({
-                sync: {
-                    newRealmFileBehavior: {
-                        type: 'openLocal',
-                        timeOutBehavior: 'foo'
-                    }
-                }
-            });
-            TestCase.assertThrows(() => Realm.open(config));
+        await TestCase.assertThrowsAsync(() => Realm.open(createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "openLocal", timeOutBehavior: "foo" } // this should fail
+        })));
 
-            config = user.createConfiguration({
-                sync: {
-                    newRealmFileBehavior: {
-                        type: 'openLocal',
-                        timeOut: 'bar'
-                    }
-                }
-            });
-            TestCase.assertThrows(() => Realm.open(config));
-        });
+        await TestCase.assertThrowsAsync(() => Realm.open(createSyncConfig({
+            user,
+            partitionValue,
+            _sessionStopPolicy: "immediately",
+            newRealmFileBehavior: { type: "openLocal", timeOut: "bar" } // this should fail
+        })));
+
+        await user.logOut();
     },
 };

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -140,7 +140,6 @@ module.exports = {
 
         const realm = await Realm.open(config);
 
-        // NOTE: Not quite sure what we're testing here?
         TestCase.assertTrue(realm.empty);
 
         realm.close();

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -165,7 +165,7 @@ module.exports = {
         }
 
         {
-            // Update realm with different user (different path)
+            // Update realm with different (anonymous) user
             const user = await app.logIn(Realm.Credentials.anonymous());
             const config = {
                 schema: [schemas.DogForSync],
@@ -263,7 +263,7 @@ module.exports = {
         }
 
         {
-            // Reopen with impossible timeOut and test that "timeOutBehavior" holds true.
+            // Reopen with impossible "timeOut" and test that "timeOutBehavior" holds true.
             const config = {
                 schema: [schemas.DogForSync],
                 sync: {
@@ -301,6 +301,7 @@ module.exports = {
         const partitionValue = Utils.genPartition();
 
         {
+            // Add data to the realm with a different user
             const user = await app.logIn(Realm.Credentials.anonymous());
             const config = {
                 schema: [schemas.DogForSync],
@@ -324,6 +325,7 @@ module.exports = {
         }
 
         {
+            // Reopen with impossible "timeOut" and test that "timeOutBehavior" holds true.
             const user = await app.logIn(Realm.Credentials.anonymous());
             const config = {
                 schema: [schemas.DogForSync],
@@ -362,6 +364,7 @@ module.exports = {
         const returningUserCredentials = await Utils.getRegisteredEmailPassCredentials(app);
 
         {
+            // Ensure a realm file exists for the returning user
             const user = await app.logIn(returningUserCredentials);
             const config = {
                 schema: [schemas.DogForSync],
@@ -379,6 +382,7 @@ module.exports = {
         }
 
         {
+            // Add data to the realm with a different user
             const user = await app.logIn(Realm.Credentials.anonymous());
             const config = {
                 schema: [schemas.DogForSync],
@@ -402,6 +406,7 @@ module.exports = {
         }
 
         {
+            // Reopen with impossible "timeOut" and test that "timeOutBehavior" holds true.
             const user = await app.logIn(returningUserCredentials);
             const config = {
                 schema: [schemas.DogForSync],

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -20,6 +20,17 @@
 
 const Realm = require('realm');
 
+exports.DogForSync = {
+    name: 'Dog',
+    primaryKey: '_id',
+    properties: {
+        _id: 'objectId?',
+        breed: 'string?',
+        name: 'string',
+        realm_id: 'string?',
+    }
+}
+
 exports.TestObject = {
     name: 'TestObject',
     properties: {

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -24,7 +24,7 @@ exports.DogForSync = {
     name: 'Dog',
     primaryKey: '_id',
     properties: {
-        _id: 'objectId?',
+        _id: 'objectId?', // NOTE: this needs to be changed to non-optional in the docker image.
         breed: 'string?',
         name: 'string',
         realm_id: 'string?',

--- a/tests/js/test-utils.js
+++ b/tests/js/test-utils.js
@@ -18,19 +18,43 @@
 
 /* eslint-env es6, node */
 
-'use strict';
+"use strict";
+
+function uuid() {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
+        let r = Math.random() * 16 | 0, v = c == "x" ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+function genPartition() {
+    return "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx".replace(/[xy]/g, function(c) {
+        let r = Math.random() * 16 | 0, v = c == "x" ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+function randomVerifiableEmail() {
+    // according to the custom register function, emails will register if they contain "realm_tests_do_autoverify"
+    return `realm_tests_do_autoverify_${uuid()}_@test.com`;
+}
+
+async function getRegisteredEmailPassCredentials(app) {
+    if (!app) {
+      throw new Error("No app supplied to 'getRegisteredEmailPassCredentials'");
+    }
+
+    const email = randomVerifiableEmail();
+    const pass = "test1234567890";
+    // Create the user (see note in 'randomVerifiableEmail')
+    await app.emailPasswordAuth.registerUser(email, pass);
+
+    return Realm.Credentials.emailPassword(email, pass);
+}
 
 module.exports = {
-    uuid: function() {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
-    },
-    genPartition: function() {
-        return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
-    }
+    uuid,
+    genPartition,
+    randomVerifiableEmail,
+    getRegisteredEmailPassCredentials
 };

--- a/tests/js/test-utils.js
+++ b/tests/js/test-utils.js
@@ -36,7 +36,7 @@ function genPartition() {
 
 function randomVerifiableEmail() {
     // according to the custom register function, emails will register if they contain "realm_tests_do_autoverify"
-    return `realm_tests_do_autoverify_${uuid()}_@test.com`;
+    return `realm_tests_do_autoverify_${uuid()}_@testing.mongodb.com`;
 }
 
 async function getRegisteredEmailPassCredentials(app) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -366,9 +366,6 @@ declare namespace Realm {
         ThrowException = 'throwException'
     }
 
-    let openLocalRealmBehavior: OpenRealmBehaviorConfiguration;
-    let downloadBeforeOpenBehavior: OpenRealmBehaviorConfiguration;
-
     enum ConnectionState {
         Disconnected = "disconnected",
         Connecting = "connecting",
@@ -436,6 +433,16 @@ declare namespace Realm {
         function initiateClientReset(app: App, path: string): void;
         function _hasExistingSessions(app: App): boolean;
         function reconnect(app: App): void;
+
+        /**
+         * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
+         * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
+         */
+        const openLocalRealmBehavior: OpenRealmBehaviorConfiguration;
+        /**
+         * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
+         */
+        const downloadBeforeOpenBehavior: OpenRealmBehaviorConfiguration;
     }
 }
 


### PR DESCRIPTION
## What, How & Why?

This PR currently:
- Re-introduces the `open-behavior-tests` (re-written to `async/await` for non-cancelable promises).
- Moves TS declarations of `openLocalRealmBehavior` & `downloadBeforeOpenBehavior` to `Realm.App.Sync` (from `Realm`).

Please see any `// NOTE:` in the changes.

https://github.com/realm/realm-js/issues/3339 has been created to track documentation.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests: Add a unit and preferably also an integration test to avoid regressions.
* [x] Run prettier on the source code changed.
* [x] 📝 Public documentation PR created or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated