### PR TITLE
Aborting CI when changes only happen to /packages (revisited)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
 
 ### Internal
-* Changed CI to abort if changes are exclusively made to the /packages directory. ([#3298](https://github.com/realm/realm-js/pull/3298))
+* Changed CI to abort if changes are exclusively made to the /packages directory. ([#3298](https://github.com/realm/realm-js/pull/3298)) & ([#3307](https://github.com/realm/realm-js/pull/3307))
 
 10.0.0-rc.1 Release notes (2020-10-1)
 =============================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ def exclusivelyChanged(regexp) {
   return env.CHANGE_TARGET && sh(
     returnStatus: true,
     script: "git diff origin/$CHANGE_TARGET --name-only | grep --invert-match '${regexp}'"
-  ) == 0
+  ) != 0
 }
 
 // == Methods


### PR DESCRIPTION
## What, How & Why?

This is an attempt to fix any issues from #3299

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually on this PR)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
