### PR TITLE
Improving the building realm-js for react-native Android from scratch experience.

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -189,7 +189,7 @@ def findNdkBuildFullPath() {
         ndkDir = properties.getProperty('ndk.dir')
         if(ndkDir != null)
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }catch(FileNotFoundException e){
+    } catch(FileNotFoundException e) {
         println("[Warning]: local.properties not found ")
         println("Error: ", e)
     }

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -269,7 +269,7 @@ def checkForHeadersFile(folder){
     File[] files = new File("$projectDir/../../$folder").listFiles();
 
     if (files == null || files.length == 0)
-        throw new GradleException("Didn't found any headers in the \\$folder folder \n" +
+        throw new GradleException("Didn't found any headers in the /$folder folder \n" +
         "Please you go to the root folder (realm-js) and do: \n git submodule update --init --recursive")
 }
 

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -202,7 +202,7 @@ def findNdkBuildFullPath() {
         if (ndkDir) {
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
         }
-    }catch(MissingPropertyException e){
+    } catch(MissingPropertyException e) {
         throw new GradleException("Unable to locate your NDK configuration. Did you forget to install the Android NDK?\n" +
                 "more info: https://developer.android.com/studio/projects/install-ndk \n")
     }

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -187,10 +187,7 @@ def findNdkBuildFullPath() {
 
     if(ndkDir != null)
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-
-    // If not there we try the next approach...
-    
-
+        
     try {
         ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
                 plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -270,7 +270,7 @@ def checkForHeadersFile(folder){
 
     if (files == null || files.length == 0)
         throw new GradleException("Didn't found any headers in the /$folder folder \n" +
-        "Please you go to the root folder (realm-js) and do: \n git submodule update --init --recursive")
+        "Please make sure you go to the root folder (realm-js) and do: \n git submodule update --init --recursive")
 }
 
 task buildReactNdkLib(dependsOn: [prepareRealmCore, prepareOpenSSL_x86, prepareOpenSSL_x86_64, prepareOpenSSL_arm, prepareOpenSSL_arm_64], type: Exec) {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -318,10 +318,6 @@ android {
     lintOptions {
         abortOnError false
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-    }
-    buildToolsVersion '28.0.3'
 }
 
 task publishAndroid(dependsOn: [generateVersionClass, packageReactNdkLibs], type: Sync) {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -182,7 +182,6 @@ def findNdkBuildFullPath() {
     def ndkDir = null
 
     try {
-        println("wtf?")
         // Reading [ndk.dir] from local.properties
         Properties properties = new Properties()
         properties.load(project.rootProject.file('local.properties').newDataInputStream())

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -187,8 +187,9 @@ def findNdkBuildFullPath() {
         properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
         ndkDir = properties.getProperty('ndk.dir')
-        if(ndkDir != null)
+        if (ndkDir != null) {
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+        }
     } catch(FileNotFoundException e) {
         println("[Warning]: local.properties not found ")
         println("Error: ", e)

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -182,18 +182,21 @@ def findNdkBuildFullPath() {
     def ndkDir = null
 
     try {
+        println("wtf?")
         // Reading [ndk.dir] from local.properties
         Properties properties = new Properties()
         properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
-        properties.getProperty('ndk.dir')
+        ndkDir = properties.getProperty('ndk.dir')
         if(ndkDir != null)
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }catch(FileNotFoundException e){
         println("[Warning]: local.properties not found ")
+        println("Error: ", e)
     }
 
     try {
+
         ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
                 plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
 

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -169,6 +169,13 @@ def findNdkBuildFullPath() {
         def ndkDir = property('ndk.path')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
+
+    // or just a path to the containing directory
+    if (hasProperty('ndk.dir')) {
+        def ndkDir = property('ndk.dir')
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
     if (System.getenv('ANDROID_NDK') != null) {
         def ndkDir = System.getenv('ANDROID_NDK')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
@@ -178,7 +185,17 @@ def findNdkBuildFullPath() {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 
-    def ndkDir
+    // Reading [ndk.dir] from local.properties
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+    def ndkDir = properties.getProperty('ndk.dir')
+
+    if(ndkDir != null)
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+
+    // If not there we try the next approach...
+    
 
     try {
         ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
@@ -188,7 +205,8 @@ def findNdkBuildFullPath() {
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
         }
     }catch(MissingPropertyException e){
-        throw new GradleException("Unable to locate your NDK configuration. ¿Have you forgot to install Android NDK? \n more info: https://developer.android.com/studio/projects/install-ndk")
+        throw new GradleException("Unable to locate your NDK configuration. ¿Have you forgot to install Android NDK? \n" +
+                "more info: https://developer.android.com/studio/projects/install-ndk \n")
     }
 
     return null
@@ -306,6 +324,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
+    buildToolsVersion '28.0.3'
 }
 
 task publishAndroid(dependsOn: [generateVersionClass, packageReactNdkLibs], type: Sync) {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -177,11 +177,20 @@ def findNdkBuildFullPath() {
         def ndkDir = System.getenv('ANDROID_NDK_HOME')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+
+    def ndkDir
+
+    try {
+        ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
+                plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
+
+        if (ndkDir) {
+            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+        }
+    }catch(MissingPropertyException e){
+        throw new GradleException("Unable to locate your NDK configuration. ¿Have you forgot to install Android NDK? \n more info: https://developer.android.com/studio/projects/install-ndk")
     }
+
     return null
 }
 
@@ -194,7 +203,7 @@ def checkNdkVersion(ndkBuildFullPath) {
         detectedNdkVersion = releaseFile.text.trim().split()[0].split('-')[0]
     } else if (propertyFile.isFile()) {
         detectedNdkVersion = getValueFromPropertiesFile(propertyFile, 'Pkg.Revision')
-        if (detectedNdkVersion == null) {
+            if (detectedNdkVersion == null) {
             throw new GradleException("Failed to obtain the NDK version information from ${ndkPath}/source.properties")
         }
     } else {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -179,15 +179,20 @@ def findNdkBuildFullPath() {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 
-    // Reading [ndk.dir] from local.properties
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    def ndkDir = null
 
-    def ndkDir = properties.getProperty('ndk.dir')
+    try {
+        // Reading [ndk.dir] from local.properties
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
-    if(ndkDir != null)
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-        
+        properties.getProperty('ndk.dir')
+        if(ndkDir != null)
+            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }catch(FileNotFoundException e){
+        println("[Warning]: local.properties not found ")
+    }
+
     try {
         ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
                 plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
@@ -260,7 +265,19 @@ def getNdkBuildFullPath() {
     return ndkBuildFullPath
 }
 
+def checkForHeadersFile(folder){
+    File[] files = new File("$projectDir/../../$folder").listFiles();
+
+    if (files == null || files.length == 0)
+        throw new GradleException("Didn't found any headers in the \\$folder folder \n" +
+        "Please you go to the root folder (realm-js) and do: \n git submodule update --init --recursive")
+}
+
 task buildReactNdkLib(dependsOn: [prepareRealmCore, prepareOpenSSL_x86, prepareOpenSSL_x86_64, prepareOpenSSL_arm, prepareOpenSSL_arm_64], type: Exec) {
+    checkForHeadersFile('src/object-store')
+    checkForHeadersFile('docs/jsdoc-template')
+    checkForHeadersFile('vendor/GCDWebServer')
+
     inputs.files('src/main/jni')
     outputs.dir("$buildDir/realm-react-ndk/all")
     commandLine getNdkBuildFullPath(),

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -271,8 +271,9 @@ def checkForHeadersFile(folder){
     File[] files = new File("$projectDir/../../$folder").listFiles();
 
     if (files == null || files.length == 0)
-        throw new GradleException("Didn't found any headers in the /$folder folder \n" +
-        "Please make sure you go to the root folder (realm-js) and do: \n git submodule update --init --recursive")
+        throw new GradleException("Unable to locate any headers in the '/$folder' folder.\n" +
+        "Please make sure you go to the root folder (realm-js) and do:\n" +
+        "git submodule update --init --recursive")
 }
 
 task buildReactNdkLib(dependsOn: [prepareRealmCore, prepareOpenSSL_x86, prepareOpenSSL_x86_64, prepareOpenSSL_arm, prepareOpenSSL_arm_64], type: Exec) {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -199,7 +199,7 @@ def findNdkBuildFullPath() {
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
         }
     }catch(MissingPropertyException e){
-        throw new GradleException("Unable to locate your NDK configuration. ¿Have you forgot to install Android NDK? \n" +
+        throw new GradleException("Unable to locate your NDK configuration. Did you forget to install the Android NDK?\n" +
                 "more info: https://developer.android.com/studio/projects/install-ndk \n")
     }
 

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -221,7 +221,7 @@ def checkNdkVersion(ndkBuildFullPath) {
         detectedNdkVersion = releaseFile.text.trim().split()[0].split('-')[0]
     } else if (propertyFile.isFile()) {
         detectedNdkVersion = getValueFromPropertiesFile(propertyFile, 'Pkg.Revision')
-            if (detectedNdkVersion == null) {
+        if (detectedNdkVersion == null) {
             throw new GradleException("Failed to obtain the NDK version information from ${ndkPath}/source.properties")
         }
     } else {

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -170,12 +170,6 @@ def findNdkBuildFullPath() {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 
-    // or just a path to the containing directory
-    if (hasProperty('ndk.dir')) {
-        def ndkDir = property('ndk.dir')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
     if (System.getenv('ANDROID_NDK') != null) {
         def ndkDir = System.getenv('ANDROID_NDK')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
-APP_PLATFORM := android-16
+APP_PLATFORM := android-9
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
-APP_PLATFORM := android-9
+APP_PLATFORM := android-21
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/react-native/android/src/main/jni/Application.mk
+++ b/react-native/android/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
-APP_PLATFORM := android-21
+APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 


### PR DESCRIPTION
## What, How & Why?

It was difficult to compile Android out-of-the-box so here I make three modification that hopefully will make things easier when trying to compile from scratch for react-native Android. 

First change is the error messaging when running ``./gradlew publishAndroid``, in case you don't have the NDK installed you get this error: 

```No such property: sdkHandler for class: com.android.build.gradle.LibraryPlugin```

I added some failure checking and change the message to: 

```
Unable to locate your NDK configuration. ¿Have you forgot to install Android NDK? 
More info: https://developer.android.com/studio/projects/install-ndk
```

Second change: I have added an additional way to get information about the NDK by reading the ```local.properties``` and extracting from there (if any) the information about the NDK path. This make it easier to use in Android Studio.

And third and last was to bump to ```Android-21``` from ```Android-9``` otherwise the user will get some cryptic errors (it won't be able to find the toolchain for ```Android-9``` SDK) if you are trying to use the latest NDK (```21.3.6528147```) to compile.
