### PR TITLE
Improving the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Note: If you have cloned the repo previously make sure you remove your node_modu
 
 ### Building for Android:
 * `cd react-native/android`
+* `export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.0.6113669  #Location for your NDK folder`
 * `./gradlew publishAndroid`
 * The compiled version of the Android module is here: `<project-root>/android`
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git submodule update --init --recursive
 
 Note: On Windows the RealmJS repo should be cloned with symlinks enabled
 ```
-#run in elevated 
+#run in elevated command prompt
 
 
 prompt

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ git submodule update --init --recursive
 Note: On Windows the RealmJS repo should be cloned with symlinks enabled
 ```
 #run in elevated command prompt
-
-
-prompt
 git clone -c core.symlinks=true https://github.com/realm/realm-js
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Prerequisites:
 * nvm (on Mac)
 * cocoapods (on Mac)
 * Android SDK 23+
-* Android NDK 21.0 (Only available on the SDK Manager on Android Studio)
+* Android NDK 21.0 (available via the SDK Manager in Android Studio / Android SDK Tools)
 
 Clone RealmJS repository:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Prerequisites:
 * nvm (on Mac)
 * cocoapods (on Mac)
 * Android SDK 23+
-* [Android NDK 21](https://developer.android.com/ndk/downloads/index.html)
+* Android NDK 21.0 (Only available on the SDK Manager on Android Studio)
 
 Clone RealmJS repository:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Prerequisites:
 * nvm (on Mac)
 * cocoapods (on Mac)
 * Android SDK 23+
-* Android NDK 21.0 (available via the SDK Manager in Android Studio / Android SDK Tools)
+* Android NDK 21.0 
+    - Available via the SDK Manager in Android Studio **Tools > SDK Manager**.  
+    - From the command-line: ```$ANDROID_HOME/tools/bin/sdkmanager --install "ndk;21.0.6113669"```.
 
 Clone RealmJS repository:
 
@@ -50,7 +52,10 @@ git submodule update --init --recursive
 
 Note: On Windows the RealmJS repo should be cloned with symlinks enabled
 ```
-#run in elevated command prompt
+#run in elevated 
+
+
+prompt
 git clone -c core.symlinks=true https://github.com/realm/realm-js
 ```
 


### PR DESCRIPTION
The old version links to an NDK version that is not supported by the current project configuration. 

[related to this discussion](https://github.com/realm/realm-js/pull/3315#issuecomment-706054896)