### PR TITLE
[v6] Cache Realm instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed a bug preventing caching of Realm instances. In certain cases, the Realm file would grow without any new objects added. ([](), since v6.0.0).
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -622,6 +622,7 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
         }
     }
 
+    config.cache = true;
     config.path = normalize_realm_path(config.path);
     ensure_directory_exists_for_file(config.path);
     return schema_updated;

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1541,8 +1541,9 @@ module.exports = {
     testManualCompactMultipleInstances: function() {
         const realm1 = new Realm({schema: [schemas.StringOnly]});
         const realm2 = new Realm({schema: [schemas.StringOnly]});
+        // realm1 and realm2 are wrapping the same Realm instance
         realm2.objects('StringOnlyObject');
-        TestCase.assertFalse(realm1.compact());
+        TestCase.assertTrue(realm1.compact());
     },
 
     testRealmDeleteFileDefaultConfigPath: function() {


### PR DESCRIPTION
## What, How & Why?

The introduction of Realm Core v6, Realm Object Store changed disabled the caching of Realm instances.

**Currently**: https://github.com/realm/realm-object-store/blob/301642fe90212c379f550656a7234f41db158ddf/src/shared_realm.hpp#L235
**Pre Core v6**: https://github.com/realm/realm-object-store/blob/5d8bfcac9804962945d47530f372c6f8dee77416/src/shared_realm.hpp#L234

By disabling caching, user might see growing Realm files when they forgot to call `Realm.close()`.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
