### PR TITLE
Realm Web: Removed the typescript declarations for app.services and app.functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
+
+### Breaking changes
+* Removed the types for `app.services` and `app.functions` (which never had an implementation). ([#3322](https://github.com/realm/realm-js/pull/3322)).
+
 ### Enhancements
 * Added descriptive errors for `partitionValue` of unsupported formats & ranges.
 

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -2,7 +2,7 @@
 =============================================================
 
 ### Breaking Changes
-* Removed the `functions` and `services` properties from `App`, use the `functions` property and `mongoClient` method on `User` instances instead. ([#3298](https://github.com/realm/realm-js/pull/3298))
+* Removed the `functions` and `services` properties from `App`, use the `functions` property and `mongoClient` method on `User` instances instead. ([#3298](https://github.com/realm/realm-js/pull/3298) and [#3322](https://github.com/realm/realm-js/pull/3322))
 
 ### Enhancements
 * Changing the behaviour when refreshing an access token fails. With this change, if the refresh token cannot be used to refresh an access token, the user is logged out. ([#3269](https://github.com/realm/realm-js/pull/3269))

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -246,16 +246,6 @@ declare namespace Realm {
         readonly id: string;
 
         /**
-         * Use this to call functions defined by the MongoDB Realm app.
-         */
-        readonly functions: FunctionsFactoryType & BaseFunctionsFactory;
-
-        /**
-         * Use this to call services within by the MongoDB Realm app.
-         */
-        services: Realm.Services;
-
-        /**
          * Perform operations related to the email/password auth provider.
          */
         emailPasswordAuth: Realm.Auth.EmailPasswordAuth;


### PR DESCRIPTION
## What, How & Why?

This is a follow-up to https://github.com/realm/realm-js/pull/3298 where I forgot to remove the types from the root projects /types directory.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually by building Realm Web)
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
