### PR TITLE
open-behavior-tests argument fix

### DIFF
--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -172,7 +172,7 @@ module.exports = {
                     sync: {
                         fullSynchronization: true,
                         _sessionStopPolicy: 'immediately',
-                        existingRealmBehavior: {
+                        existingRealmFileBehavior: {
                             type: 'downloadBeforeOpen'
                         },
                         url: 'realm://127.0.0.1:9080/' + realmName


### PR DESCRIPTION
Renamed incorrect `existingRealmBehavior` to `existingRealmFileBehavior`.
This doesn't seem to have an influence on the test outcome...