### PR TITLE
Stop JsonSerializationReplacer being redefined to avoid Jest breaking (v10)

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -529,55 +529,56 @@ module.exports = function(realmConstructor, context) {
         },
         configurable: true
     });
+    if (!realmConstructor.JsonSerializationReplacer) {
+        Object.defineProperty(realmConstructor, "JsonSerializationReplacer", {
+            get: function () {
+                const seen = [];
 
-    Object.defineProperty(realmConstructor, "JsonSerializationReplacer", {
-        get: function () {
-            const seen = [];
-
-            return function(_, value) {
-                // Only check for circular references when dealing with objects & arrays.
-                if (value === null || typeof value !== "object") {
-                    return value;
-                }
-
-                // 'this' refers to the object or array containing the the current key/value.
-                const parent = this;
-
-                if (value.$refId) {
-                    // Expose the non-enumerable prop $refId for circular serialization, if it exists.
-                    Object.defineProperty(value, "$refId", { enumerable: true })
-                }
-
-                if (!seen.length) {
-                    // If we haven't seen anything yet, we only push the current value (root element/array).
-                    seen.push(value);
-                    return value;
-                }
-
-                const pos = seen.indexOf(parent);
-                if (pos !== -1) {
-                    // If we have seen the parent before, we have already traversed a sibling in the array.
-                    // We then discard information gathered for the sibling (zero back to the current array).
-                    seen.splice(pos + 1);
-                } else {
-                    // If we haven't seen the parent before, we add it to the seen-path.
-                    // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
-                    seen.push(parent);
-                }
-
-                if (seen.includes(value)) {
-                    // If we have seen the current value before, return a reference-structure if possible.
-                    if (value._primaryKeyProp) {
-                      return { $ref: value[value._primaryKeyProp] };
+                return function(_, value) {
+                    // Only check for circular references when dealing with objects & arrays.
+                    if (value === null || typeof value !== "object") {
+                        return value;
                     }
+
+                    // 'this' refers to the object or array containing the the current key/value.
+                    const parent = this;
+
                     if (value.$refId) {
-                      return { $ref: value.$refId };
+                        // Expose the non-enumerable prop $refId for circular serialization, if it exists.
+                        Object.defineProperty(value, "$refId", { enumerable: true })
                     }
-                    return "[Circular reference]";
-                }
 
-                return value;
-            };
-        }
-    });
+                    if (!seen.length) {
+                        // If we haven't seen anything yet, we only push the current value (root element/array).
+                        seen.push(value);
+                        return value;
+                    }
+
+                    const pos = seen.indexOf(parent);
+                    if (pos !== -1) {
+                        // If we have seen the parent before, we have already traversed a sibling in the array.
+                        // We then discard information gathered for the sibling (zero back to the current array).
+                        seen.splice(pos + 1);
+                    } else {
+                        // If we haven't seen the parent before, we add it to the seen-path.
+                        // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
+                        seen.push(parent);
+                    }
+
+                    if (seen.includes(value)) {
+                        // If we have seen the current value before, return a reference-structure if possible.
+                        if (value._primaryKeyProp) {
+                        return { $ref: value[value._primaryKeyProp] };
+                        }
+                        if (value.$refId) {
+                        return { $ref: value.$refId };
+                        }
+                        return "[Circular reference]";
+                    }
+
+                    return value;
+                };
+            }
+        });
+    }
 };

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -529,6 +529,7 @@ module.exports = function(realmConstructor, context) {
         },
         configurable: true
     });
+
     if (!realmConstructor.JsonSerializationReplacer) {
         Object.defineProperty(realmConstructor, "JsonSerializationReplacer", {
             get: function () {


### PR DESCRIPTION
"ported" master-PR https://github.com/realm/realm-js/pull/3321 by @nori-y to v10.