### PR TITLE
realm-web workflow fix (v10)

### DIFF
--- a/.github/workflows/publish-realm-web.yml
+++ b/.github/workflows/publish-realm-web.yml
@@ -1,9 +1,9 @@
 name: Publish Realm Web
 
 on:
-  create:
+  push:
     tags:
-      - realm-web-v*
+      - 'realm-web-v*'
 
 jobs:
   test-build-and-publish:


### PR DESCRIPTION
attempt to limit publish-realm-web to only trigger on created tags of format: 'realm-web-v*'