### PR TITLE
recreate EventLoopDispatcher in NetworkTransport on hot reload in RN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.
+
+NOTE: This version uses the Realm file format to version 20. It is not possible to downgrade to earlier versions than v10.0.0-beta.13. Non-sync Realms will be upgraded automatically. Synced Realms can only be automatically upgraded if created with Realm JavaScript v10.0.0-beta.1 and above.
+
+### Breaking changes
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* Realm.login() will not run after hot reloading in RN. ([#3236](https://github.com/realm/realm-js/issues/3236), since v10.0.0-beta.12)
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
+
+### Internal
+* None
+
 10.0.0-rc.2 Release notes (2020-10-12)
 =============================================================
 NOTE: Support for syncing with realm.cloud.io and/or Realm Object Server has been replaced with support for syncing with MongoDB Realm Cloud.

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -93,7 +93,6 @@ public:
 template<typename T>
 inline typename T::Function AppClass<T>::create_constructor(ContextType ctx) {
     FunctionType app_constructor = ObjectWrap<T, AppClass<T>>::create_constructor(ctx);
-    NetworkTransport::init(ctx);
     return app_constructor;
 }
 

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -168,7 +168,10 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
 
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
 
-    JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx) {};
+    JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx),
+        m_dispatcher { JavaScriptNetworkTransport::send_request_to_server_impl }
+    {
+    };
 
     static ObjectType makeRequest(ContextType ctx, const app::Request& request) {
         ObjectType headers_object = Object::create_empty(ctx);
@@ -187,34 +190,24 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
         return request_object;
     }
 
-    static void init(ContextType ctx) {
-        //this initializes the EventLoopDispatcher on the main JS thread
-        get_send_request_handler();
-    }
-
     void send_request_to_server(const app::Request request, std::function<void(const app::Response)> completion_callback) override {
-        auto& send_request_handler = get_send_request_handler();
-        send_request_handler(m_ctx, request, completion_callback);
+        m_dispatcher(m_ctx, request, completion_callback);
     }
 
 private:
     ContextType m_ctx;
+    realm::util::EventLoopDispatcher<SendRequestHandler> m_dispatcher;
 
-    static realm::util::EventLoopDispatcher<SendRequestHandler>& get_send_request_handler() {
-        static auto dispatcher = realm::util::EventLoopDispatcher([]
-            (ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback) {
-                HANDLESCOPE(m_ctx);
+    static void send_request_to_server_impl(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback) {
+        HANDLESCOPE(m_ctx);
 
-                ObjectType realm_constructor = Value::validated_to_object(m_ctx, Object::get_global(m_ctx, "Realm"));
-                ValueType network_transport = Object::get_property(m_ctx, realm_constructor, "_networkTransport");
+        ObjectType realm_constructor = Value::validated_to_object(m_ctx, Object::get_global(m_ctx, "Realm"));
+        ValueType network_transport = Object::get_property(m_ctx, realm_constructor, "_networkTransport");
 
-                Object::call_method(m_ctx, Value::to_object(m_ctx, network_transport), "fetchWithCallbacks", {
-                    makeRequest(m_ctx, request),
-                    ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
-                });
-            });
-
-        return dispatcher;
+        Object::call_method(m_ctx, Value::to_object(m_ctx, network_transport), "fetchWithCallbacks", {
+            makeRequest(m_ctx, request),
+            ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
+        });
     }
 
     std::string static fromHttpMethod(app::HttpMethod method) {

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -168,10 +168,10 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
 
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
 
-    JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx),
-        m_dispatcher { JavaScriptNetworkTransport::send_request_to_server_impl }
-    {
-    };
+	JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx),
+		m_dispatcher {JavaScriptNetworkTransport::send_request_to_server_impl}
+	{
+	};
 
     static ObjectType makeRequest(ContextType ctx, const app::Request& request) {
         ObjectType headers_object = Object::create_empty(ctx);


### PR DESCRIPTION
This fixes NetworkTransport EvenetLoopDispatcher to be recreated each time a new NetworkTransport is created. This is needed on RN for hot reload which creates a new main thread each time.
this fixes https://github.com/realm/realm-js/issues/3236