### PR TITLE
Realm Web: allUser object keyed by ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: This version uses the Realm file format to version 20. It is not possible 
 
 ### Fixed
 * Fixed RN Android error: couldn't find DSO to load: librealmreact.so caused by: dlopen failed: cannot locate symbol. ([#3347](https://github.com/realm/realm-js/issues/3347), since v10.0.0)
+* Fixed TS declaration for `app.allUsers` to `Record<string, User>` instead of an array of `User`. ([#3346](https://github.com/realm/realm-js/pull/3346))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -40,7 +40,7 @@ describe("App#constructor", () => {
         const user = await app.logIn(credentials);
         expect(typeof user.id).equals("string");
         expect(app.currentUser).equals(user);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
     });
 
     it("can log in two users, switch between them and log out", async () => {
@@ -49,36 +49,50 @@ describe("App#constructor", () => {
         // Authenticate the first user
         const user1 = await app.logIn(credentials);
         expect(app.currentUser).equals(user1);
-        expect(app.allUsers).deep.equals([user1]);
+        expect(app.allUsers).deep.equals({ [user1.id]: user1 });
         // Authenticate the second user
         const user2 = await app.logIn(credentials);
         expect(app.currentUser).equals(user2);
-        expect(app.allUsers).deep.equals([user2, user1]);
+        expect(app.allUsers).deep.equals({
+            [user1.id]: user1,
+            [user2.id]: user2,
+        });
         // Ensure that the two users are not one and the same
         expect(user1.id).to.not.equals(user2.id);
         // Switch back to the first user
         app.switchUser(user1);
         expect(app.currentUser).equals(user1);
-        expect(app.allUsers).deep.equals([user1, user2]);
+        expect(app.allUsers).deep.equals({
+            [user1.id]: user1,
+            [user2.id]: user2,
+        });
         // Switch back to the second user
         app.switchUser(user2);
         expect(app.currentUser).equals(user2);
-        expect(app.allUsers).deep.equals([user2, user1]);
+        expect(app.allUsers).deep.equals({
+            [user1.id]: user1,
+            [user2.id]: user2,
+        });
         // Switch back to the first user and log out
         app.switchUser(user1);
         expect(app.currentUser).equals(user1);
         await user1.logOut();
         expect(app.currentUser).equals(user2);
-        expect(app.allUsers).deep.equals([user2, user1]);
+        expect(app.allUsers).deep.equals({
+            [user1.id]: user1,
+            [user2.id]: user2,
+        });
         await app.removeUser(user1);
-        expect(app.allUsers).deep.equals([user2]);
+        expect(app.allUsers).deep.equals({
+            [user2.id]: user2,
+        });
     });
 
     it("restores a user", async () => {
         let user: User<object>;
         {
             const app = createApp();
-            expect(app.allUsers.length).equals(0);
+            expect(app.allUsers).deep.equals({});
             const credentials = Credentials.anonymous();
             user = await app.logIn(credentials);
             expect(typeof user.id).equals("string");
@@ -86,7 +100,7 @@ describe("App#constructor", () => {
         // Recreate the app and expect the user to be restored
         {
             const app = createApp();
-            expect(app.allUsers.length).equals(1);
+            expect(Object.keys(app.allUsers).length).equals(1);
             expect(app.currentUser).instanceOf(User);
             expect(app.currentUser?.id).equals(user.id);
             expect(app.currentUser?.profile).deep.equals(user.profile);

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,18 @@
+?.?.? Release notes (2020-??-??)
+=============================================================
+
+### Breaking Changes
+* Changed the `allUsers` property into an object keyed by user id. Use `Object.values(app.allUsers)` to retrieve a list of all users. ([#3346](https://github.com/realm/realm-js/pull/3346))
+
+### Enhancements
+* None
+
+### Fixed
+* None
+
+### Internal
+* None
+
 1.0.0-rc.2 Release notes (2020-10-13)
 =============================================================
 

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -271,17 +271,10 @@ export class App<
      * @returns An array of users active or loggedout users (current user being the first).
      */
     public get allUsers(): Readonly<
-        Realm.User<FunctionsFactoryType, CustomDataType>[]
+        Record<string, Realm.User<FunctionsFactoryType, CustomDataType>>
     > {
-        // We need to peek into refresh tokens to avoid cyclic code
-        const activeUsers = this.users.filter(
-            user => user.refreshToken !== null,
-        );
-        const loggedOutUsers = this.users.filter(
-            user => user.refreshToken === null,
-        );
         // Returning a freezed copy of the list of users to prevent outside changes
-        return Object.freeze([...activeUsers, ...loggedOutUsers]);
+        return Object.fromEntries(this.users.map(user => [user.id, user]));
     }
 
     /**

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -174,12 +174,12 @@ export class User<
      * @returns The current state of the user.
      */
     get state(): UserState {
-        if (this.app.allUsers.indexOf(this) === -1) {
-            return UserState.Removed;
-        } else {
+        if (this.id in this.app.allUsers) {
             return this.refreshToken === null
                 ? UserState.LoggedOut
                 : UserState.Active;
+        } else {
+            return UserState.Removed;
         }
     }
 

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -207,7 +207,7 @@ describe("App", () => {
         const user = await app.logIn(credentials, false);
         // Expect that we logged in
         expect(app.currentUser).equals(user);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
         expect(user.isLoggedIn).equals(true);
 
         await user.logOut();
@@ -216,7 +216,7 @@ describe("App", () => {
         expect(user.state).equals(UserState.LoggedOut);
         expect(user.state).equals("logged-out");
         expect(user.isLoggedIn).equals(false);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
         // Assume the correct requests made it to the transport
         expect(transport.requests).deep.equals([
             LOCATION_REQUEST,
@@ -350,12 +350,12 @@ describe("App", () => {
         const user = await app.logIn(credentials, false);
         // Expect that we logged in
         expect(app.currentUser).equals(user);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
         await app.removeUser(user);
         expect(app.currentUser).equals(null);
         expect(user.state).equals(UserState.Removed);
         expect(user.state).equals("removed");
-        expect(app.allUsers).deep.equals([]);
+        expect(app.allUsers).deep.equals({});
         // Assume the correct requests made it to the transport
         expect(transport.requests).deep.equals([
             LOCATION_REQUEST,
@@ -398,7 +398,7 @@ describe("App", () => {
         const user = await app.logIn(credentials, false);
         // Expect that we logged in
         expect(app.currentUser).equals(user);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
         const anotherUser = {} as User;
         // Switch
         try {
@@ -420,7 +420,7 @@ describe("App", () => {
         }
         // Expect the first user to remain logged in and known to the app
         expect(app.currentUser).equals(user);
-        expect(app.allUsers).deep.equals([user]);
+        expect(app.allUsers).deep.equals({ [user.id]: user });
         expect(user.state).equals("active");
         // Assume the correct requests made it to the transport
         expect(transport.requests).deep.equals([
@@ -664,15 +664,15 @@ describe("App", () => {
             baseUrl: "http://localhost:1337",
         });
 
-        expect(app.allUsers.length).equals(2);
+        expect(Object.keys(app.allUsers).length).equals(2);
 
-        const alice = app.allUsers[0];
+        const alice = app.allUsers["alices-id"];
         expect(alice.id).equals("alices-id");
         expect(alice.accessToken).equals("alices-access-token");
         expect(alice.refreshToken).equals("alices-refresh-token");
         expect(alice.profile.firstName).equals("Alice");
 
-        const bob = app.allUsers[1];
+        const bob = app.allUsers["bobs-id"];
         expect(bob.id).equals("bobs-id");
         expect(bob.accessToken).equals("bobs-access-token");
         expect(bob.refreshToken).equals("bobs-refresh-token");
@@ -842,12 +842,18 @@ describe("App", () => {
             "v3ry-s3cret-2",
         );
         const gilfoyle1 = await app.logIn(credentials1, false);
-        expect(app.allUsers).deep.equals([gilfoyle1]);
+        expect(app.allUsers).deep.equals({ [gilfoyle1.id]: gilfoyle1 });
         const dinesh = await app.logIn(credentials2, false);
         const gilfoyle2 = await app.logIn(credentials1, false);
         // Expect all users to equal the user being returned on either login
-        expect(app.allUsers).deep.equals([gilfoyle1, dinesh]);
-        expect(app.allUsers).deep.equals([gilfoyle2, dinesh]);
+        expect(app.allUsers).deep.equals({
+            [gilfoyle1.id]: gilfoyle1,
+            [dinesh.id]: dinesh,
+        });
+        expect(app.allUsers).deep.equals({
+            [gilfoyle2.id]: gilfoyle2,
+            [dinesh.id]: dinesh,
+        });
         // Expect that the current user has the tokens from the second login
         {
             const { currentUser } = app;
@@ -868,8 +874,14 @@ describe("App", () => {
             expect(currentUser).equals(dinesh);
         }
         const gilfoyle3 = await app.logIn(credentials1, false);
-        expect(app.allUsers).deep.equals([gilfoyle2, dinesh]);
-        expect(app.allUsers).deep.equals([gilfoyle3, dinesh]);
+        expect(app.allUsers).deep.equals({
+            [gilfoyle2.id]: gilfoyle2,
+            [dinesh.id]: dinesh,
+        });
+        expect(app.allUsers).deep.equals({
+            [gilfoyle3.id]: gilfoyle3,
+            [dinesh.id]: dinesh,
+        });
         // Expect that the current user has the tokens from the third login
         {
             const { currentUser } = app;
@@ -880,7 +892,10 @@ describe("App", () => {
         // Removing the user and logging in, will give two different user objects
         await app.removeUser(gilfoyle3);
         const gilfoyle4 = await app.logIn(credentials1, false);
-        expect(app.allUsers).deep.equals([gilfoyle4, dinesh]);
+        expect(app.allUsers).deep.equals({
+            [gilfoyle4.id]: gilfoyle4,
+            [dinesh.id]: dinesh,
+        });
         expect(gilfoyle4).not.equals(gilfoyle3);
         // Expect that the current user has the tokens from the forth login
         {

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -259,7 +259,7 @@ declare namespace Realm {
          * All authenticated users.
          */
         readonly allUsers: Readonly<
-            User<FunctionsFactoryType, CustomDataType>[]
+            Record<string, User<FunctionsFactoryType, CustomDataType>>
         >;
 
         /**


### PR DESCRIPTION
## What, How & Why?

This closes RJS-869 by aligning with the Realm JS (and other SDKs) implementation of the `allUsers` property on an instance of `App`.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
