### PR TITLE
Fixing chrome debugging on v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ NOTE: This version uses the Realm file format to version 20. It is not possible 
 ### Fixed
 * Fixed RN Android error: couldn't find DSO to load: librealmreact.so caused by: dlopen failed: cannot locate symbol. ([#3347](https://github.com/realm/realm-js/issues/3347), since v10.0.0)
 * Fixed TS declaration for `app.allUsers` to `Record<string, User>` instead of an array of `User`. ([#3346](https://github.com/realm/realm-js/pull/3346))
-* Fixing the creation of an RPC session when running in React Native Chrome debugging mode. ([#3411](https://github.com/realm/realm-js/pull/3411), since v10.0.0)
+* Fixing the creation of an RPC session when running in React Native Chrome debugging mode. ([#3411](https://github.com/realm/realm-js/pull/3411), [#3358](https://github.com/realm/realm-js/issues/3358), [#3361](https://github.com/realm/realm-js/issues/3361), since v10.0.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ NOTE: This version uses the Realm file format to version 20. It is not possible 
 ### Fixed
 * Fixed RN Android error: couldn't find DSO to load: librealmreact.so caused by: dlopen failed: cannot locate symbol. ([#3347](https://github.com/realm/realm-js/issues/3347), since v10.0.0)
 * Fixed TS declaration for `app.allUsers` to `Record<string, User>` instead of an array of `User`. ([#3346](https://github.com/realm/realm-js/pull/3346))
+* Fixing the creation of an RPC session when running in React Native Chrome debugging mode. ([#3411](https://github.com/realm/realm-js/pull/3411), since v10.0.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -404,6 +404,11 @@ class Credentials {
      * @returns {string} The identity provider, such as Google, Facebook, etc.
      */
     get provider() { }
+
+    /**
+     * @returns {object} A simple object which can be passed to the server as the body of a request to authenticate.
+     */
+    get payload() { }
 }
 
 /**

--- a/lib/app.js
+++ b/lib/app.js
@@ -22,7 +22,7 @@ const {promisify} = require("./utils.js");
 
 const instanceMethods = {
     logIn(credentials) {
-        return promisify(cb => this._login(credentials, cb));
+        return promisify(cb => this._logIn(credentials, cb));
     },
 
     removeUser(user) {

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -33,13 +33,6 @@ export default class App {
     constructor(config) {
         let info = createAppRPC(config);
         setupApp(this, info);
-
-        [
-            "currentUser",
-            "allUsers",
-        ].forEach((name) => {
-            Object.defineProperty(this, name, { get: getterForProperty(name) });
-        });
     }
 
     logIn(credentials) {
@@ -49,20 +42,13 @@ export default class App {
 
 createMethods(App.prototype, objectTypes.APP, [
     "_logIn",
-    // "allUsers",
-    // "currentUser",
     "switchUser"
 ]);
 
-/*
-Object.defineProperties(App, {
-    _logIn: {
-        value: function(creds, callback) {
-            return _logInRPC(App[keys.id], creds, callback)
-        },
-    },
+Object.defineProperties(App.prototype, {
+    currentUser: { get: getterForProperty("currentUser") },
+    allUsers: { get: getterForProperty("allUsers") },
 });
-*/
 
 export function createApp(realmId, info) {
     const appProxy = Object.create(App.prototype);

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -20,7 +20,7 @@
 
 import { keys, objectTypes } from "./constants";
 import { createMethods, getterForProperty } from "./util";
-import { createAppRPC, _logInRPC } from "./rpc";
+import { setVersions, createAppRPC, _logInRPC } from "./rpc";
 import { promisify } from "../utils";
 
 function setupApp(app, info) {
@@ -33,6 +33,15 @@ export default class App {
     constructor(config) {
         let info = createAppRPC(config);
         setupApp(this, info);
+    }
+
+    /**
+     * Invokes the RPC client to set versions.
+     * @todo Turn this into a call to the static App._setVersions method if the RPC layer supported invoking remote static methods.
+     * @param {object} versions An object containing package and platform names and versions.
+     */
+    static _setVersions(versions) {
+        return setVersions(versions);
     }
 
     logIn(credentials) {

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-import { keys, objectTypes } from './constants';
-import { createMethods } from './util';
-import { createAppRPC } from "./rpc";
+import { keys, objectTypes } from "./constants";
+import { createMethods } from "./util";
+import { createAppRPC, _logInRPC } from "./rpc";
 
 function setupApp(app, info) {
     app[keys.id] = info.id;
-    app[keys.realm] = info.realmId;
+    app[keys.realm] = "(App object)";
     app[keys.type] = objectTypes.APP;
 }
 
@@ -33,22 +33,33 @@ export default class App {
         let info = createAppRPC(config);
         setupApp(this, info);
     }
+
+    _logIn(creds, callback) {
+        return _logInRPC(creds, callback);
+    }
 }
 
 createMethods(App.prototype, objectTypes.APP, [
-    'logIn',
-    'allUsers',
-    'currentUser',
-    'switchUser'
+    "logIn",
+    "allUsers",
+    "currentUser",
+    "switchUser"
 ]);
+
+Object.defineProperties(App, {
+    _logIn: {
+        value: function(creds, callback) {
+            return _logInRPC(App[keys.id], creds, callback)
+        },
+    },
+});
 
 export function createApp(realmId, info) {
     const appProxy = Object.create(App.prototype);
 
     // FIXME: This is currently necessary because util/createMethod expects
     // the realm id to be present on any object that is used over rpc
-    // appProxy[keys.realm] = "(App object)";
-    appProxy[keys.realm] = realmId;
+    appProxy[keys.realm] = "(App object)";
 
     appProxy[keys.id] = info.id;
     appProxy[keys.type] = objectTypes.APP;

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -57,6 +57,7 @@ createMethods(App.prototype, objectTypes.APP, [
 Object.defineProperties(App.prototype, {
     currentUser: { get: getterForProperty("currentUser") },
     allUsers: { get: getterForProperty("allUsers") },
+    emailPasswordAuth: { get: getterForProperty("emailPasswordAuth") },
 });
 
 export function createApp(realmId, info) {

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -16,11 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
 import { keys, objectTypes } from "./constants";
-import { createMethods } from "./util";
+import { createMethods, getterForProperty } from "./util";
 import { createAppRPC, _logInRPC } from "./rpc";
+import { promisify } from "../utils";
 
 function setupApp(app, info) {
     app[keys.id] = info.id;
@@ -32,20 +33,28 @@ export default class App {
     constructor(config) {
         let info = createAppRPC(config);
         setupApp(this, info);
+
+        [
+            "currentUser",
+            "allUsers",
+        ].forEach((name) => {
+            Object.defineProperty(this, name, { get: getterForProperty(name) });
+        });
     }
 
-    _logIn(creds, callback) {
-        return _logInRPC(creds, callback);
+    logIn(credentials) {
+        return promisify(cb => this._logIn(credentials, cb));
     }
 }
 
 createMethods(App.prototype, objectTypes.APP, [
-    "logIn",
-    "allUsers",
-    "currentUser",
+    "_logIn",
+    // "allUsers",
+    // "currentUser",
     "switchUser"
 ]);
 
+/*
 Object.defineProperties(App, {
     _logIn: {
         value: function(creds, callback) {
@@ -53,6 +62,7 @@ Object.defineProperties(App, {
         },
     },
 });
+*/
 
 export function createApp(realmId, info) {
     const appProxy = Object.create(App.prototype);

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -20,8 +20,19 @@
 
 import { keys, objectTypes } from './constants';
 import { createMethods } from './util';
+import { createAppRPC } from "./rpc";
+
+function setupApp(app, info) {
+    app[keys.id] = info.id;
+    app[keys.realm] = info.realmId;
+    app[keys.type] = objectTypes.APP;
+}
 
 export default class App {
+    constructor(config) {
+        let info = createAppRPC(config);
+        setupApp(this, info);
+    }
 }
 
 createMethods(App.prototype, objectTypes.APP, [
@@ -36,7 +47,8 @@ export function createApp(realmId, info) {
 
     // FIXME: This is currently necessary because util/createMethod expects
     // the realm id to be present on any object that is used over rpc
-    appProxy[keys.realm] = "(App object)";
+    // appProxy[keys.realm] = "(App object)";
+    appProxy[keys.realm] = realmId;
 
     appProxy[keys.id] = info.id;
     appProxy[keys.type] = objectTypes.APP;

--- a/lib/browser/constants.js
+++ b/lib/browser/constants.js
@@ -47,6 +47,7 @@ export const propTypes = {};
     'CREDENTIALS',
     'FETCHRESPONSEHANDLER',
     'UNDEFINED',
+    'EMAILPASSWORDAUTH'
 ].forEach(function(type) {
     Object.defineProperty(objectTypes, type, {
         value: type.toLowerCase(),

--- a/lib/browser/constants.js
+++ b/lib/browser/constants.js
@@ -34,6 +34,7 @@ export const propTypes = {};
     'DATA',
     'DATE',
     'DICT',
+    'ERROR',
     'FUNCTION',
     'LIST',
     'OBJECT',
@@ -44,6 +45,7 @@ export const propTypes = {};
     'ASYNCOPENTASK',
     'APP',
     'CREDENTIALS',
+    'FETCHRESPONSEHANDLER',
     'UNDEFINED',
 ].forEach(function(type) {
     Object.defineProperty(objectTypes, type, {

--- a/lib/browser/credentials.js
+++ b/lib/browser/credentials.js
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
 import { keys, objectTypes } from "./constants";
 import { _anonymousRPC, _facebookRPC, _functionRPC, _googleRPC, _appleRPC, _emailPasswordRPC, _userApiKeyRPC, _serverApiKeyRPC, _jwtRPC } from "./rpc";

--- a/lib/browser/email-password-auth.js
+++ b/lib/browser/email-password-auth.js
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+import { keys, objectTypes } from "./constants";
+import { createMethods } from "./util";
+import { promisify } from "../utils";
+
+export class EmailPasswordAuth {
+  registerUser(email, password) {
+    return promisify(cb => this._registerUser(email, password, cb));
+  }
+
+  confirmUser(token, token_id) {
+      return promisify(cb => this._confirmUser(token, token_id, cb));
+  }
+
+  resendConfirmationEmail(email) {
+      return promisify(cb => this._resendConfirmationEmail(email, cb));
+  }
+
+  sendResetPasswordEmail(email) {
+      return promisify(cb => this._sendResetPasswordEmail(email, cb));
+  }
+
+  resetPassword(password, token, token_id) {
+      return promisify(cb => this._resetPassword(password, token, token_id, cb));
+  }
+
+  callResetPasswordFunction(email, password, ...bsonArgs) {
+      return promisify(cb => this._callResetPasswordFunction(email, password, bsonArgs, cb));
+  }
+}
+
+createMethods(EmailPasswordAuth.prototype, objectTypes.EMAILPASSWORDAUTH, [
+    "_registerUser",
+    "_confirmUser",
+    "_resendConfirmationEmail",
+    "_sendResetPasswordEmail",
+    "_resetPassword",
+    "_callResetPasswordFunction",
+]);
+
+export function createEmailPasswordAuth(realmId, info) {
+    const proxy = Object.create(EmailPasswordAuth.prototype);
+
+    // FIXME: This is currently necessary because util/createMethod expects
+    // the realm id to be present on any object that is used over rpc
+    proxy[keys.realm] = "(EmailPasswordAuth object)";
+    proxy[keys.id] = info.id;
+    proxy[keys.type] = objectTypes.EMAILPASSWORDAUTH;
+
+    return proxy;
+}

--- a/lib/browser/fetch.js
+++ b/lib/browser/fetch.js
@@ -23,13 +23,13 @@ import { callMethod, registerTypeConverter } from "./rpc";
 
 export function performFetch(request, responseHandler) {
   const { url, ...init } = request;
-  const { onSuccess, onError } = responseHandler;
   if (typeof url !== "string") {
     throw new Error("Expected a URL");
   }
   if (typeof responseHandler !== "object") {
     throw new Error("Expected a response handler object");
   }
+  const { onSuccess, onError } = responseHandler;
   // Delegate to fetch
   fetch(url, init).then(async (response) => {
     const decodedBody = await response.text();

--- a/lib/browser/fetch.js
+++ b/lib/browser/fetch.js
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+import { objectTypes } from "./constants";
+import { callMethod, registerTypeConverter } from "./rpc";
+
+export function performFetch(request, responseHandler) {
+  const { url, ...init } = request;
+  const { onSuccess, onError } = responseHandler;
+  if (typeof url !== "string") {
+    throw new Error("Expected a URL");
+  }
+  if (typeof responseHandler !== "object") {
+    throw new Error("Expected a response handler object");
+  }
+  // Delegate to fetch
+  fetch(url, init).then(async (response) => {
+    const decodedBody = await response.text();
+    // Pull out the headers of the response
+    const headers = {};
+    response.headers.forEach((value, key) => {
+        headers[key] = value;
+    });
+    return {
+          statusCode: response.status,
+          headers,
+          body: decodedBody,
+    };
+  }).then(onSuccess, onError);
+}
+
+function deserializeResponseHandler(realmId, info) {
+  const { id } = info;
+  if (typeof id !== "number") {
+    throw new Error("Expected a nummeric id");
+  }
+  return {
+    onSuccess: function() {
+      callMethod(undefined, id, "onSuccess", Array.from(arguments));
+    },
+    onError: function() {
+      callMethod(undefined, id, "onError", Array.from(arguments));
+    },
+  }
+}
+
+registerTypeConverter(objectTypes.FETCHRESPONSEHANDLER, deserializeResponseHandler);

--- a/lib/browser/fetch.js
+++ b/lib/browser/fetch.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -30,7 +30,6 @@ import App, { createApp } from './app';
 import Credentials, { createCredentials } from './credentials';
 import * as rpc from './rpc';
 import * as util from './util';
-import { static as staticUserMethods } from '../user';
 import { createSession } from './session';
 import { invalidateCache } from './cache';
 
@@ -212,9 +211,7 @@ Object.defineProperties(Realm, {
 
 for (let i = 0, len = debugHosts.length; i < len; i++) {
     try {
-        let refreshAccessTokenCallback = staticUserMethods && staticUserMethods._refreshAccessToken ? staticUserMethods._refreshAccessToken.bind(User) : () => {};
-        // The session ID refers to the Realm constructor object in the RPC server.
-        Realm[keys.id] = createSession(refreshAccessTokenCallback, debugHosts[i] + ':' + debugPort);
+        Realm[keys.id] = rpc.createSession(debugHosts[i] + ":" + debugPort);
         break;
     } catch (e) {
         // Only throw exception after all hosts have been tried.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -32,6 +32,7 @@ import * as rpc from './rpc';
 import * as util from './util';
 import { createSession } from './session';
 import { invalidateCache } from './cache';
+import { performFetch } from "./fetch";
 
 const {debugHosts, debugPort} = NativeModules.Realm;
 
@@ -211,7 +212,7 @@ Object.defineProperties(Realm, {
 
 for (let i = 0, len = debugHosts.length; i < len; i++) {
     try {
-        Realm[keys.id] = rpc.createSession(debugHosts[i] + ":" + debugPort);
+        Realm[keys.id] = rpc.createSession(debugHosts[i] + ":" + debugPort, { performFetch });
         break;
     } catch (e) {
         // Only throw exception after all hosts have been tried.

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -33,6 +33,7 @@ import * as util from './util';
 import { createSession } from './session';
 import { invalidateCache } from './cache';
 import { performFetch } from "./fetch";
+import { createEmailPasswordAuth } from './email-password-auth';
 
 const {debugHosts, debugPort} = NativeModules.Realm;
 
@@ -45,6 +46,7 @@ rpc.registerTypeConverter(objectTypes.SESSION, createSession);
 rpc.registerTypeConverter(objectTypes.ASYNCOPENTASK, createAsyncOpenTask);
 rpc.registerTypeConverter(objectTypes.APP, createApp);
 rpc.registerTypeConverter(objectTypes.CREDENTIALS, createCredentials);
+rpc.registerTypeConverter(objectTypes.EMAILPASSWORDAUTH, createEmailPasswordAuth);
 
 function createRealm(_, info) {
     let realm = Object.create(Realm.prototype);

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -165,11 +165,11 @@ export function callSyncFunction(name, args) {
 }
 
 export function callMethod(realmId, id, name, args) {
-    if (args && Array.isArray(args)) {
-        args = args.map((arg) => serialize(realmId, arg));
+    if (!Array.isArray(args)) {
+        throw new Error("Expected an array of arguments");
     }
-
-    let result = sendRequest("call_method", { realmId, id, name, arguments: args });
+    const serializedArgs = args.map((arg) => serialize(realmId, arg));
+    const result = sendRequest("call_method", { realmId, id, name, arguments: serializedArgs });
     return deserialize(realmId, result);
 }
 

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -65,6 +65,14 @@ function beforeNotify(realm) {
     invalidateCache(realm[keys.realm]);
 }
 
+
+export function createSession(host) {
+    sessionId = sendRequest("create_session", null, host);
+    sessionHost = host;
+
+    return sessionId;
+}
+
 export function createRealm(args) {
     if (args) {
         args = args.map((arg) => serialize(null, arg));

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -19,7 +19,6 @@
 'use strict';
 
 import * as base64 from './base64';
-import * as util from './util';
 import { keys, objectTypes } from './constants';
 import { invalidateCache } from './cache';
 
@@ -96,6 +95,19 @@ export function asyncOpenRealm(id, config, callback) {
                     realm.addListener('beforenotify', beforeNotify);
                 }
                 callback(realm, error);
+            })
+        ]
+    }));
+}
+
+export function _logInRPC(id, creds, callback) {
+    return deserialize(undefined, sendRequest("call_method", {
+        id,
+        name: "_logIn",
+        arguments: [
+            serialize(null, creds),
+            serialize(null, (user, error) => {
+                callback(user, error);
             })
         ]
     }));

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -16,11 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
-import * as base64 from './base64';
-import { keys, objectTypes } from './constants';
-import { invalidateCache } from './cache';
+import * as base64 from "./base64";
+import { keys, objectTypes } from "./constants";
+import { invalidateCache } from "./cache";
 
 const { id: idKey, realm: _realmKey } = keys;
 let registeredCallbacks = [];
@@ -45,6 +45,7 @@ if (XMLHttpRequest.__proto__ != global.XMLHttpRequestEventTarget) {
 registerTypeConverter(objectTypes.DATA, (_, { value }) => base64.decode(value));
 registerTypeConverter(objectTypes.DATE, (_, { value }) => new Date(value));
 registerTypeConverter(objectTypes.DICT, deserializeDict);
+registerTypeConverter(objectTypes.ERROR, deserializeError);
 registerTypeConverter(objectTypes.FUNCTION, deserializeFunction);
 
 export function registerTypeConverter(type, handler) {
@@ -65,9 +66,14 @@ function beforeNotify(realm) {
 }
 
 
-export function createSession(host) {
+export function createSession(host, { performFetch }) {
     sessionHost = host;
-    sessionId = sendRequest("create_session", null, host);
+
+    sessionId = sendRequest(
+        "create_session",
+        { fetch: serialize(undefined, performFetch) },
+        host,
+    );
 
     return sessionId;
 }
@@ -77,7 +83,7 @@ export function createRealm(args) {
         args = args.map((arg) => serialize(null, arg));
     }
 
-    return sendRequest('create_realm', { arguments: args, beforeNotify: serialize(null, beforeNotify) });
+    return sendRequest("create_realm", { arguments: args, beforeNotify: serialize(null, beforeNotify) });
 }
 
 export function createAppRPC(config) {
@@ -85,14 +91,14 @@ export function createAppRPC(config) {
 }
 
 export function asyncOpenRealm(id, config, callback) {
-    return deserialize(undefined, sendRequest('call_method', {
+    return deserialize(undefined, sendRequest("call_method", {
         id,
-        name: '_asyncOpen',
+        name: "_asyncOpen",
         arguments: [
             serialize(null, config),
             serialize(null, (realm, error) => {
                 if (realm) {
-                    realm.addListener('beforenotify', beforeNotify);
+                    realm.addListener("beforenotify", beforeNotify);
                 }
                 callback(realm, error);
             })
@@ -100,88 +106,75 @@ export function asyncOpenRealm(id, config, callback) {
     }));
 }
 
-export function _logInRPC(id, creds, callback) {
-    return deserialize(undefined, sendRequest("call_method", {
-        id,
-        name: "_logIn",
-        arguments: [
-            serialize(null, creds),
-            serialize(null, (user, error) => {
-                callback(user, error);
-            })
-        ]
-    }));
-}
-
 export function _anonymousRPC() {
-    const result = sendRequest('_anonymous', { arguments: undefined });
+    const result = sendRequest("_anonymous", { arguments: undefined });
     return deserialize(undefined, result);
 }
 
 export function _appleRPC(token) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_apple', { arguments: args });
+    const result = sendRequest("_apple", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _emailPasswordRPC(email, password) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_emailPassword', { arguments: args });
+    const result = sendRequest("_emailPassword", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _facebookRPC(token) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_facebook', { arguments: args });
+    const result = sendRequest("_facebook", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _functionRPC(payload) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_function', { arguments: args });
+    const result = sendRequest("_function", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _googleRPC(authCode) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_google', { arguments: args });
+    const result = sendRequest("_google", { arguments: args });
     return deserialize(undefined, result);
 }
 export function _userApiKeyRPC(user_key) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_userAPIKey', { arguments: args });
+    const result = sendRequest("_userAPIKey", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _serverApiKeyRPC(server_key) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_serverAPIKey', { arguments: args });
+    const result = sendRequest("_serverAPIKey", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function _jwtRPC(token) {
     const args = Array.prototype.map.call(arguments, (arg) => serialize(null, arg));
-    const result = sendRequest('_jwt', { arguments: args });
+    const result = sendRequest("_jwt", { arguments: args });
     return deserialize(undefined, result);
 }
 
 export function callSyncFunction(name, args) {
     args = (args || []).map((arg) => serialize(null, arg));
-    let result = sendRequest('call_sync_function', { name, arguments: args });
+    let result = sendRequest("call_sync_function", { name, arguments: args });
     return deserialize(undefined, result);
 }
 
 export function callMethod(realmId, id, name, args) {
-    if (args) {
+    if (args && Array.isArray(args)) {
         args = args.map((arg) => serialize(realmId, arg));
     }
 
-    let result = sendRequest('call_method', { realmId, id, name, arguments: args });
+    let result = sendRequest("call_method", { realmId, id, name, arguments: args });
     return deserialize(realmId, result);
 }
 
 export function getObject(realmId, id, name) {
-    let result = sendRequest('get_object', { realmId, id, name });
+    let result = sendRequest("get_object", { realmId, id, name });
     if (!result) {
         return result;
     }
@@ -192,17 +185,17 @@ export function getObject(realmId, id, name) {
 }
 
 export function getProperty(realmId, id, name) {
-    let result = sendRequest('get_property', { realmId, id, name });
+    let result = sendRequest("get_property", { realmId, id, name });
     return deserialize(realmId, result);
 }
 
 export function setProperty(realmId, id, name, value) {
     value = serialize(realmId, value);
-    sendRequest('set_property', { realmId, id, name, value });
+    sendRequest("set_property", { realmId, id, name, value });
 }
 
 export function clearTestState() {
-    sendRequest('clear_test_state');
+    sendRequest("clear_test_state");
 
     // Clear all registered callbacks that are specific to this session.
     registeredCallbacks = registeredCallbacks.filter(cb => Reflect.has(cb, persistentCallback));
@@ -214,13 +207,13 @@ function registerCallback(callback) {
 }
 
 function serialize(realmId, value) {
-    if (typeof value == 'undefined') {
+    if (typeof value == "undefined") {
         return { type: objectTypes.UNDEFINED };
     }
-    if (typeof value == 'function') {
+    if (typeof value == "function") {
         return { type: objectTypes.FUNCTION, value: registerCallback(value) };
     }
-    if (!value || typeof value != 'object') {
+    if (!value || typeof value != "object") {
         return { value: value };
     }
 
@@ -273,6 +266,13 @@ function deserializeDict(realmId, info) {
     return object;
 }
 
+function deserializeError(realmId, info) {
+    const { message, stack } = info.error;
+    const err =  new Error(message.value);
+    err.stack = stack.value;
+    return err;
+}
+
 function deserializeFunction(realmId, info) {
     return registeredCallbacks[info.value];
 }
@@ -283,8 +283,8 @@ function makeRequest(url, data) {
 
     // The global __debug__ object is provided by Visual Studio Code.
     if (global.__debug__) {
-        let request = global.__debug__.require('sync-request');
-        let response = request('POST', url, {
+        let request = global.__debug__.require("sync-request");
+        let response = request("POST", url, {
             body: JSON.stringify(data),
             headers: {
                 "Content-Type": "text/plain;charset=UTF-8"
@@ -292,12 +292,12 @@ function makeRequest(url, data) {
         });
 
         statusCode = response.statusCode;
-        responseText = response.body.toString('utf-8');
+        responseText = response.body.toString("utf-8");
     } else {
         let body = JSON.stringify(data);
         let request = new XMLHttpRequest();
 
-        request.open('POST', url, false);
+        request.open("POST", url, false);
         request.send(body);
 
         statusCode = request.status;
@@ -320,7 +320,7 @@ function deserialize_json_value(value) {
     for (let index = 0; index < value.keys.length; index++) {
         var propName = value.keys[index];
         var propValue = value.values[index];
-        if (propValue.type && propValue.type == 'dict') {
+        if (propValue.type && propValue.type == "dict") {
             result[propName] = deserialize_json_value(propValue);
         }
         else {
@@ -335,19 +335,19 @@ function sendRequest(command, data, host = sessionHost) {
     clearTimeout(pollTimeoutId);
     try {
         if (!host) {
-            throw new Error('Must first create RPC session with a valid host');
+            throw new Error("Must first create RPC session with a valid host");
         }
 
         data = Object.assign({}, data, sessionId ? { sessionId } : null);
 
-        let url = 'http://' + host + '/' + command;
+        let url = "http://" + host + "/" + command;
         let response = makeRequest(url, data);
         let callback = response && response.callback;
 
         // Reset the callback poll interval to 10ms every time we either hit a
         // callback or call any other method, and double it each time we poll
         // for callbacks and get nothing until it's over a second.
-        if (callback || command !== 'callbacks_poll') {
+        if (callback || command !== "callbacks_poll") {
             pollTimeout = 10;
         }
         else if (pollTimeout < 1000) {
@@ -358,20 +358,12 @@ function sendRequest(command, data, host = sessionHost) {
             let error = response && response.error;
 
             // Remove the type prefix from the error message (e.g. "Error: ").
-            if (error && error.replace) {
-                error = error.replace(/^[a-z]+: /i, '');
-            }
-            else if (error.type && error.type === 'dict') {
-                const responseError = deserialize_json_value(error);
-                let responeMessage;
-                if (response.message && response.message !== '') {
-                    // Remove the type prefix from the error message (e.g. "Error: ").
-                    responeMessage = response.message.replace(/^[a-z]+: /i, '');
-                }
-
-                const exceptionToReport = new Error(responeMessage);
-                Object.assign(exceptionToReport, responseError);
-                throw exceptionToReport;
+            if (error && typeof error === "string") {
+                error = error.replace(/^[a-z]+: /i, "");
+            } else if (error.type && error.type === "error") {
+                const err =  new Error(error.message.value);
+                err.stack = error.stack.value;
+                throw err;
             }
 
             throw new Error(error || `Invalid response for "${command}"`);
@@ -390,14 +382,14 @@ function sendRequest(command, data, host = sessionHost) {
                     error = `Unknown callback id: ${callback}`
                 }
             } catch (e) {
-                error = e.message || ('' + e);
+                error = e.message || ("" + e);
                 if (e.stack) {
                     stack = JSON.stringify(e.stack);
                 }
             }
 
             let callbackCommand = "callback_result";
-            if (command === 'callbacks_poll' || command === 'callback_poll_result') {
+            if (command === "callbacks_poll" || command === "callback_poll_result") {
                 callbackCommand = "callback_poll_result";
             }
 
@@ -407,6 +399,6 @@ function sendRequest(command, data, host = sessionHost) {
         return response.result;
     }
     finally {
-        pollTimeoutId = setTimeout(() => sendRequest('callbacks_poll'), pollTimeout);
+        pollTimeoutId = setTimeout(() => sendRequest("callbacks_poll"), pollTimeout);
     }
 }

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -66,12 +66,15 @@ function beforeNotify(realm) {
 }
 
 
-export function createSession(host, { performFetch }) {
+export function createSession(host, { versions, performFetch }) {
     sessionHost = host;
 
     sessionId = sendRequest(
         "create_session",
-        { fetch: serialize(undefined, performFetch) },
+        {
+            versions,
+            fetch: serialize(undefined, performFetch),
+        },
         host,
     );
 
@@ -104,6 +107,10 @@ export function asyncOpenRealm(id, config, callback) {
             })
         ]
     }));
+}
+
+export function setVersions(versions) {
+    sendRequest("set_versions", { versions: serialize(null, versions) });
 }
 
 export function _anonymousRPC() {

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -67,8 +67,8 @@ function beforeNotify(realm) {
 
 
 export function createSession(host) {
-    sessionId = sendRequest("create_session", null, host);
     sessionHost = host;
+    sessionId = sendRequest("create_session", null, host);
 
     return sessionId;
 }
@@ -79,6 +79,10 @@ export function createRealm(args) {
     }
 
     return sendRequest('create_realm', { arguments: args, beforeNotify: serialize(null, beforeNotify) });
+}
+
+export function createAppRPC(config) {
+    return sendRequest("create_app", { arguments: [ serialize(null, config) ] });
 }
 
 export function asyncOpenRealm(id, config, callback) {

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -17,16 +17,20 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
-import { keys, objectTypes } from './constants';
-import { getterForProperty, createMethods } from './util';
+import { keys, objectTypes } from "./constants";
+import { getterForProperty, createMethods, createMethod } from "./util";
+import { promisify } from "../utils";
 
 export default class User {
+    logOut() {
+        return promisify(cb => this._logOut(cb));
+    }
 }
 
 createMethods(User.prototype, objectTypes.USER, [
-    "logOut",
+    "_logOut",
     "_sessionForOnDiskPath",
     "_deleteUser",
     "_linkCredentials",
@@ -38,14 +42,14 @@ createMethods(User.prototype, objectTypes.USER, [
 ]);
 
 Object.defineProperties(User.prototype, {
-    id: { get: getterForProperty('id') },
-    accessToken: { get: getterForProperty('accessToken') },
-    refreshToken: { get: getterForProperty('refreshToken') },
-    profile: { get: getterForProperty('profile') },
-    isLoggedIn: { get: getterForProperty('isLoggedIn') },
-    state: { get: getterForProperty('state') },
-    customData: { get: getterForProperty('customData') },
-    apiKeys: { get: getterForProperty('apiKeys') },
+    id: { get: getterForProperty("id") },
+    accessToken: { get: getterForProperty("accessToken") },
+    refreshToken: { get: getterForProperty("refreshToken") },
+    profile: { get: getterForProperty("profile") },
+    isLoggedIn: { get: getterForProperty("isLoggedIn") },
+    state: { get: getterForProperty("state") },
+    customData: { get: getterForProperty("customData") },
+    apiKeys: { get: getterForProperty("apiKeys") },
 });
 
 export function createUser(realmId, info) {
@@ -54,10 +58,8 @@ export function createUser(realmId, info) {
     // FIXME: This is currently necessary because util/createMethod expects
     // the realm id to be present on any object that is used over rpc
     userProxy[keys.realm] = "(User object)";
-
     userProxy[keys.id] = info.id;
     userProxy[keys.type] = objectTypes.USER;
-    Object.assign(userProxy, info.data);
 
     return userProxy;
 }

--- a/lib/browser/util.js
+++ b/lib/browser/util.js
@@ -16,11 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
-import { keys } from './constants';
-import * as rpc from './rpc';
-import {invalidateCache, getRealmCache} from './cache';
+import { keys } from "./constants";
+import * as rpc from "./rpc";
+import {invalidateCache, getRealmCache} from "./cache";
 
 export function createMethods(prototype, type, methodNames, mutating) {
     let props = {};

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -473,30 +473,6 @@ module.exports = function(realmConstructor, context) {
             Manual: 'manual',
             Recover: 'recover'
         };
-
-        Object.defineProperties(realmConstructor, getOwnPropertyDescriptors({
-            // Creates the user agent description for the JS binding itself. Users must specify the application
-            // user agent using Realm.App.Sync.setUserAgent(...)
-            _createUserAgentDescription() {
-                // Detect if in ReactNative (running on a phone) or in a Node.js environment
-                // Credit: https://stackoverflow.com/questions/39468022/how-do-i-know-if-my-code-is-running-as-react-native
-                try {
-                    var userAgent = "RealmJS/";
-                    userAgent = userAgent + require('../package.json').version + " (" + context + ", ";
-                    if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
-                        // Running on ReactNative
-                        const Platform = require('react-native').Platform;
-                        userAgent += Platform.OS + ", v" + Platform.Version;
-                    } else {
-                        // Running on a normal machine
-                        userAgent += process.version;
-                    }
-                    return userAgent += ")";
-                } catch (e) {
-                    return "RealmJS/Unknown"
-                }
-            },
-        }));
     }
 
     // TODO: Remove this now useless object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,137 +16,54 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
+
+const utils = require("./utils");
 
 // Prevent React Native packager from seeing modules required with this
 const nodeRequire = require;
 
-function getContext() {
-    // If process.release.name is an object with we're probably running in Node or Electron
-    // From: http://stackoverflow.com/a/24279593/1417293
-    if (typeof process === 'object' && typeof process.release === "object" && process.release.name === "node") {
-
-        // Visual Studio Code defines the global.__debug__ object.
-        if (typeof global === 'object' && global.__debug__) {
-            return 'vscodedebugger';
-        }
-
-        return typeof process.versions === "object" && typeof process.versions.electron === "string" ? 'electron' : 'node.js';
-    }
-
-    // When running via Jest, the jest object is defined.
-    if (typeof jest === 'object') {
-        return 'node.js';
-    }
-
-    if (typeof navigator === 'object' && navigator.product === 'ReactNative') { // eslint-disable-line no-undef
-        // Visual Studio Code defines the global.__debug__ object.
-        if (typeof global !== 'undefined' && global.__debug__) {
-            return 'vscodedebugger'
-        }
-
-        // Check if its in remote js debugging mode
-        // https://stackoverflow.com/a/50377644
-        if (typeof DedicatedWorkerGlobalScope !== 'undefined') {
-            return 'chromedebugger';
-        }
-
-        // Otherwise, we must be in a "normal" react native situation.
-        // In that case, the Realm type should have been injected by the native code.
-        // If it hasn't, the user likely forgot to install the RealmJS CocoaPod
-        if (typeof Realm === 'undefined') {
-            throw new Error('Missing Realm constructor. Did you run "pod install"? Please see https://realm.io/docs/react-native/latest/#missing-realm-constructor for troubleshooting');
-        }
-
-        return 'reactnative';
-    }
-
-    // If we're not running in React Native but we already injected the Realm class,
-    // we are probably running in a pure jscore environment
-    if (typeof Realm !== 'undefined') {
-        return 'jscore';
-    }
-
-    // Visual Studio Code defines the global.__debug__ object.
-    if (typeof global !== 'undefined' && global.__debug__) {
-        return 'vscodedebugger';
-    }
-
-    // Finally, if the navigator.userAgent contains the string "Chrome", we're likely
-    // running via the chrome debugger, even if navigator.product isn't set to "ReactNative"
-    if (typeof navigator !== 'undefined' &&
-        /Chrome/.test(navigator.userAgent)) { // eslint-disable-line no-undef
-        return 'chromedebugger';
-    }
-
-    throw new Error("Unknown execution context");
-}
-
 function getRealmConstructor(context) {
     switch(context) {
-        case 'node.js':
-        case 'electron':
-            nodeRequire('./submit-analytics')('Run', context);
+        case "node.js":
+        case "electron":
+            nodeRequire("./submit-analytics")("Run", context);
 
-            var binary = nodeRequire('node-pre-gyp');
-            var path = nodeRequire('path');
-            var pkg = path.resolve(path.join(__dirname,'../package.json'));
+            var binary = nodeRequire("node-pre-gyp");
+            var path = nodeRequire("path");
+            var pkg = path.resolve(path.join(__dirname,"../package.json"));
             var binding_path = binary.find(pkg);
 
             return nodeRequire(binding_path).Realm;
-        case 'reactnative':
+        case "reactnative":
             //switch how babel transpiled code creates children objects.
             //Inheriting from Realm.Object with class syntax does not support using Reflect.construct the way babel transpiles it.
             //Defining Reflect.construct.sham makes the transpiled code use different standart mechanism for inheriting. (Function.apply with setPrototypeOf)
             if (typeof Reflect !== "undefined" && Reflect.construct) {
                 Reflect.construct.sham = 1;
             }
-        case 'jscore':
             return global.Realm;
-        case 'chromedebugger':
-        case 'vscodedebugger':
+        case "jscore":
+            return global.Realm;
+        case "chromedebugger":
+        case "vscodedebugger":
             // This condition is for stripping "browser" folder from production bundles.
             if (global.__DEV__) {
-                return require('./browser').default; // (exported as ES6 module)
+                return require("./browser").default; // (exported as ES6 module)
             } else {
-                throw new Error('Can´t use debugger if __DEV__ isn´t true.');
+                throw new Error("Can´t use debugger if __DEV__ isn´t true.");
             }
         default:
             throw new Error("Unexpected execution context (" + context + ")");
     }
 }
 
-const context = getContext();
+const context = utils.getContext();
 const realmConstructor = getRealmConstructor(context);
-realmConstructor._createPlatformDescription = function () {
-    try {
-        const sdk_version = `RealmJS/${require("../package.json").version}`;
-        let platform = "(unknown)";
-        let platform_version = "(unknown)";
 
-        if (context === "reactnative") {
-            const Platform = require("react-native").Platform;
-            platform = "react-native";
-            platform_version = `${Platform.Version}`; // Android reports a number!
-        } else if (context === "node.js" || context === "electron") {
-            platform = "node.js";
-            platform_version = process.version;
-        }
+require("./extensions")(realmConstructor, context);
 
-        return {
-            platform,
-            platform_version,
-            sdk_version
-        }
-    } catch (e) {
-        return {
-            platform: "Unknown",
-            platform_version: "(undefined)",
-            sdk_version: "RealmJS/(undefined)"
-        };
-    }
-}
-
-require('./extensions')(realmConstructor, context);
+const versions = utils.getVersions();
+realmConstructor.App._setVersions(versions);
 
 module.exports = realmConstructor;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,4 +44,107 @@ module.exports = {
             });
         });
     },
+
+    /**
+     * Determines the context in which the package is being loaded.
+     * @returns A string representing the context.
+     */
+    getContext() {
+        // If process.release.name is an object with we're probably running in Node or Electron
+        // From: http://stackoverflow.com/a/24279593/1417293
+        if (typeof process === "object" && typeof process.release === "object" && process.release.name === "node") {
+    
+            // Visual Studio Code defines the global.__debug__ object.
+            if (typeof global === "object" && global.__debug__) {
+                return "vscodedebugger";
+            }
+    
+            return typeof process.versions === "object" && typeof process.versions.electron === "string" ? "electron" : "node.js";
+        }
+    
+        // When running via Jest, the jest object is defined.
+        if (typeof jest === "object") {
+            return "node.js";
+        }
+    
+        if (typeof navigator === "object" && navigator.product === "ReactNative") { // eslint-disable-line no-undef
+            // Visual Studio Code defines the global.__debug__ object.
+            if (typeof global !== "undefined" && global.__debug__) {
+                return "vscodedebugger"
+            }
+    
+            // Check if its in remote js debugging mode
+            // https://stackoverflow.com/a/50377644
+            if (typeof DedicatedWorkerGlobalScope !== "undefined") {
+                return "chromedebugger";
+            }
+    
+            // Otherwise, we must be in a "normal" react native situation.
+            // In that case, the Realm type should have been injected by the native code.
+            // If it hasn't, the user likely forgot to install the RealmJS CocoaPod
+            if (typeof Realm === "undefined") {
+                throw new Error("Missing Realm constructor. Did you run \"pod install\"? Please see https://realm.io/docs/react-native/latest/#missing-realm-constructor for troubleshooting");
+            }
+    
+            return "reactnative";
+        }
+    
+        // If we're not running in React Native but we already injected the Realm class,
+        // we are probably running in a pure jscore environment
+        if (typeof Realm !== "undefined") {
+            return "jscore";
+        }
+    
+        // Visual Studio Code defines the global.__debug__ object.
+        if (typeof global !== "undefined" && global.__debug__) {
+            return "vscodedebugger";
+        }
+    
+        // Finally, if the navigator.userAgent contains the string "Chrome", we're likely
+        // running via the chrome debugger, even if navigator.product isn't set to "ReactNative"
+        if (typeof navigator !== "undefined" &&
+            /Chrome/.test(navigator.userAgent)) { // eslint-disable-line no-undef
+            return "chromedebugger";
+        }
+    
+        throw new Error("Unknown execution context");
+    },
+
+    /**
+     * @returns An object with names and versions of the various components making up the context.
+     */
+    getVersions() {
+        const packageJson = require("../package.json");
+        const packageVersion = packageJson.version;
+        const context = this.getContext();
+
+        try {
+            if (context === "reactnative") {
+                const { Platform } = require("react-native");
+                return {
+                    packageVersion,
+                    platformContext: context,
+                    platformOs: Platform.OS,
+                    // Android reports a number ...
+                    platformVersion: `${Platform.Version}`,
+                };
+            } else if (context === "node.js" || context === "electron") {
+                return {
+                    packageVersion,
+                    platformContext: context,
+                    platformOs: process.platform,
+                    platformVersion: process.versions.electron || process.version,
+                };
+            }
+        } catch (err) {
+            console.warn("Error getting versions:", err.stack);
+        }
+        
+        return {
+            packageVersion,
+            platformContext: context,
+            platformOs: "unknown",
+            platformVersion: "?.?.?",
+        };
+    },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5387,7 +5387,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/src/RealmJS.xcodeproj/project.pbxproj
+++ b/src/RealmJS.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		A4F1ACB52563E0E600D52257 /* mongo_client.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_client.cpp; path = "object-store/src/sync/mongo_client.cpp"; sourceTree = "<group>"; };
 		A4F1ACB62563E0E600D52257 /* mongo_collection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_collection.cpp; path = "object-store/src/sync/mongo_collection.cpp"; sourceTree = "<group>"; };
 		A4F1ACB72563E0E600D52257 /* mongo_database.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_database.cpp; path = "object-store/src/sync/mongo_database.cpp"; sourceTree = "<group>"; };
+		DC0FCC4C256817E80028429B /* jsc_rpc_network_transport.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = jsc_rpc_network_transport.hpp; sourceTree = "<group>"; };
 		F60102CF1CBB814A00EC01BA /* node_init.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = node_init.hpp; sourceTree = "<group>"; };
 		F60102D11CBB865A00EC01BA /* jsc_init.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = jsc_init.hpp; sourceTree = "<group>"; };
 		F60102F71CBDA6D400EC01BA /* js_collection.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = js_collection.hpp; sourceTree = "<group>"; };
@@ -727,6 +728,7 @@
 		F6874A441CAD2ACD00EEEE36 /* JSC */ = {
 			isa = PBXGroup;
 			children = (
+				DC0FCC4C256817E80028429B /* jsc_rpc_network_transport.hpp */,
 				F620F0531CAF2EF70082977B /* jsc_class.hpp */,
 				F60103091CC4B5E800EC01BA /* jsc_context.hpp */,
 				F60103111CC4BA6500EC01BA /* jsc_exception.hpp */,

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -173,9 +173,8 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
 
     auto realm_constructor = js::Value<T>::validated_to_object(ctx, js::Object<T>::get_global(ctx, "Realm"));
     
-    Protected<typename T::GlobalContext> protected_ctx(Context::get_global_context(ctx));
-    config.transport_generator = [protected_ctx] {
-        return AppClass<T>::transport_generator(protected_ctx);
+    config.transport_generator = [ctx = Protected(Context::get_global_context(ctx))] {
+        return AppClass<T>::transport_generator(ctx);
     };
 
     std::string user_agent_binding_info;

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -172,6 +172,10 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
         auto result = js::Function<T>::call(ctx, js::Value<T>::to_function(ctx, user_agent_function), realm_constructor, 0, nullptr);
         user_agent_binding_info = js::Value<T>::validated_to_string(ctx, result);
     }
+    else {
+        // FIXME: When debugging RN apps, _createUserAgentDescription cannot be found
+        user_agent_binding_info = "N/A";
+    }
     ensure_directory_exists_for_file(default_realm_file_directory());
 
     auto platform_description_function = js::Object<T>::get_property(ctx, realm_constructor, "_createPlatformDescription");
@@ -184,6 +188,12 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
         config.platform = js::Value<T>::validated_to_string(ctx, Object::get_property(ctx, result_object, platform_name));
         config.platform_version = js::Value<T>::validated_to_string(ctx, Object::get_property(ctx, result_object, platform_version_name));
         config.sdk_version = js::Value<T>::validated_to_string(ctx, Object::get_property(ctx, result_object, sdk_version_name));
+    }
+    else {
+        // FIXME: When debugging RN apps, _createPlatformDescription() cannot be found
+        config.platform = "N/A";
+        config.platform_version = "N/A";
+        config.sdk_version = "N/A";
     }
 
     SyncClientConfig client_config;

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -185,8 +185,8 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
         user_agent_binding_info = js::Value<T>::validated_to_string(ctx, result);
     }
     else {
-        // FIXME: When debugging RN apps, _createUserAgentDescription cannot be found
-        user_agent_binding_info = "N/A";
+        // The `_createUserAgentDescription` method is undefined when chrome debugging a React Native app
+        user_agent_binding_info = "unknown";
     }
     ensure_directory_exists_for_file(default_realm_file_directory());
 
@@ -202,10 +202,10 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
         config.sdk_version = js::Value<T>::validated_to_string(ctx, Object::get_property(ctx, result_object, sdk_version_name));
     }
     else {
-        // FIXME: When debugging RN apps, _createPlatformDescription() cannot be found
-        config.platform = "N/A";
-        config.platform_version = "N/A";
-        config.sdk_version = "N/A";
+        // The `_createPlatformDescription` method is undefined when chrome debugging a React Native app
+        config.platform = "js-unknown";
+        config.platform_version = "unknown";
+        config.sdk_version = "unknown";
     }
 
     SyncClientConfig client_config;

--- a/src/js_app_credentials.hpp
+++ b/src/js_app_credentials.hpp
@@ -63,6 +63,12 @@ public:
         {"serverApiKey",     wrap<server_api_key>},
         {"jwt",              wrap<jwt>},
     };
+    
+    static void get_payload(ContextType, ObjectType, ReturnValue &);
+    
+    PropertyMap<T> const properties = {
+        {"payload", {wrap<get_payload>, nullptr}},
+    };
 
     static void provider(ContextType, ObjectType, Arguments &, ReturnValue &);
 
@@ -171,6 +177,12 @@ void CredentialsClass<T>::provider(ContextType ctx, ObjectType this_object, Argu
 
     auto credentials = get_internal<T, CredentialsClass<T>>(ctx, this_object);
     return_value.set(Value::from_string(ctx, credentials->provider_as_string()));
+}
+
+template<typename T>
+void CredentialsClass<T>::get_payload(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
+    auto credentials = get_internal<T, CredentialsClass<T>>(ctx, this_object);
+    return_value.set(Value::from_string(ctx, credentials->serialize_as_json()));
 }
 
 }

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -61,7 +61,7 @@ public:
 
     MethodMap<T> const methods = {
         {"onSuccess", wrap<on_success>},
-        {"onError", wrap<on_error>}
+        {"onError", wrap<on_error>},
     };
 };
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -311,7 +311,6 @@ public:
         {"copyBundledRealmFiles", wrap<copy_bundled_realm_files>},
         {"deleteFile", wrap<delete_file>},
         {"exists", wrap<realm_file_exists>},
-        {"_createUserAgentDescription", wrap<create_user_agent_description>},
         {"_bsonParseJsonForTest", wrap<bson_parse_json>},
 #if REALM_ENABLE_SYNC
         {"_asyncOpen", wrap<async_open_realm>},

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -126,6 +126,7 @@ struct Value {
     static bool is_boolean(ContextType, const ValueType &);
     static bool is_constructor(ContextType, const ValueType &);
     static bool is_date(ContextType, const ValueType &);
+    static bool is_error(ContextType, const ValueType &);
     static bool is_function(ContextType, const ValueType &);
     static bool is_null(ContextType, const ValueType &);
     static bool is_number(ContextType, const ValueType &);

--- a/src/jsc/jsc_rpc_network_transport.hpp
+++ b/src/jsc/jsc_rpc_network_transport.hpp
@@ -24,7 +24,7 @@
 #include <string>
 
 namespace realm {
-namespace js {
+namespace rpc {
 
 /*
 struct RPCFetchRef {
@@ -36,8 +36,8 @@ struct RPCFetchRef {
  * Provides an implementation of GenericNetworkTransport for use when the library is loaded in a runtime which doesn't provide the APIs required to perform network requests directly.
  * Instead it uses the RPC server to ask the RPC client to perform network requests on its behalf.
  */
-template<typename T>
 struct RPCNetworkTransport : public app::GenericNetworkTransport {
+    using T = jsc::Types;
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
     using ObjectType = typename T::Object;
@@ -49,22 +49,18 @@ struct RPCNetworkTransport : public app::GenericNetworkTransport {
 
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
     
-    static inline ValueType fetch_function;
+    static inline js::Protected<FunctionType> fetch_function;
 
     RPCNetworkTransport(ContextType ctx) : m_ctx(ctx) {}
 
     void send_request_to_server(const app::Request request, std::function<void(const app::Response)> completion_callback) override {
-        if (Value::is_function(m_ctx, fetch_function)) {
-            // Build up a JS request object
-            auto request_object = JavaScriptNetworkTransport<T>::makeRequest(m_ctx, request);
-            // Ask the RPC layer to enqueue a call to the client-side fetch function
-            Function::call(m_ctx, (FunctionType)fetch_function, nullptr, {
-                request_object,
-                ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
-            });
-        } else {
-            throw std::runtime_error("Missing a fetch callback from the RPC client");
-        }
+        // Build up a JS request object
+        auto request_object = js::JavaScriptNetworkTransport<T>::makeRequest(m_ctx, request);
+        // Ask the RPC layer to enqueue a call to the client-side fetch function
+        Function::call(m_ctx, fetch_function, nullptr, {
+            request_object,
+            js::ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
+        });
     }
 
 private:

--- a/src/jsc/jsc_value.hpp
+++ b/src/jsc/jsc_value.hpp
@@ -86,6 +86,12 @@ inline bool jsc::Value::is_constructor(JSContextRef ctx, const JSValueRef &value
 }
 
 template<>
+inline bool jsc::Value::is_error(JSContextRef ctx, const JSValueRef &value) {
+    static const jsc::String type = "Error";
+    return is_object_of_type(ctx, value, type);
+}
+
+template<>
 inline bool jsc::Value::is_function(JSContextRef ctx, const JSValueRef &value) {
     return JSValueIsObject(ctx, value) && JSObjectIsFunction(ctx, (JSObjectRef)value);
 }

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -84,6 +84,11 @@ inline bool node::Value::is_constructor(Napi::Env env, const Napi::Value& value)
 
 
 template<>
+inline bool node::Value::is_error(Napi::Env env, const Napi::Value& value) {
+	return value.IsObject() && value.As<Napi::Object>().InstanceOf(env.Global().Get("Error").As<Napi::Function>());
+}
+
+template<>
 inline bool node::Value::is_function(Napi::Env env, const Napi::Value& value) {
 	return value.IsFunction();
 }

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -34,6 +34,7 @@
 using namespace realm;
 using namespace realm::rpc;
 
+using Value = js::Value<jsc::Types>;
 using Accessor = realm::js::NativeAccessor<jsc::Types>;
 using AppClass = js::AppClass<jsc::Types>;
 
@@ -267,12 +268,8 @@ RPCServer::RPCServer() {
         JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(m_context, JSContextGetGlobalObject(m_context), realm_string);
 
         // Enable the RCP network transport to issue calls to the remote fetch function
-        jsc::Types::Value fetch_function = deserialize_json_value(dict["fetch"]);
-        if (js::Value<jsc::Types>::is_function(m_context, fetch_function)) {
-            RPCNetworkTransport::fetch_function = js::Protected<jsc::Types::Function>(m_context, (jsc::Types::Function)fetch_function);
-        } else {
-            throw std::runtime_error("Expected 'fetch' to be a function");
-        }
+        jsc::Types::Function fetch_function = Value::validated_to_function(m_context, deserialize_json_value(dict["fetch"]), "fetch");
+        RPCNetworkTransport::fetch_function = js::Protected<jsc::Types::Function>(m_context, fetch_function);
          
         m_session_id = store_object(realm_constructor);
         return (json){{"result", m_session_id}};

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -269,7 +269,7 @@ RPCServer::RPCServer() {
 
         // Enable the RCP network transport to issue calls to the remote fetch function
         jsc::Types::Function fetch_function = Value::validated_to_function(m_context, deserialize_json_value(dict["fetch"]), "fetch");
-        RPCNetworkTransport::fetch_function = js::Protected<jsc::Types::Function>(m_context, fetch_function);
+        RPCNetworkTransport::fetch_function = js::Protected(m_context, fetch_function);
          
         m_session_id = store_object(realm_constructor);
         return (json){{"result", m_session_id}};
@@ -623,6 +623,9 @@ RPCServer::~RPCServer() {
     // The protected values should be unprotected before releasing the context.
     m_objects.clear();
     m_callbacks.clear();
+
+    // Clear the Object Store App cache, to prevent instances from using the context which is going to be released.
+    app::App::clear_cached_apps();
 
     get_rpc_server(m_context) = nullptr;
     JSGlobalContextRelease(m_context);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -55,6 +55,7 @@ static const char * const RealmObjectTypesCredentials = "credentials";
 static const char * const RealmObjectTypesUndefined = "undefined";
 static const char * const RealmObjectTypesError = "error";
 static const char * const RealmObjectTypesFetchResponseHandler = "fetchresponsehandler";
+static const char * const RealmObjectTypesEmailPasswordAuth = "emailpasswordauth";
 
 json serialize_object_schema(const realm::ObjectSchema &object_schema) {
     std::vector<std::string> properties;
@@ -895,6 +896,12 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
     else if (jsc::Object::is_instance<js::ResponseHandlerClass<jsc::Types>>(m_context, js_object)) {
         return {
             {"type", RealmObjectTypesFetchResponseHandler},
+            {"id", store_object(js_object)},
+        };
+    }
+    else if (jsc::Object::is_instance<js::EmailPasswordAuthClass<jsc::Types>>(m_context, js_object)) {
+        return {
+            {"type", RealmObjectTypesEmailPasswordAuth},
             {"id", store_object(js_object)},
         };
     }

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -527,9 +527,7 @@ RPCServer::RPCServer() {
         }
 
         JSObjectRef credentials_object = (JSObjectRef)jsc::Function::call(m_context, email_password_method, arg_count, arg_values);
-        
-        auto serialized_result = serialize_json_value(credentials_object);
-        return (json){{"result", serialized_result}};
+        return (json){{"result", serialize_json_value(credentials_object)}};
     };
     m_requests["/_function"] = [this](const json dict) {
         JSObjectRef realm_constructor = get_realm_constructor();

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -248,6 +248,19 @@ RPCServer::RPCServer() {
         setIncludesNativeCallStack(m_context, false);
     }
 
+    m_requests["/create_session"] = [this](const json dict) {
+        JSObjectRef realm_constructor = get_realm_constructor();
+
+        // json::array_t args = dict["arguments"];
+        // size_t arg_count = args.size();
+        // JSValueRef arg_values[arg_count];
+
+        // for (size_t i = 0; i < arg_count; i++) {
+        //     arg_values[i] = deserialize_json_value(args[i]);
+        // }
+
+        return (json){{"result", serialize_json_value(realm_constructor)}};
+    };
     m_requests["/create_realm"] = [this](const json dict) {
         JSObjectRef realm_constructor = get_realm_constructor();
 

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -249,17 +249,10 @@ RPCServer::RPCServer() {
     }
 
     m_requests["/create_session"] = [this](const json dict) {
+        RJSInitializeInContext(m_context);
         JSObjectRef realm_constructor = get_realm_constructor();
-
-        // json::array_t args = dict["arguments"];
-        // size_t arg_count = args.size();
-        // JSValueRef arg_values[arg_count];
-
-        // for (size_t i = 0; i < arg_count; i++) {
-        //     arg_values[i] = deserialize_json_value(args[i]);
-        // }
-
-        return (json){{"result", serialize_json_value(realm_constructor)}};
+        m_session_id = store_object(realm_constructor);
+        return (json){{"result", m_session_id}};
     };
     m_requests["/create_realm"] = [this](const json dict) {
         JSObjectRef realm_constructor = get_realm_constructor();

--- a/src/rpc_network_transport.hpp
+++ b/src/rpc_network_transport.hpp
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "sync/generic_network_transport.hpp"
+#include "js_types.hpp"
+#include "js_network_transport.hpp"
+#include <string>
+
+namespace realm {
+namespace js {
+
+/*
+struct RPCFetchRef {
+    static JSValueRef value;
+};
+*/
+
+/**
+ * Provides an implementation of GenericNetworkTransport for use when the library is loaded in a runtime which doesn't provide the APIs required to perform network requests directly.
+ * Instead it uses the RPC server to ask the RPC client to perform network requests on its behalf.
+ */
+template<typename T>
+struct RPCNetworkTransport : public app::GenericNetworkTransport {
+    using ContextType = typename T::Context;
+    using FunctionType = typename T::Function;
+    using ObjectType = typename T::Object;
+    using ValueType = typename T::Value;
+    using String = js::String<T>;
+    using Object = js::Object<T>;
+    using Value = js::Value<T>;
+    using Function = js::Function<T>;
+
+    using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
+    
+    static inline ValueType fetch_function;
+
+    RPCNetworkTransport(ContextType ctx) : m_ctx(ctx) {}
+
+    void send_request_to_server(const app::Request request, std::function<void(const app::Response)> completion_callback) override {
+        if (Value::is_function(m_ctx, fetch_function)) {
+            // Build up a JS request object
+            auto request_object = JavaScriptNetworkTransport<T>::makeRequest(m_ctx, request);
+            // Ask the RPC layer to enqueue a call to the client-side fetch function
+            Function::call(m_ctx, (FunctionType)fetch_function, nullptr, {
+                request_object,
+                ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
+            });
+        } else {
+            throw std::runtime_error("Missing a fetch callback from the RPC client");
+        }
+    }
+
+private:
+    ContextType m_ctx;
+};
+
+}
+}


### PR DESCRIPTION
## What, How & Why?

This closes #3358 and #3361 by
1. Fixing the implementation of the RPC stub for `App`
2. Introducing a `RPCNetworkTransport` implementation of the `GenericNetworkTransport` provided by object store. This struct is statically provided a function (assigned by the `RPCServer` when a session gets created), which calls back into the browser to execute fetch requests, ultimately on behalf of object store.
3. Bonus: Introduced a better serialization+deserialization of `Error` instances to propagate the stack when an error is thrown during an RPC call.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
