### PR TITLE
use custom node-addon until official release for node-addon-api@3.0.3…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6702,9 +6702,8 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+      "version": "https://github.com/realm/node-addon-api/tarball/realm",
+      "integrity": "sha512-WZVHtiH89EjndpUfuDhWOduCKItm9OEvaGwWvwNR+6H754ncS8AcG0I326HqxJkn6+KGS4sXhTMztl3w8m3cJw=="
     },
     "node-emoji": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "fs-extra": "^4.0.3",
     "https-proxy-agent": "^2.2.4",
     "ini": "^1.3.5",
-    "node-addon-api": "^3.0.0",
+    "node-addon-api": "https://github.com/realm/node-addon-api/tarball/realm",
     "node-fetch": "^1.7.3",
     "node-machine-id": "^1.1.10",
     "node-pre-gyp": "^0.15.0",


### PR DESCRIPTION
use custom node-addon until official release for node-addon-api@3.0.3 to use this fix nodejs/node-addon-api#832