### PR TITLE
Making getApp return an App instead of Realm.App

### DIFF
--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -25,13 +25,23 @@ import { createApp } from "./utils";
 const environment = getEnvironment();
 
 describe("App#constructor", () => {
+    afterEach(() => {
+        environment.defaultStorage.clear();
+    });
+
     it("constructs", () => {
         const app = new App("default-app-id");
         expect(app).to.be.instanceOf(App);
     });
 
-    afterEach(() => {
-        environment.defaultStorage.clear();
+    it("construct singletons", () => {
+        const app1 = App.getApp("default-app-id");
+        const app2 = App.getApp("default-app-id");
+        expect(app1).to.be.instanceOf(App);
+        expect(app1).equals(app2);
+        // Assume that the current user's type match the exported User type
+        const user: User | null = app1.currentUser;
+        expect(user).equals(null);
     });
 
     it("can login a user", async () => {

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -19,7 +19,7 @@
 import { expect } from "chai";
 import { Base64 } from "js-base64";
 
-import { Credentials, User, UserState, handleAuthRedirect } from "realm-web";
+import { Credentials, User, UserState } from "realm-web";
 
 import { createApp, INVALID_TOKEN, describeIf } from "./utils";
 

--- a/packages/realm-web-integration-tests/test/mocha.opts
+++ b/packages/realm-web-integration-tests/test/mocha.opts
@@ -1,2 +1,2 @@
 --watch-extensions ts
---require ts-node/register/transpile-only
+--require ts-node/register

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,18 @@
+?.?.? Release notes (2020-??-??)
+=============================================================
+
+### Breaking Changes
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* Fixed the type returned by `getApp` and `App.getApp`, such that an `app.currentUser` will match the `User` exported by the package. ([#3420](https://github.com/realm/realm-js/pull/3420), since v1.0.0-rc.1)
+
+### Internal
+* None
+
 1.0.0 Release notes (2020-10-16)
 =============================================================
 

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -62,7 +62,7 @@ export class App<
     /**
      * A map of app instances returned from calling getApp.
      */
-    private static appCache: { [id: string]: Realm.App } = {};
+    private static appCache: { [id: string]: App } = {};
 
     /**
      * Get or create a singleton Realm App from an id.


### PR DESCRIPTION
## What, How & Why?

A fix to a slight inconvenience I discovered while reproducing a different bug.
Basically the `App.getApp` static method was returning instances of type `Realm.App` which resulted in the `app.currentUser` type being incompatible with the package's concrete `User` type (which extends the `Realm.User` type).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
