### PR TITLE
{Monorepo} Fixes the release build on Windows

### DIFF
--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -195,8 +195,6 @@ class ObjectWrap {
 	static bool has_native_method(const std::string& name);
 
   private:
-    //These wrapper methods exists to force the compiler to initialize these class template static members in sequence before they are used
-	//https://stackoverflow.com/questions/42743048/c-template-the-static-member-in-a-global-object-is-not-initialized (https://stackoverflow.com/a/42743520)
 	static ClassType& get_class();
 	static auto& get_nativeMethods();
 	static auto& get_schemaObjectTypes();
@@ -267,7 +265,6 @@ static inline std::vector<napi_value> napi_get_arguments(const Napi::CallbackInf
 	return arguments;
 }
 
-//This forces initialization of the static member in sequence
 template<typename ClassType>
 inline ClassType& ObjectWrap<ClassType>::get_class() {
 	static ClassType s_class;
@@ -1102,7 +1099,7 @@ template<typename ClassType>
 Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, Internal* internal) {
 	Napi::EscapableHandleScope scope(env);
 	auto& s_schemaObjectTypes = get_schemaObjectTypes();
-	ClassType& s_class = get_class();
+	auto& s_class = get_class();
 
 	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 	if (!isRealmObjectClass) {

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -896,7 +896,7 @@ static Napi::Value property_getter_callback(const Napi::CallbackInfo& info) {
 template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		return s_class.string_accessor.getter(info, info.This().As<Napi::Object>(), propertyName->ToString(env));
@@ -910,7 +910,7 @@ Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& inf
 template<typename ClassType>
 void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		auto value = info[0];
@@ -923,7 +923,7 @@ void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 	Napi::Function ctor = init_class(env);
 	
 	//If the class has no index accessor we can create an instance of the class itself and can skip proxy objects
@@ -951,7 +951,7 @@ Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::init_class(Napi::Env env) {
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 	//check if the constructor is already created. It means this class and it's parent are already initialized.
 	Napi::Function ctor = WrappedObject<ClassType>::get_constructor(env);
 	if (!ctor.IsNull()) {
@@ -1102,7 +1102,7 @@ template<typename ClassType>
 Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, Internal* internal) {
 	Napi::EscapableHandleScope scope(env);
 	auto& s_schemaObjectTypes = get_schemaObjectTypes();
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 
 	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 	if (!isRealmObjectClass) {
@@ -1308,7 +1308,7 @@ template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
 	Napi::EscapableHandleScope scope(env);
-	ClassType s_class = get_class();
+	ClassType& s_class = get_class();
 
 	if (reinterpret_cast<void*>(s_class.constructor) != nullptr) {
 		auto arguments = get_arguments(info);

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -896,7 +896,7 @@ static Napi::Value property_getter_callback(const Napi::CallbackInfo& info) {
 template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	typename ClassType s_class = get_class();
+	ClassType s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		return s_class.string_accessor.getter(info, info.This().As<Napi::Object>(), propertyName->ToString(env));
@@ -910,7 +910,7 @@ Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& inf
 template<typename ClassType>
 void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
-	typename ClassType s_class = get_class();
+	ClassType s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		auto value = info[0];
@@ -923,7 +923,7 @@ void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
-	typename ClassType s_class = get_class();
+	ClassType s_class = get_class();
 	Napi::Function ctor = init_class(env);
 	
 	//If the class has no index accessor we can create an instance of the class itself and can skip proxy objects
@@ -951,7 +951,7 @@ Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::init_class(Napi::Env env) {
-	typename ClassType s_class = get_class();
+	ClassType s_class = get_class();
 	//check if the constructor is already created. It means this class and it's parent are already initialized.
 	Napi::Function ctor = WrappedObject<ClassType>::get_constructor(env);
 	if (!ctor.IsNull()) {
@@ -1308,7 +1308,7 @@ template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
 	Napi::EscapableHandleScope scope(env);
-	typename ClassType s_class = get_class();
+	ClassType s_class = get_class();
 
 	if (reinterpret_cast<void*>(s_class.constructor) != nullptr) {
 		auto arguments = get_arguments(info);

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -195,7 +195,11 @@ class ObjectWrap {
 	static bool has_native_method(const std::string& name);
 
   private:
-    static ClassType s_class;
+    //These wrapper methods exists to force the compiler to initialize these class template static members in sequence before they are used
+	//https://stackoverflow.com/questions/42743048/c-template-the-static-member-in-a-global-object-is-not-initialized (https://stackoverflow.com/a/42743520)
+	static ClassType& get_class();
+	static auto& get_nativeMethods();
+	static auto& get_schemaObjectTypes();
 	
 	//Gives access to ObjectWrap<ClassType> init_class private static member. See https://stackoverflow.com/a/40937193
 	template<typename T>
@@ -207,9 +211,6 @@ class ObjectWrap {
 	static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_static_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback);
     static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_property(Napi::Env env, const std::string& name, const PropertyType&);
 	static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_static_property(Napi::Env env, const std::string& name, const PropertyType&);
-	
-	static std::unordered_set<std::string> s_nativeMethods;
-	static std::unordered_map<std::string, std::unordered_map<std::string, SchemaObjectType*>*> s_schemaObjectTypes;
 	
 	static Napi::Value property_getter(const Napi::CallbackInfo& info);
 	static void property_setter(const Napi::CallbackInfo& info);
@@ -266,15 +267,25 @@ static inline std::vector<napi_value> napi_get_arguments(const Napi::CallbackInf
 	return arguments;
 }
 
-// The static class variable must be defined as well.
+//This forces initialization of the static member in sequence
 template<typename ClassType>
-ClassType ObjectWrap<ClassType>::s_class;
+inline ClassType& ObjectWrap<ClassType>::get_class() {
+	static ClassType s_class;
+	return s_class;
+}
+ 
+template<typename ClassType>
+inline auto& ObjectWrap<ClassType>::get_nativeMethods() {
+	static std::unordered_set<std::string> s_nativeMethods;
+	return s_nativeMethods;
+}
 
+ 
 template<typename ClassType>
-std::unordered_set<std::string> ObjectWrap<ClassType>::s_nativeMethods;
-
-template<typename ClassType>
-std::unordered_map<std::string, std::unordered_map<std::string, SchemaObjectType*>*> ObjectWrap<ClassType>::s_schemaObjectTypes;
+inline auto& ObjectWrap<ClassType>::get_schemaObjectTypes() {
+	static std::unordered_map<std::string, std::unordered_map<std::string, SchemaObjectType*>*> s_schemaObjectTypes;
+	return s_schemaObjectTypes;
+}
 
 //A cache for property names. The pair is property name and a node::String* to the same string representation.
 //The cache is persisted throughout the process life time to preseve property names between constructor cache invalidations (on_destory_context is called) 
@@ -885,6 +896,7 @@ static Napi::Value property_getter_callback(const Napi::CallbackInfo& info) {
 template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
+	typename ClassType s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		return s_class.string_accessor.getter(info, info.This().As<Napi::Object>(), propertyName->ToString(env));
@@ -898,6 +910,7 @@ Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& inf
 template<typename ClassType>
 void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
+	typename ClassType s_class = get_class();
 	try {
 		auto propertyName = (node::String*)info.Data();
 		auto value = info[0];
@@ -910,6 +923,7 @@ void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
+	typename ClassType s_class = get_class();
 	Napi::Function ctor = init_class(env);
 	
 	//If the class has no index accessor we can create an instance of the class itself and can skip proxy objects
@@ -937,6 +951,7 @@ Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
 
 template<typename ClassType>
 Napi::Function ObjectWrap<ClassType>::init_class(Napi::Env env) {
+	typename ClassType s_class = get_class();
 	//check if the constructor is already created. It means this class and it's parent are already initialized.
 	Napi::Function ctor = WrappedObject<ClassType>::get_constructor(env);
 	if (!ctor.IsNull()) {
@@ -1086,6 +1101,8 @@ inline std::vector<Napi::PropertyDescriptor> ObjectWrap<ClassType>::create_napi_
 template<typename ClassType>
 Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, Internal* internal) {
 	Napi::EscapableHandleScope scope(env);
+	auto& s_schemaObjectTypes = get_schemaObjectTypes();
+	ClassType s_class = get_class();
 
 	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 	if (!isRealmObjectClass) {
@@ -1237,6 +1254,7 @@ Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Nap
 template<typename ClassType>
 inline void ObjectWrap<ClassType>::on_context_destroy(Napi::Env env, std::string realmPath) {
 	std::unordered_map<std::string, SchemaObjectType*>* schemaObjects = nullptr;
+	auto& s_schemaObjectTypes = get_schemaObjectTypes();
 	if (!s_schemaObjectTypes.count(realmPath)) {
 		return;
 	}
@@ -1290,8 +1308,9 @@ template<typename ClassType>
 Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo& info) {
 	Napi::Env env = info.Env();
 	Napi::EscapableHandleScope scope(env);
+	typename ClassType s_class = get_class();
 
-	if (reinterpret_cast<void*>(ObjectWrap<ClassType>::s_class.constructor) != nullptr) {
+	if (reinterpret_cast<void*>(s_class.constructor) != nullptr) {
 		auto arguments = get_arguments(info);
 		node::Arguments args { env, arguments.size(), arguments.data() };
 		s_class.constructor(env, info.This().As<Napi::Object>(), args);
@@ -1309,6 +1328,7 @@ Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo
 
 template<typename ClassType>
 bool ObjectWrap<ClassType>::has_native_method(const std::string& name) {
+	auto& s_nativeMethods = get_nativeMethods();
 	if (s_nativeMethods.find(name) != s_nativeMethods.end()) {
 		return true;
 	}
@@ -1318,6 +1338,7 @@ bool ObjectWrap<ClassType>::has_native_method(const std::string& name) {
 
 template<typename ClassType>
 Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> ObjectWrap<ClassType>::setup_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback) {
+	auto& s_nativeMethods = get_nativeMethods();
 	auto methodCallback = (typename WrappedObject<ClassType>::InstanceMethodCallback)(&WrappedObject<ClassType>::method_callback);
 	s_nativeMethods.insert(name);
 	return WrappedObject<ClassType>::InstanceMethod(name.c_str(), methodCallback, napi_default | realm::js::PropertyAttributes::DontEnum, (void*)callback);


### PR DESCRIPTION
fix the windows release build. 
The MSVC compiler is optimizing the initialization of static members of template class out of sequence which causes access violations on startup. This change makes sure all static members are initialized before they are used.