### PR TITLE
Rolling back some of PR #3356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * Fixed an issue in `toJSON()`, in combination with primaryKeys, where data from another table could be returned. ([#3331](https://github.com/realm/realm-js/issues/3331), since v10.0.0)
-* Fixed an issue in `toJSON()` where `data` would output as `{}`, it now returns the data base64 encoded. ([#3356](https://github.com/realm/realm-js/pull/3356), since v10.0.0)
 * TS: `RealmInsertionModel<T>` used in `realm.create<T>(...)` now ignores functions on Class Models. ([#3421](https://github.com/realm/realm-js/pull/3421), since v10.0.0)
 
 ### Compatibility

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -123,19 +123,13 @@ module.exports = function(realmConstructor, context) {
 
                     // skip any functions & constructors (in case of class models).
                     if (typeof value === "function") {
-                      return; // continue
+                        return; // continue
                     }
 
-                    if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
-                        // recursively trigger `toJSON` for Realm instances with the same cache.
-                        result[key] = value.toJSON(key, cache);
-                    } else if (value instanceof ArrayBuffer) {
-                        // convert "data" to base64 strings.
-                        result[key] = Buffer.from(value).toString("base64");
-                    } else {
-                        // default to original value.
-                        result[key] = value;
-                    }
+                    // recursively trigger `toJSON` for Realm instances with the same cache.
+                    result[key] = (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection)
+                        ? value.toJSON(key, cache)
+                        : value;
                 });
 
             return result;


### PR DESCRIPTION
This reverts a part of #3356 

Realm' s `toJSON` should not make assumptions as to how `ArrayBuffer`s are serialized.
This change would also be a challenge to devs, who are currently using `toJSON` for purposes other than serialization.

Sidenote: @kraenhansen I'll implement `toJSON` for `ArrayBuffer` in Studio v10 (soon).

**Merge at will.**

(just for clarification these changes were originally made by me..)