### PR TITLE
Fixing _expandEmbeddedObjectSchemas must be of type 'function'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixing the construction of Realm instances declararing the schema, when running in the React Native Chrome debugging mode, by removing it. Note: This is not considered a breaking change, since this behaviour was never documented. ([#3442](https://github.com/realm/realm-js/pull/3442), since v10.0.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -52,7 +52,7 @@ export default class App {
 createMethods(App.prototype, objectTypes.APP, [
     "_logIn",
     "switchUser"
-]);
+], true);
 
 Object.defineProperties(App.prototype, {
     currentUser: { get: getterForProperty("currentUser") },

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -323,64 +323,6 @@ module.exports = function(realmConstructor, context) {
             }
             return obj;
         },
-
-        _expandEmbeddedObjectSchemas(schemas) {
-            // we only work on arrays and let object store's schema parser produce the error messages
-            if (!(schemas instanceof Array)) {
-                return schemas;
-            }
-
-            let newSchema = [];
-            schemas.forEach(schema => {
-                // a schema must be an object and have 'name' and 'properties'
-                // we let object store's schema parser produce the error messages
-                if (!(schema instanceof Object) || !schema.hasOwnProperty('name') || !schema.hasOwnProperty('properties')) {
-                    newSchema.push(schema);
-                    return;
-                }
-
-                // is the schema defined as a constructor?
-                if (schema instanceof Function) {
-                    schema = schema.schema;
-                }
-
-                let os = {};
-                os.name = schema.name;
-                if (schema.primaryKey) {
-                    os.primaryKey = schema.primaryKey;
-                }
-                if (schema.embedded) {
-                    os.embedded = true;
-                } else {
-                    os.embedded = false;
-                }
-
-                if ((schema.properties instanceof Array)) {
-                    newSchema.push(schema);
-                } else {
-                    os.properties = {};
-                    for (let key in schema.properties) {
-                        let prop = schema.properties[key];
-                        if (prop instanceof Object && prop.hasOwnProperty('name') && prop.hasOwnProperty('properties')) {
-                            let embeddedSchema = {};
-                            embeddedSchema.name = prop.name;
-                            embeddedSchema.embedded = true;
-                            embeddedSchema.properties = prop.properties;
-                            if (prop.hasOwnProperty('type') && prop.type === 'list') {
-                                os.properties[key] = { type: 'list', objectType: prop.name };
-                            } else {
-                                os.properties[key] = { type: prop.name };
-                            }
-                            newSchema.push(embeddedSchema);
-                        } else {
-                            os.properties[key] = schema.properties[key];
-                        }
-                    }
-                    newSchema.push(os);
-                }
-            });
-            return newSchema;
-        }
     }));
 
     // Add static properties to Realm Object

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -342,7 +342,6 @@ public:
     static void delete_file(ContextType, ObjectType, Arguments &, ReturnValue &);
     static void realm_file_exists(ContextType, ObjectType, Arguments &, ReturnValue &);
 
-    static void create_user_agent_description(ContextType, ObjectType, Arguments &, ReturnValue &);
     static void bson_parse_json(ContextType, ObjectType, Arguments &, ReturnValue &);
 
     // static properties
@@ -599,12 +598,8 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
             static const String schema_string = "schema";
             ValueType schema_value = Object::get_property(ctx, object, schema_string);
             if (!Value::is_undefined(ctx, schema_value)) {
-                auto realm_constructor = Value::validated_to_object(ctx, Object::get_global(ctx, "Realm"));
-
-                // embedded object schemas need to expanded into regular object schemas
-                ObjectType expanded_schema_object = Value::validated_to_array(ctx, Object::call_method(ctx, realm_constructor, "_expandEmbeddedObjectSchemas", 1, &schema_value), "schema");
-
-                config.schema.emplace(Schema<T>::parse_schema(ctx, expanded_schema_object, defaults, constructors));
+                ObjectType schema_array = Value::validated_to_array(ctx, schema_value, "schema");
+                config.schema.emplace(Schema<T>::parse_schema(ctx, schema_array, defaults, constructors));
                 schema_updated = true;
             }
 
@@ -1341,12 +1336,6 @@ void RealmClass<T>::update_schema(ContextType ctx, ObjectType this_object, Argum
         nullptr,
         true
     );
-}
-
-// These are replaced by the JS-defined functions when running outside of the RPC environment
-template<typename T>
-void RealmClass<T>::create_user_agent_description(ContextType, ObjectType, Arguments&, ReturnValue &return_value) {
-    return_value.set("RealmJS/RPC");
 }
 
 template<typename T>

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -428,22 +428,13 @@ exports.EmbeddedObjectSchemas = [
         name: 'Person',
         properties: {
             id: 'int',
-            dog: {
-                name: 'Dog',
-                properties: {
-                    'name': 'string',
-                    'color': 'string'
-                }
-            },
+            dog: 'Dog',
             cars: 'Car[]',
             truck: 'Car',
             vans: { type: 'list', objectType: 'Car' },
             cat: {
                 type: 'list',
-                name: 'Cat',
-                properties: {
-                    name: 'string'
-                }
+                objectType: 'Cat'
             }
         }
     },
@@ -455,6 +446,19 @@ exports.EmbeddedObjectSchemas = [
             model: 'string',
             mileage: { type: 'int', optional: true, indexed: true },
             owners: { type: 'linkingObjects', objectType: 'Person', property: 'cars' }
+        }
+    },
+    {
+        name: 'Dog',
+        properties: {
+            'name': 'string',
+            'color': 'string'
+        }
+    },
+    {
+        name: 'Cat',
+        properties: {
+            name: 'string'
         }
     }
 ];

--- a/tests/js/schemas.js
+++ b/tests/js/schemas.js
@@ -450,6 +450,7 @@ exports.EmbeddedObjectSchemas = [
     },
     {
         name: 'Dog',
+        embedded: true,
         properties: {
             'name': 'string',
             'color': 'string'
@@ -457,6 +458,7 @@ exports.EmbeddedObjectSchemas = [
     },
     {
         name: 'Cat',
+        embedded: true,
         properties: {
             name: 'string'
         }


### PR DESCRIPTION
## What, How & Why?

This closes #3442 by removing a feature which was never documented.
I choose this approach since reimplementing the method in C++ was non-trivial and exposing it via the RPC layer seemed wrong now that the feature was never documented either.

I do think the functionality is valuable, so I've added an issue to track an enhancement https://github.com/realm/realm-js/issues/3445

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
