### PR TITLE
Update RealmReact.mm

### DIFF
--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -214,6 +214,7 @@ RCT_REMAP_METHOD(emit, emitEvent:(NSString *)eventName withObject:(id)object) {
 }
 
 - (void)startRPC {
+    realm::_impl::RealmCoordinator::clear_all_caches();
     [GCDWebServer setLogLevel:3];
     _webServer = [[GCDWebServer alloc] init];
     _rpcServer = std::make_unique<RPCServer>();


### PR DESCRIPTION
## What, How & Why?
Old session where not properly disposed of when reloading the app, that's why we can clear the old sessions just before starting the rpc service (because the rpc service _is_ restarted)

This closes realm/realm-js#2799 ???

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

