### PR TITLE
Fix debugging synced realms (which uses BSON types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* Fixing creating objects and assigning properties of BSON Decimal128 and ObjectId types, when running in React Native Chrome debugging mode. ([#3452](https://github.com/realm/realm-js/issues/3452) & [#3454](https://github.com/realm/realm-js/issues/3454), since v10.0.0)
-* Fixed a crash that would happen if the app did a network request after the app got refreshed during development and the Chrome debugging mode was disabled. ([#3457](https://github.com/realm/realm-js/issues/3457), since v10.0.2)
+* Fixed creating objects and assigning properties of BSON Decimal128 and ObjectId types, when running in React Native Chrome debugging mode. ([#3452](https://github.com/realm/realm-js/issues/3452) & [#3454](https://github.com/realm/realm-js/issues/3454), since v10.0.0)
+* Fixed a crash that would happen if the app did a network request after the app got refreshed during development and the Chrome debugging mode was disabled. NOTE: Because of [#3206](https://github.com/realm/realm-js/issues/3206) the fix has not been implemented on Android. ([#3457](https://github.com/realm/realm-js/issues/3457), since v10.0.2)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * Fixing creating objects and assigning properties of BSON Decimal128 and ObjectId types, when running in React Native Chrome debugging mode. ([#3452](https://github.com/realm/realm-js/issues/3452) & [#3454](https://github.com/realm/realm-js/issues/3454), since v10.0.0)
+* Fixed a crash that would happen if the app did a network request after the app got refreshed during development and the Chrome debugging mode was disabled. ([#3457](https://github.com/realm/realm-js/issues/3457), since v10.0.2)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixing creating objects and assigning properties of BSON Decimal128 and ObjectId types, when running in React Native Chrome debugging mode. ([#3452](https://github.com/realm/realm-js/issues/3452) & [#3454](https://github.com/realm/realm-js/issues/3454), since v10.0.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/browser/constants.js
+++ b/lib/browser/constants.js
@@ -47,7 +47,8 @@ export const propTypes = {};
     'CREDENTIALS',
     'FETCHRESPONSEHANDLER',
     'UNDEFINED',
-    'EMAILPASSWORDAUTH'
+    'EMAILPASSWORDAUTH',
+    'EJSON'
 ].forEach(function(type) {
     Object.defineProperty(objectTypes, type, {
         value: type.toLowerCase(),

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -18,10 +18,11 @@
 
 "use strict";
 
+import { EJSON, ObjectId, Decimal128 } from "bson";
+
 import * as base64 from "./base64";
 import { keys, objectTypes } from "./constants";
 import { invalidateCache } from "./cache";
-import { EJSON } from "bson";
 
 const { id: idKey, realm: _realmKey } = keys;
 let registeredCallbacks = [];
@@ -242,6 +243,13 @@ function serialize(realmId, value) {
 
     if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
         return { type: objectTypes.DATA, value: base64.encode(value) };
+    }
+
+    if (value instanceof ObjectId || value instanceof Decimal128) {
+        return {
+            type: objectTypes.EJSON,
+            value: EJSON.serialize(value, { relaxed: false }),
+        };
     }
 
     let keys = Object.keys(value);

--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -21,6 +21,7 @@
 import * as base64 from "./base64";
 import { keys, objectTypes } from "./constants";
 import { invalidateCache } from "./cache";
+import { EJSON } from "bson";
 
 const { id: idKey, realm: _realmKey } = keys;
 let registeredCallbacks = [];
@@ -44,6 +45,7 @@ if (XMLHttpRequest.__proto__ != global.XMLHttpRequestEventTarget) {
 
 registerTypeConverter(objectTypes.DATA, (_, { value }) => base64.decode(value));
 registerTypeConverter(objectTypes.DATE, (_, { value }) => new Date(value));
+registerTypeConverter(objectTypes.EJSON, (_, { value }) => EJSON.deserialize(value));
 registerTypeConverter(objectTypes.DICT, deserializeDict);
 registerTypeConverter(objectTypes.ERROR, deserializeError);
 registerTypeConverter(objectTypes.FUNCTION, deserializeFunction);

--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -23,6 +23,7 @@
 
 #import "impl/realm_coordinator.hpp"
 #import "shared_realm.hpp"
+#import "sync/app.hpp"
 
 #import <React/RCTBridge+Private.h>
 #import <React/RCTJavaScriptExecutor.h>
@@ -267,6 +268,10 @@ RCT_REMAP_METHOD(emit, emitEvent:(NSString *)eventName withObject:(id)object) {
 #endif
 
 - (void)invalidate {
+    // Close all cached Realms
+    realm::_impl::RealmCoordinator::clear_all_caches();
+    // Clear the Object Store App cache, to prevent instances from using a context that was released
+    realm::app::App::clear_cached_apps();
 #if DEBUG
     // shutdown rpc if in chrome debug mode
     [self shutdownRPC];
@@ -286,9 +291,6 @@ void _initializeOnJSThread(JSContextRefExtractor jsContextExtractor) {
         [NSThread sleepForTimeInterval:0.1];
     }
     s_currentJSThread = [NSThread currentThread];
-
-    // Close all cached Realms from the previous JS thread.
-    realm::_impl::RealmCoordinator::clear_all_caches();
 
     RJSInitializeInContext(jsContextExtractor());
 }

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -166,6 +166,7 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
     using Object = js::Object<T>;
     using Value = js::Value<T>;
 
+    using NetworkTransportFactory = std::function<std::unique_ptr<app::GenericNetworkTransport>(ContextType)>;
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
 
 	JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx),

--- a/src/jsc/jsc_value.hpp
+++ b/src/jsc/jsc_value.hpp
@@ -141,7 +141,7 @@ inline bool is_bson_type(JSContextRef ctx, const JSValueRef &value, std::string 
         throw jsc::Exception(ctx, error);
     }
 
-    JSValueRef bsonType = JSObjectGetProperty(ctx, object, JSStringCreateWithUTF8CString("_bsontype"), &error);
+    JSValueRef bson_type = JSObjectGetProperty(ctx, object, JSStringCreateWithUTF8CString("_bsontype"), &error);
     if (error) {
         throw jsc::Exception(ctx, error);
     }
@@ -150,25 +150,47 @@ inline bool is_bson_type(JSContextRef ctx, const JSValueRef &value, std::string 
         return false;
     }
 
-    jsc::String bsonTypeValue = JSValueToStringCopy(ctx, bsonType, &error);
+    jsc::String bson_type_value = JSValueToStringCopy(ctx, bson_type, &error);
     // Since the string's retain value is +2 here, we need to manually release it before returning.
-    JSStringRelease(bsonTypeValue);
+    JSStringRelease(bson_type_value);
     if (error) {
         throw jsc::Exception(ctx, error);
     }
 
-    std::string bsonTypeStringValue = bsonTypeValue;
-    return bsonTypeStringValue == type;
+    return (std::string)bson_type_value == type;
+}
+
+/**
+ * Checks if a `value` is an EJSON representation of a particular type (determined by the existance of a particular property).
+ */
+inline bool is_ejson_type(JSContextRef ctx, const JSValueRef &value, std::string property_name) {
+    if (JSValueIsNull(ctx, value) || JSValueIsUndefined(ctx, value) || !JSValueIsObject(ctx, value)) {
+        return false;
+    }
+
+    JSValueRef error = nullptr;
+    JSObjectRef object = JSValueToObject(ctx, value, &error);
+    if (error) {
+        throw jsc::Exception(ctx, error);
+    }
+
+    JSStringRef property_name_string = JSStringCreateWithUTF8CString(property_name.c_str());
+    auto property = JSObjectGetProperty(ctx, object, property_name_string, &error);
+    if (error) {
+        throw jsc::Exception(ctx, error);
+    }
+
+    return JSValueIsUndefined(ctx, property) == false;
 }
 
 template<>
 inline bool jsc::Value::is_decimal128(JSContextRef ctx, const JSValueRef &value) {
-    return is_bson_type(ctx, value, "Decimal128");
+    return is_bson_type(ctx, value, "Decimal128") || is_ejson_type(ctx, value, "$numberDecimal");
 }
 
 template<>
 inline bool jsc::Value::is_object_id(JSContextRef ctx, const JSValueRef &value) {
-    return is_bson_type(ctx, value, "ObjectID");
+    return is_bson_type(ctx, value, "ObjectID") || is_ejson_type(ctx, value, "$oid");
 }
 
 template<>

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -237,20 +237,18 @@ static json read_object_properties(Object& object) {
                 }
                 break;
             }
-            case PropertyType::Decimal: {
+            case PropertyType::Decimal:
                 cache[property.name] = {
                     {"type", RealmObjectTypesEJSON},
                     {"value", {"$numberDecimal", obj.get<Decimal>(property.column_key).to_string()}},
                 };
                 break;
-            }
-            case PropertyType::ObjectId: {
+            case PropertyType::ObjectId:
                 cache[property.name] = {
                     {"type", RealmObjectTypesEJSON},
                     {"value", {"$oid", obj.get<ObjectId>(property.column_key).to_string()}},
                 };
                 break;
-            }
             case PropertyType::Data:
             case PropertyType::Object:
             break;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -56,6 +56,7 @@ static const char * const RealmObjectTypesUndefined = "undefined";
 static const char * const RealmObjectTypesError = "error";
 static const char * const RealmObjectTypesFetchResponseHandler = "fetchresponsehandler";
 static const char * const RealmObjectTypesEmailPasswordAuth = "emailpasswordauth";
+static const char * const RealmObjectTypesEJSON = "ejson";
 
 json serialize_object_schema(const realm::ObjectSchema &object_schema) {
     std::vector<std::string> properties;
@@ -234,6 +235,20 @@ static json read_object_properties(Object& object) {
                 if (str.size() < 100) {
                     cache_value(str);
                 }
+                break;
+            }
+            case PropertyType::Decimal: {
+                cache[property.name] = {
+                    {"type", RealmObjectTypesEJSON},
+                    {"value", {"$numberDecimal", obj.get<Decimal>(property.column_key).to_string()}},
+                };
+                break;
+            }
+            case PropertyType::ObjectId: {
+                cache[property.name] = {
+                    {"type", RealmObjectTypesEJSON},
+                    {"value", {"$oid", obj.get<ObjectId>(property.column_key).to_string()}},
+                };
                 break;
             }
             case PropertyType::Data:

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -266,6 +266,7 @@ RPCServer::RPCServer() {
     m_callback_call_counter = 1;
     
     // Make the App use the RPC Network Transport from now on
+    previous_transport_generator = AppClass::transport_generator;
     AppClass::transport_generator = [] (jsc::Types::Context ctx) {
         return std::make_unique<RPCNetworkTransport>(ctx);
     };
@@ -640,8 +641,8 @@ RPCServer::~RPCServer() {
     m_objects.clear();
     m_callbacks.clear();
 
-    // Clear the Object Store App cache, to prevent instances from using the context which is going to be released.
-    app::App::clear_cached_apps();
+    // Restore the previous transport generator
+    AppClass::transport_generator = previous_transport_generator;
 
     get_rpc_server(m_context) = nullptr;
     JSGlobalContextRelease(m_context);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1037,6 +1037,14 @@ JSValueRef RPCServer::deserialize_json_value(const json dict) {
         else if (type_string == RealmObjectTypesUndefined) {
             return jsc::Value::from_undefined(m_context);
         }
+        else if (type_string == RealmObjectTypesEJSON) {
+            JSObjectRef js_object = jsc::Object::create_empty(m_context);
+            for (auto& el : value.items()) {
+                auto el_value = jsc::Value::from_string(m_context, el.value().get<std::string>());
+                jsc::Object::set_property(m_context, js_object, el.key(), el_value);
+            }
+            return js_object;
+        }
         assert(0);
     }
 

--- a/src/rpc.hpp
+++ b/src/rpc.hpp
@@ -22,10 +22,10 @@
 #include <future>
 #include <thread>
 
+#include "jsc_init.hpp"
 #include "concurrent_deque.hpp"
 #include "json.hpp"
-#include "jsc/jsc_types.hpp"
-#include "jsc/jsc_protected.hpp"
+#include "js_network_transport.hpp"
 
 namespace realm {
 
@@ -37,6 +37,7 @@ using json = nlohmann::json;
 
 using RPCObjectID = u_int64_t;
 using RPCRequest = std::function<json(const json)>;
+using NetworkTransportFactory = typename js::JavaScriptNetworkTransport<jsc::Types>::NetworkTransportFactory;
 
 class RPCWorker {
   public:
@@ -91,6 +92,8 @@ class RPCServer {
 
     std::mutex m_pending_callbacks_mutex;
     std::map<std::pair<uint64_t, uint64_t>, std::promise<json>> m_pending_callbacks;
+
+    NetworkTransportFactory previous_transport_generator;
 
     static JSValueRef run_callback(JSContextRef, JSObjectRef, JSObjectRef, size_t, const JSValueRef[], JSValueRef *exception);
 


### PR DESCRIPTION
## What, How & Why?

This closes #3452  and #3454 by serializing BSON types and allowing EJSON to be used for property values when creating objects and assigning values (on React Native only). We might want to consider making this a more general feature to avoid diverging implementations on Node.js and React Native and allow for easy object creation from EJSON (useful when dumping data and restoring it via EJSON serialization).

## ☑️ ToDos
* [x] Extend the RPC server to send ObjectId and Decimal128 values as EJSON.
* [x] Extend the RPC client to deserialize ObjectId and Decimal128 values using the "bson" package.
* [x] Extend the RPC client to serialize ObjectId and Decimal128 values when calling functions (create) and setting values.
* [x] Extend the RPC server to passthrough EJSON values, when deserializing.
* [x] Change the `jsc::Value::is_decimal128` to look for a `$numberDecimal` property as an alternative.
* [x] Change the `jsc::Value::is_object_id` to look for a `$oid` property as an alternative.
* [x] Change the `jsc::Value::to_decimal128` to use the `$numberDecimal` property as an alternative.
* [x] Change the `jsc::Value::to_object_id` to use the `$oid` property as an alternative.
* [ ] Investigate the impact and an alternative solution to the missing `_bson` constant for the `Object<T>::create_bson_type` and `Value<T>::to_bson`
* [x] Ensure the `get_property` RPC command works, when the cache is bypassed and the property is accessed directly. I think it wouldn't, since getting a property using the regular accessors depends on the missing `_ObjectId` and `_Decimal128` properties on the `Realm` constructor.
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests: Only manually and locally and the chrome debugging on Android is broken by [a seemingly unrelated issue](https://github.com/realm/realm-js/issues/3206).
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
