### PR TITLE
Exposing all data of the profile.data on User#profile, renamed userId…

### DIFF
--- a/.github/workflows/pr-realm-web.yml
+++ b/.github/workflows/pr-realm-web.yml
@@ -30,7 +30,8 @@ jobs:
         working-directory: packages/realm-web
       - run: npm run build
         working-directory: packages/realm-web
-      - run: npm test
+      - name: Run unit tests
+        run: npm test
         working-directory: packages/realm-web
       # Login with the Docker CLI to enable the integration test harness to pull the mongodb-realm-test-server
       - name: Docker Login
@@ -39,7 +40,8 @@ jobs:
           login-server: docker.pkg.github.com
           username: realm-ci
           password: ${{ secrets.REALM_CI_GITHUB_API_KEY }}
-      - run: npm run test:github
+      - name: Run integration tests
+        run: npm run test:github
         working-directory: packages/realm-web-integration-tests
         env:
           MONGODB_REALM_TEST_SERVER: '2020-11-04' # TODO: Try using 'latest' once it's fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed a bug where elements in the `User#identities` array would have a `userId` which was actually an `id` of the identity. ([#3481](https://github.com/realm/realm-js/pull/3481), since v10.0.0-beta.13)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -554,7 +554,8 @@ class ApiKeyAuth {
  */
 
 /**
- * Describes an error when an incompatible synced Realm is opened. The old version of the Realm can be accessed in readonly mode using the configuration() member
+ * The identity of a user with a specific authentication provider.
+ * NOTE: A particular user might have identities with multiple providers.
  * @memberof Realm.App.Sync
  */
 class UserIdentity {

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -547,6 +547,30 @@ class ApiKeyAuth {
     disable(id) { }
 }
 
+/**
+ * The type of an authentication provider, used to authenticate a user.
+ * @typedef Realm.App.Sync~ProviderType
+ * @type {("anon-user"|"api-key"|"local-userpass"|"custom-function"|"custom-token"|"oauth2-google"|"oauth2-facebook"|"oauth2-apple")}
+ */
+
+/**
+ * Describes an error when an incompatible synced Realm is opened. The old version of the Realm can be accessed in readonly mode using the configuration() member
+ * @memberof Realm.App.Sync
+ */
+class UserIdentity {
+    /**
+     * The id of a users identity at an authentication provider.
+     * @type {string}
+     */
+    get id() { }
+
+    /**
+     * The type of the authentication provider.
+     * @type {Realm.App.Sync~ProviderType}
+     */
+    get providerType() { }
+}
+
 
 /**
  * Class for managing users.
@@ -554,22 +578,21 @@ class ApiKeyAuth {
  */
 class User {
     /**
-     * Gets the identity of this user on MongoDB Realm Cloud.
-     * The identity is a guaranteed to be unique among all users on MongoDB Realm Cloud .
+     * Gets the id of this user on MongoDB Realm Cloud.
+     * The id is a guaranteed to be unique among all users on MongoDB Realm Cloud .
      * @type {string}
      */
     get id() { }
 
     /**
-     * Gets an array of identities for this user on MongoDB Realm Cloud.
-     * Each element in the array is an object with properties userId and providerType.
-     * @type {Array<Object>}
+     * Gets an array of identities for this user.
+     * @type {Array<Realm.App.Sync.UserIdentity>}
      */
     get identities() { }
 
     /**
      * Gets the provider type for the identity.
-     * @type {string}
+     * @type {Realm.App.Sync~ProviderType}
      */
     get providerType() { }
 

--- a/lib/browser/user.js
+++ b/lib/browser/user.js
@@ -46,10 +46,13 @@ Object.defineProperties(User.prototype, {
     accessToken: { get: getterForProperty("accessToken") },
     refreshToken: { get: getterForProperty("refreshToken") },
     profile: { get: getterForProperty("profile") },
+    identities: { get: getterForProperty("identities") },
+    providerType: { get: getterForProperty("providerType") },
     isLoggedIn: { get: getterForProperty("isLoggedIn") },
     state: { get: getterForProperty("state") },
     customData: { get: getterForProperty("customData") },
     apiKeys: { get: getterForProperty("apiKeys") },
+    deviceId: { get: getterForProperty("deviceId") },
 });
 
 export function createUser(realmId, info) {

--- a/packages/realm-web-integration-tests/harness/index.ts
+++ b/packages/realm-web-integration-tests/harness/index.ts
@@ -116,9 +116,7 @@ export async function run(devtools = false) {
 
     // Start the mocha remote server
     const mochaServer = new MochaRemoteServer(undefined, {
-        runOnConnection: true,
-        // Only stop after completion if we're not showing dev-tools
-        stopAfterCompletion: !devtools,
+        runOnConnection: devtools,
     });
 
     process.once("exit", () => {
@@ -153,6 +151,10 @@ export async function run(devtools = false) {
         }
     });
     await page.goto("http://localhost:8080");
+    // We will have to manually invoke running the tests if we're not running on connections
+    if (!devtools) {
+        await mochaServer.runAndStop();
+    }
     // Wait for the tests to complete
     await mochaServer.stopped;
     // Check the issues logged in the browser

--- a/packages/realm-web-integration-tests/src/credentials.test.ts
+++ b/packages/realm-web-integration-tests/src/credentials.test.ts
@@ -91,7 +91,10 @@ describe("Credentials", () => {
             const credentials = Credentials.jwt(token);
             const user = await app.logIn(credentials);
             expect(user).to.be.instanceOf(User);
-            // TODO: Expect that we can read "some-secret-stuff" out of the accessToken
+            // Expect that we can read "some-secret-stuff" out of the profile
+            // NOTE: The mapping from mySecretField → secret is declared in the Realm App configuration
+            expect(Object.keys(user.profile)).deep.equals(["secret"]);
+            expect(user.profile.secret).equals("some-secret-stuff");
         });
     });
 

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -49,11 +49,25 @@ describe("User", () => {
         expect(typeof user.id).equals("string");
         expect(user.state).equals(UserState.Active);
         expect(user.state).equals("active");
+        expect(user.isLoggedIn).equals(true);
+    });
+
+    it("has a profile", async () => {
+        const app = createApp();
+        const credentials = Credentials.anonymous();
+        const user = await app.logIn(credentials);
         // Expect something of the user profile
-        expect(user.profile.type).equals("normal");
-        // TODO: expect(Array.isArray(user.profile.identities)).equals(true);
-        // TODO: expect(user.profile.identities.length).equals(1);
+        expect(typeof user.profile).equals("object");
         expect(user.profile.name).equals(undefined);
+        expect(Array.isArray(user.identities)).equals(true);
+        expect(user.identities.length).equals(1);
+    });
+
+    it("has custom data", async () => {
+        const app = createApp();
+        const credentials = Credentials.anonymous();
+        const user = await app.logIn(credentials);
+        // TODO: Add some data first ...
         expect(user.customData).deep.equals({});
     });
 

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -5,10 +5,11 @@
 * None
 
 ### Enhancements
-* None
+* Adding data from authentication providers, to be included in the `User#profile` object. ([#3268](https://github.com/realm/realm-js/issues/3268) via [#3481](https://github.com/realm/realm-js/pull/3481))
+* Exposing the authentication provider used to authenticate a user as a `providerType` property on a `User` instance. ([#3481](https://github.com/realm/realm-js/pull/3481))
 
 ### Fixed
-* None
+* Fixed an error in the types, where elements in the `User#identities` array would have a `userId` which was actually an `id` of the identity. ([#3481](https://github.com/realm/realm-js/pull/3481), since v0.9.0)
 
 ### Internal
 * None

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -15,6 +15,7 @@
     "update-types": "ts-node --project scripts/tsconfig.json scripts/update-types.ts",
     "generate-types": "tsc --project src/dom/tsconfig.json --declaration --emitDeclarationOnly --declarationDir types/generated",
     "build": "npm run generate-types && rollup --config",
+    "start": "npm run build -- --watch",
     "lint": "eslint --ext .js,.ts .",
     "test": "mocha 'src/tests/**/*.test.ts'",
     "postversion": "ts-node --project scripts/tsconfig.json scripts/postversion.ts"

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -23,7 +23,7 @@ import {
 import { ObjectId } from "bson";
 
 import { User, UserState } from "./User";
-import { Credentials } from "./Credentials";
+import { Credentials, ProviderType } from "./Credentials";
 import { EmailPasswordAuth } from "./auth-providers";
 import { Storage } from "./storage";
 import { AppStorage } from "./AppStorage";
@@ -199,11 +199,14 @@ export class App<
      * @param fetchProfile Should the users profile be fetched? (default: true)
      */
     public async logIn(
-        credentials: Realm.Credentials<any>,
+        credentials: Credentials<any>,
         fetchProfile = true,
     ): Promise<User<FunctionsFactoryType, CustomDataType>> {
         const response = await this.authenticator.authenticate(credentials);
-        const user = this.createOrUpdateUser(response);
+        const user = this.createOrUpdateUser(
+            response,
+            credentials.providerType,
+        );
         // Let's ensure this will be the current user, in case the user object was reused.
         this.switchUser(user);
         // If neeeded, fetch and set the profile on the user
@@ -329,10 +332,12 @@ export class App<
      * This helps de-duplicating users in the list of users known to the app.
      *
      * @param response A response from the Authenticator.
+     * @param providerType The type of the authentication provider used.
      * @returns A new or an existing user.
      */
     private createOrUpdateUser(
         response: AuthResponse,
+        providerType: ProviderType,
     ): User<FunctionsFactoryType, CustomDataType> {
         const existingUser = this.users.find(u => u.id === response.userId);
         if (existingUser) {
@@ -342,11 +347,15 @@ export class App<
             return existingUser;
         } else {
             // Create and store a new user
+            if (!response.refreshToken) {
+                throw new Error("No refresh token in response from server");
+            }
             const user = new User<FunctionsFactoryType, CustomDataType>({
                 app: this,
                 id: response.userId,
                 accessToken: response.accessToken,
                 refreshToken: response.refreshToken,
+                providerType,
             });
             this.users.unshift(user);
             return user;
@@ -359,7 +368,7 @@ export class App<
     private hydrate() {
         try {
             const userIds = this.storage.getUserIds();
-            this.users = userIds.map(id => User.hydrate(this, id));
+            this.users = userIds.map(id => new User({ app: this, id }));
         } catch (err) {
             // The storage was corrupted
             this.storage.clear();

--- a/packages/realm-web/src/Authenticator.ts
+++ b/packages/realm-web/src/Authenticator.ts
@@ -80,7 +80,7 @@ export class Authenticator {
      */
     public async authenticate(
         credentials: Realm.Credentials<any>,
-        linkingUser?: User<object, object>,
+        linkingUser?: User<object, object, unknown>,
     ): Promise<AuthResponse> {
         const deviceInformation = this.getDeviceInformation();
         const isLinking = typeof linkingUser === "object";

--- a/packages/realm-web/src/Credentials.ts
+++ b/packages/realm-web/src/Credentials.ts
@@ -245,7 +245,7 @@ export class Credentials<PayloadType extends object = any>
     /**
      * The type of the authentication provider used when authenticating.
      */
-    public readonly providerType: string;
+    public readonly providerType: ProviderType;
 
     /**
      * The data being sent to the service when authenticating.

--- a/packages/realm-web/src/Fetcher.ts
+++ b/packages/realm-web/src/Fetcher.ts
@@ -76,7 +76,7 @@ export type UserContext = {
     /**
      * The currently active user.
      */
-    currentUser: User<object, object> | null;
+    currentUser: User<object, object, unknown> | null;
 };
 
 /**
@@ -113,7 +113,7 @@ export type AuthenticatedRequest<RequestBody> = {
     /**
      * The user issuing the request.
      */
-    user?: User<object, object>;
+    user?: User<object, object, unknown>;
 } & (RequestWithUrl<RequestBody> | RequestWithPath<RequestBody>);
 
 /**
@@ -153,7 +153,7 @@ export class Fetcher implements LocationUrlContext {
      * @returns An object containing the user's token as "Authorization" header or undefined if no user is given.
      */
     private static buildAuthorizationHeader(
-        user: User<object, object> | null,
+        user: User<object, object, unknown> | null,
         tokenType: TokenType,
     ): Headers {
         if (!user || tokenType === "none") {

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -123,11 +123,14 @@ export class User<
             "providerType" in parameters
         ) {
             this._accessToken = parameters.accessToken;
-            this.storage.accessToken = parameters.accessToken;
             this._refreshToken = parameters.refreshToken;
-            this.storage.refreshToken = parameters.refreshToken;
             this.providerType = parameters.providerType;
+            // Save the parameters to storage, for future instances to be hydrated from
+            this.storage.accessToken = parameters.accessToken;
+            this.storage.refreshToken = parameters.refreshToken;
+            this.storage.providerType = parameters.providerType;
         } else {
+            // Hydrate the rest of the parameters from storage
             this._accessToken = this.storage.accessToken;
             this._refreshToken = this.storage.refreshToken;
             const providerType = this.storage.providerType;

--- a/packages/realm-web/src/UserProfile.ts
+++ b/packages/realm-web/src/UserProfile.ts
@@ -96,7 +96,6 @@ export class UserProfile<UserProfileDataType = Realm.DefaultUserProfileData> {
                 this.identities = identities.map((identity: any) => {
                     return {
                         id: identity.id,
-                        // providerId: identity["provider_id"],
                         providerType: identity["provider_type"],
                     };
                 });

--- a/packages/realm-web/src/UserProfile.ts
+++ b/packages/realm-web/src/UserProfile.ts
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { deserialize } from "./utils/ejson";
+
 /**
  * The type of a user.
  */
@@ -52,7 +54,7 @@ enum DataKey {
     MAX_AGE = "max_age",
 }
 
-const DATA_MAPPING: { [k in DataKey]: keyof UserProfile } = {
+const DATA_MAPPING: { [k in DataKey]: keyof Realm.DefaultUserProfileData } = {
     [DataKey.NAME]: "name",
     [DataKey.EMAIL]: "email",
     [DataKey.PICTURE]: "pictureUrl",
@@ -65,56 +67,36 @@ const DATA_MAPPING: { [k in DataKey]: keyof UserProfile } = {
 };
 
 /** @inheritdoc */
-export class UserProfile implements Realm.UserProfile {
-    /** @inheritdoc */
-    public readonly name?: string;
-
-    /** @inheritdoc */
-    public readonly email?: string;
-
-    /** @inheritdoc */
-    public readonly pictureUrl?: string;
-
-    /** @inheritdoc */
-    public readonly firstName?: string;
-
-    /** @inheritdoc */
-    public readonly lastName?: string;
-
-    /** @inheritdoc */
-    public readonly gender?: string;
-
-    /** @inheritdoc */
-    public readonly birthday?: string;
-
-    /** @inheritdoc */
-    public readonly minAge?: string;
-
-    /** @inheritdoc */
-    public readonly maxAge?: string;
-
-    /** @inheritdoc */
+export class UserProfile<UserProfileDataType = Realm.DefaultUserProfileData> {
+    /** @ignore */
     public readonly type: Realm.UserType = UserType.Normal;
 
-    /** @inheritdoc */
+    /** @ignore */
     public readonly identities: Realm.UserIdentity[] = [];
+
+    /** @ignore */
+    public readonly data: UserProfileDataType;
 
     /**
      * @param response The response of a call fetching the users profile.
      */
-    constructor(response?: any) {
-        if (response) {
-            if (typeof response.type === "string") {
-                this.type = response.type;
+    constructor(response?: unknown) {
+        if (typeof response === "object" && response !== null) {
+            const { type, identities, data } = response as {
+                [k: string]: unknown;
+            };
+
+            if (typeof type === "string") {
+                this.type = type as UserType;
             } else {
                 throw new Error("Expected 'type' in the response body");
             }
 
-            if (Array.isArray(response.identities)) {
-                this.identities = response.identities.map((identity: any) => {
+            if (Array.isArray(identities)) {
+                this.identities = identities.map((identity: any) => {
                     return {
                         id: identity.id,
-                        providerId: identity["provider_id"],
+                        // providerId: identity["provider_id"],
                         providerType: identity["provider_type"],
                     };
                 });
@@ -122,22 +104,26 @@ export class UserProfile implements Realm.UserProfile {
                 throw new Error("Expected 'identities' in the response body");
             }
 
-            const { data } = response;
-            if (typeof data === "object") {
-                for (const key in DATA_MAPPING) {
-                    const value = data[key];
-                    const propertyName = DATA_MAPPING[key as DataKey];
-                    if (
-                        typeof value === "string" &&
-                        propertyName !== "identities" &&
-                        propertyName !== "type"
-                    ) {
-                        this[propertyName] = value;
-                    }
-                }
+            if (typeof data === "object" && data !== null) {
+                const mappedData = Object.fromEntries(
+                    Object.entries(data).map(([key, value]) => {
+                        if (key in DATA_MAPPING) {
+                            // Translate any known data field to its JS idiomatic alias
+                            return [DATA_MAPPING[key as DataKey], value];
+                        } else {
+                            // Pass through any other values
+                            return [key, value];
+                        }
+                    }),
+                );
+                // We can use `any` since we trust the user supplies the correct type
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                this.data = deserialize<any>(mappedData);
             } else {
                 throw new Error("Expected 'data' in the response body");
             }
+        } else {
+            this.data = {} as UserProfileDataType;
         }
     }
 }

--- a/packages/realm-web/src/UserStorage.ts
+++ b/packages/realm-web/src/UserStorage.ts
@@ -18,15 +18,19 @@
 
 import { PrefixedStorage, Storage } from "./storage";
 import { UserProfile } from "./UserProfile";
+import { ProviderType } from "./Credentials";
 
 const ACCESS_TOKEN_STORAGE_KEY = "accessToken";
 const REFRESH_TOKEN_STORAGE_KEY = "refreshToken";
 const PROFILE_STORAGE_KEY = "profile";
+const PROVIDER_TYPE_STORAGE_KEY = "providerType";
 
 /**
  * Storage specific to the app.
  */
-export class UserStorage extends PrefixedStorage {
+export class UserStorage<
+    UserProfileDataType = Realm.DefaultUserProfileData
+> extends PrefixedStorage {
     /**
      * Construct a storage for a `User`.
      *
@@ -89,7 +93,7 @@ export class UserStorage extends PrefixedStorage {
     get profile() {
         const value = this.get(PROFILE_STORAGE_KEY);
         if (value) {
-            const profile = new UserProfile();
+            const profile = new UserProfile<UserProfileDataType>();
             // Patch in the values
             Object.assign(profile, JSON.parse(value));
             return profile;
@@ -101,11 +105,36 @@ export class UserStorage extends PrefixedStorage {
      *
      * @param value User profile (undefined if its unknown).
      */
-    set profile(value: UserProfile | undefined) {
-        if (!value) {
-            this.remove(PROFILE_STORAGE_KEY);
-        } else {
+    set profile(value: UserProfile<UserProfileDataType> | undefined) {
+        if (value) {
             this.set(PROFILE_STORAGE_KEY, JSON.stringify(value));
+        } else {
+            this.remove(PROFILE_STORAGE_KEY);
+        }
+    }
+
+    /**
+     * Get the type of authentication provider used to authenticate
+     *
+     * @returns User profile (undefined if its unknown).
+     */
+    get providerType() {
+        const value = this.get(PROVIDER_TYPE_STORAGE_KEY);
+        if (value) {
+            return value as ProviderType;
+        }
+    }
+
+    /**
+     * Set the type of authentication provider used to authenticate
+     *
+     * @param value Type of authentication provider.
+     */
+    set providerType(value: ProviderType | undefined) {
+        if (value) {
+            this.set(PROVIDER_TYPE_STORAGE_KEY, value);
+        } else {
+            this.remove(PROVIDER_TYPE_STORAGE_KEY);
         }
     }
 }

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -644,18 +644,22 @@ describe("App", () => {
         const alicesStorage = appStorage.prefix("user(alices-id)");
         alicesStorage.set("accessToken", "alices-access-token");
         alicesStorage.set("refreshToken", "alices-refresh-token");
+        alicesStorage.set("providerType", "anon-user");
         alicesStorage.set(
             "profile",
             JSON.stringify({
                 type: "normal",
                 identities: [],
-                firstName: "Alice",
+                data: {
+                    firstName: "Alice",
+                },
             }),
         );
 
         const bobsStorage = appStorage.prefix("user(bobs-id)");
         bobsStorage.set("accessToken", "bobs-access-token");
         bobsStorage.set("refreshToken", "bobs-refresh-token");
+        bobsStorage.set("providerType", "anon-user");
 
         const app = new App({
             id: "my-mocked-app",
@@ -670,12 +674,14 @@ describe("App", () => {
         expect(alice.id).equals("alices-id");
         expect(alice.accessToken).equals("alices-access-token");
         expect(alice.refreshToken).equals("alices-refresh-token");
+        expect(alice.providerType).equals("anon-user");
         expect(alice.profile.firstName).equals("Alice");
 
         const bob = app.allUsers["bobs-id"];
         expect(bob.id).equals("bobs-id");
         expect(bob.accessToken).equals("bobs-access-token");
         expect(bob.refreshToken).equals("bobs-refresh-token");
+        expect(bob.providerType).equals("anon-user");
     });
 
     it("saves users to storage when logging in", async () => {
@@ -775,7 +781,9 @@ describe("App", () => {
         expect(bobsProfileBefore).deep.equals({
             type: "normal",
             identities: [],
-            firstName: "Bobby",
+            data: {
+                firstName: "Bobby",
+            },
         });
 
         await bob.logOut();

--- a/packages/realm-web/src/tests/User.test.ts
+++ b/packages/realm-web/src/tests/User.test.ts
@@ -19,7 +19,7 @@
 import { expect } from "chai";
 import { inspect } from "util";
 
-import { UserType, User, Credentials } from "..";
+import { User, Credentials } from "..";
 import { MongoDBRealmError } from "../MongoDBRealmError";
 
 import {
@@ -42,6 +42,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Assume that the user has an access token
         expect(user.accessToken).equals("deadbeef");
@@ -54,6 +55,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef.eyJleHAiOjAsImlhdCI6MH0=.e30=",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         {
             const output = inspect(user);
@@ -74,6 +76,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Log out the user
         await user.logOut();
@@ -111,6 +114,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Log out the user
         try {
@@ -139,6 +143,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Expect an exception if the profile was never fetched
         expect(() => {
@@ -146,11 +151,7 @@ describe("User", () => {
         }).throws("A profile was never fetched for this user");
         // Refresh the profile and expect a firstName
         await user.refreshProfile();
-        expect(user.profile).deep.equals({
-            identities: [],
-            type: UserType.Normal,
-            firstName: "John",
-        });
+        expect(user.profile).deep.equals({ firstName: "John" });
     });
 
     it("exposes custom data", async () => {
@@ -161,6 +162,7 @@ describe("User", () => {
             accessToken:
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1OTg2NDAzMTIsImlhdCI6MTU5MzQ1NjMxMiwidXNlcl9kYXRhIjp7Im5hbWUiOiJKb2hubnkifX0.l-ElbkTTcmMmM4EqO6gm--cIH6dmgtb5vdYfArPtBAE",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Try calling a function on the user
         expect(user.customData).deep.equals({
@@ -177,6 +179,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Try calling a function on the user
         const pong = await user.functions.ping();
@@ -201,6 +204,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Try calling a function on the user
         const keys = await user.apiKeys.fetchAll();
@@ -230,6 +234,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
         // Fetch the profile
         await user.refreshProfile();
@@ -240,7 +245,9 @@ describe("User", () => {
         const profileBefore = JSON.parse(userStorage.get("profile") || "");
 
         expect(profileBefore).deep.equals({
-            firstName: "John",
+            data: {
+                firstName: "John",
+            },
             identities: [],
             type: "normal",
         });
@@ -249,9 +256,9 @@ describe("User", () => {
         expect(userStorage.get("accessToken")).equals(null);
         expect(userStorage.get("refreshToken")).equals(null);
         // Logging out shouldn't delete information about the profile
-        expect(user.profile).deep.equals(profileBefore);
+        expect(user.profile).deep.equals(profileBefore.data);
         const profileAfter = JSON.parse(userStorage.get("profile") || "");
-        expect(profileAfter).deep.equals(profileBefore);
+        expect(profileAfter.data).deep.equals(profileBefore.data);
     });
 
     it("can link credentials", async () => {
@@ -274,6 +281,7 @@ describe("User", () => {
             id: "some-user-id",
             accessToken: "deadbeef",
             refreshToken: "very-refreshing",
+            providerType: "anon-user",
         });
 
         const credentials = Credentials.emailPassword(

--- a/src/js_user.hpp
+++ b/src/js_user.hpp
@@ -224,7 +224,7 @@ void UserClass<T>::get_identities(ContextType ctx, ObjectType object, ReturnValu
     std::vector<ValueType> identity_objects;
     for (auto identity : identities) {
         auto identity_object = Object::create_empty(ctx);
-        Object::set_property(ctx, identity_object, "userId", Value::from_string(ctx, identity.id));
+        Object::set_property(ctx, identity_object, "id", Value::from_string(ctx, identity.id));
         Object::set_property(ctx, identity_object, "providerType", Value::from_string(ctx, identity.provider_type));
         identity_objects.push_back(identity_object);
     }

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -23,6 +23,19 @@
 /// <reference path="auth-providers.d.ts" />
 
 declare namespace Realm {
+    /**
+     * Types of an authentication provider.
+     */
+    type ProviderType =
+        | "anon-user"
+        | "api-key"
+        | "local-userpass"
+        | "custom-function"
+        | "custom-token"
+        | "oauth2-google"
+        | "oauth2-facebook"
+        | "oauth2-apple";
+
     namespace Credentials {
         /**
          * Payload sent when authenticating using the [Anonymous Provider](https://docs.mongodb.com/realm/authentication/anonymous/).
@@ -142,7 +155,7 @@ declare namespace Realm {
         /**
          * Type of the authentication provider.
          */
-        readonly providerType: string;
+        readonly providerType: ProviderType;
 
         /**
          * A simple object which can be passed to the server as the body of a request to authenticate.
@@ -380,7 +393,8 @@ declare namespace Realm {
      */
     class User<
         FunctionsFactoryType extends object = DefaultFunctionsFactory,
-        CustomDataType extends object = any
+        CustomDataType extends object = any,
+        UserProfileDataType = DefaultUserProfileData
     > {
         /**
          * The automatically-generated internal ID of the user.
@@ -388,9 +402,9 @@ declare namespace Realm {
         readonly id: string;
 
         /**
-         * The provider type for the user.
+         * The provider type used when authenticating the user.
          */
-        readonly providerType: string;
+        readonly providerType: ProviderType;
 
         /**
          * The id of the device.
@@ -433,7 +447,7 @@ declare namespace Realm {
         /**
          * A profile containing additional information about the user.
          */
-        readonly profile: UserProfile;
+        readonly profile: UserProfileDataType;
 
         /**
          * Use this to call functions defined by the MongoDB Realm app, as this user.
@@ -535,20 +549,20 @@ declare namespace Realm {
      */
     interface UserIdentity {
         /**
-         * The id of the user.
+         * The id of the identity.
          */
-        userId: string;
+        id: string;
 
         /**
          * The type of the provider associated with the identity.
          */
-        providerType: string;
+        providerType: ProviderType;
     }
 
     /**
      * An extended profile with detailed information about the user.
      */
-    interface UserProfile {
+    type DefaultUserProfileData = {
         /**
          * The commonly displayed name of the user.
          */
@@ -593,13 +607,12 @@ declare namespace Realm {
          * The maximal age of the user.
          */
         maxAge?: string;
-
+    } & {
         /**
-         * The type of user
-         * // TODO: Determine the meaning of the different possibilities.
+         * Authentication providers might store other data here.
          */
-        type: UserType;
-    }
+        [key: string]: string;
+    };
 
     /**
      * A function which executes on the MongoDB Realm platform.


### PR DESCRIPTION
## What, How & Why?

Merging this PR will:
- Expose all data of the `profile.data` on `User#profile` (Realm Web only - still missing on Realm JS)
- Rename `userId` to `id` on `User#identities` elements (Realm JS and types)
- Expose `providerType` on a `User` (Realm Web).
- Add three properties missing from the RPC User proxy object.

This closes #3268 and a few other untracked issues.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
