### PR TITLE
Upgrade to node-addon-api v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6748,8 +6748,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "https://github.com/realm/node-addon-api/tarball/realm",
-      "integrity": "sha512-WZVHtiH89EjndpUfuDhWOduCKItm9OEvaGwWvwNR+6H754ncS8AcG0I326HqxJkn6+KGS4sXhTMztl3w8m3cJw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node-emoji": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "fs-extra": "^4.0.3",
     "https-proxy-agent": "^2.2.4",
     "ini": "^1.3.7",
-    "node-addon-api": "https://github.com/realm/node-addon-api/tarball/realm",
+    "node-addon-api": "^3.1.0",
     "node-fetch": "^2.6.1",
     "node-machine-id": "^1.1.10",
     "node-pre-gyp": "^0.15.0",


### PR DESCRIPTION
## What, How & Why?

In #3419 we started using a custom version of `node-addon-api` with an important  bug fix. In v3.1.0 the bug fix has been release, and we switch back to depend on upstream.
