### PR TITLE
Hotfix: async realm open exception crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* App crashed if a native error was thrown during `Realm.open(...)` ([#3414](https://github.com/realm/realm-js/issues/3414), since v10.0.0)
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
+
+### Internal
+* None.
+
 10.1.3 Release notes (2021-1-15)
 =============================================================
 ### Enhancements

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -924,7 +924,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
         if (error) {
             try {
                 std::rethrow_exception(error);
-            } catch (const std::system_error& e) {
+            } catch (const std::exception& e) {
                 ObjectType object = Object::create_empty(protected_ctx);
                 Object::set_property(protected_ctx, object, "message", Value::from_string(protected_ctx, e.what()));
                 Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -177,6 +177,39 @@ module.exports = {
             });
     },
 
+    testRealmOpenWithDestructiveSchemaUpdate() {
+        if (!isNodeProcess) {
+            return;
+        }
+
+        const partition = Utils.genPartition();
+        const expectedObjectsCount = 3;
+
+        let user, config;
+        let credentials = Realm.Credentials.anonymous();
+        let app = new Realm.App(appConfig);
+        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+            .then(() => { return app.logIn(credentials) })
+            .then(u => {
+                user = u;
+                config = getSyncConfiguration(u, partition);
+                return Realm.open(config)
+            }).then(realm => {
+                realm.close();
+                // change the 'breed' property from 'string?' to 'string'
+                config.schema[0].properties.breed = "string";
+            }).then(() => {
+                return Realm.open(config);
+            }).then((realm) => {
+                // this should never happen (a better way of doing this?)
+                TestCase.assertNull(realm, "UNEXPECTED: Realm.open() with destructive schema update resolved.");
+            }).catch((err) => {
+                TestCase.assertDefined(err);
+                TestCase.assertDefined(err.message);
+                TestCase.assertTrue(/^The following changes cannot be made in additive-only schema mode:/.test(err.message));
+            });
+    },
+
     testRealmOpenWithExistingLocalRealm() {
         if (!platformSupported) {
             return;

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -190,8 +190,6 @@ module.exports = {
         const user = await app.logIn(Realm.Credentials.anonymous());
         const config = getSyncConfiguration(user, partition);
 
-        throw new Error('Steffen threw a new Error()');
-
         const realm = await Realm.open(config)
         realm.close();
 


### PR DESCRIPTION
## What, How & Why?
App crashed if a native error was thrown during `Realm.open(...)` - (fix by: @RedBeard0531).

This closes #3414 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
