### PR TITLE
Web: Update App.ts allUser type to use the internal type

### DIFF
--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -274,7 +274,7 @@ export class App<
      * @returns An array of users active or loggedout users (current user being the first).
      */
     public get allUsers(): Readonly<
-        Record<string, Realm.User<FunctionsFactoryType, CustomDataType>>
+        Record<string, User<FunctionsFactoryType, CustomDataType>>
     > {
         // Returning a freezed copy of the list of users to prevent outside changes
         return Object.fromEntries(this.users.map(user => [user.id, user]));


### PR DESCRIPTION
## What, How & Why?

This fix an issue when iterating the `app.allUsers` value and passing these to for example `app.removeUser`:

```typescript
for (const u of Object.values(app.allUsers)) {
  appendLog(`Removing ${u.id}`);
  await app.removeUser(u); // will error
}
```

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
