### PR TITLE
Make JSNetworkTransport objects own their EventLoopDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Fixed
 * App crashed if a native error was thrown during `Realm.open(...)` ([#3414](https://github.com/realm/realm-js/issues/3414), since v10.0.0)
-* Fixed an issue in Node.js, where utilizing an ArrayBuffer for setting a binary property, would mangle the data. ([3518](https://github.com/realm/realm-js/issues/3518))
+* Fixed an issue in Node.js, where utilizing an ArrayBuffer for setting a binary property, would mangle the data. ([#3518](https://github.com/realm/realm-js/issues/3518))
+* Fixed an issue where scripts may hang rather than executing after all code has executed. ([#3525](https://github.com/realm/realm-js/issues/3518))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -166,10 +166,22 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
     using Object = js::Object<T>;
     using Value = js::Value<T>;
 
-    using NetworkTransportFactory = std::function<std::unique_ptr<app::GenericNetworkTransport>(ContextType)>;
-    using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
+    using Dispatcher = util::EventLoopDispatcher<void(std::function<void()>)>;
 
-    JavaScriptNetworkTransport(ContextType ctx) : m_ctx(ctx) {};
+    // Creates a dispatcher to pass into the constructor. This must be called from the JS thread, even if
+    // the NetworkTransport will be constructed elsewhere.
+    static Dispatcher make_dispatcher() {
+        // This is just a thin "run any function" dispatcher to allow the actual logic to be executed
+        // to live in a more natural location (send_request_to_server).
+        return util::EventLoopDispatcher([] (std::function<void()> func) {
+            func();
+        });
+    }
+
+    using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
+    using NetworkTransportFactory = std::function<std::unique_ptr<app::GenericNetworkTransport>(ContextType, Dispatcher)>;
+
+    JavaScriptNetworkTransport(ContextType ctx, Dispatcher eld) : m_ctx(ctx), m_dispatcher(std::move(eld)) {};
 
     static ObjectType makeRequest(ContextType ctx, const app::Request& request) {
         ObjectType headers_object = Object::create_empty(ctx);
@@ -188,30 +200,26 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
         return request_object;
     }
 
-    static void init(ContextType ctx) {
-        // This initializes the EventLoopDispatcher on the main JS thread.
-        s_dispatcher.reset(new realm::util::EventLoopDispatcher([]
-            (ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback) {
-                HANDLESCOPE(m_ctx);
+    void send_request_to_server(app::Request request, std::function<void(const app::Response)> completion_callback) override {
+        m_dispatcher([ctx = m_ctx,
+                      request = std::move(request),
+                      completion_callback = std::move(completion_callback)
+                     ] () mutable {
+                HANDLESCOPE(ctx);
 
-                ObjectType realm_constructor = Value::validated_to_object(m_ctx, Object::get_global(m_ctx, "Realm"));
-                ValueType network_transport = Object::get_property(m_ctx, realm_constructor, "_networkTransport");
+                ObjectType realm_constructor = Value::validated_to_object(ctx, Object::get_global(ctx, "Realm"));
+                ValueType network_transport = Object::get_property(ctx, realm_constructor, "_networkTransport");
 
-                Object::call_method(m_ctx, Value::to_object(m_ctx, network_transport), "fetchWithCallbacks", {
-                    makeRequest(m_ctx, request),
-                    ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
+                Object::call_method(ctx, Value::to_object(ctx, network_transport), "fetchWithCallbacks", {
+                    makeRequest(ctx, request),
+                    ResponseHandlerClass<T>::create_instance(ctx, std::move(completion_callback)),
                 });
-            }));
-
-    }
-
-    void send_request_to_server(const app::Request request, std::function<void(const app::Response)> completion_callback) override {
-        (*s_dispatcher)(m_ctx, request, completion_callback);
+            });
     }
 
 private:
     ContextType m_ctx;
-    inline static std::unique_ptr<realm::util::EventLoopDispatcher<SendRequestHandler>> s_dispatcher;
+    Dispatcher m_dispatcher;
 
     std::string static fromHttpMethod(app::HttpMethod method) {
         switch (method) {

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -265,7 +265,8 @@ RPCServer::RPCServer() {
     
     // Make the App use the RPC Network Transport from now on
     previous_transport_generator = AppClass::transport_generator;
-    AppClass::transport_generator = [] (jsc::Types::Context ctx) {
+    AppClass::transport_generator = [] (jsc::Types::Context ctx, auto&& dispatcher) {
+        (void)dispatcher; // We don't need to use the dispatcher because JSC separately guarantees thread-safety.
         return std::make_unique<RPCNetworkTransport>(ctx);
     };
 


### PR DESCRIPTION
This means that it will be destroyed when the JSNetworkTransport object is
destroyed, rather than living forever in a static member.

Fixes #3525.
Refines change in #3505.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [X] 📝 Changelog entry
* ~~[ ] 📝 `Compatibility` label is updated or copied from previous entry~~
* [ ] 🚦 Tests
* ~~[ ] 📝 Public documentation PR created or is not necessary~~
* ~~[ ] 💥 `Breaking` label has been applied or is not necessary~~

*If this PR adds or changes public API's:*
* ~~[ ] typescript definitions file is updated~~
* ~~[ ] jsdoc files updated~~
* ~~[ ] Chrome debug API is updated if API is available on React Native~~
