### PR TITLE
Rephrasing API doc on client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * App crashed if a native error was thrown during `Realm.open(...)` ([#3414](https://github.com/realm/realm-js/issues/3414), since v10.0.0)
 * Fixed an issue in Node.js, where utilizing an ArrayBuffer for setting a binary property, would mangle the data. ([#3518](https://github.com/realm/realm-js/issues/3518))
 * Fixed an issue where scripts may hang rather than executing after all code has executed. ([#3525](https://github.com/realm/realm-js/issues/3518))
+* Fixed TS definitions for `Realm.ErrorCallback`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * App crashed if a native error was thrown during `Realm.open(...)` ([#3414](https://github.com/realm/realm-js/issues/3414), since v10.0.0)
 * Fixed an issue in Node.js, where utilizing an ArrayBuffer for setting a binary property, would mangle the data. ([#3518](https://github.com/realm/realm-js/issues/3518))
 * Fixed an issue where scripts may hang rather than executing after all code has executed. ([#3525](https://github.com/realm/realm-js/issues/3518))
-* Fixed TS definitions for `Realm.ErrorCallback`.
+* Fixed TS declarations for `Realm.ErrorCallback`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -39,11 +39,10 @@
  * @typedef {Object} Realm.App.Sync~SyncConfiguration
  * @property {Realm.User} user - A {@link Realm.User} object obtained by calling `Realm.App.logIn`.
  * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key.
- * @property {function} [error] - A callback function which is called in error situations.
- *    The errpr callback can take up to two arguments: `session` and `syncErr`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
- *    and `syncError.readOnly` is true. Otherwise, `syncError` can have up to five properties: `name`, `message`, `isFatal`,
- *    `category`, and `code`.
- *
+ * @property {callback(session, syncError)} [error] - A callback function which is called in error situations.
+ *    The callback is passed two arguments: `session` and `syncErr`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
+ *    and `syncError.readOnly` is true. Otherwise, `syncError` can have upto five properties:
+ *    `name`, `message`, `isFatal`, `category`, and `code`.
  * @property {Object} [customHttpHeaders] - A map (string, string) of custom HTTP headers.
  * @property {Realm.App.Sync~OpenRealmBehaviorConfiguration} [newRealmFileBehavior] - Whether to create a new file and sync in background or wait for the file to be synced.
        If not set, the Realm will be downloaded before opened.
@@ -246,39 +245,40 @@ class Sync {
     /**
      * Initiate a client reset. The Realm must be closed prior to the reset.
      *
-     * A synced Realm may need to be reset because the MongoDB Realm Server encountered an error and had
-     * to be restored from a backup or because it has been too long since the client connected to the
-     * server so the server has rotated the logs.
+     * A synced Realm may need to be reset if the communications with the MongoDB Realm Server
+     * indicate an unrecoverable error that prevents continuing with normal synchronization. The
+     * most common reason for this is if a client has been disconnected for too long.
      *
-     * The Client Reset thus occurs because the server does not have the full information required to
-     * bring the Client fully up to date.
+     * The local copy of the Realm is moved into a recovery directory
+     * for safekeeping.
      *
-     * The reset process is as follows: the local copy of the Realm is copied into a recovery directory
-     * for safekeeping, and then deleted from the original location. The next time the Realm for that
-     * URL is opened, the Realm will automatically be re-downloaded from MongoDB Realm, and
-     * can be used as normal.
-     *
-     * Data written to the Realm after the local copy of the Realm diverged from the backup remote copy
+     * Local writes that were not successfully synchronized to the MongoDB Realm server
      * will be present in the local recovery copy of the Realm file. The re-downloaded Realm will
-     * initially contain only the data present at the time the Realm was backed up on the server.
+     * initially contain only the data present at the time the Realm was synchronized up on the server.
      *
      * @param {Realm.App} [app] - The app where the Realm was opened.
      * @param {string} [path] - The path to the Realm to reset.
      * Throws error if reset is not possible.
      * @example
      * {
-     *   const config = { sync: { user, partitionValue } };
-     *   config.sync.error = (session, error) => {
-     *     if (error.name === 'ClientReset') {
-     *       let path = realm.path;
-     *       realm.close();
-     *       Realm.App.Sync.initiateClientReset(app, path);
-     *       // - open Realm at `error.config.path` (oldRealm)
-     *       // - open Realm with `config` (newRealm)
-     *       // - copy required objects from oldRealm to newRealm
-     *       // - close both Realms
+     *   const config = {
+     *     // schema, etc.
+     *     sync: {
+     *       user,
+     *       partitionValue,
+     *       error: (session, error) => {
+     *         if (error.name === 'ClientReset') {
+     *           let path = realm.path; // realm.path will no be accessible after realm.close()
+     *           realm.close();
+     *           Realm.App.Sync.initiateClientReset(app, path);
+     *           // - open Realm at `error.config.path` (oldRealm)
+     *           // - open Realm with `config` (newRealm)
+     *           // - copy required objects from oldRealm to newRealm
+     *           // - close both Realms
+     *         }
+     *       }
      *     }
-     *   }
+     *   };
      * }
      */
     static initiateClientReset(app, path) { }

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -39,9 +39,9 @@
  * @typedef {Object} Realm.App.Sync~SyncConfiguration
  * @property {Realm.User} user - A {@link Realm.User} object obtained by calling `Realm.App.logIn`.
  * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key.
- * @property {function} [callback] - A callback function which is called in error situations.
- *    The callback can take up to two arguments: `session` and `error`. If `error.name == "ClientReset"`, `error.path` and `error.config` are set
- *    and `error.readOnly` is true. Otherwise, `error` can have up to five properties: `name`, `message`, `isFatal`,
+ * @property {function} [error] - A callback function which is called in error situations.
+ *    The errpr callback can take up to two arguments: `session` and `syncErr`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
+ *    and `syncError.readOnly` is true. Otherwise, `syncError` can have up to five properties: `name`, `message`, `isFatal`,
  *    `category`, and `code`.
  *
  * @property {Object} [customHttpHeaders] - A map (string, string) of custom HTTP headers.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -40,8 +40,8 @@
  * @property {Realm.User} user - A {@link Realm.User} object obtained by calling `Realm.App.logIn`.
  * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key.
  * @property {callback(session, syncError)} [error] - A callback function which is called in error situations.
- *    The callback is passed two arguments: `session` and `syncErr`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
- *    and `syncError.readOnly` is true. Otherwise, `syncError` can have upto five properties:
+ *    The callback is passed two arguments: `session` and `syncError`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
+ *    and `syncError.readOnly` is true. Otherwise, `syncError` can have up to five properties:
  *    `name`, `message`, `isFatal`, `category`, and `code`.
  * @property {Object} [customHttpHeaders] - A map (string, string) of custom HTTP headers.
  * @property {Realm.App.Sync~OpenRealmBehaviorConfiguration} [newRealmFileBehavior] - Whether to create a new file and sync in background or wait for the file to be synced.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3354,9 +3354,9 @@
       }
     },
     "entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "env-paths": {
@@ -5760,37 +5760,31 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+      "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.9.4",
-        "bluebird": "^3.7.2",
+        "@babel/parser": "^7.4.4",
+        "bluebird": "^3.5.4",
         "catharsis": "^0.8.11",
         "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.1",
+        "js2xmlparser": "^4.0.0",
         "klaw": "^3.0.0",
-        "markdown-it": "^10.0.0",
-        "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
-        "mkdirp": "^1.0.4",
+        "markdown-it": "^8.4.2",
+        "markdown-it-anchor": "^5.0.2",
+        "marked": "^0.7.0",
+        "mkdirp": "^0.5.1",
         "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
+        "strip-json-comments": "^3.0.1",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.9.1"
       },
       "dependencies": {
         "escape-string-regexp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
         "strip-json-comments": {
@@ -6238,13 +6232,13 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~2.0.0",
+        "entities": "~1.1.1",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
@@ -6257,9 +6251,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
     "mdurl": {
@@ -9274,9 +9268,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "jasmine": "^3.4.0",
     "jasmine-console-reporter": "^3.1.0",
     "jasmine-xml-reporter": "^1.2.1",
-    "jsdoc": "^3.6.3",
+    "jsdoc": "3.6.3",
     "lerna": "^3.20.2",
     "license-checker": "^8.0.3",
     "mockery": "^2.0.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -343,7 +343,13 @@ declare namespace Realm {
         code: number;
     }
 
-    type ErrorCallback = (session: App.Sync.Session, error: SyncError) => void;
+    interface ClientResetError {
+        name: string;
+        path: string;
+        config: SyncConfiguration;
+    }
+
+    type ErrorCallback = (session: App.Sync.Session, error: SyncError | ClientResetError) => void;
 
     const enum SessionStopPolicy {
         AfterUpload = "after-upload",
@@ -471,7 +477,7 @@ type RealmListsRemappedModelPart<T> = {
  * Joins T stripped of all keys which value extends Realm.Collection and all inherited from Realm.Object,
  * with only the keys which value extends Realm.List, remapped as Arrays.
  */
-type RealmInsertionModel<T> = 
+type RealmInsertionModel<T> =
     Omit<Omit<Omit<T, ExtractPropertyNamesOfType<T, Function>>, keyof Realm.Object>, ExtractPropertyNamesOfType<T, Realm.Collection<any>>>
     & RealmListsRemappedModelPart<Pick<T, ExtractPropertyNamesOfType<T, Realm.List<any>>>>
 


### PR DESCRIPTION
## What, How & Why?

The API doc and TS defs for client reset are inaccurate.

Notice: freezing JSdoc to v3.6.3.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
