### PR TITLE
This should fix the array-buffer problem by inserting a empty-string …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
+* Fixing regression on [Array Buffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) throwing an error when inserting an empty value in an optional binary field. [#3536](https://github.com/realm/realm-js/issues/3536).
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * None.
 

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -233,7 +233,8 @@ inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value v
     }
 
     if(node_binary->is_empty()) {
-        throw std::runtime_error("A non-empty ArrayBuffer, BufferView or Buffer is expected.");
+        char placeholder;
+        return OwnedBinaryData(&placeholder, 0);
     }
 
     return node_binary->create_binary_blob();

--- a/tests/js/array-buffer-tests.js
+++ b/tests/js/array-buffer-tests.js
@@ -127,10 +127,13 @@ module.exports = {
             return;
         }
 
-        SingleSchema.properties.a = 'data'
+        SingleSchema.properties.a = 'data?'
         let realm = new Realm({schema: [SingleSchema]})
 
-        TestCase.assertThrowsException(() => realm.write(()=> realm.create(SingleSchema.name, { a:new ArrayBuffer() } )), new Error("A non-empty ArrayBuffer, BufferView or Buffer is expected.") )
+        //should not throw.
+        realm.write(()=> realm.create(SingleSchema.name, { a:new ArrayBuffer() } ))
+
+       // TestCase.assertThrowsException(() => realm.write(()=> realm.create(SingleSchema.name, { a:new ArrayBuffer() } )), new Error("A non-empty ArrayBuffer, BufferView or Buffer is expected.") )
     },
 
 


### PR DESCRIPTION

## What, How & Why?
Fixing a problem with the way we handle empty array-buffer for fields that are nullable. 

This closes https://github.com/realm/realm-js/issues/3536

## ☑️ ToDos
<!-- Add your own todos here -->
~~* [ ] 📝 Changelog entry~~
~~* [ ] 📝 `Compatibility` label is updated or copied from previous entry~~
* [x] 🚦 Tests
~~* [ ] 📝 Public documentation PR created or is not necessary~~
~~* [ ] 💥 `Breaking` label has been applied or is not necessary~~

*If this PR adds or changes public API's:*
~~* [ ] typescript definitions file is updated~~
~~* [ ] jsdoc files updated~~
~~* [ ] Chrome debug API is updated if API is available on React Native~~
