### PR TITLE
Fix type definition of sync in configuration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -121,7 +121,7 @@ declare namespace Realm {
         inMemory?: boolean;
         schema?: (ObjectClass | ObjectSchema)[];
         schemaVersion?: number;
-        sync?: SyncConfiguration;
+        sync?: true | SyncConfiguration;
         deleteRealmIfMigrationNeeded?: boolean;
         disableFormatUpgrade?: boolean;
     }


### PR DESCRIPTION
## What, How & Why?
The type of `sync` in `Configuration` should be `boolean | SyncConfiguration`

*If this PR adds or changes public API's:*
- [x] typescript definitions file is updated
