### PR TITLE
Clarified `Realm.App.removeUser()` method description in typedoc

### DIFF
--- a/docs/sync.js
+++ b/docs/sync.js
@@ -125,7 +125,7 @@
     switchUser(user) { }
 
     /**
-     * Removes the user from MongoDB Realm.
+     * Removes the user from the client.
      *
      * @param {Realm.User} user - The user to remove.
      * @returns {Promise<void>}

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -342,7 +342,7 @@ declare namespace Realm {
         switchUser(user: User<FunctionsFactoryType, CustomDataType>): void;
 
         /**
-         * Logs out and removes a user from the app.
+         * Logs out and removes a user from the client.
          *
          * @returns A promise that resolves once the user has been logged out and removed from the app.
          */


### PR DESCRIPTION
## What, How & Why?
Following a MongoDB slack [discussion](https://mongodb.slack.com/archives/CUSNYAJ4R/p1612473658124000), I updated the description to the method `Realm.App.removeUser()`. In the master branch this method has the description, "Removes the user from MongoDB Realm". This can be confusing because readers may assume the user is deleted from the MongoDB Realm Server as well as the device. I altered the description in this PR  to be "Removes the user from the client". This clarifies that the user is only removed from the user's device.
