### PR TITLE
[v6 hotfix] Upcoming webkit update correctly checks "configurable" in property-descriptors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Fixed an issue where creating an object after file format upgrade may fail with error message `Assertion failed: lo() <= std::numeric_limits<uint32_t>::max()`. ([realm/realm-core#4295](https://github.com/realm/realm-core/issues/4295), since v6.0.0)
+* Due to an upcoming WebKit update (currently accessible through Xcode beta simulators), apps would throw `"Attempting to change configurable attribute of unconfigurable property"` at runtime ([#3557](https://github.com/realm/realm-js/issues/3557))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/src/jsc/jsc_class.hpp
+++ b/src/jsc/jsc_class.hpp
@@ -325,7 +325,7 @@ inline std::vector<JSStaticFunction> ObjectWrap<ClassType>::get_methods(const Me
     std::vector<JSStaticFunction> functions;
     functions.reserve(methods.size() + 1);
 
-    JSPropertyAttributes attributes = kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontEnum | kJSPropertyAttributeDontDelete;
+    JSPropertyAttributes attributes = kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontEnum;
     size_t index = 0;
 
     for (auto &pair : methods) {


### PR DESCRIPTION
## What, How & Why?

This webkit change is currently only encountered through the bundled simulators in Xcode 12.5 beta, where the app will break with the following error: `"Attempting to change configurable attribute of unconfigurable property"`

As the property descriptor `configurable` has previously been ignored by webkit, we now avoid setting it.

This closes #3557

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
