### PR TITLE
avoid instantiating extra schema on instance creation

### DIFF
--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -131,8 +131,8 @@ typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::
     static String prototype_string = "prototype";
 
     auto delegate = get_delegate<T>(realm_object.realm().get());
-    auto schema = realm_object.get_object_schema();
-    auto name = schema.name;
+    auto& schema = realm_object.get_object_schema();
+    auto& name = schema.name;
 
     auto internal = new realm::js::RealmObject<T>(std::move(realm_object));
 


### PR DESCRIPTION
Fixes a performance bug.

We unintentionally created (and subsequently destroyed) an object schema for each object instance created. For larger schema instances this has substantial overhead.

Perhaps also illustrates why Linus Thorvalds prefers C over C++ for performance sensitive work.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry

