### PR TITLE
Fix segmentation fault when pushing a class object based on Realm.Object to a list [v6 backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* There seems to be a few issues regarding class support in realm-js. We are currently coming up with strategies to better support this in the future.  In the meantime, the following fixes have been applied to help avoid crashes and failures.
+  * When creating a class that extends Realm.Object and pushing the instantiated object to a list, a segmentation fault would occur.  This has been fixed by a null check and throwing an exception.
+  * Creating an object from an instance of Realm.Object that was manually constructed (detached from Realm) would fail the second time.  Now we throw an meaningful exception the first time.
+
+### Compatibility
+* MongoDB Realm Cloud.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.x.y series.
+* File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
+
+### Internal
+* None.
+
 6.1.6 Release notes (2021-2-15)
+=============================================================
+
 ### Enhancements
 * None.
 

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -307,6 +307,9 @@ struct Unbox<JSEngine, Obj> {
         auto object = Value::validated_to_object(ctx->m_ctx, value);
         if (js::Object<JSEngine>::template is_instance<RealmObjectClass<JSEngine>>(ctx->m_ctx, object)) {
             auto realm_object = get_internal<JSEngine, RealmObjectClass<JSEngine>>(ctx->m_ctx, object);
+            if (!realm_object) {
+                throw std::runtime_error("Cannot reference a detached instance of Realm.Object");
+            }
             if (realm_object->realm() == ctx->m_realm) {
                 return realm_object->obj();
             }

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -983,6 +983,13 @@ void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments &a
         object = Schema<T>::dict_for_property_array(ctx, object_schema, object);
     }
 
+    if (Object::template is_instance<RealmObjectClass<T>>(ctx, object)) {
+        auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
+        if (!realm_object) {
+            throw std::runtime_error("Cannot create an object from a detached Realm.Object instance");
+        }
+    }
+
     NativeAccessor accessor(ctx, realm, object_schema);
     auto realm_object = realm::Object::create<ValueType>(accessor, realm, object_schema, object, policy);
     return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -1386,4 +1386,61 @@ module.exports = {
         TestCase.assertEqual(names[0]['given'].length, 2);
         realm2.close();
     },
+
+    testClassObjectCreation: function() {
+        class TodoItem extends Realm.Object {
+            constructor(description) {
+                super()
+                this.id = new ObjectId()
+                this.description = description;
+                this.done = false;
+            }
+        }
+
+        TodoItem.schema =  {
+            name: "TodoItem",
+            properties: {
+                id: "objectId",
+                description: "string",
+                done: {type: "bool", default: false},
+                deadline: "date?"
+            },
+            primaryKey: "id"
+        }
+
+        class TodoList extends Realm.Object {
+            constructor(name) {
+                super()
+                this.id = new ObjectId()
+                this.name = name;
+                this.items = []
+            }
+        }
+
+        TodoList.schema = {
+            name: "TodoList",
+            properties: {
+                id: "objectId",
+                name: "string",
+                items: "TodoItem[]"
+            },
+            primaryKey: "id"
+        }
+
+        const realm = new Realm({schema: [TodoList, TodoItem]});
+        realm.write(() => {
+            const list = realm.create(TodoList, {
+                id: new ObjectId(),
+                name: 'MyTodoList'
+            })
+
+            TestCase.assertThrows(() => {
+                list.items.push(new TodoItem("Fix that bug"))
+            }, "Cannot reference a detached instance of Realm.Object")
+
+            TestCase.assertThrows(() => {
+                realm.create(TodoItem, new TodoItem("Fix that bug"))
+            }, "Cannot create an object from a detached Realm.Object instance")
+        })
+    }
 };


### PR DESCRIPTION
## What, How & Why?
When creating a class that extends Realm.Object and pushing the instantiated object to a list, a segmentation fault would occur.  
```
class TodoItem extends Realm.Object {
    constructor(description) {
        super()
        this.id = `${new ObjectId()}`
        this.description = description;
        this.done = false;
    }

    static schema = {
        name: "TodoItem",
        properties: {
            id: "string",
            description: "string",
            done: {type: "bool", default: false},
            deadline: "date?"
        },
        primaryKey: "id"
    }
}

class TodoList extends Realm.Object {

    constructor(name ) {
        super()
        this.id = `${new ObjectId()}`
        this.name = name;
        this.items = []
    }

    static schema = {
        name: "TodoList",
        properties: {
            id: "string",
            name: "string",
            items: "TodoItem[]"
        },
        primaryKey: "id"
    }
}

const realm = new Realm({schema: [TodoList, TodoItem]});
realm.write(() => {
    const list = realm.create(TodoList, new TodoList('My Todo List'))
    list.items.push(new TodoItem("Fix that bug"))

    TestCase.assertEqual(1, list.items.length)
})
```

The problem is that realm was assuming that if the object is of type Realm.Object that it has already been created.  This assumption was causing a null pointer to be dereferenced which had caused the segmentation fault.  The logic now checks for null and throws an exception.
    
Also attempting to create an object with an unmanged instance of Realm.Object will throw an exception. This is to avoid future attempts to create which fail, as the prototype has been changed.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] ~📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* [ ] ~📝 Public documentation PR created or is not necessary~
* [ ] ~💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [ ] ~typescript definitions file is updated~
* [ ] ~jsdoc files updated~
* [ ] ~Chrome debug API is updated if API is available on React Native~
