### PR TITLE
Throw meaningful error if SO load fails on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v20 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 for synced Realms).
 
 ### Internal
-* None.
+* Throwing a more meaningful error when librealmreact.so loading fails from being loaded in an app using Hermes. ([#3633](https://github.com/realm/realm-js/pull/3633))
 
 10.2.0 Release notes (2021-2-5)
 =============================================================

--- a/react-native/android/src/main/java/io/realm/react/RealmReactModule.java
+++ b/react-native/android/src/main/java/io/realm/react/RealmReactModule.java
@@ -53,7 +53,14 @@ class RealmReactModule extends ReactContextBaseJavaModule {
     private final AssetManager assetManager;
 
     static {
-        SoLoader.loadLibrary("realmreact");
+        try {
+            SoLoader.loadLibrary("realmreact");
+        } catch (UnsatisfiedLinkError e) {
+            if (e.getMessage().contains("library \"libjsc.so\" not found")) {
+                throw new RuntimeException("Realm JS does not support the Hermes engine yet. Express your 💚 on https://github.com/realm/realm-js/issues/2455", e);
+            }
+            throw e;
+        }
     }
 
     private Handler worker;


### PR DESCRIPTION
## What, How & Why?

With this change a user would see a more meaningful error if loading the librealmreact.so fails from being loaded in an Android app without libjsc.so:

> `Realm JS does not support the Hermes engine yet. Express your 💚  on https://github.com/realm/realm-js/issues/2455`

![Screenshot 2021-03-10 at 10 04 32](https://user-images.githubusercontent.com/1243959/110606272-4fd8a480-818a-11eb-956f-a8cd49dcc025.png)

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
