### PR TITLE
Make AppClass::transport_generator initialized at const-init time

### DIFF
--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -59,7 +59,7 @@ public:
      * Generates instances of GenericNetworkTransport, eventually allowing Realm Object Store to perform network requests.
      * Exposed to allow other components (ex the RPCServer) to override the underlying implementation.
      */
-    static inline NetworkTransportFactory transport_generator = [] (ContextType ctx, typename NetworkTransport::Dispatcher eld) {
+    static inline NetworkTransportFactory transport_generator = +[] (ContextType ctx, typename NetworkTransport::Dispatcher eld) -> std::unique_ptr<app::GenericNetworkTransport> {
         return std::make_unique<NetworkTransport>(ctx, std::move(eld));
     };
 

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -179,6 +179,8 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
     }
 
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
+
+    // This needs to be a plain function pointer to ensure that AppClass::transport_factory is correctly initialized on MSVC builds.
     using NetworkTransportFactory = std::unique_ptr<app::GenericNetworkTransport>(*)(ContextType, Dispatcher);
 
     JavaScriptNetworkTransport(ContextType ctx, Dispatcher eld) : m_ctx(ctx), m_dispatcher(std::move(eld)) {};

--- a/src/js_network_transport.hpp
+++ b/src/js_network_transport.hpp
@@ -179,7 +179,7 @@ struct JavaScriptNetworkTransport : public app::GenericNetworkTransport {
     }
 
     using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
-    using NetworkTransportFactory = std::function<std::unique_ptr<app::GenericNetworkTransport>(ContextType, Dispatcher)>;
+    using NetworkTransportFactory = std::unique_ptr<app::GenericNetworkTransport>(*)(ContextType, Dispatcher);
 
     JavaScriptNetworkTransport(ContextType ctx, Dispatcher eld) : m_ctx(ctx), m_dispatcher(std::move(eld)) {};
 

--- a/src/jsc/rpc.cpp
+++ b/src/jsc/rpc.cpp
@@ -46,7 +46,8 @@ using json = nlohmann::json;
 
 using RPCObjectID = u_int64_t;
 using RPCRequest = std::function<json(const json)>;
-using NetworkTransportFactory = typename js::JavaScriptNetworkTransport<jsc::Types>::NetworkTransportFactory;
+using NetworkTransport = js::JavaScriptNetworkTransport<jsc::Types>;
+using NetworkTransportFactory = typename NetworkTransport::NetworkTransportFactory
 
 using Value = js::Value<jsc::Types>;
 using Accessor = realm::js::NativeAccessor<jsc::Types>;
@@ -347,7 +348,7 @@ RPCServerImpl::RPCServerImpl() {
 
     // Make the App use the RPC Network Transport from now on
     previous_transport_generator = AppClass::transport_generator;
-    AppClass::transport_generator = [] (jsc::Types::Context ctx, auto&& dispatcher) -> std::unique_ptr<app::GenericNetworkTransport> {
+    AppClass::transport_generator = [] (jsc::Types::Context ctx, NetworkTransport::Dispatcher dispatcher) -> std::unique_ptr<app::GenericNetworkTransport> {
         (void)dispatcher; // We don't need to use the dispatcher because JSC separately guarantees thread-safety.
         return std::make_unique<RPCNetworkTransport>(ctx);
     };

--- a/src/jsc/rpc.cpp
+++ b/src/jsc/rpc.cpp
@@ -347,7 +347,7 @@ RPCServerImpl::RPCServerImpl() {
 
     // Make the App use the RPC Network Transport from now on
     previous_transport_generator = AppClass::transport_generator;
-    AppClass::transport_generator = +[] (jsc::Types::Context ctx, auto&& dispatcher) -> std::unique_ptr<app::GenericNetworkTransport> {
+    AppClass::transport_generator = [] (jsc::Types::Context ctx, auto&& dispatcher) -> std::unique_ptr<app::GenericNetworkTransport> {
         (void)dispatcher; // We don't need to use the dispatcher because JSC separately guarantees thread-safety.
         return std::make_unique<RPCNetworkTransport>(ctx);
     };

--- a/src/jsc/rpc.cpp
+++ b/src/jsc/rpc.cpp
@@ -47,7 +47,7 @@ using json = nlohmann::json;
 using RPCObjectID = u_int64_t;
 using RPCRequest = std::function<json(const json)>;
 using NetworkTransport = js::JavaScriptNetworkTransport<jsc::Types>;
-using NetworkTransportFactory = typename NetworkTransport::NetworkTransportFactory
+using NetworkTransportFactory = typename NetworkTransport::NetworkTransportFactory;
 
 using Value = js::Value<jsc::Types>;
 using Accessor = realm::js::NativeAccessor<jsc::Types>;

--- a/src/jsc/rpc.cpp
+++ b/src/jsc/rpc.cpp
@@ -347,7 +347,7 @@ RPCServerImpl::RPCServerImpl() {
 
     // Make the App use the RPC Network Transport from now on
     previous_transport_generator = AppClass::transport_generator;
-    AppClass::transport_generator = [] (jsc::Types::Context ctx, auto&& dispatcher) {
+    AppClass::transport_generator = +[] (jsc::Types::Context ctx, auto&& dispatcher) -> std::unique_ptr<app::GenericNetworkTransport> {
         (void)dispatcher; // We don't need to use the dispatcher because JSC separately guarantees thread-safety.
         return std::make_unique<RPCNetworkTransport>(ctx);
     };


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This fixes the "bad_function_call" issue where it was invoked while null                                                                                                                                                                                             (probably actually uninitialized). I'm not sure why it wasn't                                                                                                                                                                                                        initialized yet, since the compiler should have ensured that it was.                                                                                                                                                                                                 There is likely a compiler bug there but I'll need to dig in more. To                                                                                                                                                                                                work around that, I made it a simple function pointer, which lambdas can                                                                                                                                                                                             implicitly convert to, and all of that should be possible at const-init                                                                                                                                                                                              time (basically, it should be burned into the binary image with nothing                                                                                                                                                                                              happening at runtime). Unfortunately due to a different compiler bug,                                                                                                                                                                                                (https://developercommunity.visualstudio.com/t/const-init-of-function-pointers-from-lambdas/1383098),                                                                                                                                                                this requires putting a `+` in front of the lambda to explicitly decay                                                                                                                                                                                               it to a function pointer, rather than relying on the implicit conversion.  


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
