### PR TITLE
BSON package reference update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2552,8 +2552,9 @@
       }
     },
     "bson": {
-      "version": "github:steffenagger/js-bson#1521e1dab2b14b7227fddc924ff80ffbd7e02c42",
-      "from": "github:steffenagger/js-bson#uuid-realm",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
       "requires": {
         "buffer": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "bson": "github:steffenagger/js-bson#uuid-realm",
+    "bson": "^4.3.0",
     "command-line-args": "^4.0.6",
     "deepmerge": "2.1.0",
     "deprecated-react-native-listview": "0.0.6",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -55,8 +55,9 @@
       }
     },
     "bson": {
-      "version": "github:steffenagger/js-bson#1521e1dab2b14b7227fddc924ff80ffbd7e02c42",
-      "from": "github:steffenagger/js-bson#uuid-realm",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -567,7 +568,7 @@
       "version": "file:..",
       "requires": {
         "bindings": "^1.5.0",
-        "bson": "github:steffenagger/js-bson#23bccbdabd07a5ca04aab59a3ad3997ac903121c",
+        "bson": "^4.3.0",
         "command-line-args": "^4.0.6",
         "deepmerge": "2.1.0",
         "deprecated-react-native-listview": "0.0.6",
@@ -2901,13 +2902,6 @@
             "node-int64": "^0.4.0"
           }
         },
-        "bson": {
-          "version": "github:steffenagger/js-bson#23bccbdabd07a5ca04aab59a3ad3997ac903121c",
-          "from": "github:steffenagger/js-bson#23bccbdabd07a5ca04aab59a3ad3997ac903121c",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
         "btoa-lite": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
@@ -3187,7 +3181,8 @@
           }
         },
         "cmake-js": {
-          "version": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.1.0.tgz",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.1.0.tgz",
           "integrity": "sha512-utmukLQftpgrCpGRCaHnkv4K27HZNNFqmBl4vnvccy0xp4c1erxjFU/Lq4wn5ngAhFZmpwBPQfoKWKThjSBiwg==",
           "requires": {
             "debug": "^4",
@@ -3354,6 +3349,10 @@
               "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
             }
           }
+        },
+        "compare-versions": {
+          "version": "3.6.0",
+          "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
         },
         "component-emitter": {
           "version": "1.3.0",
@@ -4678,7 +4677,8 @@
           "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "fb-watchman": {
-          "version": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
           "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
           "requires": {
             "bser": "2.1.1"
@@ -8037,7 +8037,8 @@
           "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "prebuild": {
-          "version": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
           "integrity": "sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==",
           "requires": {
             "cmake-js": "~5.2.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@types/jasmine": "^3.6.2",
-    "bson": "github:steffenagger/js-bson#uuid-realm",
     "debug": "^4.3.1",
     "es6-promise": "^3.2.1",
     "http-proxy": "^1.18.1",
@@ -16,7 +15,7 @@
     "needle": "^1.3.0",
     "node-fetch": "^2.6.1",
     "node-rsa": "^1.1.1",
-    "realm": "..",
+    "realm": "file:..",
     "spawn-sync": "^2.0.0",
     "terminate": "^1.0.8",
     "tmp": "^0.0.30",


### PR DESCRIPTION
[bson@4.3.0](https://github.com/mongodb/js-bson/releases/tag/v4.3.0) was released, including the UUID changes. This PR just updates back to the official npm-package, again.