### PR TITLE
Fix test script for android tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -397,7 +397,7 @@ case "$TARGET" in
   cleanup
   echo "********* TESTS COMPLETED *********";
 
-  if $TESTS_FAILED; then
+  if [ $TESTS_FAILED = 'TRUE' ]; then
     exit 20
   fi
   ;;


### PR DESCRIPTION
The if statement logic in the test.sh resolves a bit differently
in the Docker.android image.  This fix does an explicit string
comparison to ensure compatibility with all POSIX shells.