### PR TITLE
Adding a Realm.Set when chrome debugging

### DIFF
--- a/lib/browser/constants.js
+++ b/lib/browser/constants.js
@@ -37,6 +37,7 @@ export const propTypes = {};
     'ERROR',
     'FUNCTION',
     'LIST',
+    'SET',
     'OBJECT',
     'REALM',
     'RESULTS',

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -22,6 +22,7 @@ import { NativeModules } from 'react-native';
 import { keys, objectTypes } from './constants';
 import Collection from './collections';
 import List, { createList } from './lists';
+import Set, { createSet } from './sets';
 import Results, { createResults } from './results';
 import RealmObject, * as objects from './objects';
 import User, { createUser } from './user';
@@ -38,6 +39,7 @@ import { createEmailPasswordAuth } from './email-password-auth';
 const {debugHosts, debugPort} = NativeModules.Realm;
 
 rpc.registerTypeConverter(objectTypes.LIST, createList);
+rpc.registerTypeConverter(objectTypes.SET, createSet);
 rpc.registerTypeConverter(objectTypes.RESULTS, createResults);
 rpc.registerTypeConverter(objectTypes.OBJECT, objects.createObject);
 rpc.registerTypeConverter(objectTypes.REALM, createRealm);
@@ -158,6 +160,9 @@ Object.defineProperties(Realm, {
     },
     List: {
         value: List,
+    },
+    Set: {
+        value: Set,
     },
     Results: {
         value: Results,

--- a/lib/browser/sets.js
+++ b/lib/browser/sets.js
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+import Collection, { createCollection } from "./collections";
+
+export default class Set extends Collection {
+    constructor() {
+        throw new Error("Sets are not yet supported in Chrome debugging mode");
+    }
+}
+
+export function createSet(realmId, info) {
+    return createCollection(Set.prototype, realmId, info, true);
+}


### PR DESCRIPTION
## What, How & Why?

This unbreaks Chrome debugging, allowing an app to start in chrome debugging mode again.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary