### PR TITLE
Fixed Set not properly exposing 'objectType' to Realm.schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ NOTE: Bump file format version to 21. NO DOWNGRADE PATH IS AVAILABLE.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Set didn't export `objectType` to Realm.schema when it contained scalar types.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -453,7 +453,7 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
     if (property.object_type.size()) {
         Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, property.object_type));
     }
-    else if (is_array(property.type) || is_dictionary(property.type)) {
+    else if (is_array(property.type) || is_dictionary(property.type) || is_set(property.type)) {
         Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, local_string_for_property_type(property.type & ~realm::PropertyType::Flags)));
     }
 


### PR DESCRIPTION
Fixed Set of scalar types not properly exposing 'objectType' to Realm.schema.

## What, How & Why?
Fixed an issue with the Set dataype not exporting its `objectType` property to the Realm.schema object when it contained non-object types.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
~* [ ] 📝 `Compatibility` label is updated or copied from previous entry~
~* [ ] 🚦 Tests~
~* [ ] 📝 Public documentation PR created or is not necessary~
~* [ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
~* [ ] typescript definitions file is updated~
~* [ ] jsdoc files updated~
~* [ ] Chrome debug API is updated if API is available on React Native~
