### PR TITLE
"url" → "baseUrl" renamed on App configurations (#3725 on master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed the naming of `url` (now `baseUrl`) property on an app config to match the TypeScript declaration and other SDKs. ([#3612](https://github.com/realm/realm-js/issues/3612))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -22,9 +22,9 @@
  * This describes the options used to create a {@link Realm.App} instance.
  * @typedef {Object} Realm.App~AppConfiguration
  * @property {string} id - The id of the MongoDB Realm app.
- * @property {string} url - The URL of the MongoDB Realm end-point.
- * @property {number} timeout - General timeout (in millisecs) for requests.
- * @property {Realm.App~LocalAppConfiguration} app - local app configuration
+ * @property {string} [baseUrl] - The base URL of the MongoDB Realm server.
+ * @property {number} [timeout] - General timeout (in millisecs) for requests.
+ * @property {Realm.App~LocalAppConfiguration} [app] - local app configuration
  */
 
 /**

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -125,7 +125,7 @@ inline typename T::Object AppClass<T>::create_instance(ContextType ctx, SharedAp
 template<typename T>
 void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args) {
     static const String config_id = "id";
-    static const String config_url = "url";
+    static const String config_base_url = "baseUrl";
     static const String config_timeout = "timeout";
     static const String config_app = "app";
     static const String config_app_name = "name";
@@ -149,9 +149,9 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
             throw std::runtime_error("App configuration must have an id.");
         }
 
-        ValueType config_url_value = Object::get_property(ctx, config_object, config_url);
-        if (!Value::is_undefined(ctx, config_url_value)) {
-            config.base_url = util::Optional<std::string>(Value::validated_to_string(ctx, config_url_value, "url"));
+        ValueType config_base_url_value = Object::get_property(ctx, config_object, config_base_url);
+        if (!Value::is_undefined(ctx, config_base_url_value)) {
+            config.base_url = util::Optional<std::string>(Value::validated_to_string(ctx, config_base_url_value, "baseUrl"));
         }
 
         ValueType config_timeout_value = Object::get_property(ctx, config_object, config_timeout);

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -45,7 +45,7 @@ module.exports = {
     testInvalidServer() {
         const conf = {
             id: 'smurf',
-            url: 'http://localhost:9999',
+            baseUrl: 'http://localhost:9999',
             timeout: 1000,
             app: {
                 name: 'realm-sdk-integration-tests',

--- a/tests/js/download-api-helper.js
+++ b/tests/js/download-api-helper.js
@@ -1,10 +1,10 @@
 /*
 This script creates 3 new objects into a new realm. These are objects are validated to exists by the download api tests.
 */
-'use strict';
+"use strict";
 console.log("download-api-helper started");
 const appId = process.argv[2];
-const appUrl = process.argv[3];
+const baseUrl = process.argv[3];
 const partition = process.argv[4];
 const realmModule = process.argv[5];
 
@@ -71,7 +71,7 @@ function createObjects(user) {
 const credentials = Realm.Credentials.anonymous();
 const appConfig = {
     id: appId,
-    url: appUrl,
+    baseUrl,
     timeout: 1000,
     app: {
         name: "default",

--- a/tests/js/nested-list-helper.js
+++ b/tests/js/nested-list-helper.js
@@ -5,7 +5,7 @@ This script creates new nested objects into a new Realm.
 'use strict';
 console.log("nested-list-helper started", JSON.stringify(process.argv));
 const appid = process.argv[2];
-const appurl = process.argv[3];
+const baseUrl = process.argv[3];
 const realmName = process.argv[4];
 const realmModule = process.argv[5];
 
@@ -81,7 +81,7 @@ function createObjects(user) {
 
 const config = {
     id: appid,
-    url: appurl,
+    baseUrl,
     timeout: 1000,
     app: {
         name: 'default',

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -160,7 +160,7 @@ module.exports = {
         let user, config;
         let credentials = Realm.Credentials.anonymous();
         let app = new Realm.App(appConfig);
-        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH)
             .then(() => { return app.logIn(credentials) })
             .then(u => {
                 user = u;
@@ -188,7 +188,7 @@ module.exports = {
 
         const partition = Utils.genPartition();
 
-        await runOutOfProcess(__dirname + "/download-api-helper.js", appConfig.id, appConfig.url, partition, REALM_MODULE_PATH);
+        await runOutOfProcess(__dirname + "/download-api-helper.js", appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH);
 
         const app = new Realm.App(appConfig);
         const user = await app.logIn(Realm.Credentials.anonymous());
@@ -216,7 +216,7 @@ module.exports = {
         let user, config;
         let app = new Realm.App(appConfig);
         const credentials = Realm.Credentials.anonymous();
-        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH)
             .then(() => app.logIn(credentials))
             .then(u => {
                 user = u;
@@ -299,7 +299,7 @@ module.exports = {
         const partition = Utils.genPartition();
         let app = new Realm.App(appConfig);
         const credentials = Realm.Credentials.anonymous();
-        return runOutOfProcess(__dirname + '/nested-list-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+        return runOutOfProcess(__dirname + '/nested-list-helper.js', appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH)
             .then(() => {
                 return app.logIn(credentials)
             })
@@ -343,7 +343,7 @@ module.exports = {
 
         let app = new Realm.App(appConfig);
         const credentials = Realm.Credentials.anonymous();
-        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH)
             .then(() => app.logIn(credentials))
             .then(user => {
                 let config = getSyncConfiguration(user, partition);
@@ -405,7 +405,7 @@ module.exports = {
 
         const credentials = Realm.Credentials.anonymous();
         let app = new Realm.App(appConfig);
-        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.url, partition, REALM_MODULE_PATH)
+        return runOutOfProcess(__dirname + '/download-api-helper.js', appConfig.id, appConfig.baseUrl, partition, REALM_MODULE_PATH)
             .then(() => { return app.logIn(credentials) })
             .then(user => {
                 let config = getSyncConfiguration(user, partition);

--- a/tests/js/support/testConfig.js
+++ b/tests/js/support/testConfig.js
@@ -17,7 +17,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-'use strict';
+"use strict";
 
 // If the docker instance has imported this stitch config, it will have written the app id
 // back into the config file, so we can read it out again here.
@@ -29,27 +29,28 @@ function nodeRequire(module) {
 }
 
 let pathToStitchJson = "../../../tests/mongodb/stitch.json";
-const isNodeProcess = typeof process === 'object' && process + '' === '[object process]';
+const isNodeProcess = typeof process === "object" && process + "" === "[object process]";
 
 if (isNodeProcess && process.env.ELECTRON_TESTS_REALM_MODULE_PATH) {
     const path = nodeRequire("path");
     console.log("ELECTRON_TESTS_REALM_MODULE_PATH " + process.env.ELECTRON_TESTS_REALM_MODULE_PATH);
-    pathToStitchJson = path.resolve(process.env.ELECTRON_TESTS_REALM_MODULE_PATH, '../../../../tests/mongodb/stitch.json')
+    pathToStitchJson = path.resolve(process.env.ELECTRON_TESTS_REALM_MODULE_PATH, "../../../../tests/mongodb/stitch.json")
 }
 console.log("pathToStitchJson " + pathToStitchJson);
 
 const integrationTestsAppId = `${nodeRequire(pathToStitchJson).app_id}`;
-const appUrl = process.env.MONGODB_REALM_ENDPOINT ? process.env.MONGODB_REALM_ENDPOINT.replace(/\"/g,'') : "http://localhost";
-const appPort = process.env.MONGODB_REALM_PORT || "9090";
-console.log(`tests are using integration tests app id: ${integrationTestsAppId} on ${appUrl}:${appPort}`);
+const baseUrlHostname = process.env.MONGODB_REALM_ENDPOINT ? process.env.MONGODB_REALM_ENDPOINT.replace(/"/g,"") : "http://localhost";
+const baseUrlPort = process.env.MONGODB_REALM_PORT || "9090";
+const baseUrl = `${baseUrlHostname}:${baseUrlPort}`;
+console.log(`tests are using integration tests app id: ${integrationTestsAppId} on ${baseUrl}`);
 
 const integrationAppConfig = {
     id: integrationTestsAppId,
-    url: `${appUrl}:${appPort}`,
+    baseUrl,
     timeout: 1000,
     app: {
         name: "default",
-        version: '0'
+        version: "0"
     },
 };
 


### PR DESCRIPTION
## What, How & Why?

This backport of https://github.com/realm/realm-js/pull/3725 closes #3612 on our master branch.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary: Since the server can no longer be self-hosted, I believe only the Realm JS tests and the Realm Cloud E2E tests would consider this change breaking.

