### PR TITLE
Fix Electron for Windows

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(realm-js SHARED
     node_init.cpp
     platform.cpp
+    ${CMAKE_JS_SRC}
 )
 
 set_target_properties(realm-js PROPERTIES 


### PR DESCRIPTION
There is an issue where Windows incorrectly binds the DLL.  This
fix corrects this.

This potentially fixes #  https://github.com/realm/realm-studio/issues/1420

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
