### PR TITLE
dictionary toJSON fix

### DIFF
--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -244,5 +244,20 @@ describe("Realm objects", () => {
             const persons = realm.objects(PersonWithId);
             expect(persons.length).equals(1);
         });
+        it("can be transmitted to JSON", () => {
+            const realm = new Realm({ schema: [PersonSchema] });
+            let john: Person;
+
+            realm.write(() => {
+                john = realm.create<Person>(PersonSchema.name, {
+                    name: "John Doe",
+                    age: 42,
+                });
+            });
+
+            const jsonObject = john.toJSON()
+
+            expect(JSON.stringify(jsonObject)).equals('{"age":42,"name":"John Doe","friends":[]}')
+        })
     });
 });

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -106,9 +106,18 @@ module.exports = function(realmConstructor, environment) {
                     }
 
                     // recursively trigger `toJSON` for Realm instances with the same cache.
-                    result[key] = (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection)
-                        ? value.toJSON(key, cache)
-                        : value;
+                    if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
+                        result[key] = value.toJSON(key, cache);
+                    } else if (value && value.put && value.remove) {
+                        // Dictionary special case to share the "cache" for dictionary-values,
+                        // in case of circular structures.
+                        result[key] =  Object.entries(value).reduce((total, [k, v]) => {
+                            total[k] = v instanceof realmConstructor.Object ? v.toJSON(k, cache) : v;
+                            return total;
+                        }, {});
+                    } else {
+                        result[key] = value;
+                    }
                 });
 
             return result;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint .",
     "test": "scripts/test.sh",
     "package": "npm ci --ignore-scripts && prebuild",
-    "install": "prebuild-install -r napi || cmake-js rebuild",
+    "install": "prebuild-install -r napi || cmake-js build",
     "rebuild": "npm run rebuild-changes",
     "build": "npm run build-changes",
     "build:arm": "npm run build-changes:arm",

--- a/tests/js/dictionary-tests.js
+++ b/tests/js/dictionary-tests.js
@@ -20,7 +20,6 @@
 
 const Realm = require("realm");
 let TestCase = require("./asserts");
-let {Decimal128, ObjectId, UUID} = require("bson")
 
 const DictSchema = {
     name: "Dictionary",
@@ -521,8 +520,23 @@ module.exports = {
         TestCase.assertThrowsException(() =>  realm.write(()=> {  D.remove( ['unknown_key'] )  }) , error)
 
         realm.close();
-    }
+    },
 
+    testDictionaryToJSON() {
+        //Shouldn't throw
+        let realm = new Realm({ schema: [DictSchema] });
+        realm.write(() =>
+            realm.create(DictSchema.name, { a: { x: 1, y: 2, z: 3 } }),
+        );
+
+        let data = realm.objects(DictSchema.name);
+
+        TestCase.assertEqual(
+            JSON.stringify(data.toJSON()),
+            '[{"a":{"x":1,"z":3,"y":2}}]',
+            "toJSON should return the correct result",
+        );
+    },
 
 
     /*TODO Comment this until we merge Mixed->Link code.


### PR DESCRIPTION
As our `toJSON` implementation keeps track (a "cache") of `Realm.Object`s traversed, additional handling is needed for dictionaries. Even though dictionaries behaves more like JS objects, dictionaries can contain object references which still needs a helping hand, in case of circular structures.