### PR TITLE
Fixed  `Realm not defined` error under Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ NOTE: Bump file format version to 21. NO DOWNGRADE PATH IS AVAILABLE.
 * Set didn't export `objectType` to Realm.schema when it contained scalar types.
 * Fixed the naming of `url` (now `baseUrl`) property on an app config to match the TypeScript declaration and other SDKs. ([#3612](https://github.com/realm/realm-js/issues/3612))
 * Add explicity support for Nullable/Undefined values for the Mixed type. ([#3731](https://github.com/realm/realm-js/issues/3731))
+* Fixed `Realm not defined` error experienced when using `Realm.Set` iterators under Jest
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/collection-methods.js
+++ b/lib/collection-methods.js
@@ -55,7 +55,7 @@ Object.defineProperty(iteratorPrototype, Symbol.iterator, {
 
 ['entries', 'keys', 'values'].forEach(function(methodName) {
     var method = function() {
-        const isSet = this instanceof Realm.Set;
+        const isSet = (this.constructor && this.constructor.name && this.constructor.name === 'Set');
         var self = (this.type === "object" || isSet) ? this.snapshot() : this;
         var index = 0;
 

--- a/src/js_set.hpp
+++ b/src/js_set.hpp
@@ -138,9 +138,9 @@ struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
 
     // properties
     static void get_size(ContextType, ObjectType, ReturnValue &);
-     static void get_optional(ContextType, ObjectType, ReturnValue &);
-     static void get_indexed(ContextType, ObjectType, uint32_t, ReturnValue &);
-     static void get_type(ContextType, ObjectType, ReturnValue &);
+    static void get_optional(ContextType, ObjectType, ReturnValue &);
+    static void get_indexed(ContextType, ObjectType, uint32_t, ReturnValue &);
+    static void get_type(ContextType, ObjectType, ReturnValue &);
 
     // methods
     static void add(ContextType, ObjectType, Arguments &, ReturnValue &);
@@ -158,34 +158,34 @@ struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
     static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
     static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
 
-     std::string const name = "Set";
+    std::string const name = "Set";
 
-     MethodMap<T> const methods = {
-        {"add", wrap<add>},
-        {"clear", wrap<clear>},
-        {"delete", wrap<delete_element>},
-        {"has", wrap<has>},
-        {"filtered", wrap<filtered>},
+    MethodMap<T> const methods = {
+       {"add", wrap<add>},
+       {"clear", wrap<clear>},
+       {"delete", wrap<delete_element>},
+       {"has", wrap<has>},
+       {"filtered", wrap<filtered>},
 
-        {"min", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Min>>},
-        {"max", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Max>>},
-        {"sum", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Sum>>},
-        {"avg", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Avg>>},
+       {"min", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Min>>},
+       {"max", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Max>>},
+       {"sum", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Sum>>},
+       {"avg", wrap<compute_aggregate_on_collection<SetClass<T>, AggregateFunc::Avg>>},
 
 
-        {"snapshot", wrap<snapshot>},
-        {"addListener", wrap<add_listener>},
-        {"removeListener", wrap<remove_listener>},
-        {"removeAllListeners", wrap<remove_all_listeners>},
-     };
+       {"snapshot", wrap<snapshot>},
+       {"addListener", wrap<add_listener>},
+       {"removeListener", wrap<remove_listener>},
+       {"removeAllListeners", wrap<remove_all_listeners>},
+    };
 
-     PropertyMap<T> const properties = {
-         {"size", {wrap<get_size>, nullptr}},
-         {"type", {wrap<get_type>, nullptr}},
-         {"optional", {wrap<get_optional>, nullptr}},
-     };
+    PropertyMap<T> const properties = {
+        {"size", {wrap<get_size>, nullptr}},
+        {"type", {wrap<get_type>, nullptr}},
+        {"optional", {wrap<get_optional>, nullptr}},
+    };
 
-     IndexPropertyType<T> const index_accessor = {nullptr, nullptr};
+    IndexPropertyType<T> const index_accessor = {nullptr, nullptr};
 
 private:
     static void validate_value(ContextType, realm::object_store::Set &, ValueType);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Fixed error that would cause `Realm.Set`'s iterators to throw a `Realm not defined` error.
This closes RJS-1196.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
~* [ ] 📝 `Compatibility` label is updated or copied from previous entry~
~* [ ] 🚦 Tests~
~* [ ] 📝 Public documentation PR created or is not necessary~
~* [ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
~* [ ] typescript definitions file is updated~
~* [ ] jsdoc files updated~
~* [ ] Chrome debug API is updated if API is available on React Native~
