### PR TITLE
Quickfix: Run Realm.App._clearAppCache() on load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * A warning to polyfill `crypto.getRandomValues` was triggered prematurely ([#3714](https://github.com/realm/realm-js/issues/3714), since v10.4.0)
+* App login function to not hang after React-Native environment was reloaded ([#3668](https://github.com/realm/realm-js/issues/3668))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,5 +65,7 @@ require("./extensions")(realmConstructor, environment);
 
 const versions = utils.getVersions();
 realmConstructor.App._setVersions(versions);
+// Temporary solution to clear the app cache when a new JS context is created (this is require for hot reloading).
+realmConstructor.App._clearAppCache();
 
 module.exports = realmConstructor;


### PR DESCRIPTION
This PR executes `Realm.App._clearAppCache()` on load, to re-matchup C++ & JS environments for RN hot-reloading.

This closes #3668