### PR TITLE
Realm Web: Added the "skipLocationRequest" configuration parameter

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,19 @@
+1.3.0 Release notes (2021-05-27)
+=============================================================
+
+### Breaking Changes
+* None
+
+### Enhancements
+* Added a configuration parameter (`disableLocationRequest`) to disable requesting a location URL via the baseUrl and use the `baseUrl` as the url prefixed for any requests initiated by this app. This can useful when connecting to a server through a reverse proxy, to avoid the location request to make the client "break out" and start requesting another server. ([#3759](https://github.com/realm/realm-js/pull/3759))
+
+
+### Fixed
+* None
+
+### Internal
+* None
+
 1.2.1 Release notes (2021-02-17)
 =============================================================
 

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -50,6 +50,11 @@ export interface AppConfiguration extends Realm.AppConfiguration {
      * Used when persisting app state, such as tokens of authenticated users.
      */
     storage?: Storage;
+    /**
+     * Skips requesting a location URL via the baseUrl and use the `baseUrl` as the url prefixed for any requests initiated by this app.
+     * This can useful when connecting to a server through a reverse proxy, to avoid the location request to make the client "break out" and start requesting another server.
+     */
+    skipLocationRequest?: boolean;
 }
 
 /**
@@ -150,6 +155,10 @@ export class App<
             throw new Error("Missing a MongoDB Realm app-id");
         }
         this.baseUrl = configuration.baseUrl || DEFAULT_BASE_URL;
+        if (configuration.skipLocationRequest) {
+            // Use the base url directly, instead of requesting a location URL from the server
+            this._locationUrl = Promise.resolve(this.baseUrl);
+        }
         this.localApp = configuration.app;
         const {
             storage,

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -116,6 +116,36 @@ describe("App", () => {
         ]);
     });
 
+    it("skips fetching the location if asked to", async () => {
+        const transport = new MockNetworkTransport([
+            {
+                user_id: "totally-valid-user-id",
+                access_token: "deadbeef",
+                refresh_token: "very-refreshing",
+            },
+        ]);
+        const app = new App({
+            id: "my-mocked-app",
+            storage: new MemoryStorage(),
+            transport,
+            baseUrl: "http://localhost:1234",
+            skipLocationRequest: true,
+        });
+        const credentials = Credentials.anonymous();
+        await app.logIn(credentials, false);
+        // Expect only a single request made via the transport
+        expect(transport.requests).deep.equals([
+            {
+                method: "POST",
+                url: `http://localhost:1234/api/client/v2.0/app/my-mocked-app/auth/providers/anon-user/login`,
+                body: {
+                    options: DEFAULT_AUTH_OPTIONS,
+                },
+                headers: SENDING_JSON_HEADERS,
+            },
+        ]);
+    });
+
     it("can log in a user", async () => {
         const storage = new MemoryStorage();
         const transport = new MockNetworkTransport([


### PR DESCRIPTION
## What, How & Why?

This closes #3758 by adding a configuration parameter to the `App` constructor that will use the `baseUrl` as `locationUrl` instead of fetching it.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
