### PR TITLE
fix dangling c_str()

### DIFF
--- a/src/android/platform.cpp
+++ b/src/android/platform.cpp
@@ -74,10 +74,10 @@ namespace realm {
                 char buf[BUFSIZ];
                 int nb_read = 0;
 
-                const char* dest_filename = (s_default_realm_directory + '/' + filename).c_str();
-                if (access(dest_filename, F_OK ) == -1) {
+                auto dest_filename = s_default_realm_directory + '/' + filename;
+                if (access(dest_filename.c_str(), F_OK ) == -1) {
                     // file doesn't exist, copy
-                    FILE* out = fopen(dest_filename, "w");
+                    FILE* out = fopen(dest_filename.c_str(), "w");
                     while ((nb_read = AAsset_read(asset, buf, BUFSIZ)) > 0) {
                         fwrite(buf, nb_read, 1, out);
                     }


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Saw a compiler warning about this, and it is a real bug, not a false positive.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
