### PR TITLE
Android RN should use same cache clearing logic as iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * A warning to polyfill `crypto.getRandomValues` was triggered prematurely ([#3714](https://github.com/realm/realm-js/issues/3714), since v10.4.0)
+* Don't hang when using the network after hot-reloading an RN app. ([#3668](https://github.com/realm/realm-js/issues/3668))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/android/jsc_override.cpp
+++ b/src/android/jsc_override.cpp
@@ -134,7 +134,7 @@ static JSGlobalContextRef create_context(JSContextGroupRef group, JSClassRef glo
     swap_function();
 
     // Clear cache from previous instances.
-    realm::_impl::RealmCoordinator::clear_all_caches();
+    RJSInvalidateCaches();
 
     RJSInitializeInContext(ctx);
     realmContextInjected = true;


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
This makes it also call `realm::app::App::clear_cached_apps()`, which
fixes #3668. This also makes it more maintainable by having a single place to
put all cache clearing logic for all RN platforms.

This PR replaces and closes #3755.


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

<del>
*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
</del>