### PR TITLE
Extend the .gitignore for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,11 @@ tests/react-test-app/ios/out.txt
 crash.log
 tests/react-test-app/ios/Pods/
 tests/react-test-app/ios/ReactTests.xcworkspace/
+tests/sync-bundle/
+tests/junitresults-*.xml
+tests/.lock
+tests/mongodb-realm/
+tests/realm-bundle.realm.backup-log
 examples/ReactExample/ios/Pods/
 examples/ReactExample/ios/ReactExample.xcworkspace/
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,0 @@
-/sync-bundle/
-/junitresults-*.xml


### PR DESCRIPTION
## What, How & Why?

The current tests are generating artifacts that do not belong in the repository.
This adds these to the .gitignore