### PR TITLE
Allow object spread syntax on realm objects

### DIFF
--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -787,7 +787,7 @@ module.exports = {
     ];
 
     realm.write(() => {
-      firstObjects.forEach(o => {
+      firstObjects.forEach((o) => {
         realm.create(schemas.IntPrimary.name, o);
       });
     });
@@ -801,5 +801,26 @@ module.exports = {
         TestCase.assertEqual(firstObjects[key], secondObjects[key], `${i}: ${key}`);
       });
     }
+
+    realm.close();
+  },
+
+  testObjectKeys: function () {
+    let realm = new Realm({ schema: [schemas.IntPrimary] });
+
+    const firstObject = { primaryCol: 1, valueCol: "one" };
+    realm.write(() => {
+      realm.create(schemas.IntPrimary.name, firstObject);
+    });
+
+    let secondObject = realm.objectForPrimaryKey(schemas.IntPrimary.name, 1);
+    const keys = Object.keys(secondObject);
+    TestCase.assertArraysEqual(keys, ["primaryCol", "valueCol"]);
+
+    const entries = Object.entries(secondObject);
+    TestCase.assertArraysEqual(entries[0], ["primaryCol", 1]);
+    TestCase.assertArraysEqual(entries[1], ["valueCol", "one"]);
+
+    realm.close();
   },
 };

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -777,4 +777,29 @@ module.exports = {
       obj.getPropertyType("foo");
     }, new Error("No such property: foo"));
   },
+
+  testObjectSpread: function () {
+    let realm = new Realm({ schema: [schemas.IntPrimary] });
+
+    const firstObjects = [
+      { primaryCol: 1, valueCol: "one" },
+      { primaryCol: 2, valueCol: "two" },
+    ];
+
+    realm.write(() => {
+      firstObjects.forEach(o => {
+        realm.create(schemas.IntPrimary.name, o);
+      });
+    });
+
+    let objects = realm.objects(schemas.IntPrimary.name);
+    const secondObjects = [{ ...objects[0] }, { ...objects[1] }];
+
+    for (let i = 0; i < firstObjects.length; i++) {
+      TestCase.assertArraysEqual(Object.keys(secondObjects[i]), Object.keys(firstObjects[i]), `${i}`);
+      Object.keys(firstObjects[i]).forEach((key) => {
+        TestCase.assertEqual(firstObjects[key], secondObjects[key], `${i}: ${key}`);
+      });
+    }
+  },
 };


### PR DESCRIPTION
## What, How & Why?

This adds a `Proxy` wrapper to each object, but only traps `ownKeys` and `getOwnPropertyDescriptor`, not `get` or `set` operations. This means that it has ~20-40% overhead in tight loops rather than a full order of magnitude from prior solutions.

If we want to, there is an easy way to allow the user to opt-in or out getting the Proxy wrapper, without too much additional code or complexity. But of course it is simpler both for us and users if there isn't an additional knob to consider.

This is still 🚧 WIP 🚧 . In particular I only changed the behavior on Node. I want to get feedback on whether we like this direction before doing the JSC implementation and adding some tests.

Fixes #2844


## ☑️ ToDos
* [ ] address all `XXX` comments
* [ ] add JSC support

<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
