### PR TITLE
Change install script to 'build' instead of 'rebuild'

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint .",
     "test": "scripts/test.sh",
     "package": "npm ci --ignore-scripts && prebuild",
-    "install": "prebuild-install -r napi || cmake-js rebuild",
+    "install": "prebuild-install -r napi || cmake-js build",
     "rebuild": "npm run rebuild-changes",
     "build": "npm run build-changes",
     "build:arm": "npm run build-changes:arm",


### PR DESCRIPTION
Everytime `npm install` is invoked for this project, the entire build is thrown away and built from scratch.  The change to `rebuild` will make sure the build artifacts are reused.  In the case that the build artifacts are not there, it will build anyway.

This change will remove the annoyance of inadvertently rebuilding the entire project during development.
