### PR TITLE
Dictionaries disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: Bump file format version to 22. NO DOWNGRADE PATH IS AVAILABLE.
 
 ### Known Issues
 * Set iterators do not work under Jest ([#3788](https://github.com/realm/realm-js/issues/3788)).
+* Properties of type dictionary is temporarily disabled and will be reintroduced.
 
 ### Internal
 * Improved the integration test harness to increase developer experience, enable tests needing a server and importing Realm apps on demand. ([#3690](https://github.com/realm/realm-js/pull/3690))

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -181,6 +181,7 @@ public:
         return SetClass<JSEngine>::create_instance(m_ctx, std::move(set));
     }
     ValueType box(realm::object_store::Dictionary dictionary) {
+        throw std::runtime_error("Dictionaries are not yet supported");
         return dictionary_adapter.wrap(m_ctx, dictionary);
     }
 

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -25,7 +25,6 @@
 #include "js_realm_object.hpp"
 #include "js_schema.hpp"
 #include "js_links.hpp"
-#include "dictionary/js_dictionary.hpp"
 
 #if REALM_ENABLE_SYNC
 #include <realm/util/base64.hpp>
@@ -182,7 +181,6 @@ public:
     }
     ValueType box(realm::object_store::Dictionary dictionary) {
         throw std::runtime_error("Dictionaries are not yet supported");
-        return dictionary_adapter.wrap(m_ctx, dictionary);
     }
 
     bool is_null(ValueType const& value) {
@@ -276,7 +274,6 @@ public:
 private:
     ContextType m_ctx;
     std::shared_ptr<Realm> m_realm;
-    DictionaryAdapter<JSEngine> dictionary_adapter;
     Obj m_parent;
     const Property* m_property = nullptr;
     const ObjectSchema* m_object_schema;

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -92,6 +92,7 @@ static inline void parse_property_type(StringData object_name, Property& prop, S
     DictionarySchema dictionary {type};
 
     if(dictionary.is_dictionary()){
+        throw std::runtime_error(util::format("The dictionary type are not yet supported: Change the type of '%1.%2'", object_name, prop.name));
         prop.type |= dictionary.schema();
         prop.object_type = "";
         return;

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <map>
-#include "dictionary/dictionary_schema.hpp"
 #include "js_types.hpp"
 #include <realm/object-store/schema.hpp>
 
@@ -89,13 +88,9 @@ static inline void parse_property_type(StringData object_name, Property& prop, S
         prop.type |= PropertyType::Nullable;
         type = type.substr(0, type.size() - 1);
     }
-    DictionarySchema dictionary {type};
 
-    if(dictionary.is_dictionary()){
+    if (type.ends_with("{}")) {
         throw std::runtime_error(util::format("The dictionary type are not yet supported: Change the type of '%1.%2'", object_name, prop.name));
-        prop.type |= dictionary.schema();
-        prop.object_type = "";
-        return;
     }
 
     if (type == "bool") {

--- a/tests/js/dictionary-tests.js
+++ b/tests/js/dictionary-tests.js
@@ -536,3 +536,9 @@ module.exports = {
 
     } */
 }
+
+module.exports = {
+    disabledDictionaryTests() {
+        console.log("Dictionary tests have been disabled");
+    }
+};


### PR DESCRIPTION
## What, How & Why?

This disables the dictionary type and related tests.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated: No, the types are left in for now.
* [ ] jsdoc files updated: No, dictionaries were never mentioned here.
* [ ] Chrome debug API is updated if API is available on React Native: Was never added.
