### PR TITLE
Realm Web: Vue reactive app instances

### DIFF
--- a/packages/realm-web-integration-tests/package-lock.json
+++ b/packages/realm-web-integration-tests/package-lock.json
@@ -279,6 +279,19 @@
 				}
 			}
 		},
+		"@vue/reactivity": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.2.tgz",
+			"integrity": "sha512-glJzJoN2xE7I2lRvwKM5u1BHRPTd1yc8iaf//Lai/78/uYAvE5DXp5HzWRFOwMlbRvMGJHIQjOqoxj87cDAaag==",
+			"requires": {
+				"@vue/shared": "3.1.2"
+			}
+		},
+		"@vue/shared": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.2.tgz",
+			"integrity": "sha512-EmH/poaDWBPJaPILXNI/1fvUbArJQmmTyVCwvvyDYDFnkPoTclAbHRAtyIvqfez7jybTDn077HTNILpxlsoWhg=="
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/packages/realm-web-integration-tests/package.json
+++ b/packages/realm-web-integration-tests/package.json
@@ -11,6 +11,7 @@
     "test:github": "ts-node harness/github.ts"
   },
   "dependencies": {
+    "@vue/reactivity": "^3.1.2",
     "chai": "^4.2.0",
     "js-base64": "^3.4.5",
     "jwt-encode": "^1.0.1",

--- a/packages/realm-web-integration-tests/src/vue/reactivity.test.ts
+++ b/packages/realm-web-integration-tests/src/vue/reactivity.test.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { reactive } from "@vue/reactivity";
+import { Credentials } from "realm-web";
+
+import { createApp } from "../utils";
+
+describe("Vue integration", () => {
+    it("authenticates", async () => {
+        const app = createApp();
+        const reactiveApp = reactive(app);
+        const credentials = Credentials.anonymous();
+        const user = await reactiveApp.logIn(credentials);
+        console.log(user);
+    });
+});

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -375,7 +375,8 @@ export class App<
                 providerType,
             });
             this.users.unshift(user);
-            return user;
+            // return user;
+            return this.users[0];
         }
     }
 


### PR DESCRIPTION
## What, How & Why?

This PR will eventually close #3820 - feel free to take over and complete the outstanding TODOs.

## ☑️ ToDos
* [ ] Refactor the packages/realm-web-integration-tests/src/utils.ts createApp function to optionally be instrumented to pass the app instance to a function before returning it.
* [ ] Use the mechanism above to run all tests in a mode where apps created using the utils.ts createApp function will wrap instances making them "Vue reactive".
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
