### PR TITLE
Optimize build-ios

### DIFF
--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -9,25 +9,77 @@ PROJECT_ROOT=$(pwd)
 SCRIPT=$(basename "${BASH_SOURCE[0]}")
 
 function usage {
-    echo "Usage: ${SCRIPT} [-c <configuration>] [-s]"
+    echo "Usage: ${SCRIPT} [-c <configuration>] [<platforms>]"
     echo ""
     echo "Arguments:"
     echo "   -c : build configuration (Debug or Release)"
-    echo "   -s : simulator-only build"
+    echo "   <platforms> : platforms to build for (catalyst, ios, or simulator)"
     exit 1;
 }
 
 CONFIGURATION=Release
+SUPPORT_PLATFORMS=(catalyst ios simulator)
+
+function is_supported_platform(){
+    for platform in "${SUPPORT_PLATFORMS[@]}"; do
+        [[ "${platform}" == $1 ]] && return 0
+    done
+    return 1
+}
 
 # Parse the options
-while getopts ":c:s" opt; do
+while getopts ":c:" opt; do
     case "${opt}" in
         c) CONFIGURATION=${OPTARG};;
-        s) SIMULATOR_ONLY=1;;
         *) usage;;
     esac
 done
+
 shift $((OPTIND-1))
+PLATFORMS=($@)
+
+if [ -z ${PLATFORMS} ]; then
+    echo "No platform given. building all platforms...";
+    PLATFORMS=(ios catalyst simulator)
+else
+    echo "Building for...";
+    for check_platform in "${PLATFORMS[@]}"; do
+        if ! is_supported_platform $check_platform; then
+            echo "${check_platform} is not a supported platform"
+            usage
+            exit 1
+        fi
+        echo ${check_platform};
+    done
+fi
+
+DESTINATIONS=()
+LIBRARIES=()
+BUILD_LIB_CMDS=()
+for platform in "${PLATFORMS[@]}"; do
+    case "$platform" in 
+        ios)
+            DESTINATIONS+=(-destination 'generic/platform=iOS')
+            LIBRARIES+=(-library ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a -headers ./_include)
+            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a ./out/$CONFIGURATION-iphoneos/*.a")
+        ;;
+        catalyst)
+            DESTINATIONS+=(-destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst')
+            LIBRARIES+=(-library ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a -headers ./_include)
+            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a ./out/$CONFIGURATION-maccatalyst/*.a")
+        ;;
+        simulator)
+            DESTINATIONS+=(-destination 'generic/platform=iOS Simulator')
+            LIBRARIES+=(-library ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a -headers ./_include)
+            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a ./out/$CONFIGURATION-iphonesimulator/*.a")
+        ;;
+        *)
+            echo "${platform} not supported"
+            usage
+            exit 1
+        ;;
+    esac
+done
 
 pushd react-native/ios
 
@@ -39,29 +91,18 @@ cmake "$PROJECT_ROOT" -GXcode \
     -DCMAKE_TOOLCHAIN_FILE="$PROJECT_ROOT/cmake/ios.toolchain.cmake" \
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="$(pwd)/out/$<CONFIG>\$EFFECTIVE_PLATFORM_NAME" \
 
-destinations=(-destination 'generic/platform=iOS Simulator')
-[[ -z $SIMULATOR_ONLY ]] && destinations+=(-destination 'generic/platform=iOS')
-destinations+=(-destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst')
-
 xcodebuild build \
     -scheme realm-js-ios \
-    "${destinations[@]}" \
+    "${DESTINATIONS[@]}" \
     -configuration $CONFIGURATION \
     ONLY_ACTIVE_ARCH=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     SUPPORTS_MACCATALYST=YES
 
-xcrun libtool -static -o ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a ./out/$CONFIGURATION-maccatalyst/*.a
-[[ -z $SIMULATOR_ONLY ]] && xcrun libtool -static -o ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a ./out/$CONFIGURATION-iphoneos/*.a
-xcrun libtool -static -o ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a ./out/$CONFIGURATION-iphonesimulator/*.a
-
 mkdir -p _include/realm-js-ios
 cp "$PROJECT_ROOT"/src/jsc/{jsc_init.h,rpc.hpp} _include/realm-js-ios/
 
 rm -rf ../realm-js-ios.xcframework
-libraries=(-library ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a -headers ./_include)
-libraries+=(-library ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a -headers ./_include)
-[[ -z $SIMULATOR_ONLY ]] && libraries+=(-library ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a -headers ./_include)
 xcodebuild -create-xcframework \
-    "${libraries[@]}" \
+    "${LIBRARIES[@]}" \
     -output ../realm-js-ios.xcframework

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -308,7 +308,7 @@ case "$TARGET" in
   npm run check-environment
 
   echo "building iOS binaries"
-  ./scripts/build-ios.sh -s -c $CONFIGURATION
+  ./scripts/build-ios.sh -c $CONFIGURATION simulator
 
   set_nvm_default
   start_server
@@ -324,12 +324,33 @@ case "$TARGET" in
   xctest ReactTestApp
   stop_server
   ;;
+"catalyst-tests")
+  npm ci --ignore-scripts
+  npm run check-environment
+
+  echo "building catalyst binaries"
+  ./scripts/build-ios.sh -c $CONFIGURATION catalyst
+
+  set_nvm_default
+  start_server
+
+  pushd tests/ReactTestApp
+  npm ci --no-optional
+  ./node_modules/.bin/install-local
+  open_chrome
+  start_packager
+
+  pushd ios
+  pod install
+  catalystTest ReactTestApp
+  stop_server
+  ;;
 "react-example")
   npm ci --ignore-scripts
   npm run check-environment
 
   echo "building iOS binaries"
-  ./scripts/build-ios.sh -s -c $CONFIGURATION
+  ./scripts/build-ios.sh -c $CONFIGURATION simulator
 
   set_nvm_default
 


### PR DESCRIPTION
After adding Catalyst, the build script would always build catalyst, even if "simulator-only" was selected.
This change removees the simulator-only flag in favor of an a list of supported platforms.
Example usage:

builds all:
./script/build-ios.sh

builds catalyst only:
./script/build-ios.sh catalyst

builds catalyst and ios in debug mode
./script/build-ios.sh -c Debug ios catalyst

## ☑️ ToDos

* [ ] 📝 Changelog entry
* [ ] Update any documentation

