### PR TITLE
Fixing "Right-hand side of 'instanceof' is not an object" and adding dictionary integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fix TypeScript definition of `Realm.Dictionary.remove()`. (since v10.6.0)
+* Fixed TypeScript definition of `Realm.Dictionary.remove()`. (since v10.6.0)
+* Fixed Realm.Object#toJSON as it threw "Right-hand side of 'instanceof' is not an object". (since v10.6.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -27,7 +27,7 @@ const logcat = require("./logcat");
 const IOS_DEVICE_NAME = "realm-js-integration-tests";
 const IOS_DEVICE_TYPE_ID = "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
 
-const { MOCHA_REMOTE_PORT, PLATFORM, HEADLESS_DEBUGGER, SPAWN_LOGCAT } = process.env;
+const { MOCHA_REMOTE_PORT, PLATFORM, HEADLESS_DEBUGGER, SPAWN_LOGCAT, SKIP_RUNNER } = process.env;
 
 if (typeof PLATFORM !== "string") {
   throw new Error("Expected a 'PLATFORM' environment variable");
@@ -204,6 +204,10 @@ function optionalStringToBoolean(value) {
 }
 
 if (module.parent === null) {
+  if (SKIP_RUNNER === "true") {
+    console.log("Skipping the runner - you're on your own");
+    process.exit(0);
+  }
   const headlessDebugger = optionalStringToBoolean(HEADLESS_DEBUGGER);
   const spawnLogcat = optionalStringToBoolean(SPAWN_LOGCAT);
   run(headlessDebugger, spawnLogcat).catch((err) => {

--- a/integration-tests/environments/react-native/ios/RealmReactNativeTests/AppDelegate.m
+++ b/integration-tests/environments/react-native/ios/RealmReactNativeTests/AppDelegate.m
@@ -53,7 +53,8 @@ static void InitializeFlipper(UIApplication *application) {
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  // Fetching with inlineSourceMap=true to ease debugging.
+  return [NSURL URLWithString:[[[[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil] absoluteString] stringByAppendingString:@"&inlineSourceMap=true" ]];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -46,5 +46,6 @@ require("./tests/objects");
 require("./tests/iterators");
 require("./tests/dynamic-schema-updates");
 require("./tests/bson");
+require("./tests/dictionary");
 require("./tests/credentials/anonymous");
 require("./tests/sync/mixed");

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -181,6 +181,20 @@ describe("Dictionary", () => {
       });
     });
 
+    it("can JSON.stringify via the object", function (this: RealmContext) {
+      this.realm.write(() => {
+        const values: DictValues = {
+          key1: "hello",
+          key2: 1234,
+          key3: false,
+          key4: null,
+        };
+        const item = this.realm.create<Item>("Item", { dict: values });
+        const stringifiedAndParsed = JSON.parse(JSON.stringify(item));
+        expect(stringifiedAndParsed).deep.equals({ dict: values });
+      });
+    });
+
     // TODO: Unskip once https://github.com/realm/realm-core/issues/4805 is fixed
     it.skip("throws a meaningful error if accessed after deletion", function (this: RealmContext) {
       this.realm.write(() => {
@@ -241,7 +255,7 @@ describe("Dictionary", () => {
       it("fails if type mismatch", function (this: RealmContext) {
         this.realm.write(() => {
           expect(() => {
-            const item = this.realm.create<Item>("Item", {
+            this.realm.create<Item>("Item", {
               dict: badValues,
             });
           }).throws(expectedError);

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -1,0 +1,283 @@
+import { assert, expect } from "chai";
+import Realm from "realm";
+
+import { openRealmBefore } from "../hooks";
+
+type Item<ValueType = Realm.Mixed> = {
+  dict: Realm.Dictionary<ValueType>;
+}
+
+type DictValues = { [key: string]: unknown };
+
+type ValueGenerator = (realm: Realm) => DictValues;
+
+type TypedDictionarySuite = {
+  extraSchema?: Realm.ObjectSchema[];
+  type: string;
+  goodValues: DictValues | ValueGenerator;
+  badValues: DictValues;
+  expectedError: string;
+};
+
+describe("Dictionary", () => {
+  describe("with unconstrained (mixed) values", () => {
+    openRealmBefore({
+      schema: [{
+        name: "Item",
+        properties: { dict: "{}" },
+      }, {
+        name: "Person",
+        properties: { name: "string" },
+      }],
+    });
+    
+    it("can be used as a property type in a schema", function(this: RealmContext) {
+      expect(this.realm.isClosed).equals(false);
+      const dictSchemaProperty = this.realm.schema[0].properties.dict as Realm.ObjectSchemaProperty;
+      expect(typeof dictSchemaProperty).equals("object");
+      expect(dictSchemaProperty.type).equals("dictionary");
+      expect(dictSchemaProperty.objectType).equals("mixed");
+    });
+  
+    it("is instanceof Dictionary", function(this: RealmContext) {
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+        expect(item.dict instanceof Realm.Dictionary);
+      });
+    });
+  
+    const methodNames = [
+      // "get",
+      "set",
+      "remove",
+      "addListener",
+      "removeListener",
+      "removeAllListeners",
+    ];
+    for (const name of methodNames) {
+      it(`expose a method named '${name}'`, function(this: RealmContext) {
+        this.realm.write(() => {
+          const item = this.realm.create<Item>("Item", {});
+          expect(typeof item.dict[name]).equals("function");
+        });
+      });
+    }
+  
+    it("can store string values using string keys", function(this: RealmContext) {
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+        item.dict.key1 = "hello";
+        expect(item.dict.key1).equals("hello");
+      });
+    });
+  
+    it("can store number values using string keys", function(this: RealmContext) {
+      this.realm.write(() => {
+        // Creation
+        const item = this.realm.create<Item<number>>("Item", {
+          dict: { key1: 0 }
+        });
+        expect(item.dict).deep.equals({ key1: 0 });
+        // Assignment
+        item.dict.key1 = 1234;
+        item.dict.key2 = Number.MAX_VALUE;
+        item.dict.key3 = Number.MIN_VALUE;
+        expect(item.dict).deep.equals({
+          key1: 1234,
+          key2: Number.MAX_VALUE,
+          key3: Number.MIN_VALUE
+        });
+        // Increments
+        item.dict.key1++;
+        expect(item.dict.key1).equals(1235);
+      });
+    });
+  
+    it("can store boolean values using string keys", function(this: RealmContext) {
+      this.realm.write(() => {
+        // Creation
+        const item = this.realm.create<Item>("Item", {
+          dict: {
+            key1: true,
+            key2: false,
+          }
+        });
+        expect(item.dict).deep.equals({
+          key1: true,
+          key2: false
+        });
+        // After assignment
+        item.dict.key1 = false;
+        item.dict.key2 = true;
+        expect(item.dict).deep.equals({
+          key1: false,
+          key2: true
+        });
+      });
+    });
+  
+    it("can store object link values using string keys", function(this: RealmContext) {
+      this.realm.write(() => {
+        const alice = this.realm.create("Person", { name: "Alice" });
+        const bob = this.realm.create("Person", { name: "Bob" });
+        // Creation
+        const item = this.realm.create<Item>("Item", {
+          dict: {
+            key1: alice,
+          }
+        });
+        expect(item.dict).deep.equals({
+          key1: alice,
+        });
+        // After assignment
+        item.dict.key1 = bob;
+        expect(item.dict).deep.equals({
+          key1: bob
+        });
+      });
+    });
+  
+    it("is spreadable", function(this: RealmContext) {
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {
+          dict: { key1: "hi" },
+        });
+        expect({ ...item.dict }).deep.equals({ key1: "hi" });
+      });
+    });
+    
+    it("can JSON.stringify", function(this: RealmContext) {
+      this.realm.write(() => {
+        const values: DictValues = {
+          key1: "hello",
+          key2: 1234,
+          key3: false,
+          key4: null
+        };
+        const item = this.realm.create<Item>("Item", { dict: values });
+        const stringifiedAndParsed = JSON.parse(JSON.stringify(item.dict));
+        expect(stringifiedAndParsed).deep.equals(values);
+      });
+    });
+    
+    // TODO: Unskip once https://github.com/realm/realm-core/issues/4805 is fixed
+    it.skip("throws a meaningful error if accessed after deletion", function(this: RealmContext) {
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+        const dict = item.dict
+        this.realm.delete(item);
+        expect(() => {
+          JSON.stringify(dict);
+        }).throws("Access to invalidated Dictionary object");
+      });
+    });
+  
+    it("can have values deleted", function(this: RealmContext) {
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {
+          dict: { key1: "hi" },
+        });
+        expect(item.dict).deep.equals({ key1: "hi" });
+        delete item.dict.key1;
+        expect(Object.keys(item.dict)).deep.equals([]);
+        // TODO: Investigate why this blocks
+        // expect(item.dict).deep.equals({});
+      });
+    });
+  });
+
+  function describeTypedSuite({
+    extraSchema = [],
+    type,
+    goodValues,
+    badValues,
+    expectedError
+  }: TypedDictionarySuite) {
+    return describe(`with constrained '${type}' values`, () => {
+      openRealmBefore({
+        schema: [{
+          name: "Item",
+          properties: { dict: `${type}{}` },
+        }, ...extraSchema],
+      });
+
+      it("can initialize", function(this: RealmContext) {
+        this.realm.write(() => {
+          const values = typeof goodValues === "function" ? goodValues(this.realm) : goodValues;
+          const item = this.realm.create<Item>("Item", { dict: values });
+          expect(item.dict).deep.equals(values);
+        });
+      });
+
+      it("can assign", function(this: RealmContext) {
+        this.realm.write(() => {
+          const item = this.realm.create<Item>("Item", {});
+          const values = typeof goodValues === "function" ? goodValues(this.realm) : goodValues;
+          for (const [k, v] of Object.entries(values)) {
+            item.dict[k] = v;
+          }
+          expect(item.dict).deep.equals(values);
+        });
+      });
+
+      it("fails if type mismatch", function(this: RealmContext) {
+        this.realm.write(() => {
+          expect(() => {
+            const item = this.realm.create<Item>("Item", {
+              dict: badValues,
+            });
+          }).throws(expectedError);
+        });
+      });
+    });
+  }
+
+  describeTypedSuite({
+    type: "int",
+    goodValues: {
+      key1: 0,
+      key2: 0,
+      key3: 0,
+    },
+    badValues: {
+      key1: "this is a string"
+    },
+    expectedError: "Property must be of type 'number'"
+  });
+
+  describeTypedSuite({
+    type: "string",
+    goodValues: {
+      key1: "hi",
+      key2: "there"
+    },
+    badValues: {
+      key1: false
+    },
+    expectedError: "Property must be of type 'string'"
+  });
+
+  describeTypedSuite({
+    type: "bool",
+    goodValues: {
+      key1: true,
+      key2: false
+    },
+    badValues: {
+      key1: 1234
+    },
+    expectedError: "Property must be of type 'boolean'"
+  });
+
+  describeTypedSuite({
+    extraSchema: [{ name: "Person", properties: { name: "string" }}],
+    type: "Person",
+    goodValues: realm => ({
+      key1: realm.create("Person", { name: "Alice" })
+    }),
+    badValues: {
+      key1: "unexpected string"
+    },
+    expectedError: "JS value must be of type 'object'"
+  });
+});

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -27,16 +27,6 @@ type Item<ValueType = Realm.Mixed> = {
 
 type DictValues = { [key: string]: unknown };
 
-type ValueGenerator = (realm: Realm) => DictValues;
-
-type TypedDictionarySuite = {
-  extraSchema?: Realm.ObjectSchema[];
-  type: string;
-  goodValues: DictValues | ValueGenerator;
-  badValues: DictValues;
-  expectedError: string;
-};
-
 describe("Dictionary", () => {
   describe("with unconstrained (mixed) values", () => {
     openRealmBefore({
@@ -60,7 +50,7 @@ describe("Dictionary", () => {
       expect(dictSchemaProperty.objectType).equals("mixed");
     });
 
-    it("is instanceof Dictionary", function (this: RealmContext) {
+    it("is an instance of Dictionary", function (this: RealmContext) {
       this.realm.write(() => {
         const item = this.realm.create<Item>("Item", {});
         expect(item.dict instanceof Realm.Dictionary);
@@ -76,7 +66,7 @@ describe("Dictionary", () => {
       "removeAllListeners",
     ];
     for (const name of methodNames) {
-      it(`expose a method named '${name}'`, function (this: RealmContext) {
+      it(`exposes a method named '${name}'`, function (this: RealmContext) {
         this.realm.write(() => {
           const item = this.realm.create<Item>("Item", {});
           expect(typeof item.dict[name]).equals("function");
@@ -108,9 +98,6 @@ describe("Dictionary", () => {
           key2: Number.MAX_VALUE,
           key3: Number.MIN_VALUE,
         });
-        // Increments
-        item.dict.key1++;
-        expect(item.dict.key1).equals(1235);
       });
     });
 
@@ -160,10 +147,8 @@ describe("Dictionary", () => {
 
     it("is spreadable", function (this: RealmContext) {
       this.realm.write(() => {
-        const item = this.realm.create<Item>("Item", {
-          dict: { key1: "hi" },
-        });
-        expect({ ...item.dict }).deep.equals({ key1: "hi" });
+        const item = this.realm.create<Item>("Item", { dict: { key1: "hi" } });
+        expect({ ...item.dict, key2: "hello" }).deep.equals({ key1: "hi", key2: "hello" });
       });
     });
 
@@ -220,6 +205,16 @@ describe("Dictionary", () => {
       });
     });
   });
+
+  type ValueGenerator = (realm: Realm) => DictValues;
+
+  type TypedDictionarySuite = {
+    extraSchema?: Realm.ObjectSchema[];
+    type: string;
+    goodValues: DictValues | ValueGenerator;
+    badValues: DictValues;
+    expectedError: string;
+  };
 
   function describeTypedSuite({ extraSchema = [], type, goodValues, badValues, expectedError }: TypedDictionarySuite) {
     return describe(`with constrained '${type}' values`, () => {

--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import { expect } from "chai";
+import Realm from "realm";
 
 import { importAppBefore, authenticateUserBefore, openRealmBefore } from "../../hooks";
 

--- a/lib/browser/constants.js
+++ b/lib/browser/constants.js
@@ -32,6 +32,7 @@ export const propTypes = {};
   "FUNCTION",
   "LIST",
   "SET",
+  "DICTIONARY",
   "OBJECT",
   "REALM",
   "RESULTS",

--- a/lib/browser/dictionaries.js
+++ b/lib/browser/dictionaries.js
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Collection, { createCollection } from "./collections";
+
+export default class Dictionary extends Collection {
+  constructor() {
+    throw new Error("Dictionaries are not yet supported in Chrome debugging mode");
+  }
+}
+
+export function createDictionary(realmId, info) {
+  return createCollection(Dictionary.prototype, realmId, info, true);
+}

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -21,6 +21,7 @@ import { keys, objectTypes } from "./constants";
 import Collection from "./collections";
 import List, { createList } from "./lists";
 import Set, { createSet } from "./sets";
+import Dictionary, { createDictionary } from "./dictionaries";
 import Results, { createResults } from "./results";
 import RealmObject, * as objects from "./objects";
 import User, { createUser } from "./user";
@@ -38,6 +39,7 @@ const { debugHosts, debugPort } = NativeModules.Realm;
 
 rpc.registerTypeConverter(objectTypes.LIST, createList);
 rpc.registerTypeConverter(objectTypes.SET, createSet);
+rpc.registerTypeConverter(objectTypes.DICTIONARY, createDictionary);
 rpc.registerTypeConverter(objectTypes.RESULTS, createResults);
 rpc.registerTypeConverter(objectTypes.OBJECT, objects.createObject);
 rpc.registerTypeConverter(objectTypes.REALM, createRealm);
@@ -161,6 +163,9 @@ Object.defineProperties(Realm, {
   },
   Set: {
     value: Set,
+  },
+  Dictionary: {
+    value: Dictionary,
   },
   Results: {
     value: Results,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -254,6 +254,11 @@ declare namespace Realm {
 
     type DictionaryChangeCallback = (dict: Dictionary, changes: DictionaryChangeSet) => void;
 
+    const Dictionary: {
+        new(): never; // This type isn't supposed to be constructed manually by end users.
+        readonly prototype: Dictionary;
+    };
+
     interface DictionaryBase<ValueType = Mixed> {
         /**
          * Adds given element to the dictionary
@@ -340,6 +345,7 @@ declare namespace Realm {
     }
 
     const Collection: {
+        new(): never; // This type isn't supposed to be constructed manually by end users.
         readonly prototype: Collection<any>;
     };
 
@@ -375,6 +381,7 @@ declare namespace Realm {
     }
 
     const List: {
+        new(): never; // This type isn't supposed to be constructed manually by end users.
         readonly prototype: List<any>;
     };
 
@@ -414,6 +421,7 @@ declare namespace Realm {
     }
 
     const Set: {
+        new(): never; // This type isn't supposed to be constructed manually by end users.
         readonly prototype: Set<any>;
     };
 
@@ -432,6 +440,7 @@ declare namespace Realm {
     }
 
     const Results: {
+        new(): never; // This type isn't supposed to be constructed manually by end users.
         readonly prototype: Results<any>;
     };
 


### PR DESCRIPTION
## What, How & Why?

While debugging the alternative dictionary implementation last week, I wrote a couple of tests in our integration test suite.

This fixes #3836 and #3860.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary