### PR TITLE
Fix linking libraries for multiple platforms

### DIFF
--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -99,7 +99,7 @@ xcodebuild build \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     SUPPORTS_MACCATALYST=YES
 
-for cmd in "${BUILD_LIB_CMDS}"; do
+for cmd in "${BUILD_LIB_CMDS[@]}"; do
     eval "${cmd}"
 done
 


### PR DESCRIPTION
There is a bug in the build script.  It was only linking the core realm libraries for the first platform given.