### PR TITLE
Fix TS definition of Realm.Dictionary.remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fix TypeScript definition of `Realm.Dictionary.remove()`. (since v10.6.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -261,9 +261,10 @@ declare namespace Realm {
         set(element:{[key:string]: ValueType}): void;
 
         /**
-         * @returns Removes given element from the dictionary
+         * Removes given element from the dictionary
+         * @returns The dictionary
          */
-        remove(element:{[key:string]: ValueType}): void;
+        remove(key:string|string[]): DictionaryBase<ValueType>;
 
         /**
          * @returns void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -258,7 +258,7 @@ declare namespace Realm {
         /**
          * @returns Adds given element to the dictionary
          */
-        set(element:{[key:string]: ValueType}): void;
+        set(element:{[key:string]: ValueType}): DictionaryBase<ValueType>;
 
         /**
          * Removes given element from the dictionary

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -256,7 +256,8 @@ declare namespace Realm {
 
     interface DictionaryBase<ValueType = Mixed> {
         /**
-         * @returns Adds given element to the dictionary
+         * Adds given element to the dictionary
+         * @returns The dictionary
          */
         set(element:{[key:string]: ValueType}): DictionaryBase<ValueType>;
 


### PR DESCRIPTION
## What, How & Why?

A fix of `Realm.Dictionary.remove()`'s TypeScript definition.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
