### PR TITLE
Fix Integration Test and Linter Pipelines

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -236,6 +236,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          target: google_apis
           script: npm run test:android --prefix integration-tests/environments/react-native
         env:
           MOCHA_REMOTE_CONTEXT: missingServer
@@ -247,6 +248,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          target: google_apis
           script: npm run test:android:chrome --prefix integration-tests/environments/react-native
         env:
           MOCHA_REMOTE_CONTEXT: missingServer

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -20,7 +20,7 @@
     "runner": "node harness/runner.js",
     "prepare": "npm run install-local && npm run pod-install",
     "install-local": "npm_config_ignore_scripts=true install-local",
-    "pod-install": "cd ios && pod install"
+    "pod-install": "npx pod-install"
   },
   "dependencies": {
     "@react-native-community/art": "^1.2.0",


### PR DESCRIPTION
There seems to be a problem with the android-emulator-runner action.  Using the workaround posted in this issue:
https://github.com/ReactiveCircus/android-emulator-runner/issues/168

The linting pipeline is running ubuntu-latest, which does not have cocoa pods.  One of the lerna dependencies (realm-react-native-tests) was invoking `pod install`.  Changed this to use the npm package `pod-install` which will not crash on non-mac systems.
