### PR TITLE
Fix some errors in Node.js caused by react-native

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { NativeModules } from "react-native";
+//import { NativeModules } from "react-native";
 import { keys, objectTypes } from "./constants";
 import Collection from "./collections";
 import List, { createList } from "./lists";
@@ -35,7 +35,7 @@ import { invalidateCache } from "./cache";
 import { performFetch } from "./fetch";
 import { createEmailPasswordAuth } from "./email-password-auth";
 
-const { debugHosts, debugPort } = NativeModules.Realm;
+//const { debugHosts, debugPort } = NativeModules.Realm;
 
 rpc.registerTypeConverter(objectTypes.LIST, createList);
 rpc.registerTypeConverter(objectTypes.SET, createSet);
@@ -220,7 +220,7 @@ Object.defineProperties(Realm, {
   },
 });
 
-for (let i = 0, len = debugHosts.length; i < len; i++) {
+/*for (let i = 0, len = debugHosts.length; i < len; i++) {
   try {
     Realm[keys.id] = rpc.createSession(debugHosts[i] + ":" + debugPort, { performFetch });
     break;
@@ -239,4 +239,4 @@ for (let i = 0, len = debugHosts.length; i < len; i++) {
         "reachable on the same network as this machine.",
     );
   }
-}
+}*/


### PR DESCRIPTION
This React-Native lines caused some problems for Svelte Node.js App.
I had to comment `NativeModules` and `debugHosts, debugPort` avoid errors in `Node.js`.
