### PR TITLE
Set the GHA job timeout for RN tests to 60 minutes.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,6 +99,7 @@ jobs:
   react-native-ios:
     name: React Native on ${{matrix.platform.name}} (${{ matrix.type }})
     runs-on: macos-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +191,7 @@ jobs:
         #TODO: Reactivate debug when builds are optimized
         #type: [Release, Debug]
         type: [Release]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## What, How & Why?
This adds an explicit timeout for RN test jobs set to 60 minutes to avoid situations where they run forever.