### PR TITLE
Disable analytics on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+* Disable analytics if the `CI` environment variable is set to some value.
 
 10.7.0 Release notes (2021-8-30)
 =============================================================

--- a/lib/submit-analytics.js
+++ b/lib/submit-analytics.js
@@ -95,8 +95,8 @@ function isAnalyticsDisabled() {
     // ignore error
   }
 
-  // Or if the user has specifically opted-out
-  return "REALM_DISABLE_ANALYTICS" in process.env;
+  // If the user has specifically opted-out or if we're running in a CI environment
+  return "REALM_DISABLE_ANALYTICS" in process.env || "CI" in process.env;
 }
 
 function sha256(data) {

--- a/react-native/android/analytics.gradle
+++ b/react-native/android/analytics.gradle
@@ -57,8 +57,9 @@ class SendAnalyticsTask extends DefaultTask {
     def sendAnalytics() {
        try {
             def env = System.getenv()
-            def disableAnalytics= env['REALM_DISABLE_ANALYTICS']
-            if (disableAnalytics == null || disableAnalytics != "true") {
+            def disableAnalytics = env['REALM_DISABLE_ANALYTICS'] != null
+            def isCI = env['CI'] != null
+            if (!disableAnalytics && !isCI) {
                 send()
             }
        } catch(all) {}

--- a/react-native/ios/RealmReact/RealmAnalytics.mm
+++ b/react-native/ios/RealmReact/RealmAnalytics.mm
@@ -227,7 +227,7 @@ static NSDictionary *RLMAnalyticsPayload() {
 }
 
 void RLMSendAnalytics() {
-    if (getenv("REALM_DISABLE_ANALYTICS") || !RLMIsDebuggerAttached()) {
+    if (getenv("REALM_DISABLE_ANALYTICS") || getenv("CI") || !RLMIsDebuggerAttached()) {
         return;
     }
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Most CI services will set the environment variable `CI` to some value, so it's a good idea to check for it and make sure we don't count CI builds as actual developers.

* [Github Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables)
* [Travis CI](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)
* [Appveyor](https://www.appveyor.com/docs/environment-variables/)
* [Jenkins](https://github.com/jenkinsci/jenkins/pull/5370)

Additionally, it modifies the Gradle analytics plugin to not check for the value of `REALM_DISABLE_ANALYTICS` since that is what we do on node/electron and React Native for iOS.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry