### PR TITLE
Get Realm.Object property type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Enhancements
 * Synchronized Realms are no longer opened twice, cutting the address space and file descriptors used in half. ([realm/realm-core#4839](https://github.com/realm/realm-core/pull/4839))
 * `Realm.write()` now returns callback return value. ([#2237](https://github.com/realm/realm-js/issues/2237))
+* Added `Realm.Object.getPropertyType()` which returns the type of the property. For a mixed property, the underlying type will be returned. ([#3646](https://github.com/realm/realm-js/issues/3646))
 
 ### Fixed
 * Fixed issue when opening a synced Realm is prevented by assertion "m_state == SyncUser::State::LoggedIn". ([realm/realm-core#4875](https://github.com/realm/realm-core/issues/4875), since v10.0.0)

--- a/docs/object.js
+++ b/docs/object.js
@@ -99,5 +99,5 @@ class Object {
    * @throws {Error} If property does not exist.
    * @since 10.8.0
    */
-   getPropertyType(propertyName) {}
+  getPropertyType(propertyName) {}
 }

--- a/docs/object.js
+++ b/docs/object.js
@@ -91,4 +91,13 @@ class Object {
    * @since 2.23.0
    */
   removeAllListeners() {}
+
+  /**
+   * Get underlying type of a property value.
+   * @param {string} propertyName - The name of the property to retrieve the type of.
+   * @returns {string} Underlying type of the property value.
+   * @throws {Error} If property does not exist.
+   * @since 10.8.0
+   */
+   getPropertyType(propertyName) {}
 }

--- a/lib/browser/objects.js
+++ b/lib/browser/objects.js
@@ -36,6 +36,7 @@ createMethods(RealmObject.prototype, objectTypes.OBJECT, [
   "addListener",
   "removeListener",
   "removeAllListeners",
+  "getPropertyType",
 ]);
 
 export function clearRegisteredConstructors() {

--- a/src/common/type_deduction.hpp
+++ b/src/common/type_deduction.hpp
@@ -51,7 +51,7 @@ class GenericTypeDeductionImpl {
         realm_to_js_map = {
             {types::String, "String"},       {types::Integer, "Int"},
             {types::Float, "Float"},         {types::Double, "Double"},
-            {types::Decimal, "Decimal128"},  {types::Boolean, "Boolean"},
+            {types::Decimal, "Decimal128"},  {types::Boolean, "Bool"},
             {types::ObjectId, "ObjectId"},   {types::Object, "Object"},
             {types::UUID, "UUID"},       {types::Object, "Object"},
             {types::Undefined, "Undefined"}, {types::Null, "Null"}};

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -741,7 +741,7 @@ module.exports = {
     realm.write(() => {
       obj = realm.create(schemas.AllTypes.name, allTypesValues);
       mixedNull = realm.create(MixedSchema.name, { key: "zero", value: null });
-      mixedInt = realm.create(MixedSchema.name, { key: "one", value: 1 });
+      mixedInt = realm.create(MixedSchema.name, { key: "one", value: 1 }); // for mixed, all JavaScript numbers are saved as "double"
       mixedString = realm.create(MixedSchema.name, { key: "two", value: "two" });
       mixedFloat = realm.create(MixedSchema.name, { key: "three", value: 3.0 });
       mixedBool = realm.create(MixedSchema.name, { key: "five", value: true });
@@ -764,9 +764,9 @@ module.exports = {
     TestCase.assertEqual(obj.getPropertyType("objectArrayCol"), "array<TestObject>");
 
     TestCase.assertEqual(mixedNull.getPropertyType("value"), "null");
-    TestCase.assertEqual(mixedInt.getPropertyType("value"), "double"); // we translate all numbers to "double"
+    TestCase.assertEqual(mixedInt.getPropertyType("value"), "double"); // see comment above
     TestCase.assertEqual(mixedString.getPropertyType("value"), "string");
-    TestCase.assertEqual(mixedFloat.getPropertyType("value"), "double"); // we translate all numbers to "double"
+    TestCase.assertEqual(mixedFloat.getPropertyType("value"), "double");
     TestCase.assertEqual(mixedBool.getPropertyType("value"), "bool");
     [mixedNull, mixedInt, mixedFloat, mixedString, mixedBool].forEach((mixed) => {
       TestCase.assertEqual(mixed.getPropertyType("key"), "string", `${mixed.key}`);

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -734,7 +734,7 @@ module.exports = {
     realm.write(function () {
       obj = realm.create("AllTypesObject", allTypesValues);
     });
-    
+
     TestCase.assertEqual(obj.getPropertyType("boolCol"), "bool");
     TestCase.assertEqual(obj.getPropertyType("floatCol"), "float");
     TestCase.assertEqual(obj.getPropertyType("doubleCol"), "double");
@@ -753,7 +753,7 @@ module.exports = {
 
     // property that does not exist
     TestCase.assertThrowsException(() => {
-      obj.getPropertyType('foo');
+      obj.getPropertyType("foo");
     }, new Error("No such property: foo"));
   },
 };

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -724,4 +724,36 @@ module.exports = {
       }, 2000);
     });
   },
+
+  testGetPropertyType: function () {
+    const realm = new Realm({
+      schema: [schemas.AllTypes, schemas.TestObject, schemas.LinkToAllTypes],
+    });
+    let obj;
+
+    realm.write(function () {
+      obj = realm.create("AllTypesObject", allTypesValues);
+    });
+    
+    TestCase.assertEqual(obj.getPropertyType("boolCol"), "bool");
+    TestCase.assertEqual(obj.getPropertyType("floatCol"), "float");
+    TestCase.assertEqual(obj.getPropertyType("doubleCol"), "double");
+    TestCase.assertEqual(obj.getPropertyType("stringCol"), "string");
+    TestCase.assertEqual(obj.getPropertyType("dateCol"), "date");
+    TestCase.assertEqual(obj.getPropertyType("dataCol"), "data");
+    TestCase.assertEqual(obj.getPropertyType("objectCol"), "<TestObject>");
+
+    TestCase.assertEqual(obj.getPropertyType("boolArrayCol"), "array<bool>");
+    TestCase.assertEqual(obj.getPropertyType("floatArrayCol"), "array<float>");
+    TestCase.assertEqual(obj.getPropertyType("doubleArrayCol"), "array<double>");
+    TestCase.assertEqual(obj.getPropertyType("stringArrayCol"), "array<string>");
+    TestCase.assertEqual(obj.getPropertyType("dateArrayCol"), "array<date>");
+    TestCase.assertEqual(obj.getPropertyType("dataArrayCol"), "array<data>");
+    TestCase.assertEqual(obj.getPropertyType("objectArrayCol"), "array<TestObject>");
+
+    // property that does not exist
+    TestCase.assertThrowsException(() => {
+      obj.getPropertyType('foo');
+    }, new Error("No such property: foo"));
+  },
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,6 +223,11 @@ declare namespace Realm {
         removeListener(callback: ObjectChangeCallback): void;
 
         removeAllListeners(): void;
+
+        /**
+         * @returns string
+         */
+        getPropertyType(propertyName: string) : string;
     }
 
     /**


### PR DESCRIPTION
## What, How & Why?

Since all numeric types (int, long, double) are represented as a `number` when read from our SDK, it makes sense to implement a method to get the underlying type of the property value, if your application (such as MongoDB Realm Studio) cares about this. Throws an exception if a property with the given name does not exist.

E.g.

```js
realmObject.getPropertyType(propertyName);
```

This closes #3646 

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
