### PR TITLE
Create github workflow to build and publish jsdocs (#3762)

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -1,0 +1,45 @@
+name: JSDoc
+on:
+  pull_request:
+    paths:
+      # documentation
+      - "docs/**"
+      - "*.md"
+      # changes to this workflow
+      # seems there is no way to get this easily yet https://github.com/actions/runner/issues/853
+      - ".github/workflows/jsdoc.yml"
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+env:
+  REALM_DISABLE_ANALYTICS: 1
+jobs:
+  jsdoc:
+    name: JSDoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - name: Install npm v7
+        run: npm install -g npm@7
+      # Install the root package (--ignore-scripts to avoid downloading or building the native module)
+      - name: Install root package dependencies
+        run: npm ci --ignore-scripts
+      - name: Run JSDoc documentation build
+        run: npm run jsdoc
+      - name: Configure AWS Credentials
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
+          aws-region: us-west-1
+      - name: Upload docs
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: aws s3 sync --acl public-read docs/output/realm s3://${{ secrets.DOCS_S3_BUCKET_NAME }}

--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/jsdoc.yml"
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]*
 
 env:
   REALM_DISABLE_ANALYTICS: 1


### PR DESCRIPTION
The workflow is triggered for PRs that change documentation files as well as for
major and minor release tags (vX.Y.0).
Additionally for tags the documentation is published to an S3 bucket under
a direcotry with the version as its name.

For uploading to work, three secrets need to be configured: DOCS_S3_ACCESS_KEY,
DOCS_S3_SECRET_KEY and DOCS_S3_BUCKET_NAME

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #3762

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
