### PR TITLE
Updated Android Docker image to newer version to fix SSL errors

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,5 +1,5 @@
 # Starting from a slimmed version of the latest stable Debian
-FROM debian:stretch-20210721-slim
+FROM debian:stretch-20210927-slim
 
 # Setting environment variables for versions
 # See https://developer.android.com/studio/#command-tools for the latest SDK version
@@ -13,9 +13,6 @@ ENV LANG C.UTF-8
 
 ENV NPM_CONFIG_UNSAFE_PERM true
 ENV NVM_DIR /tmp/.nvm
-
-# Because we're using the slim variant of Debian some directories (expected when installing openjdk) are missing
-RUN mkdir /usr/share/man/man1
 
 # Install dependencies
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
## What, How & Why?
Updated our Android Docker image to a more recent version of Debian-slim.
This fixes SSL errors that `curl` emits during CI due to expired CAs

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
~* [ ] 📝 `Compatibility` label is updated or copied from previous entry~
~* [ ] 🚦 Tests~
~* [ ] 📝 Public documentation PR created or is not necessary~
~* [ ] 💥 `Breaking` label has been applied or is not necessary~
