### PR TITLE
Allow empty string as a valid `partitionValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * React Native templates now transfer hidden files into new projects([#3971](https://github.com/realm/realm-js/issues/3971))
 * Remove usage of deprecated features for Gradle 7 ([#3946](https://github.com/realm/realm-js/issues/3946), [#3879](https://github.com/realm/realm-js/issues/3879))
 * A `sync` configuration value of `undefined` now behaves the same as a missing `sync` configuration ([#3999](https://github.com/realm/realm-js/issues/3999), since v2.2.0)
+* Empty string is now a valid `partitionValue` ([#4002](https://github.com/realm/realm-js/issues/4002), since v10.0.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -63,9 +63,6 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
     bson::Bson partition_bson;
     if (Value<T>::is_string(ctx, partition_value_value)) {
         std::string pv = Value<T>::validated_to_string(ctx, partition_value_value);
-        if (pv.length() == 0) {
-            throw std::runtime_error("partitionValue of type 'string' may not be an empty string.");
-        }
         partition_bson = bson::Bson(pv);
     }
     else if (Value<T>::is_number(ctx, partition_value_value)) {

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -918,6 +918,7 @@ module.exports = {
       new ObjectId("603fa0af4caa9c90ff6e126c"),
       new UUID("f3287217-d1a2-445b-a4f7-af0520413b2a"),
       null,
+      "",
     ];
 
     for (const partitionValue of testPartitionValues) {
@@ -951,7 +952,6 @@ module.exports = {
   async testNonAcceptedPartitionValueTypes() {
     const testPartitionValues = [
       undefined,
-      "",
       Number.MAX_SAFE_INTEGER + 1,
       1.2,
       0.0000000000000001,


### PR DESCRIPTION
## What, How & Why?

An empty string is a valid `partitionValue` on the sync server, but was not allowed by Realm JS. This change makes an empty string a valid `partitionValue`.

This closes #4002

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] ~typescript definitions file is updated~
* [ ] ~jsdoc files updated~
* [ ] ~Chrome debug API is updated if API is available on React Native~
