### PR TITLE
Make sync configuration of `undefined` behave the same as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * React Native templates now transfer hidden files into new projects([#3971](https://github.com/realm/realm-js/issues/3971))
+* A `sync` configuration value of `undefined` now behaves the same as a missing `sync` configuration ([#3999](https://github.com/realm/realm-js/issues/3999), since v2.2.0)
 * None.
 
 ### Compatibility

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -164,7 +164,7 @@ module.exports = function (realmConstructor) {
         }
 
         // For local Realms we open the Realm and return it in a resolved Promise.
-        if (!("sync" in config)) {
+        if (config.sync === undefined) {
           return openLocalRealm(realmConstructor, config);
         }
 

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -148,6 +148,16 @@ module.exports = {
     TestCase.assertNull(realm.syncSession);
   },
 
+  testRealmSyncUndefinedHasNoSession() {
+    const config = {
+      sync: undefined,
+    };
+
+    return Realm.open(config).then((realm) => {
+      TestCase.assertNull(realm.syncSession);
+    });
+  },
+
   async testRealmInvalidSyncConfiguration1() {
     const config = {
       sync: true,


### PR DESCRIPTION
## What, How & Why?

When opening a Realm and passing in undefined as the sync property on the config the library should behave the same as if the key is missing entirely. This change makes `sync: undefined` behave the same way, i.e. it opens a local Realm.

This closes #3999

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
