### PR TITLE
Add setTimeout(0) after closing Realm in Jest test to avoid Node 12 segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Lint react-native templates and ensure they are checked by the CI.
 * Updated `README.md` and `building.md` with updated instructions on building from source.
 * Changed logo to a 'dark-mode' aware SVG ([#4020](https://github.com/realm/realm-js/pull/4020))
+* Added workaround for crash when closing Realm in Jest test on Node 12 ([#4025](https://github.com/realm/realm-js/pull/4025), since v10.8.0)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/tests/test-runners/jest/realm.test.js
+++ b/tests/test-runners/jest/realm.test.js
@@ -46,6 +46,12 @@ describe("Realm", function () {
 
       expect(realm.isClosed).toBe(true);
       Realm.clearTestState();
+
+      // Workaround for segfault issue – Node 12 environment teardown after the end of the test
+      // seems to happen before the Realm is fully closed, resulting in a segfault. Delaying
+      // the end of the test until the main thread code has finished running with setTimeout
+      // avoids this. See: https://github.com/realm/realm-js/pull/4025
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
   });
 });


### PR DESCRIPTION
## What, How & Why?

Our Jest test started often failing with a segmentation fault on Node 12. This issue started happening after https://github.com/realm/realm-core/pull/4892/ was merged. The issue only occurs when `npm install` is run prior to `npm test` and is not 100% consistent, which suggests some kind of race condition.

We are assuming that this is a very specific timing issue on Node 12 only, related to the Node environment being torn down before the Realm is properly closed, and unlikely to have any real world impact. Adding a `setTimeout(0)` at the end of the test appears to be enough to delay the Node environment teardown and avoid the segfault.

A follow up issue https://github.com/realm/realm-js/issues/4026 has been created in case of any further possibly related issues. The referenced doc on that ticket has full notes on the investigation.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
