### PR TITLE
Colorized compiler diagnostics if using Ninja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+* Adding colorized compiler diagnostics if using Ninja.
 
 10.9.1 Release notes (2021-10-20)
 =============================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckCXXCompilerFlag)
+
 # compiling for Node.js, need to set up toolchains before project() call
 if(DEFINED CMAKE_JS_VERSION)
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
@@ -29,11 +31,20 @@ endif()
 cmake_minimum_required(VERSION 3.15)
 project(RealmJS)
 
-# Use ccache if available
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-endif()
+# Copied from Realm Core's CMakeList.txt
+function(add_cxx_flag_if_supported flag)
+    if(flag MATCHES "^-Wno-")
+        # Compilers ignore unknown -Wno-foo flags, so look for -Wfoo instead.
+        string(REPLACE "-Wno-" "-W" check_flag ${flag})
+    else()
+        set(check_flag ${flag})
+    endif()
+
+    check_cxx_compiler_flag(${check_flag} HAVE${check_flag})
+    if(HAVE${check_flag})
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${flag}>)
+    endif()
+endfunction()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -47,6 +58,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 if(DEFINED CMAKE_JS_VERSION)
     include(NodeJSTargets)
+endif()
+
+if (NOT MSVC)
+    # Ninja buffers output so we need to tell the compiler to use colors even though stdout isn't a tty.
+    if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        add_cxx_flag_if_supported(-fdiagnostics-color)
+    endif()
 endif()
 
 option(REALM_JS_BUILD_CORE_FROM_SOURCE "Build Realm Core from source, as opposed to downloading prebuilt binaries" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ endif()
 cmake_minimum_required(VERSION 3.15)
 project(RealmJS)
 
+# Use ccache if available
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 # Copied from Realm Core's CMakeList.txt
 function(add_cxx_flag_if_supported flag)
     if(flag MATCHES "^-Wno-")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 if (NOT MSVC)
     # Ninja buffers output so we need to tell the compiler to use colors even though stdout isn't a tty.
-    if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if(CMAKE_GENERATOR STREQUAL "Ninja")
         add_cxx_flag_if_supported(-fdiagnostics-color)
     endif()
 endif()


### PR DESCRIPTION
## What, How & Why?

Adding colorized compiler diagnostics.

![Screenshot 2021-10-29 at 12 00 43](https://user-images.githubusercontent.com/1225363/139416350-05f9db82-9801-49ac-a3ac-844ffa4c7bf5.png)
