### PR TITLE
Attempting to stabilize integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -202,6 +202,7 @@ jobs:
       - run: npx lerna bootstrap --scope '{realm-integration-tests,realm-react-native-tests}' --include-dependencies
       # 👇 To work around "Unable to lookup in current state: Shutdown"
       - run: killall Simulator
+        continue-on-error: true
       # Run the tests
       - name: Run tests (${{matrix.platform.name}}/ Native)
         run: npm run test:${{matrix.platform.name}} --prefix integration-tests/environments/react-native

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,11 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [
-            { name: Linux, runner: ubuntu-latest },
-            { name: Window, runner: windows-latest },
-            { name: macOS, runner: macos-latest },
-          ]
+          - name: Linux
+            runner: ubuntu-latest
+          - name: Window
+            runner: windows-latest
+          - name: macOS
+            runner: macos-latest
         node: [14, 16]
         type: [release, debug]
     steps:
@@ -155,10 +156,10 @@ jobs:
         #type: [Release, Debug]
         type: [Release]
         platform:
-          [
-            { name: ios, build-configuration: simulator },
-            { name: catalyst, build-configuration: catalyst },
-          ]
+          - name: ios
+            build-configuration: simulator
+          - name: catalyst
+            build-configuration: catalyst
     steps:
       - uses: actions/checkout@v2
         with:
@@ -199,6 +200,8 @@ jobs:
       - run: ./scripts/build-ios.sh -c ${{ matrix.type }} ${{matrix.platform.build-configuration}}
       # Bootstrap lerna sub-packages (builds the packages, the Realm JS native module and pod install)
       - run: npx lerna bootstrap --scope '{realm-integration-tests,realm-react-native-tests}' --include-dependencies
+      # 👇 To work around "Unable to lookup in current state: Shutdown"
+      - run: killall Simulator
       # Run the tests
       - name: Run tests (${{matrix.platform.name}}/ Native)
         run: npm run test:${{matrix.platform.name}} --prefix integration-tests/environments/react-native

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -160,6 +160,9 @@ jobs:
             build-configuration: simulator
           - name: catalyst
             build-configuration: catalyst
+    env:
+      # Pin the Xcode version
+      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app
     steps:
       - uses: actions/checkout@v2
         with:
@@ -200,9 +203,6 @@ jobs:
       - run: ./scripts/build-ios.sh -c ${{ matrix.type }} ${{matrix.platform.build-configuration}}
       # Bootstrap lerna sub-packages (builds the packages, the Realm JS native module and pod install)
       - run: npx lerna bootstrap --scope '{realm-integration-tests,realm-react-native-tests}' --include-dependencies
-      # 👇 To work around "Unable to lookup in current state: Shutdown"
-      - run: killall Simulator
-        continue-on-error: true
       # Run the tests
       - name: Run tests (${{matrix.platform.name}}/ Native)
         run: npm run test:${{matrix.platform.name}} --prefix integration-tests/environments/react-native


### PR DESCRIPTION
## What, How & Why?

In an attempt to increase stability of the integration tests, this will pin the version of Xcode to 12.5.1.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
