### PR TITLE
Combine type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Adding use of [ccache](https://ccache.dev/) in build scripts, XCode projects and the integration tests GHA workflow.
 * Dropped using `install-local` in the integration tests, in favour of a more involved Metro configuration.
+* Add combined type definition for Realm.object and Realm.objectForPrimaryKey so they can be cleanly wrapped.
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -748,6 +748,9 @@ declare class Realm {
      * @returns {T | undefined}
      */
     objectForPrimaryKey<T extends Realm.Object>(type: {new(...arg: any[]): T; }, key: Realm.PrimaryKey): T | undefined;
+    
+    // Combined definitions 
+    objectForPrimaryKey<T>(type: string | {new(...arg: any[]): T; }, key: Realm.PrimaryKey): (T & Realm.Object) | undefined;
 
     /**
      * @param  {string} type
@@ -760,6 +763,9 @@ declare class Realm {
      * @returns Realm.Results<T>
      */
     objects<T extends Realm.Object>(type: {new(...arg: any[]): T; }): Realm.Results<T>;
+
+    // Combined definitions 
+    objects<T>(type: string | {new(...arg: any[]): T; }): Realm.Results<T & Realm.Object>;
 
     /**
      * @param  {string} name


### PR DESCRIPTION
In order to wrap objects and objectForPrimaryKey in Realm React,
it is necessary to combine the overloaded definitions to cleanly
forward the correct typing.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
