### PR TITLE
Retrying launching the iOS integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -210,6 +210,8 @@ jobs:
           MOCHA_REMOTE_CONTEXT: missingServer
           MOCHA_REMOTE_REPORTER: mocha-github-actions-reporter
           MOCHA_REMOTE_EXIT_ON_ERROR: true
+          RETRIES: 5
+          RETRY_DELAY: 300000 # 5 min
       - name: Run tests (${{matrix.platform.name}} / Chrome Debugging)
         if: ${{ false }}
         run: npm run test:${{matrix.platform.name}}:chrome --prefix integration-tests/environments/react-native
@@ -218,6 +220,8 @@ jobs:
           MOCHA_REMOTE_REPORTER: mocha-github-actions-reporter
           MOCHA_REMOTE_EXIT_ON_ERROR: true
           HEADLESS_DEBUGGER: true
+          RETRIES: 5
+          RETRY_DELAY: 300000 # 5 min
   react-native-android:
     name: React Native on Android (${{ matrix.type }})
     runs-on: macos-latest


### PR DESCRIPTION
## What, How & Why?

This is an attempt at stabilizing the React Native integration tests running on iOS by retrying the build / lunch command if tests doesn't complete the tests within 5 minutes from the previous build command invocation exits.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

