### PR TITLE
Realm Web: Use `globalThis` instead of `window` global

### DIFF
--- a/packages/realm-network-transport/src/dom/index.ts
+++ b/packages/realm-network-transport/src/dom/index.ts
@@ -21,5 +21,5 @@ export * from "../index";
 import { DefaultNetworkTransport } from "../DefaultNetworkTransport";
 import { AbortController, Fetch } from "../types";
 
-DefaultNetworkTransport.fetch = window.fetch.bind(window) as Fetch;
-DefaultNetworkTransport.AbortController = window.AbortController as AbortController;
+DefaultNetworkTransport.fetch = globalThis.fetch.bind(globalThis) as Fetch;
+DefaultNetworkTransport.AbortController = globalThis.AbortController as AbortController;

--- a/packages/realm-web/.eslintrc.json
+++ b/packages/realm-web/.eslintrc.json
@@ -5,6 +5,7 @@
         "plugin:jsdoc/recommended"
     ],
     "rules": {
+        "no-restricted-globals": ["error", "window", "global"],
         "@typescript-eslint/explicit-function-return-type": "off",
         "jsdoc/require-param-type": "off",
         "jsdoc/require-returns-type": "off",

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,18 @@
+?.?.? Release notes (2020-??-??)
+=============================================================
+
+### Breaking Changes
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* Using `globalThis` instead of `window` global. This fix runtime issues when the package is bundled and loaded into a Cloudflare Worker. ([#4084](https://github.com/realm/realm-js/pull/4084), since 0.5.0)
+
+### Internal
+* None
+
 1.5.0 Release notes (2021-11-11)
 =============================================================
 

--- a/packages/realm-web/package-lock.json
+++ b/packages/realm-web/package-lock.json
@@ -5,13 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "realm-web",
 			"version": "1.5.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
-				"bson": "^4.2.0",
-				"detect-browser": "^5.1.1",
-				"js-base64": "^2.6.3"
+				"bson": "^4.5.4",
+				"detect-browser": "^5.2.1",
+				"js-base64": "^3.7.2"
 			},
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^13.0.1",
@@ -20,7 +19,7 @@
 				"@rollup/plugin-typescript": "^4.1.1",
 				"@types/chai": "^4.2.9",
 				"@types/fs-extra": "^8.1.0",
-				"@types/js-base64": "^2.3.2",
+				"@types/js-base64": "^3.3.1",
 				"@types/mocha": "^7.0.1",
 				"@types/node": "^13.7.6",
 				"abort-controller": "^3.0.0",
@@ -174,10 +173,14 @@
 			}
 		},
 		"node_modules/@types/js-base64": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-2.3.2.tgz",
-			"integrity": "sha512-iGjZEnheu9n53fhlU+QLovdKHsdwPJ79iammNM0opTEp18zcJ/nNAIthuMilJoDPNUQHoqRAJdDNI5rxHY4nkA==",
-			"dev": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-3.3.1.tgz",
+			"integrity": "sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==",
+			"deprecated": "This is a stub types definition. js-base64 provides its own type definitions, so you do not need this installed.",
+			"dev": true,
+			"dependencies": {
+				"js-base64": "*"
+			}
 		},
 		"node_modules/@types/mocha": {
 			"version": "7.0.2",
@@ -464,9 +467,9 @@
 			]
 		},
 		"node_modules/bson": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
-			"integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.5.4.tgz",
+			"integrity": "sha512-wIt0bPACnx8Ju9r6IsS2wVtGDHBr9Dxb+U29A1YED2pu8XOhS8aKjOnLZ8sxyXkPwanoK7iWWVhS1+coxde6xA==",
 			"dependencies": {
 				"buffer": "^5.6.0"
 			},
@@ -737,9 +740,9 @@
 			}
 		},
 		"node_modules/detect-browser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.1.1.tgz",
-			"integrity": "sha512-5n2aWI57qC3kZaK4j2zYsG6L1LrxgLptGCNhMQgdKhVn6cSdcq43pp6xHPfTHG3TYM6myF4tIPWiZtfdVDgb9w=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+			"integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
 		},
 		"node_modules/diff": {
 			"version": "3.5.0",
@@ -1129,9 +1132,9 @@
 			"dev": true
 		},
 		"node_modules/js-base64": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2056,10 +2059,13 @@
 			}
 		},
 		"@types/js-base64": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-2.3.2.tgz",
-			"integrity": "sha512-iGjZEnheu9n53fhlU+QLovdKHsdwPJ79iammNM0opTEp18zcJ/nNAIthuMilJoDPNUQHoqRAJdDNI5rxHY4nkA==",
-			"dev": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-3.3.1.tgz",
+			"integrity": "sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==",
+			"dev": true,
+			"requires": {
+				"js-base64": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "7.0.2",
@@ -2327,9 +2333,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
-			"integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.5.4.tgz",
+			"integrity": "sha512-wIt0bPACnx8Ju9r6IsS2wVtGDHBr9Dxb+U29A1YED2pu8XOhS8aKjOnLZ8sxyXkPwanoK7iWWVhS1+coxde6xA==",
 			"requires": {
 				"buffer": "^5.6.0"
 			}
@@ -2561,9 +2567,9 @@
 			}
 		},
 		"detect-browser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.1.1.tgz",
-			"integrity": "sha512-5n2aWI57qC3kZaK4j2zYsG6L1LrxgLptGCNhMQgdKhVn6cSdcq43pp6xHPfTHG3TYM6myF4tIPWiZtfdVDgb9w=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+			"integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -2883,9 +2889,9 @@
 			"dev": true
 		},
 		"js-base64": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -46,9 +46,9 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@realm.io/common": "^0.1.1",
-    "bson": "^4.2.0",
-    "detect-browser": "^5.1.1",
-    "js-base64": "^2.6.3"
+    "bson": "^4.5.4",
+    "detect-browser": "^5.2.1",
+    "js-base64": "^3.7.2"
   },
   "optionalDependencies": {
     "abort-controller": "^3.0.0",
@@ -61,7 +61,7 @@
     "@rollup/plugin-typescript": "^4.1.1",
     "@types/chai": "^4.2.9",
     "@types/fs-extra": "^8.1.0",
-    "@types/js-base64": "^2.3.2",
+    "@types/js-base64": "^3.3.1",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.7.6",
     "abort-controller": "^3.0.0",

--- a/packages/realm-web/src/FunctionsFactory.ts
+++ b/packages/realm-web/src/FunctionsFactory.ts
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { Base64 } from "js-base64";
+
 import { Fetcher } from "./Fetcher";
 import { serialize } from "./utils/ejson";
 import { encodeQueryString } from "./utils/string";

--- a/packages/realm-web/src/dom/LocalStorage.ts
+++ b/packages/realm-web/src/dom/LocalStorage.ts
@@ -26,32 +26,32 @@ export class LocalStorage implements Storage {
   /**
    * Internal state of the storage.
    */
-  private readonly window: Window;
+  private readonly global: typeof globalThis;
 
   /**
    * Constructs a LocalStorage using the global window.
    */
   constructor() {
-    if (typeof window === "object") {
-      this.window = window;
+    if (typeof globalThis.localStorage === "object") {
+      this.global = globalThis;
     } else {
-      throw new Error("Cannot use LocalStorage without a global window object");
+      throw new Error("Cannot use LocalStorage without a global localStorage object");
     }
   }
 
   /** @inheritdoc */
   public get(key: string): string | null {
-    return this.window.localStorage.getItem(key);
+    return this.global.localStorage.getItem(key);
   }
 
   /** @inheritdoc */
   public set(key: string, value: string): void {
-    return this.window.localStorage.setItem(key, value);
+    return this.global.localStorage.setItem(key, value);
   }
 
   /** @inheritdoc */
   public remove(key: string): void {
-    return this.window.localStorage.removeItem(key);
+    return this.global.localStorage.removeItem(key);
   }
 
   /** @inheritdoc */
@@ -63,25 +63,25 @@ export class LocalStorage implements Storage {
   public clear(prefix?: string): void {
     const keys = [];
     // Iterate all keys to find the once have a matching prefix.
-    for (let i = 0; i < this.window.localStorage.length; i++) {
-      const key = this.window.localStorage.key(i);
+    for (let i = 0; i < this.global.localStorage.length; i++) {
+      const key = this.global.localStorage.key(i);
       if (key && (!prefix || key.startsWith(prefix))) {
         keys.push(key);
       }
     }
     // Remove the items in a seperate loop to avoid updating while iterating.
     for (const key of keys) {
-      this.window.localStorage.removeItem(key);
+      this.global.localStorage.removeItem(key);
     }
   }
 
   /** @inheritdoc */
   public addListener(listener: StorageChangeListener): void {
-    return this.window.addEventListener("storage", listener);
+    return this.global.addEventListener("storage", listener);
   }
 
   /** @inheritdoc */
   public removeListener(listener: StorageChangeListener): void {
-    return this.window.removeEventListener("storage", listener);
+    return this.global.removeEventListener("storage", listener);
   }
 }

--- a/packages/realm-web/test/env.js
+++ b/packages/realm-web/test/env.js
@@ -25,4 +25,6 @@ const tsConfigPath = path.resolve(__dirname, "../src/tests/tsconfig.json");
 process.env.TS_NODE_PROJECT = tsConfigPath;
 console.log(`Loading TypeScript configuration from ${tsConfigPath}`);
 
+// We can disable no-restricted-globals, since we know this will run on node.js
+// eslint-disable-next-line no-restricted-globals
 global.__SDK_VERSION__ = "0.0.0-test";


### PR DESCRIPTION
## What, How & Why?

This updates Realm Web to adopt best practices in regards to usage of the `window` property, namely use [the `globalThis` instead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) to avoid runtime errors when the package if the browser bundle get loaded on a runtime not providing the browser (read `window` global) API.

Incidentally this also fix a minor inconvenience when using Realm Web from a Cloudflare Worker.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
