### PR TITLE
Add core `.clang-format` and format all source

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,136 @@
+---
+BasedOnStyle: LLVM
+TabWidth: 4
+UseTab: Never
+---
+Language:  JavaScript
+DisableFormat: true
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     118
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+  - SECTION
+  - TEST_CASE
+  - DYNAMIC_SECTION
+  - BENCHMARK
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/src/android/hack.cpp
+++ b/src/android/hack.cpp
@@ -27,16 +27,16 @@
 
 #if REALM_WRAP_MEMMOVE
 extern "C" {
-void* __wrap_memmove(void *dest, const void *src, size_t n);
-void* __real_memmove(void *dest, const void *src, size_t n);
+void* __wrap_memmove(void* dest, const void* src, size_t n);
+void* __real_memmove(void* dest, const void* src, size_t n);
 
-void* __wrap_memcpy(void *dest, const void *src, size_t n);
-void* __real_memcpy(void *dest, const void *src, size_t n);
+void* __wrap_memcpy(void* dest, const void* src, size_t n);
+void* __real_memcpy(void* dest, const void* src, size_t n);
 }
 
 using namespace realm::jni_util;
 
-typedef void* (*MemMoveFunc)(void *dest, const void *src, size_t n);
+typedef void* (*MemMoveFunc)(void* dest, const void* src, size_t n);
 static MemMoveFunc s_wrap_memmove_ptr = &__real_memmove;
 static MemMoveFunc s_wrap_memcpy_ptr = &__real_memcpy;
 
@@ -71,12 +71,12 @@ static void* hacked_memcpy(void* s1, const void* s2, size_t n)
     return static_cast<void*>(s1);
 }
 
-void* __wrap_memmove(void *dest, const void *src, size_t n)
+void* __wrap_memmove(void* dest, const void* src, size_t n)
 {
     return (*s_wrap_memmove_ptr)(dest, src, n);
 }
 
-void* __wrap_memcpy(void *dest, const void *src, size_t n)
+void* __wrap_memcpy(void* dest, const void* src, size_t n)
 {
     return (*s_wrap_memcpy_ptr)(dest, src, n);
 }
@@ -93,9 +93,10 @@ static void check_memmove()
     size_t len = strlen(array);
     void* ptr = __real_memmove(array + 1, array, len - 1);
     if (ptr != array + 1 || strncmp(array, "FFooba", len) != 0) {
-        __android_log_print(ANDROID_LOG_DEBUG, "JSRealm", "memmove is broken on this device. Switching to the builtin implementation.");
+        __android_log_print(ANDROID_LOG_DEBUG, "JSRealm",
+                            "memmove is broken on this device. Switching to the builtin implementation.");
         s_wrap_memmove_ptr = &hacked_memmove;
-        s_wrap_memcpy_ptr  = &hacked_memcpy;
+        s_wrap_memcpy_ptr = &hacked_memcpy;
     }
     free(array);
 }
@@ -111,6 +112,5 @@ void hack_init()
 #endif
 }
 
-}
-}
-
+} // namespace jni_util
+} // namespace realm

--- a/src/android/hack.hpp
+++ b/src/android/hack.hpp
@@ -23,6 +23,6 @@ namespace jni_util {
 // Workaround bugs on some devices.
 void hack_init();
 
-}
-}
+} // namespace jni_util
+} // namespace realm
 #endif // REALM_JNI_UTIL_HACK_HPP

--- a/src/android/io_realm_react_RealmReactModule.cpp
+++ b/src/android/io_realm_react_RealmReactModule.cpp
@@ -29,14 +29,14 @@
 using namespace realm::rpc;
 using namespace realm::jni_util;
 
-static RPCServer *s_rpc_server;
+static RPCServer* s_rpc_server;
 extern bool realmContextInjected;
 jclass ssl_helper_class;
 
-namespace realm {    
-    // set the AssetManager used to access bundled files within the APK
-    void set_asset_manager(AAssetManager* assetManager);
-}
+namespace realm {
+// set the AssetManager used to access bundled files within the APK
+void set_asset_manager(AAssetManager* assetManager);
+} // namespace realm
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
 {
@@ -70,13 +70,14 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void*)
     }
 }
 
-JNIEXPORT void JNICALL Java_io_realm_react_RealmReactModule_setDefaultRealmFileDirectory
-  (JNIEnv *env, jclass, jstring fileDir, jobject javaAssetManager)
+JNIEXPORT void JNICALL Java_io_realm_react_RealmReactModule_setDefaultRealmFileDirectory(JNIEnv* env, jclass,
+                                                                                         jstring fileDir,
+                                                                                         jobject javaAssetManager)
 {
     __android_log_print(ANDROID_LOG_VERBOSE, "JSRealm", "setDefaultRealmFileDirectory");
 
     // Get the assetManager in case we want to copy files from the APK (assets)
-    AAssetManager *assetManager = AAssetManager_fromJava(env, javaAssetManager);
+    AAssetManager* assetManager = AAssetManager_fromJava(env, javaAssetManager);
     if (assetManager == NULL) {
         __android_log_print(ANDROID_LOG_ERROR, "JSRealm", "Error loading the AssetManager");
     }
@@ -87,11 +88,11 @@ JNIEXPORT void JNICALL Java_io_realm_react_RealmReactModule_setDefaultRealmFileD
     realm::set_default_realm_file_directory(strFileDir);
     env->ReleaseStringUTFChars(fileDir, strFileDir);
 
-    __android_log_print(ANDROID_LOG_DEBUG, "JSRealm", "Absolute path: %s", realm::default_realm_file_directory().c_str());
+    __android_log_print(ANDROID_LOG_DEBUG, "JSRealm", "Absolute path: %s",
+                        realm::default_realm_file_directory().c_str());
 }
 
-JNIEXPORT jlong JNICALL Java_io_realm_react_RealmReactModule_setupChromeDebugModeRealmJsContext
-  (JNIEnv *, jclass)
+JNIEXPORT jlong JNICALL Java_io_realm_react_RealmReactModule_setupChromeDebugModeRealmJsContext(JNIEnv*, jclass)
 {
     __android_log_print(ANDROID_LOG_VERBOSE, "JSRealm", "setupChromeDebugModeRealmJsContext");
     if (s_rpc_server) {
@@ -101,8 +102,9 @@ JNIEXPORT jlong JNICALL Java_io_realm_react_RealmReactModule_setupChromeDebugMod
     return (jlong)s_rpc_server;
 }
 
-JNIEXPORT jstring JNICALL Java_io_realm_react_RealmReactModule_processChromeDebugCommand
-  (JNIEnv *env, jclass, jstring chrome_cmd, jstring chrome_args)
+JNIEXPORT jstring JNICALL Java_io_realm_react_RealmReactModule_processChromeDebugCommand(JNIEnv* env, jclass,
+                                                                                         jstring chrome_cmd,
+                                                                                         jstring chrome_args)
 {
     const char* cmd = env->GetStringUTFChars(chrome_cmd, NULL);
     const char* args = env->GetStringUTFChars(chrome_args, NULL);
@@ -112,21 +114,18 @@ JNIEXPORT jstring JNICALL Java_io_realm_react_RealmReactModule_processChromeDebu
     return env->NewStringUTF(response.c_str());
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_react_RealmReactModule_tryRunTask
-(JNIEnv *env, jclass)
+JNIEXPORT jboolean JNICALL Java_io_realm_react_RealmReactModule_tryRunTask(JNIEnv* env, jclass)
 {
-  jboolean result = s_rpc_server->try_run_task();
-  return result;
+    jboolean result = s_rpc_server->try_run_task();
+    return result;
 }
 
-JNIEXPORT jboolean JNICALL Java_io_realm_react_RealmReactModule_isContextInjected
-    (JNIEnv *env, jclass)
+JNIEXPORT jboolean JNICALL Java_io_realm_react_RealmReactModule_isContextInjected(JNIEnv* env, jclass)
 {
     return realmContextInjected;
 }
 
-JNIEXPORT void JNICALL Java_io_realm_react_RealmReactModule_clearContextInjectedFlag
-  (JNIEnv *env, jclass)
+JNIEXPORT void JNICALL Java_io_realm_react_RealmReactModule_clearContextInjectedFlag(JNIEnv* env, jclass)
 {
     realmContextInjected = false;
 }

--- a/src/android/jni_utils.hpp
+++ b/src/android/jni_utils.hpp
@@ -27,9 +27,7 @@ namespace jni_util {
 // Util functions for JNI.
 class JniUtils {
 public:
-    ~JniUtils()
-    {
-    }
+    ~JniUtils() {}
 
     // Call this only once in JNI_OnLoad.
     static void initialize(JavaVM* vm, jint vm_version) noexcept;
@@ -53,7 +51,7 @@ private:
     jint m_vm_version;
 };
 
-} // namespace realm
 } // namespace jni_util
+} // namespace realm
 
 #endif // REALM_JNI_UTIL_JNI_UTILS_HPP

--- a/src/android/jsc_override.cpp
+++ b/src/android/jsc_override.cpp
@@ -30,37 +30,45 @@
 /**
 `__attribute__((constructor))` will trigger a first call to swap_function() which will install the function hook.
 
-The hook function is simply a technique (originally published in 1999 https://www.microsoft.com/en-us/research/project/detours/#!publications) to replace
- the original function call by another one by substituting the address of the original function `JSGlobalContextCreateInGroup` by an assembly JUMP instruction in order to branch into our custom function `create_context`
- (which has the same signature as the original).The custom function will then remove the hook to be able to invoke the original `JSGlobalContextCreateInGroup`
- in order to obtain the JS context, needed to initialize Realm.
+The hook function is simply a technique (originally published in 1999
+https://www.microsoft.com/en-us/research/project/detours/#!publications) to replace the original function call by
+another one by substituting the address of the original function `JSGlobalContextCreateInGroup` by an assembly JUMP
+instruction in order to branch into our custom function `create_context` (which has the same signature as the
+original).The custom function will then remove the hook to be able to invoke the original
+`JSGlobalContextCreateInGroup` in order to obtain the JS context, needed to initialize Realm.
 
- The assembly code to perform the jump is architecture specific, similarly for the size of this "Hook". Here's how it's calculated for the various architectures
+ The assembly code to perform the jump is architecture specific, similarly for the size of this "Hook". Here's how
+it's calculated for the various architectures
 
  - ARM 32 bit:
  ARM supports two instruction mode, Thumb & ARM (with different size for the opcodes).
- if we're using Thumb then the jump is performed using the BX instruction (see https://web.eecs.umich.edu/~prabal/teaching/eecs373-f10/readings/ARMv7-M_ARM.pdf)
- BX allows to branch to a specific address stored in a global register with the option to switch instruction from Thumb to ARM. This is performed using this code
-  LDR R3, [PC, #0]; <---- This load the current address referenced by the current Program Counter address with a 0 offset
-  BX R3; <---- This will perform the jump
+ if we're using Thumb then the jump is performed using the BX instruction (see
+https://web.eecs.umich.edu/~prabal/teaching/eecs373-f10/readings/ARMv7-M_ARM.pdf) BX allows to branch to a specific
+address stored in a global register with the option to switch instruction from Thumb to ARM. This is performed using
+this code LDR R3, [PC, #0]; <---- This load the current address referenced by the current Program Counter address with
+a 0 offset BX R3; <---- This will perform the jump
 
   memcpy(orig_func, "\x00\x4b\x18\x47", 4);
   memcpy(orig_func + 4, &new_func, 4);
 
 For non-Thumb we simply set the current program PC to the address of the new function (swap_function)
-    LDR	PC, [PC] <---- [PC] get the address of the current PC (remember the first call of swap_function is triggered automatically when loading the shared object) so when
-                        execute this assembly later at the address of the original function, this will jump to swap_function
+    LDR	PC, [PC] <---- [PC] get the address of the current PC (remember the first call of swap_function is triggered
+automatically when loading the shared object) so when execute this assembly later at the address of the original
+function, this will jump to swap_function
 
     memcpy(orig_func, "\x00\xf0\x9f\xe5", 4);
     memcpy(orig_func + 4, &new_func, 4);
 
 - ARM 64 bit:
-Doesn't have Thumb instruction, but also doesn't expose the program counter (PC) as a general register so it cannot be used anymore. The workaround is to use a `BR`
-instruction (see https://static.docs.arm.com/ddi0596/a/DDI_0596_ARM_a64_instruction_set_architecture.pdf) (be careful to not use `BLR` accidentally BLR perform the same thing as BR
-but as a side effect will set the PC to PC + 4 after the jump, 4 is the size of the instruction, the idea of BLR is to jump to a subroutine, then go back to the next instruction
-in the assembly after the jump completes, the next instruction is located at current PC + 4, this is not our use case since we want to perform an unconditional jump).
-    LDR X3, .+8 <--- load into the global register X3 the address of the current PC + an offset of 8 bytes
-    BR X3 <---- perform the jump into the address of the new function (swap_function) located 8 bytes after the previous two assembly instructions.
+Doesn't have Thumb instruction, but also doesn't expose the program counter (PC) as a general register so it cannot be
+used anymore. The workaround is to use a `BR` instruction (see
+https://static.docs.arm.com/ddi0596/a/DDI_0596_ARM_a64_instruction_set_architecture.pdf) (be careful to not use `BLR`
+accidentally BLR perform the same thing as BR but as a side effect will set the PC to PC + 4 after the jump, 4 is the
+size of the instruction, the idea of BLR is to jump to a subroutine, then go back to the next instruction in the
+assembly after the jump completes, the next instruction is located at current PC + 4, this is not our use case since
+we want to perform an unconditional jump). LDR X3, .+8 <--- load into the global register X3 the address of the
+current PC + an offset of 8 bytes BR X3 <---- perform the jump into the address of the new function (swap_function)
+located 8 bytes after the previous two assembly instructions.
 
     memcpy(orig_func, "\x43\x00\x00\x58\x60\x00\x1F\xD6", 8);
     memcpy(orig_func + 8, &new_func, 8);
@@ -102,8 +110,8 @@ This is the method used for AMR 64bit
 The ARM_FUNCTION_HOOK_SIZE is the number of bytes the hook need to rewrite to install the jump code.
 
 Example for AARCH64:
- It's simply two ARM64 instructions, 4 bytes each (the first memcpy is 8) and the actual function address will also be 8 bytes (second memcpy)
- so the total is 16 bytes.
+ It's simply two ARM64 instructions, 4 bytes each (the first memcpy is 8) and the actual function address will also be
+8 bytes (second memcpy) so the total is 16 bytes.
 */
 #if __aarch64__
 #define HOOK_SIZE 16
@@ -147,8 +155,8 @@ static void swap_function()
     static int8_t s_orig_code[HOOK_SIZE];
     static bool s_swapped = false;
 
-    int8_t *orig_func = (int8_t*)&JSGlobalContextCreateInGroup;
-    int8_t *new_func = (int8_t*)&create_context;
+    int8_t* orig_func = (int8_t*)&JSGlobalContextCreateInGroup;
+    int8_t* new_func = (int8_t*)&create_context;
 
     bool orig_thumb = false;
 #if __arm__ && !defined(__aarch64__)
@@ -168,7 +176,8 @@ static void swap_function()
     if (s_swapped) {
         // Copy original code back into place.
         memcpy(orig_func, s_orig_code, HOOK_SIZE);
-    } else {
+    }
+    else {
         // Store the original code before replacing it.
         memcpy(s_orig_code, orig_func, HOOK_SIZE);
 
@@ -177,12 +186,14 @@ static void swap_function()
             // LDR R3, [PC, #0]; BX R3;
             memcpy(orig_func, "\x00\x4b\x18\x47", ARM_FUNCTION_HOOK_SIZE);
             memcpy(orig_func + ARM_FUNCTION_HOOK_SIZE, &new_func, ARM_FUNCTION_HOOK_SIZE);
-        } else {
+        }
+        else {
             memcpy(orig_func, ARM_FUNCTION_HOOK, ARM_FUNCTION_HOOK_SIZE);
             memcpy(orig_func + ARM_FUNCTION_HOOK_SIZE, &new_func, ARM_FUNCTION_HOOK_SIZE);
         }
 #else
-        // TODO: It would be safer to generate an indirect jump to an absolute address since distance might be greater than +/- 2^31
+        // TODO: It would be safer to generate an indirect jump to an absolute address since distance might be greater
+        // than +/- 2^31
         int32_t jmp_offset = (int64_t)new_func - (int64_t)orig_func - HOOK_SIZE;
 
         // Change original function to jump to our new one.
@@ -193,7 +204,7 @@ static void swap_function()
 
     s_swapped = !s_swapped;
 
-    __builtin___clear_cache((char *)page_start, (char *)code_end);
+    __builtin___clear_cache((char*)page_start, (char*)code_end);
 
     // Return this region to no longer being writable.
     mprotect((void*)page_start, code_end - page_start, PROT_READ | PROT_EXEC);

--- a/src/android/platform.cpp
+++ b/src/android/platform.cpp
@@ -42,80 +42,76 @@ static std::string s_default_realm_directory;
 
 namespace realm {
 
-    void set_default_realm_file_directory(std::string dir)
-    {
-        s_default_realm_directory = dir;
-    }
-
-    void set_asset_manager(AAssetManager* asset_manager)
-    {
-        s_asset_manager = asset_manager;
-    }
-
-    std::string default_realm_file_directory()
-    {
-        return s_default_realm_directory;
-    }
-
-    void ensure_directory_exists_for_file(const std::string &file)
-    {
-
-    }
-    
-    void copy_bundled_realm_files()
-    {
-        AAssetDir* assetDir = AAssetManager_openDir(s_asset_manager, "");
-        const char* filename = nullptr;
-
-        while ((filename = AAssetDir_getNextFileName(assetDir)) != nullptr) {
-            if (is_realm_file(filename)) {
-                AAsset* asset = AAssetManager_open(s_asset_manager, filename, AASSET_MODE_STREAMING);
-
-                char buf[BUFSIZ];
-                int nb_read = 0;
-
-                auto dest_filename = s_default_realm_directory + '/' + filename;
-                if (access(dest_filename.c_str(), F_OK ) == -1) {
-                    // file doesn't exist, copy
-                    FILE* out = fopen(dest_filename.c_str(), "w");
-                    while ((nb_read = AAsset_read(asset, buf, BUFSIZ)) > 0) {
-                        fwrite(buf, nb_read, 1, out);
-                    }
-                    fclose(out);
-                }
-                AAsset_close(asset);
-            }
-        }
-        AAssetDir_close(assetDir);
-    }
-
-    void remove_realm_files_from_directory(const std::string &directory)
-    {
-        std::string cmd = "rm " + s_default_realm_directory + "/*.realm " +
-                          s_default_realm_directory + "/*.realm.lock";
-        system(cmd.c_str());
-    }
-
-    void remove_directory(const std::string &path)
-    {
-        std::string cmd_clear_dir = "rm " + path + "/*";
-        system(cmd_clear_dir.c_str());
-
-        std::string cmd_rmdir = "rmdir " + path;
-        system(cmd_rmdir.c_str());
-    }
-
-    void remove_file(const std::string &path)
-    {
-        std::string cmd = "rm " + path;
-        system(cmd.c_str());
-    }
-
-    void print(const char* fmt, ...)
-    {
-        va_list vl;
-        va_start(vl, fmt);
-        __android_log_vprint(ANDROID_LOG_INFO, "RealmJS", fmt, vl);
-        va_end(vl);
-    }
+void set_default_realm_file_directory(std::string dir)
+{
+    s_default_realm_directory = dir;
 }
+
+void set_asset_manager(AAssetManager* asset_manager)
+{
+    s_asset_manager = asset_manager;
+}
+
+std::string default_realm_file_directory()
+{
+    return s_default_realm_directory;
+}
+
+void ensure_directory_exists_for_file(const std::string& file) {}
+
+void copy_bundled_realm_files()
+{
+    AAssetDir* assetDir = AAssetManager_openDir(s_asset_manager, "");
+    const char* filename = nullptr;
+
+    while ((filename = AAssetDir_getNextFileName(assetDir)) != nullptr) {
+        if (is_realm_file(filename)) {
+            AAsset* asset = AAssetManager_open(s_asset_manager, filename, AASSET_MODE_STREAMING);
+
+            char buf[BUFSIZ];
+            int nb_read = 0;
+
+            auto dest_filename = s_default_realm_directory + '/' + filename;
+            if (access(dest_filename.c_str(), F_OK) == -1) {
+                // file doesn't exist, copy
+                FILE* out = fopen(dest_filename.c_str(), "w");
+                while ((nb_read = AAsset_read(asset, buf, BUFSIZ)) > 0) {
+                    fwrite(buf, nb_read, 1, out);
+                }
+                fclose(out);
+            }
+            AAsset_close(asset);
+        }
+    }
+    AAssetDir_close(assetDir);
+}
+
+void remove_realm_files_from_directory(const std::string& directory)
+{
+    std::string cmd = "rm " + s_default_realm_directory + "/*.realm " + s_default_realm_directory + "/*.realm.lock";
+    system(cmd.c_str());
+}
+
+void remove_directory(const std::string& path)
+{
+    std::string cmd_clear_dir = "rm " + path + "/*";
+    system(cmd_clear_dir.c_str());
+
+    std::string cmd_rmdir = "rmdir " + path;
+    system(cmd_rmdir.c_str());
+}
+
+void remove_file(const std::string& path)
+{
+    std::string cmd = "rm " + path;
+    system(cmd.c_str());
+}
+
+void print(const char* fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+    __android_log_vprint(ANDROID_LOG_INFO, "RealmJS", fmt, vl);
+    va_end(vl);
+}
+} // namespace realm

--- a/src/common/object/jsc/methods.hpp
+++ b/src/common/object/jsc/methods.hpp
@@ -23,50 +23,53 @@
 #include "common/collection.hpp"
 
 namespace JSCUtil {
-    struct Error{
-        static JSValueRef handle(JSContextRef context, std::string&& message){
-            JSStringRef _str = JSStringCreateWithUTF8CString(message.c_str());
-            JSValueRef msg = JSValueMakeString(context, _str);
-            return JSObjectMakeError(context, 1, &msg, NULL);
+struct Error {
+    static JSValueRef handle(JSContextRef context, std::string&& message)
+    {
+        JSStringRef _str = JSStringCreateWithUTF8CString(message.c_str());
+        JSValueRef msg = JSValueMakeString(context, _str);
+        return JSObjectMakeError(context, 1, &msg, NULL);
+    }
+};
+}; // namespace JSCUtil
+
+namespace method {
+struct Arguments {
+    JSContextRef context;
+    ObjectObserver* observer = nullptr;
+    IOCollection* collection = nullptr;
+    size_t argumentCount;
+    const JSValueRef* values{nullptr};
+    JSValueRef* exception;
+
+    JSValueRef get(int index, std::string msg = "Missing argument for method call.")
+    {
+        if (index >= argumentCount) {
+            throw std::runtime_error(msg);
         }
-    };
+
+        return values[index];
+    }
+
+    void throw_error(std::string&& message)
+    {
+        *exception = JSCUtil::Error::handle(context, std::move(message));
+    }
 };
 
-namespace method{
-    struct Arguments {
-        JSContextRef context;
-        ObjectObserver *observer = nullptr;
-        IOCollection *collection = nullptr;
-        size_t argumentCount;
-        const JSValueRef *values{nullptr};
-        JSValueRef *exception;
+}; // namespace method
 
-        JSValueRef get(int index,
-                       std::string msg = "Missing argument for method call.") {
-            if (index >= argumentCount) {
-                throw std::runtime_error(msg);
-            }
+namespace accessor {
+struct Arguments {
+    JSContextRef context;
+    JSObjectRef object;
+    std::string property_name;
+    JSValueRef value;
+    JSValueRef* exception;
 
-            return values[index];
-        }
-
-        void throw_error(std::string&& message){
-            *exception = JSCUtil::Error::handle(context, std::move(message));
-        }
-    };
-
+    void throw_error(std::string&& message)
+    {
+        *exception = JSCUtil::Error::handle(context, std::move(message));
+    }
 };
-
-namespace accessor{
-    struct Arguments{
-        JSContextRef context;
-        JSObjectRef object;
-        std::string property_name;
-        JSValueRef value;
-        JSValueRef *exception;
-
-        void throw_error(std::string&& message){
-            *exception = JSCUtil::Error::handle(context, std::move(message));
-        }
-    };
-};
+}; // namespace accessor

--- a/src/common/object/jsc/object.hpp
+++ b/src/common/object/jsc/object.hpp
@@ -33,24 +33,25 @@ namespace realm {
 namespace common {
 
 struct PrivateStore {
-    void *accessor_data = nullptr;
-    ObjectObserver *observer = nullptr;
-    IOCollection *collection = nullptr;
+    void* accessor_data = nullptr;
+    ObjectObserver* observer = nullptr;
+    IOCollection* collection = nullptr;
     std::function<void()> finalizer = nullptr;
     std::unordered_map<std::string, bool> keys;
 };
 
 template <typename GetterSetter>
 class JavascriptObject {
-   private:
+private:
     JSClassDefinition _class;
     JSContextRef context;
     JSObjectRef object{nullptr};
     std::vector<JSStaticFunction> methods;
     std::vector<std::string> accessors;
-    PrivateStore *private_object;
+    PrivateStore* private_object;
 
-    static std::string to_string(JSContextRef context, JSStringRef value) {
+    static std::string to_string(JSContextRef context, JSStringRef value)
+    {
         std::string str;
         size_t sizeUTF8 = JSStringGetMaximumUTF8CStringSize(value);
         str.reserve(sizeUTF8);
@@ -58,45 +59,45 @@ class JavascriptObject {
         return str;
     }
 
-    static PrivateStore *get_private(JSObjectRef object) {
-        PrivateStore *store =
-            static_cast<PrivateStore *>(JSObjectGetPrivate(object));
+    static PrivateStore* get_private(JSObjectRef object)
+    {
+        PrivateStore* store = static_cast<PrivateStore*>(JSObjectGetPrivate(object));
         return store;
     }
 
     template <void cb(method::Arguments)>
-    static JSValueRef function_call(JSContextRef ctx, JSObjectRef function,
-                                    JSObjectRef thisObject,
-                                    size_t argumentCount,
-                                    const JSValueRef _arguments[],
-                                    JSValueRef *exception) {
-        PrivateStore *_private = get_private(thisObject);
-        ObjectObserver *observer = _private->observer;
-        IOCollection *collection = _private->collection;
+    static JSValueRef function_call(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+                                    size_t argumentCount, const JSValueRef _arguments[], JSValueRef* exception)
+    {
+        PrivateStore* _private = get_private(thisObject);
+        ObjectObserver* observer = _private->observer;
+        IOCollection* collection = _private->collection;
 
         cb({ctx, observer, collection, argumentCount, _arguments, exception});
         return JSValueMakeUndefined(ctx);
     }
 
-    static void dispose(JSObjectRef object) {
-        PrivateStore *_private = get_private(object);
+    static void dispose(JSObjectRef object)
+    {
+        PrivateStore* _private = get_private(object);
         if (_private->finalizer != nullptr) {
             _private->finalizer();
-        } else {
+        }
+        else {
             std::cout << "Warning: No finalizer was specified.";
         }
     }
 
-    static bool contains_key(JSContextRef ctx, JSObjectRef object,
-                             std::string key) {
+    static bool contains_key(JSContextRef ctx, JSObjectRef object, std::string key)
+    {
         auto keys = get_private(object)->keys;
         return keys[key.c_str()] == true;
     }
 
-    static void get_property_names(JSContextRef ctx, JSObjectRef object,
-                                   JSPropertyNameAccumulatorRef propertyNames) {
+    static void get_property_names(JSContextRef ctx, JSObjectRef object, JSPropertyNameAccumulatorRef propertyNames)
+    {
         auto keys = get_private(object)->keys;
-        for (const auto &pair : keys) {
+        for (const auto& pair : keys) {
             if (pair.second) {
                 auto entry = JSStringCreateWithUTF8CString(pair.first.c_str());
                 JSPropertyNameAccumulatorAddName(propertyNames, entry);
@@ -104,60 +105,63 @@ class JavascriptObject {
         }
     }
 
-    static JSValueRef getter(JSContextRef ctx, JSObjectRef object,
-                             JSStringRef propertyName, JSValueRef *exception) {
+    static JSValueRef getter(JSContextRef ctx, JSObjectRef object, JSStringRef propertyName, JSValueRef* exception)
+    {
         std::string key = to_string(ctx, propertyName);
 
         if (!contains_key(ctx, object, key)) {
             return JSValueMakeNull(ctx);
         }
 
-        IOCollection *collection = get_private(object)->collection;
+        IOCollection* collection = get_private(object)->collection;
         GetterSetter gs{collection};
-        return gs.get(
-            accessor::Arguments{ctx, object, key.c_str(), 0, exception});
+        return gs.get(accessor::Arguments{ctx, object, key.c_str(), 0, exception});
     }
 
-    static bool setter(JSContextRef ctx, JSObjectRef object,
-                       JSStringRef propertyName, JSValueRef value,
-                       JSValueRef *exception) {
+    static bool setter(JSContextRef ctx, JSObjectRef object, JSStringRef propertyName, JSValueRef value,
+                       JSValueRef* exception)
+    {
         std::string key = to_string(ctx, propertyName);
 
         if (!contains_key(ctx, object, key)) {
             return false;
         }
 
-        IOCollection *collection = get_private(object)->collection;
+        IOCollection* collection = get_private(object)->collection;
         GetterSetter gs{collection};
         gs.set(accessor::Arguments{ctx, object, key, value, exception});
         return true;
     }
 
-    static bool has_property(JSContextRef ctx, JSObjectRef object,
-                             JSStringRef propertyName) {
+    static bool has_property(JSContextRef ctx, JSObjectRef object, JSStringRef propertyName)
+    {
         auto key = to_string(ctx, propertyName);
         return contains_key(ctx, object, key);
     }
 
-    JSClassRef make_class() {
+    JSClassRef make_class()
+    {
         methods.push_back({0});
         _class.staticFunctions = methods.data();
 
         return JSClassCreate(&_class);
     }
 
-    JSObjectRef lazily_build_object() {
+    JSObjectRef lazily_build_object()
+    {
         if (object == nullptr) {
             auto class_instance = make_class();
             return JSObjectMake(context, class_instance, private_object);
-        } else {
+        }
+        else {
             return object;
         }
     }
 
-   public:
+public:
     JavascriptObject(JSContextRef _ctx, std::string name = "js_object")
-        : context{_ctx} {
+        : context{_ctx}
+    {
         _class = kJSClassDefinitionEmpty;
         _class.className = name.c_str();
         _class.finalize = dispose;
@@ -169,54 +173,67 @@ class JavascriptObject {
         private_object = new PrivateStore{nullptr, nullptr, nullptr};
     }
 
-    void dbg() {
+    void dbg()
+    {
         std::cout << "methods size: " << methods.size() << " \n";
         std::cout << "accessors size: " << accessors.size() << " \n";
     }
 
     template <class VM, void callback(method::Arguments)>
-    void add_method(std::string &&name) {
-        std::string *leak = new std::string{name};
+    void add_method(std::string&& name)
+    {
+        std::string* leak = new std::string{name};
 
-        JSStaticFunction method_definition{leak->c_str(),
-                                           function_call<callback>,
-                                           kJSPropertyAttributeDontEnum};
+        JSStaticFunction method_definition{leak->c_str(), function_call<callback>, kJSPropertyAttributeDontEnum};
 
         methods.push_back(method_definition);
     }
 
-    void add_key(std::string name) {
+    void add_key(std::string name)
+    {
         private_object->keys[name.c_str()] = true;
         accessors.push_back(name);
     }
 
-    std::vector<std::string> &get_properties() { return accessors; }
+    std::vector<std::string>& get_properties()
+    {
+        return accessors;
+    }
 
-    void remove_accessor(std::string property_name) {
+    void remove_accessor(std::string property_name)
+    {
         private_object->keys[property_name.c_str()] = false;
     }
 
-    void set_collection(IOCollection *collection) {
+    void set_collection(IOCollection* collection)
+    {
         private_object->collection = collection;
     }
 
-    void set_observer(ObjectObserver *observer) {
+    void set_observer(ObjectObserver* observer)
+    {
         private_object->observer = observer;
     }
 
-    bool is_alive(){
+    bool is_alive()
+    {
         return object != nullptr;
     }
 
-    JSObjectRef get() { return object; }
+    JSObjectRef get()
+    {
+        return object;
+    }
 
-    JSObjectRef create() {
+    JSObjectRef create()
+    {
         object = lazily_build_object();
         return object;
     }
 
     template <typename RemovalCallback>
-    void finalize(RemovalCallback &&callback, void *_unused = nullptr) {
+    void finalize(RemovalCallback&& callback, void* _unused = nullptr)
+    {
         /*
          *  JSObject and Self only apply for NodeJS.
          */
@@ -224,5 +241,5 @@ class JavascriptObject {
     }
 };
 
-}  // namespace common
-}  // namespace realm
+} // namespace common
+} // namespace realm

--- a/src/common/object/jsc/subscriber.hpp
+++ b/src/common/object/jsc/subscriber.hpp
@@ -26,9 +26,8 @@
 #include "realm/object-store/dictionary.hpp"
 
 struct Subscriber {
-    virtual void notify(JSObjectRef, realm::DictionaryChangeSet &) = 0;
+    virtual void notify(JSObjectRef, realm::DictionaryChangeSet&) = 0;
     virtual bool equals(std::unique_ptr<Subscriber>&) const = 0;
     virtual JSValueRef callback() const = 0;
     virtual ~Subscriber() = default;
 };
-

--- a/src/common/object/node/methods.hpp
+++ b/src/common/object/node/methods.hpp
@@ -22,41 +22,45 @@
 #include "common/object/observer.hpp"
 
 
-
-auto NodeCallbackWrapper(const Napi::CallbackInfo &values) {
-    return [&](int index) -> Napi::Value { return values[index]; };
+auto NodeCallbackWrapper(const Napi::CallbackInfo& values)
+{
+    return [&](int index) -> Napi::Value {
+        return values[index];
+    };
 }
 namespace method {
-    struct Arguments {
-        Napi::Env context;
-        ObjectObserver *observer = nullptr;
-        IOCollection *collection = nullptr;
-        size_t argumentCount;
-        std::function<Napi::Value(int index)> callback;
+struct Arguments {
+    Napi::Env context;
+    ObjectObserver* observer = nullptr;
+    IOCollection* collection = nullptr;
+    size_t argumentCount;
+    std::function<Napi::Value(int index)> callback;
 
-        Napi::Value get(int index,
-                        std::string msg = "Missing argument for method call.") {
-            if (index >= argumentCount) {
-                Napi::Error::New(context, msg.c_str());
-            }
-
-            return callback(index);
+    Napi::Value get(int index, std::string msg = "Missing argument for method call.")
+    {
+        if (index >= argumentCount) {
+            Napi::Error::New(context, msg.c_str());
         }
 
-        void throw_error(std::string&& message){
-            throw Napi::Error::New(context, message);
-        }
-    };
-}
+        return callback(index);
+    }
 
-namespace accessor{
-    struct Arguments{
-        Napi::Env context;
-        std::string property_name;
-        Napi::Value value;
-
-        void throw_error(std::string&& message){
-            throw Napi::Error::New(context, message);
-        }
-    };
+    void throw_error(std::string&& message)
+    {
+        throw Napi::Error::New(context, message);
+    }
 };
+} // namespace method
+
+namespace accessor {
+struct Arguments {
+    Napi::Env context;
+    std::string property_name;
+    Napi::Value value;
+
+    void throw_error(std::string&& message)
+    {
+        throw Napi::Error::New(context, message);
+    }
+};
+}; // namespace accessor

--- a/src/common/object/node/object.hpp
+++ b/src/common/object/node/object.hpp
@@ -28,20 +28,21 @@ namespace common {
 
 template <typename GetterSetter>
 class JavascriptObject {
-   private:
+private:
     Napi::Env context;
     Napi::Reference<Napi::Object> ref_object;
-    ObjectObserver *observer = nullptr;
-    IOCollection *collection = nullptr;
+    ObjectObserver* observer = nullptr;
+    IOCollection* collection = nullptr;
     std::vector<std::string> keys;
 
     template <class T>
     using ObjectAPI = realm::js::Object<T>;
     using Property = realm::js::PropertyAttributes;
 
-    bool remove_key(std::string &key) {
+    bool remove_key(std::string& key)
+    {
         int index = -1;
-        for (auto const &_key : keys) {
+        for (auto const& _key : keys) {
             index++;
             if (key == _key) {
                 keys.erase(keys.begin() + index);
@@ -51,33 +52,39 @@ class JavascriptObject {
         return false;
     }
 
-   public:
+public:
     JavascriptObject(Napi::Env _ctx, std::string name = "js_object")
-        : context{_ctx} {
-        ref_object =
-            Napi::Reference<Napi::Object>::New(Napi::Object::New(context));
+        : context{_ctx}
+    {
+        ref_object = Napi::Reference<Napi::Object>::New(Napi::Object::New(context));
     }
 
-    void set_collection(IOCollection *_collection) { collection = _collection; }
+    void set_collection(IOCollection* _collection)
+    {
+        collection = _collection;
+    }
 
-    void set_observer(ObjectObserver *_observer) { observer = _observer; }
+    void set_observer(ObjectObserver* _observer)
+    {
+        observer = _observer;
+    }
 
     template <class VM, void callback(method::Arguments)>
-    void add_method(std::string &&name) {
+    void add_method(std::string&& name)
+    {
         auto object = get();
 
-        auto method = [=](const auto &info) {
-            callback({info.Env(), observer, collection, info.Length(),
-                      NodeCallbackWrapper(info)});
+        auto method = [=](const auto& info) {
+            callback({info.Env(), observer, collection, info.Length(), NodeCallbackWrapper(info)});
         };
 
         auto method_function = Napi::Function::New(context, method, name);
 
-        ObjectAPI<VM>::set_property(context, object, name, method_function,
-                                    Property::DontEnum);
+        ObjectAPI<VM>::set_property(context, object, name, method_function, Property::DontEnum);
     }
 
-    void add_key(std::string key) {
+    void add_key(std::string key)
+    {
         auto _object = get();
         /*
          * NAPI_enumerable: Enables JSON.stringify(object) and other JS stuff
@@ -87,18 +94,17 @@ class JavascriptObject {
          * fields, very handy to reflect object-dictionary mutations.
          *
          */
-        auto rules = static_cast<napi_property_attributes>(napi_enumerable |
-                                                           napi_configurable);
+        auto rules = static_cast<napi_property_attributes>(napi_enumerable | napi_configurable);
 
-        auto Getter = [=](std::string &key) {
-            return [=](const auto &info) mutable {
+        auto Getter = [=](std::string& key) {
+            return [=](const auto& info) mutable {
                 GetterSetter gs{collection};
                 return gs.get(accessor::Arguments{info.Env(), key.c_str()});
             };
         };
 
-        auto Setter = [=](std::string &key) {
-            return [=](const auto &info) mutable {
+        auto Setter = [=](std::string& key) {
+            return [=](const auto& info) mutable {
                 GetterSetter gs{collection};
                 gs.set(accessor::Arguments{info.Env(), key.c_str(), info[0]});
             };
@@ -107,8 +113,7 @@ class JavascriptObject {
         /*
          * https://github.com/nodejs/node-addon-api/blob/main/doc/property_descriptor.md
          */
-        auto descriptor = Napi::PropertyDescriptor::Accessor(
-            context, _object, key, Getter(key), Setter(key), rules);
+        auto descriptor = Napi::PropertyDescriptor::Accessor(context, _object, key, Getter(key), Setter(key), rules);
 
         // https://github.com/nodejs/node-addon-api/blob/main/doc/object.md#defineproperty
         _object.DefineProperty(descriptor);
@@ -117,15 +122,23 @@ class JavascriptObject {
     }
 
     template <typename RemovalCallback, typename Self>
-    void finalize(RemovalCallback &&callback, Self *self) {
+    void finalize(RemovalCallback&& callback, Self* self)
+    {
         auto object = get();
-        object.AddFinalizer([callback](auto, void *data_ref) { callback(); },
-                            self);
+        object.AddFinalizer(
+            [callback](auto, void* data_ref) {
+                callback();
+            },
+            self);
     }
 
-    std::vector<std::string> &get_properties() { return keys; }
+    std::vector<std::string>& get_properties()
+    {
+        return keys;
+    }
 
-    void remove_accessor(std::string &key) {
+    void remove_accessor(std::string& key)
+    {
         Napi::Object obj = get();
 
         if (remove_key(key)) {
@@ -134,18 +147,24 @@ class JavascriptObject {
         }
     }
 
-    Napi::Object get() { return ref_object.Value(); }
+    Napi::Object get()
+    {
+        return ref_object.Value();
+    }
 
-    bool is_alive(){
+    bool is_alive()
+    {
         return !get().IsUndefined();
     }
 
-    Napi::Object create() {
+    Napi::Object create()
+    {
         // Only necessary to keep compatibility with the JSCore.
         return get();
     }
 
-    ~JavascriptObject() {
+    ~JavascriptObject()
+    {
         if (!ref_object.IsEmpty()) {
             // Liberate any retained object.
             // https://github.com/nodejs/node-addon-api/blob/main/doc/reference.md
@@ -153,5 +172,5 @@ class JavascriptObject {
         }
     }
 };
-}  // namespace common
-}  // namespace realm
+} // namespace common
+} // namespace realm

--- a/src/common/object/node/subscriber.hpp
+++ b/src/common/object/node/subscriber.hpp
@@ -25,5 +25,3 @@ struct Subscriber {
     virtual Napi::Function callback() const = 0;
     virtual ~Subscriber() = default;
 };
-
-

--- a/src/common/object/strategies.hpp
+++ b/src/common/object/strategies.hpp
@@ -21,16 +21,18 @@
 #include "common/object/interfaces.hpp"
 
 
-
 template <typename VM>
 struct NoBuilder {
     using ContextType = typename VM::Context;
     ContextType context;
-    NoBuilder(ContextType _context) : context{_context} {};
+    NoBuilder(ContextType _context)
+        : context{_context} {};
 };
 
-class NoData {};
-class EmptyGetterSetters{};
+class NoData {
+};
+class EmptyGetterSetters {
+};
 
 struct NoNotificationsStrategy {
     int empty{0};

--- a/src/common/type_deduction.hpp
+++ b/src/common/type_deduction.hpp
@@ -23,73 +23,80 @@
 #include "types.hpp"
 
 
-
 namespace realm {
 namespace js {
 
 class GenericTypeDeductionImpl {
-   private:
+private:
     std::map<types::Type, std::string> realm_to_js_map;
     std::map<std::string, types::Type> js_to_realm_map;
 
-    auto reverse_deduction_types_map() {
+    auto reverse_deduction_types_map()
+    {
         std::map<std::string, types::Type> ret;
         for (auto& [type, key] : realm_to_js_map) {
-            ret[key] = type;  // camel_case version.
+            ret[key] = type; // camel_case version.
             std::string lower_case_key;
             // in-place lower case, we want to support multiple variation of the
             // types written names.
-            std::transform(key.begin(), key.end(), key.begin(),
-                           [](unsigned char chr) { return std::tolower(chr); });
+            std::transform(key.begin(), key.end(), key.begin(), [](unsigned char chr) {
+                return std::tolower(chr);
+            });
             ret[key] = type;
         }
         return ret;
     }
 
-   public:
-    GenericTypeDeductionImpl() {
-        realm_to_js_map = {
-            {types::String, "String"},       {types::Integer, "Int"},
-            {types::Float, "Float"},         {types::Double, "Double"},
-            {types::Decimal, "Decimal128"},  {types::Boolean, "Bool"},
-            {types::ObjectId, "ObjectId"},   {types::Object, "Object"},
-            {types::UUID, "UUID"},       {types::Object, "Object"},
-            {types::Undefined, "Undefined"}, {types::Null, "Null"}};
+public:
+    GenericTypeDeductionImpl()
+    {
+        realm_to_js_map = {{types::String, "String"},     {types::Integer, "Int"},         {types::Float, "Float"},
+                           {types::Double, "Double"},     {types::Decimal, "Decimal128"},  {types::Boolean, "Bool"},
+                           {types::ObjectId, "ObjectId"}, {types::Object, "Object"},       {types::UUID, "UUID"},
+                           {types::Object, "Object"},     {types::Undefined, "Undefined"}, {types::Null, "Null"}};
         js_to_realm_map = reverse_deduction_types_map();
     }
 
-    static GenericTypeDeductionImpl& get_instance() {
+    static GenericTypeDeductionImpl& get_instance()
+    {
         static GenericTypeDeductionImpl instance;
         return instance;
     }
 
-    bool realm_type_exist(std::string const& type) {
+    bool realm_type_exist(std::string const& type)
+    {
         return js_to_realm_map.find(type) != js_to_realm_map.end();
     }
 
-    types::Type realm_type(std::string const& type) {
+    types::Type realm_type(std::string const& type)
+    {
         return js_to_realm_map[type];
     }
 
-    std::string javascript_type(types::Type value) {
+    std::string javascript_type(types::Type value)
+    {
         return realm_to_js_map[value];
     }
 
     template <typename MixedValue>
-    types::Type from(MixedValue mixed) {
-        if(mixed.is_null()) return types::Type::Null;
+    types::Type from(MixedValue mixed)
+    {
+        if (mixed.is_null())
+            return types::Type::Null;
 
         int realm_type = static_cast<int>(mixed.get_type());
         return static_cast<types::Type>(realm_type);
     }
 
-    types::Type from(DataType data_type) {
+    types::Type from(DataType data_type)
+    {
         int realm_type = static_cast<int>(data_type);
         return static_cast<types::Type>(realm_type);
     }
 
     template <typename T, typename Ctx, typename Val>
-    types::Type typeof(Ctx context, Val& value) {
+    types::Type typeof(Ctx context, Val& value)
+    {
         using Value = js::Value<T>;
 
         if (Value::is_null(context, value)) {
@@ -110,8 +117,7 @@ class GenericTypeDeductionImpl {
         if (Value::is_undefined(context, value)) {
             return types::Undefined;
         }
-        if (Value::is_array_buffer(context, value) ||
-            Value::is_array_buffer(context, value)) {
+        if (Value::is_array_buffer(context, value) || Value::is_array_buffer(context, value)) {
             return types::Binary;
         }
         if (Value::is_decimal128(context, value)) {
@@ -135,7 +141,8 @@ class GenericTypeDeductionImpl {
  * Here we encapsulate some type deduction capabilities for all supported
  * Javascript environments.
  */
-struct TypeDeduction : GenericTypeDeductionImpl {};
+struct TypeDeduction : GenericTypeDeductionImpl {
+};
 
-}  // namespace js
-}  // namespace realm
+} // namespace js
+} // namespace realm

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -28,7 +28,7 @@ namespace types {
 
 enum Type {
     NotImplemented = -100,
-    Object = 16,    // We translate TypedLink (16) -> Object 
+    Object = 16, // We translate TypedLink (16) -> Object
     Undefined = -2,
     Null = -1,
     Integer = 0,

--- a/src/concurrent_deque.hpp
+++ b/src/concurrent_deque.hpp
@@ -29,13 +29,17 @@ namespace realm {
 template <typename T>
 class ConcurrentDeque {
 public:
-    T pop_back() {
+    T pop_back()
+    {
         std::unique_lock<std::mutex> lock(m_mutex);
-        m_condition.wait(lock, [this] { return !m_deque.empty(); });
+        m_condition.wait(lock, [this] {
+            return !m_deque.empty();
+        });
         return do_pop_back();
     }
 
-    T pop_if(std::function<bool(const T&)> predicate) {
+    T pop_if(std::function<bool(const T&)> predicate)
+    {
         std::unique_lock<std::mutex> lock(m_mutex);
 
         for (auto it = m_deque.begin(); it != m_deque.end();) {
@@ -52,29 +56,34 @@ public:
         return nullptr;
     }
 
-    util::Optional<T> try_pop_back(size_t timeout) {
+    util::Optional<T> try_pop_back(size_t timeout)
+    {
         std::unique_lock<std::mutex> lock(m_mutex);
-        m_condition.wait_for(lock, std::chrono::milliseconds(timeout),
-                             [this] { return !m_deque.empty(); });
+        m_condition.wait_for(lock, std::chrono::milliseconds(timeout), [this] {
+            return !m_deque.empty();
+        });
         return m_deque.empty() ? util::none : util::make_optional(do_pop_back());
     }
 
-    void push_front(T&& item) {
+    void push_front(T&& item)
+    {
         std::unique_lock<std::mutex> lock(m_mutex);
         m_deque.push_front(std::move(item));
         lock.unlock();
         m_condition.notify_one();
     }
 
-    void push_back(T&& item) {
+    void push_back(T&& item)
+    {
         std::unique_lock<std::mutex> lock(m_mutex);
         m_deque.push_back(std::move(item));
         lock.unlock();
         m_condition.notify_one();
     }
 
-    bool empty() {
-        std::lock_guard <std::mutex> lock(m_mutex);
+    bool empty()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
         return m_deque.empty();
     }
 
@@ -83,11 +92,12 @@ private:
     std::mutex m_mutex;
     std::deque<T> m_deque;
 
-    T do_pop_back() {
+    T do_pop_back()
+    {
         T item = std::move(m_deque.back());
         m_deque.pop_back();
         return item;
     }
 };
 
-} // realm
+} // namespace realm

--- a/src/dictionary_schema.hpp
+++ b/src/dictionary_schema.hpp
@@ -25,36 +25,37 @@
 namespace realm {
 namespace js {
 class DictionarySchema {
-   private:
+private:
     const std::string DICT_SCHEMA = R"((\w+)?(\{\}))";
 
     std::string type;
     std::smatch matches;
     bool valid_schema;
 
-   public:
-    DictionarySchema(std::string _schema) {
-        std::regex dict_schema_regex{DICT_SCHEMA,
-                                     std::regex_constants::ECMAScript};
+public:
+    DictionarySchema(std::string _schema)
+    {
+        std::regex dict_schema_regex{DICT_SCHEMA, std::regex_constants::ECMAScript};
         valid_schema = std::regex_search(_schema, matches, dict_schema_regex);
         if (valid_schema) {
             type = matches[1];
         }
     }
 
-    realm::PropertyType make_generic() {
+    realm::PropertyType make_generic()
+    {
         return realm::PropertyType::Dictionary | realm::PropertyType::Mixed | realm::PropertyType::Nullable;
     }
 
-    realm::PropertyType schema() {
+    realm::PropertyType schema()
+    {
         auto type_deduction = TypeDeduction::get_instance();
         if (type.empty()) {
             return make_generic();
         }
 
         if (!type_deduction.realm_type_exist(type)) {
-            throw std::runtime_error("Schema type: " + type +
-                                     " not supported for Dictionary.");
+            throw std::runtime_error("Schema type: " + type + " not supported for Dictionary.");
         }
 
         auto dictionary_type_value = type_deduction.realm_type(type);
@@ -62,7 +63,10 @@ class DictionarySchema {
                 static_cast<realm::PropertyType>(dictionary_type_value));
     }
 
-    bool is_dictionary() { return valid_schema; }
+    bool is_dictionary()
+    {
+        return valid_schema;
+    }
 };
-}  // namespace js
-}  // namespace realm
+} // namespace js
+} // namespace realm

--- a/src/js_api_key_auth.hpp
+++ b/src/js_api_key_auth.hpp
@@ -28,19 +28,23 @@ namespace js {
 using SharedUser = std::shared_ptr<realm::SyncUser>;
 using SharedApp = std::shared_ptr<realm::app::App>;
 
-template<typename T>
+template <typename T>
 class ApiKeyAuth : public app::App::UserAPIKeyProviderClient {
 public:
-    ApiKeyAuth(app::App::UserAPIKeyProviderClient client, SharedUser user) : app::App::UserAPIKeyProviderClient(client), m_user(std::move(user)) {}
-    ApiKeyAuth(ApiKeyAuth &&) = default;
+    ApiKeyAuth(app::App::UserAPIKeyProviderClient client, SharedUser user)
+        : app::App::UserAPIKeyProviderClient(client)
+        , m_user(std::move(user))
+    {
+    }
+    ApiKeyAuth(ApiKeyAuth&&) = default;
 
-    ApiKeyAuth& operator=(ApiKeyAuth &&) = default;
+    ApiKeyAuth& operator=(ApiKeyAuth&&) = default;
     ApiKeyAuth& operator=(ApiKeyAuth const&) = default;
 
     SharedUser m_user;
 };
 
-template<typename T>
+template <typename T>
 class ApiKeyAuthClass : public ClassDefinition<T, ApiKeyAuth<T>> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -60,8 +64,7 @@ public:
     static FunctionType create_constructor(ContextType);
     static ObjectType create_instance(ContextType, SharedApp, SharedUser);
 
-    PropertyMap<T> const properties = {
-    };
+    PropertyMap<T> const properties = {};
 
     static void create_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void fetch_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -71,34 +74,36 @@ public:
     static void disable_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const methods = {
-        {"_create", wrap<create_api_key>},
-        {"_fetch", wrap<fetch_api_key>},
-        {"_fetchAll", wrap<fetch_all_api_keys>},
-        {"_delete", wrap<delete_api_key>},
-        {"_enable", wrap<enable_api_key>},
-        {"_disable", wrap<disable_api_key>},
+        {"_create", wrap<create_api_key>}, {"_fetch", wrap<fetch_api_key>},   {"_fetchAll", wrap<fetch_all_api_keys>},
+        {"_delete", wrap<delete_api_key>}, {"_enable", wrap<enable_api_key>}, {"_disable", wrap<disable_api_key>},
     };
 };
 
-template<typename T>
-inline typename T::Function ApiKeyAuthClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function ApiKeyAuthClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType constructor = ObjectWrap<T, ApiKeyAuthClass<T>>::create_constructor(ctx);
     return constructor;
 }
 
-template<typename T>
-typename T::Object ApiKeyAuthClass<T>::create_instance(ContextType ctx, SharedApp app, SharedUser user) {
-    return create_object<T, ApiKeyAuthClass<T>>(ctx, new ApiKeyAuth<T>(app->provider_client<realm::app::App::UserAPIKeyProviderClient>(), user));
+template <typename T>
+typename T::Object ApiKeyAuthClass<T>::create_instance(ContextType ctx, SharedApp app, SharedUser user)
+{
+    return create_object<T, ApiKeyAuthClass<T>>(
+        ctx, new ApiKeyAuth<T>(app->provider_client<realm::app::App::UserAPIKeyProviderClient>(), user));
 }
 
-template<typename T>
-typename T::Object make_api_key(typename T::Context ctx, util::Optional<app::App::UserAPIKey> api_key) {
+template <typename T>
+typename T::Object make_api_key(typename T::Context ctx, util::Optional<app::App::UserAPIKey> api_key)
+{
     using ObjectType = typename T::Object;
 
     ObjectType api_key_object = Object<T>::create_empty(ctx);
     if (api_key) {
         Object<T>::set_property(ctx, api_key_object, "id", Value<T>::from_object_id(ctx, api_key->id));
-        Object<T>::set_property(ctx, api_key_object, "key", api_key->key ? Value<T>::from_string(ctx, *(api_key->key)) : Value<T>::from_undefined(ctx));
+        Object<T>::set_property(ctx, api_key_object, "key",
+                                api_key->key ? Value<T>::from_string(ctx, *(api_key->key))
+                                             : Value<T>::from_undefined(ctx));
         Object<T>::set_property(ctx, api_key_object, "name", Value<T>::from_string(ctx, api_key->name));
         Object<T>::set_property(ctx, api_key_object, "disabled", Value<T>::from_boolean(ctx, api_key->disabled));
     }
@@ -106,8 +111,10 @@ typename T::Object make_api_key(typename T::Context ctx, util::Optional<app::App
     return api_key_object;
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::create_api_key(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::create_api_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                        ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
@@ -115,13 +122,14 @@ void ApiKeyAuthClass<T>::create_api_key(ContextType ctx, ObjectType this_object,
     auto name = Value::validated_to_string(ctx, args[0], "name");
     auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
-    client.create_api_key(name,
-                          client.m_user,
+    client.create_api_key(name, client.m_user,
                           Function::wrap_callback_result_first(ctx, this_object, callback, make_api_key<T>));
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::fetch_api_key(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::fetch_api_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
@@ -129,32 +137,34 @@ void ApiKeyAuthClass<T>::fetch_api_key(ContextType ctx, ObjectType this_object, 
     auto id = Value::validated_to_object_id(ctx, args[0], "id");
     auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
-    client.fetch_api_key(id,
-                         client.m_user,
+    client.fetch_api_key(id, client.m_user,
                          Function::wrap_callback_result_first(ctx, this_object, callback, make_api_key<T>));
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::fetch_all_api_keys(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::fetch_all_api_keys(ContextType ctx, ObjectType this_object, Arguments& args,
+                                            ReturnValue& return_value)
+{
     args.validate_count(1);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
     auto callback = Value::validated_to_function(ctx, args[0], "callback");
 
-    client.fetch_api_keys(client.m_user, Function::wrap_callback_result_first(ctx, this_object, callback,
-        [] (ContextType ctx, const std::vector<app::App::UserAPIKey>& api_keys) {
-            std::vector<ValueType> api_key_vector;
-            api_key_vector.reserve(api_keys.size());
-            for (auto api_key : api_keys) {
-                api_key_vector.push_back(make_api_key<T>(ctx, api_key));
-            }
-            return Object::create_array(ctx, api_key_vector);
-        }
-    ));
+    client.fetch_api_keys(client.m_user, Function::wrap_callback_result_first(
+                                             ctx, this_object, callback,
+                                             [](ContextType ctx, const std::vector<app::App::UserAPIKey>& api_keys) {
+                                                 std::vector<ValueType> api_key_vector;
+                                                 api_key_vector.reserve(api_keys.size());
+                                                 for (auto api_key : api_keys) {
+                                                     api_key_vector.push_back(make_api_key<T>(ctx, api_key));
+                                                 }
+                                                 return Object::create_array(ctx, api_key_vector);
+                                             }));
 }
 
-template<typename T>
-app::App::UserAPIKey to_api_key(typename T::Context ctx, typename T::Object api_key_object) {
+template <typename T>
+app::App::UserAPIKey to_api_key(typename T::Context ctx, typename T::Object api_key_object)
+{
     using ValueType = typename T::Value;
     using String = js::String<T>;
 
@@ -188,8 +198,10 @@ app::App::UserAPIKey to_api_key(typename T::Context ctx, typename T::Object api_
     return app::App::UserAPIKey({id, key, name, disabled});
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::delete_api_key(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::delete_api_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                        ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
@@ -200,8 +212,10 @@ void ApiKeyAuthClass<T>::delete_api_key(ContextType ctx, ObjectType this_object,
     client.delete_api_key(api_key_id, client.m_user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::enable_api_key(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::enable_api_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                        ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
@@ -212,8 +226,10 @@ void ApiKeyAuthClass<T>::enable_api_key(ContextType ctx, ObjectType this_object,
     client.enable_api_key(api_key_id, client.m_user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void ApiKeyAuthClass<T>::disable_api_key(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void ApiKeyAuthClass<T>::disable_api_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, ApiKeyAuthClass<T>>(ctx, this_object);
@@ -225,5 +241,5 @@ void ApiKeyAuthClass<T>::disable_api_key(ContextType ctx, ObjectType this_object
 }
 
 
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_app.hpp
+++ b/src/js_app.hpp
@@ -36,7 +36,7 @@ using SharedUser = std::shared_ptr<realm::SyncUser>;
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 class AppClass : public ClassDefinition<T, SharedApp> {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -54,12 +54,14 @@ class AppClass : public ClassDefinition<T, SharedApp> {
 
 public:
     const std::string name = "App";
-    
+
     /**
-     * Generates instances of GenericNetworkTransport, eventually allowing Realm Object Store to perform network requests.
-     * Exposed to allow other components (ex the RPCServer) to override the underlying implementation.
+     * Generates instances of GenericNetworkTransport, eventually allowing Realm Object Store to perform network
+     * requests. Exposed to allow other components (ex the RPCServer) to override the underlying implementation.
      */
-    static inline NetworkTransportFactory transport_generator = +[] (ContextType ctx, typename NetworkTransport::Dispatcher eld) -> std::unique_ptr<app::GenericNetworkTransport> {
+    static inline NetworkTransportFactory transport_generator =
+        +[](ContextType ctx,
+            typename NetworkTransport::Dispatcher eld) -> std::unique_ptr<app::GenericNetworkTransport> {
         return std::make_unique<NetworkTransport>(ctx, std::move(eld));
     };
 
@@ -69,7 +71,7 @@ public:
     static inline std::string platform_os = "unknown-os";
     static inline std::string platform_version = "?.?.?";
 
-    static void constructor(ContextType, ObjectType, Arguments &);
+    static void constructor(ContextType, ObjectType, Arguments&);
     static FunctionType create_constructor(ContextType);
     static ObjectType create_instance(ContextType, SharedApp);
 
@@ -78,17 +80,15 @@ public:
      */
     static std::string get_user_agent();
 
-    static void get_app_id(ContextType, ObjectType, ReturnValue &);
-    static void get_email_password_auth(ContextType, ObjectType, ReturnValue &);
-    static void get_current_user(ContextType, ObjectType, ReturnValue &);
-    static void get_all_users(ContextType, ObjectType, ReturnValue &);
+    static void get_app_id(ContextType, ObjectType, ReturnValue&);
+    static void get_email_password_auth(ContextType, ObjectType, ReturnValue&);
+    static void get_current_user(ContextType, ObjectType, ReturnValue&);
+    static void get_all_users(ContextType, ObjectType, ReturnValue&);
 
-    PropertyMap<T> const properties = {
-        {"id", {wrap<get_app_id>, nullptr}},
-        {"emailPasswordAuth", {wrap<get_email_password_auth>, nullptr}},
-        {"currentUser", {wrap<get_current_user>, nullptr}},
-        {"allUsers", {wrap<get_all_users>, nullptr}}
-    };
+    PropertyMap<T> const properties = {{"id", {wrap<get_app_id>, nullptr}},
+                                       {"emailPasswordAuth", {wrap<get_email_password_auth>, nullptr}},
+                                       {"currentUser", {wrap<get_current_user>, nullptr}},
+                                       {"allUsers", {wrap<get_all_users>, nullptr}}};
 
     static void log_in(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void switch_user(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -106,24 +106,24 @@ public:
     };
 
     MethodMap<T> const static_methods = {
-        {"_clearAppCache", wrap<clear_app_cache>},
-        {"_getApp", wrap<get_app>},
-        {"_setVersions", wrap<set_versions>}
-    };
+        {"_clearAppCache", wrap<clear_app_cache>}, {"_getApp", wrap<get_app>}, {"_setVersions", wrap<set_versions>}};
 };
 
-template<typename T>
-inline typename T::Function AppClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function AppClass<T>::create_constructor(ContextType ctx)
+{
     return ObjectWrap<T, AppClass<T>>::create_constructor(ctx);
 }
 
-template<typename T>
-inline typename T::Object AppClass<T>::create_instance(ContextType ctx, SharedApp app) {
+template <typename T>
+inline typename T::Object AppClass<T>::create_instance(ContextType ctx, SharedApp app)
+{
     return create_object<T, AppClass<T>>(ctx, new SharedApp(app));
 }
 
-template<typename T>
-void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args) {
+template <typename T>
+void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args)
+{
     static const String config_id = "id";
     static const String config_base_url = "baseUrl";
     static const String config_timeout = "timeout";
@@ -151,12 +151,14 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
 
         ValueType config_base_url_value = Object::get_property(ctx, config_object, config_base_url);
         if (!Value::is_undefined(ctx, config_base_url_value)) {
-            config.base_url = util::Optional<std::string>(Value::validated_to_string(ctx, config_base_url_value, "baseUrl"));
+            config.base_url =
+                util::Optional<std::string>(Value::validated_to_string(ctx, config_base_url_value, "baseUrl"));
         }
 
         ValueType config_timeout_value = Object::get_property(ctx, config_object, config_timeout);
         if (!Value::is_undefined(ctx, config_timeout_value)) {
-            config.default_request_timeout_ms = util::Optional<uint64_t>(Value::validated_to_number(ctx, config_timeout_value, "timeout"));
+            config.default_request_timeout_ms =
+                util::Optional<uint64_t>(Value::validated_to_number(ctx, config_timeout_value, "timeout"));
         }
 
         ValueType config_app_value = Object::get_property(ctx, config_object, config_app);
@@ -165,12 +167,14 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
 
             ValueType config_app_name_value = Object::get_property(ctx, config_app_object, config_app_name);
             if (!Value::is_undefined(ctx, config_app_name_value)) {
-                config.local_app_name = util::Optional<std::string>(Value::validated_to_string(ctx, config_app_name_value, "name"));
+                config.local_app_name =
+                    util::Optional<std::string>(Value::validated_to_string(ctx, config_app_name_value, "name"));
             }
 
             ValueType config_app_version_value = Object::get_property(ctx, config_app_object, config_app_version);
             if (!Value::is_undefined(ctx, config_app_version_value)) {
-                config.local_app_version = util::Optional<std::string>(Value::validated_to_string(ctx, config_app_version_value, "version"));
+                config.local_app_version =
+                    util::Optional<std::string>(Value::validated_to_string(ctx, config_app_version_value, "version"));
             }
         }
     }
@@ -180,13 +184,14 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
     else {
         throw std::runtime_error("Expected either a configuration object or an app id string.");
     }
-    
-    config.transport = AppClass<T>::transport_generator(Protected(Context::get_global_context(ctx)), NetworkTransport::make_dispatcher());
+
+    config.transport = AppClass<T>::transport_generator(Protected(Context::get_global_context(ctx)),
+                                                        NetworkTransport::make_dispatcher());
 
     config.platform = platform_os;
     config.platform_version = platform_version;
     config.sdk_version = "RealmJS/" + package_version;
-    
+
     auto realm_file_directory = default_realm_file_directory();
     ensure_directory_exists_for_file(realm_file_directory);
 
@@ -200,19 +205,23 @@ void AppClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments
     set_internal<T, AppClass<T>>(ctx, this_object, new SharedApp(app));
 }
 
-template<typename T>
-std::string AppClass<T>::get_user_agent() {
-    return "RealmJS/" + package_version + " (" + platform_context + ", " + platform_os + ", v" + platform_version + ")";
+template <typename T>
+std::string AppClass<T>::get_user_agent()
+{
+    return "RealmJS/" + package_version + " (" + platform_context + ", " + platform_os + ", v" + platform_version +
+           ")";
 }
 
-template<typename T>
-void AppClass<T>::get_app_id(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
+template <typename T>
+void AppClass<T>::get_app_id(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
     return_value.set(Value::from_string(ctx, app->config().app_id));
 }
 
-template<typename T>
-void AppClass<T>::log_in(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void AppClass<T>::log_in(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
@@ -221,29 +230,33 @@ void AppClass<T>::log_in(ContextType ctx, ObjectType this_object, Arguments &arg
     auto callback_function = Value::validated_to_function(ctx, args[1]);
 
     app::AppCredentials app_credentials = *get_internal<T, CredentialsClass<T>>(ctx, credentials_object);
-    
-    app->log_in_with_credentials(app_credentials, Function::wrap_callback_result_first(ctx, this_object, callback_function,
-        [app] (ContextType ctx, SharedUser user) {
-            REALM_ASSERT_RELEASE(user);
-            return UserClass<T>::create_instance(ctx, std::move(user), std::move(app));
-        }));
 
+    app->log_in_with_credentials(app_credentials,
+                                 Function::wrap_callback_result_first(
+                                     ctx, this_object, callback_function, [app](ContextType ctx, SharedUser user) {
+                                         REALM_ASSERT_RELEASE(user);
+                                         return UserClass<T>::create_instance(ctx, std::move(user), std::move(app));
+                                     }));
 }
 
-template<typename T>
-void AppClass<T>::get_all_users(ContextType ctx, ObjectType this_object, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::get_all_users(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
 
     auto users = Object::create_empty(ctx);
     for (auto user : app->all_users()) {
         auto&& identity = user->identity();
-        Object::set_property(ctx, users, identity, create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), app)), ReadOnly | DontDelete);
+        Object::set_property(ctx, users, identity,
+                             create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), app)),
+                             ReadOnly | DontDelete);
     }
     return_value.set(users);
 }
 
-template<typename T>
-void AppClass<T>::get_current_user(ContextType ctx, ObjectType this_object, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::get_current_user(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
     auto user = app->current_user();
     if (user) {
@@ -254,8 +267,9 @@ void AppClass<T>::get_current_user(ContextType ctx, ObjectType this_object, Retu
     }
 }
 
-template<typename T>
-void AppClass<T>::switch_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::switch_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
 
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
@@ -265,8 +279,9 @@ void AppClass<T>::switch_user(ContextType ctx, ObjectType this_object, Arguments
     return_value.set(Value::from_undefined(ctx));
 }
 
-template<typename T>
-void AppClass<T>::remove_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::remove_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
@@ -276,20 +291,23 @@ void AppClass<T>::remove_user(ContextType ctx, ObjectType this_object, Arguments
     app->remove_user(*user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void AppClass<T>::get_email_password_auth(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
+template <typename T>
+void AppClass<T>::get_email_password_auth(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto app = *get_internal<T, AppClass<T>>(ctx, this_object);
     return_value.set(EmailPasswordAuthClass<T>::create_instance(ctx, app));
 }
 
-template<typename T>
-void AppClass<T>::clear_app_cache(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::clear_app_cache(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(0);
     realm::app::App::clear_cached_apps();
 }
 
-template<typename T>
-void AppClass<T>::get_app(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void AppClass<T>::get_app(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     auto app_id = Value::validated_to_string(ctx, args[0]);
     if (auto app = app::App::get_cached_app(app_id)) {
@@ -300,8 +318,9 @@ void AppClass<T>::get_app(ContextType ctx, ObjectType this_object, Arguments &ar
     }
 }
 
-template<typename T>
-void AppClass<T>::set_versions(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void AppClass<T>::set_versions(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     auto versions = Value::validated_to_object(ctx, args[0]);
     AppClass<T>::package_version = Object::validated_get_string(ctx, versions, "packageVersion");
@@ -310,5 +329,5 @@ void AppClass<T>::set_versions(ContextType ctx, ObjectType this_object, Argument
     AppClass<T>::platform_version = Object::validated_get_string(ctx, versions, "platformVersion");
 }
 
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_app_credentials.hpp
+++ b/src/js_app_credentials.hpp
@@ -25,7 +25,7 @@
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 class CredentialsClass : public ClassDefinition<T, realm::app::AppCredentials> {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -43,49 +43,45 @@ public:
 
     static FunctionType create_constructor(ContextType);
 
-    static void facebook(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void anonymous(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void apple(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void email_password(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void function(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void user_api_key(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void server_api_key(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void google(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void jwt(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void facebook(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void anonymous(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void apple(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void email_password(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void function(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void user_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void server_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void google(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void jwt(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const static_methods = {
-        {"facebook",         wrap<facebook>},
-        {"anonymous",        wrap<anonymous>},
-        {"apple",            wrap<apple>},
-        {"google",           wrap<google>},
-        {"emailPassword",    wrap<email_password>},
-        {"_function",        wrap<function>},
-        {"userApiKey",       wrap<user_api_key>},
-        {"serverApiKey",     wrap<server_api_key>},
-        {"jwt",              wrap<jwt>},
+        {"facebook", wrap<facebook>},       {"anonymous", wrap<anonymous>},          {"apple", wrap<apple>},
+        {"google", wrap<google>},           {"emailPassword", wrap<email_password>}, {"_function", wrap<function>},
+        {"userApiKey", wrap<user_api_key>}, {"serverApiKey", wrap<server_api_key>},  {"jwt", wrap<jwt>},
     };
 
-    static void get_payload(ContextType, ObjectType, ReturnValue &);
+    static void get_payload(ContextType, ObjectType, ReturnValue&);
 
     PropertyMap<T> const properties = {
         {"payload", {wrap<get_payload>, nullptr}},
     };
 
-    static void provider(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void provider(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const methods = {
         {"provider", wrap<provider>},
     };
 };
 
-template<typename T>
-typename T::Function CredentialsClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+typename T::Function CredentialsClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType credentials_constructor = ObjectWrap<T, CredentialsClass<T>>::create_constructor(ctx);
     return credentials_constructor;
 }
 
-template<typename T>
-void CredentialsClass<T>::facebook(ContextType ctx, ObjectType, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::facebook(ContextType ctx, ObjectType, Arguments& arguments, ReturnValue& return_value)
+{
     arguments.validate_maximum(1);
 
     realm::app::AppCredentialsToken token = Value::validated_to_string(ctx, arguments[0]);
@@ -94,16 +90,20 @@ void CredentialsClass<T>::facebook(ContextType ctx, ObjectType, Arguments& argum
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::anonymous(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::anonymous(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                    ReturnValue& return_value)
+{
     arguments.validate_maximum(0);
 
     auto credentials = realm::app::AppCredentials::anonymous();
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::apple(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::apple(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                ReturnValue& return_value)
+{
     arguments.validate_maximum(1);
 
     realm::app::AppCredentialsToken token = Value::validated_to_string(ctx, arguments[0]);
@@ -112,8 +112,10 @@ void CredentialsClass<T>::apple(ContextType ctx, ObjectType this_object, Argumen
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                 ReturnValue& return_value)
+{
     arguments.validate_maximum(1);
 
     auto decode_arg = [&](ValueType arg) {
@@ -135,13 +137,15 @@ void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Argume
             static const String auth_code_string = "authCode";
             ValueType auth_code = Object::get_property(ctx, object, auth_code_string);
             if (!Value::is_undefined(ctx, auth_code)) {
-                return app::AppCredentials::google(app::AuthCode(std::string(Value::validated_to_string(ctx, auth_code))));
+                return app::AppCredentials::google(
+                    app::AuthCode(std::string(Value::validated_to_string(ctx, auth_code))));
             }
 
             static const String id_token_string = "idToken";
             ValueType id_token = Object::get_property(ctx, object, id_token_string);
             if (!Value::is_undefined(ctx, id_token)) {
-                return app::AppCredentials::google(app::IdToken(std::string(Value::validated_to_string(ctx, id_token))));
+                return app::AppCredentials::google(
+                    app::IdToken(std::string(Value::validated_to_string(ctx, id_token))));
             }
         }
         throw std::runtime_error("Invalid arguments for Realm.App.Credentials.google()");
@@ -151,8 +155,10 @@ void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Argume
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::jwt(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::jwt(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                              ReturnValue& return_value)
+{
     arguments.validate_maximum(1);
 
     realm::app::AppCredentialsToken token = Value::validated_to_string(ctx, arguments[0]);
@@ -161,8 +167,10 @@ void CredentialsClass<T>::jwt(ContextType ctx, ObjectType this_object, Arguments
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::email_password(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::email_password(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                         ReturnValue& return_value)
+{
     arguments.validate_maximum(2);
 
     const std::string email = Value::validated_to_string(ctx, arguments[0], "email");
@@ -172,8 +180,10 @@ void CredentialsClass<T>::email_password(ContextType ctx, ObjectType this_object
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::function(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::function(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                   ReturnValue& return_value)
+{
     arguments.validate_count(1);
     const std::string payload_json = Value::validated_to_string(ctx, arguments[0], "payload");
     const auto payload_bson = bson::parse(payload_json);
@@ -184,16 +194,20 @@ void CredentialsClass<T>::function(ContextType ctx, ObjectType this_object, Argu
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::user_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::user_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                       ReturnValue& return_value)
+{
     arguments.validate_count(1);
     const std::string user_api_key = Value::validated_to_string(ctx, arguments[0], "user API key");
 
     auto credentials = realm::app::AppCredentials::user_api_key(user_api_key);
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
-template<typename T>
-void CredentialsClass<T>::server_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::server_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                         ReturnValue& return_value)
+{
     arguments.validate_count(1);
     const std::string server_api_key = Value::validated_to_string(ctx, arguments[0], "server API key");
 
@@ -201,19 +215,22 @@ void CredentialsClass<T>::server_api_key(ContextType ctx, ObjectType this_object
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 
-template<typename T>
-void CredentialsClass<T>::provider(ContextType ctx, ObjectType this_object, Arguments& arguments, ReturnValue& return_value) {
+template <typename T>
+void CredentialsClass<T>::provider(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                   ReturnValue& return_value)
+{
     arguments.validate_count(0);
 
     auto credentials = get_internal<T, CredentialsClass<T>>(ctx, this_object);
     return_value.set(Value::from_string(ctx, credentials->provider_as_string()));
 }
 
-template<typename T>
-void CredentialsClass<T>::get_payload(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
+template <typename T>
+void CredentialsClass<T>::get_payload(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto credentials = get_internal<T, CredentialsClass<T>>(ctx, this_object);
     return_value.set(Value::from_string(ctx, credentials->serialize_as_json()));
 }
 
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_auth.hpp
+++ b/src/js_auth.hpp
@@ -25,9 +25,10 @@ namespace js {
 // JavaScript used by the auth providers EmailPassword, APIKeys, etc. No objects
 // will ever be created of the type.
 
-class Auth { };
+class Auth {
+};
 
-template<typename T>
+template <typename T>
 class AuthClass : public ClassDefinition<T, Auth> {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -39,13 +40,13 @@ public:
     static FunctionType create_constructor(ContextType);
 };
 
-template<typename T>
-inline typename T::Function AuthClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function AuthClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType constructor = ObjectWrap<T, AuthClass<T>>::create_constructor(ctx);
     return constructor;
 }
 
 
-
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_class.hpp
+++ b/src/js_class.hpp
@@ -27,70 +27,78 @@
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 struct Arguments {
     const typename T::Context ctx;
     const size_t count;
     const typename T::Value* const value;
 
-    typename T::Value operator[](size_t index) const noexcept {
+    typename T::Value operator[](size_t index) const noexcept
+    {
         if (index >= count) {
             return Value<T>::from_undefined(ctx);
         }
         return value[index];
     }
 
-    void validate_maximum(size_t max) const {
+    void validate_maximum(size_t max) const
+    {
         if (max < count) {
-            throw std::invalid_argument(util::format("Invalid arguments: at most %1 expected, but %2 supplied.", max, count));
+            throw std::invalid_argument(
+                util::format("Invalid arguments: at most %1 expected, but %2 supplied.", max, count));
         }
     }
 
-    void validate_count(size_t expected) const {
+    void validate_count(size_t expected) const
+    {
         if (count != expected) {
-            throw std::invalid_argument(util::format("Invalid arguments: %1 expected, but %2 supplied.", expected, count));
+            throw std::invalid_argument(
+                util::format("Invalid arguments: %1 expected, but %2 supplied.", expected, count));
         }
     }
 
-    void validate_between(size_t min, size_t max) const {
+    void validate_between(size_t min, size_t max) const
+    {
         if (count < min || count > max) {
-            throw std::invalid_argument(util::format("Invalid arguments: expected between %1 and %2, but %3 supplied.", min, max, count));
+            throw std::invalid_argument(
+                util::format("Invalid arguments: expected between %1 and %2, but %3 supplied.", min, max, count));
         }
     }
 };
 
-template<typename T>
-using ConstructorType = void(typename T::Context, typename T::Object, Arguments<T> &);
+template <typename T>
+using ConstructorType = void(typename T::Context, typename T::Object, Arguments<T>&);
 
-template<typename T>
-using ArgumentsMethodType = void(typename T::Context, typename T::Object, Arguments<T> &, ReturnValue<T> &);
+template <typename T>
+using ArgumentsMethodType = void(typename T::Context, typename T::Object, Arguments<T>&, ReturnValue<T>&);
 
-template<typename T>
+template <typename T>
 struct PropertyType {
-    using GetterType = void(typename T::Context, typename T::Object, ReturnValue<T> &);
+    using GetterType = void(typename T::Context, typename T::Object, ReturnValue<T>&);
     using SetterType = void(typename T::Context, typename T::Object, typename T::Value);
 
     typename T::PropertyGetterCallback getter;
     typename T::PropertySetterCallback setter;
 };
 
-template<typename T>
+template <typename T>
 struct IndexPropertyType {
-    using GetterType = void(typename T::Context, typename T::Object, uint32_t, ReturnValue<T> &);
+    using GetterType = void(typename T::Context, typename T::Object, uint32_t, ReturnValue<T>&);
     using SetterType = bool(typename T::Context, typename T::Object, uint32_t, typename T::Value);
 
     typename T::IndexPropertyGetterCallback getter;
     typename T::IndexPropertySetterCallback setter;
 
-    explicit operator bool() const {
+    explicit operator bool() const
+    {
         return getter || setter;
     }
 };
 
-template<typename T>
+template <typename T>
 struct StringPropertyType {
-    using GetterType = void(typename T::Context, typename T::Object, const String<T> &, ReturnValue<T> &);
-    using SetterType = bool(typename T::Context, typename T::Object, const String<T> &, typename T::Value);
+    using GetterType = void(typename T::Context, typename T::Object, const String<T>&, ReturnValue<T>&);
+    using SetterType = bool(typename T::Context, typename T::Object, const String<T>&, typename T::Value);
     using EnumeratorType = std::vector<String<T>>(typename T::Context, typename T::Object);
 
     typename T::StringPropertyGetterCallback getter;
@@ -98,13 +106,13 @@ struct StringPropertyType {
     typename T::StringPropertyEnumeratorCallback enumerator;
 };
 
-template<typename T>
+template <typename T>
 using MethodMap = std::map<std::string, typename T::FunctionCallback>;
 
-template<typename T>
+template <typename T>
 using PropertyMap = std::map<std::string, PropertyType<T>>;
 
-template<typename T, typename U, typename V = void>
+template <typename T, typename U, typename V = void>
 struct ClassDefinition {
     using Internal = U;
     using Parent = V;
@@ -122,8 +130,8 @@ struct ClassDefinition {
     StringPropertyType<T> const string_accessor = {};
 };
 
-template<typename T, typename ClassType>
+template <typename T, typename ClassType>
 class ObjectWrap;
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_collection.hpp
+++ b/src/js_collection.hpp
@@ -29,16 +29,17 @@
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 class RealmObject;
 
-template<typename T>
+template <typename T>
 struct RealmObjectClass;
 
 // Empty class that merely serves as useful type for now.
-class Collection {};
+class Collection {
+};
 
-template<typename T>
+template <typename T>
 struct CollectionClass : ClassDefinition<T, Collection, ObservableClass<T>> {
     using ContextType = typename T::Context;
     using ValueType = typename T::Value;
@@ -48,12 +49,17 @@ struct CollectionClass : ClassDefinition<T, Collection, ObservableClass<T>> {
 
     std::string const name = "Collection";
 
-    static inline ValueType create_collection_change_set(ContextType ctx, StringData object_type, const ObjectChangeSet &change_set, realm::SharedRealm old_realm, realm::SharedRealm new_realm);
-    static inline ValueType create_collection_change_set(ContextType ctx, const CollectionChangeSet &change_set);
+    static inline ValueType create_collection_change_set(ContextType ctx, StringData object_type,
+                                                         const ObjectChangeSet& change_set,
+                                                         realm::SharedRealm old_realm, realm::SharedRealm new_realm);
+    static inline ValueType create_collection_change_set(ContextType ctx, const CollectionChangeSet& change_set);
 };
 
-template<typename T>
-typename T::Value CollectionClass<T>::create_collection_change_set(ContextType ctx, StringData object_type, const ObjectChangeSet &change_set, realm::SharedRealm old_realm, realm::SharedRealm new_realm)
+template <typename T>
+typename T::Value CollectionClass<T>::create_collection_change_set(ContextType ctx, StringData object_type,
+                                                                   const ObjectChangeSet& change_set,
+                                                                   realm::SharedRealm old_realm,
+                                                                   realm::SharedRealm new_realm)
 {
     ObjectType object = Object::create_empty(ctx);
     std::vector<ValueType> scratch;
@@ -92,8 +98,9 @@ typename T::Value CollectionClass<T>::create_collection_change_set(ContextType c
     return object;
 }
 
-template<typename T>
-typename T::Value CollectionClass<T>::create_collection_change_set(ContextType ctx, const CollectionChangeSet &change_set)
+template <typename T>
+typename T::Value CollectionClass<T>::create_collection_change_set(ContextType ctx,
+                                                                   const CollectionChangeSet& change_set)
 {
     ObjectType object = Object::create_empty(ctx);
     std::vector<ValueType> scratch;
@@ -122,5 +129,5 @@ typename T::Value CollectionClass<T>::create_collection_change_set(ContextType c
     return object;
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_dictionary.hpp
+++ b/src/js_dictionary.hpp
@@ -32,7 +32,7 @@
 namespace realm {
 namespace js {
 
-template<typename JSEngine>
+template <typename JSEngine>
 class NativeAccessor;
 
 namespace dictionary {
@@ -43,7 +43,8 @@ namespace dictionary {
  * @param prop (mutable) Property object that will be changed to be correct for \ref Dictionary
  * @exception std::logic_error Thrown if the the prop argument contains an invalid property configuration
  */
-inline static void derive_property_type(StringData const &object_name, Property &prop) {
+inline static void derive_property_type(StringData const& object_name, Property& prop)
+{
     using realm::PropertyType;
 
     if (prop.object_type == "bool") {
@@ -92,23 +93,31 @@ inline static void derive_property_type(StringData const &object_name, Property 
     }
     else {
         if (is_nullable(prop.type)) {
-            throw std::logic_error(util::format("Dictionary property '%1.%2' cannot be optional", object_name, prop.name));
+            throw std::logic_error(
+                util::format("Dictionary property '%1.%2' cannot be optional", object_name, prop.name));
         }
         if (is_array(prop.type)) {
-            throw std::logic_error(util::format("Dictionary property '%1.%2' must have a non-list value type", object_name, prop.name));
+            throw std::logic_error(
+                util::format("Dictionary property '%1.%2' must have a non-list value type", object_name, prop.name));
         }
         prop.type = PropertyType::Object | PropertyType::Dictionary | PropertyType::Nullable;
     }
-}  // derive_property_type()
+} // derive_property_type()
 
-};  // dictionary namespace
+}; // namespace dictionary
 
 
-template<typename T>
+template <typename T>
 class Dictionary : public realm::object_store::Dictionary {
 public:
-    Dictionary(Dictionary const& dictionary) : realm::object_store::Dictionary(dictionary) {}
-    Dictionary(const realm::object_store::Dictionary &dictionary) : realm::object_store::Dictionary(dictionary) {}
+    Dictionary(Dictionary const& dictionary)
+        : realm::object_store::Dictionary(dictionary)
+    {
+    }
+    Dictionary(const realm::object_store::Dictionary& dictionary)
+        : realm::object_store::Dictionary(dictionary)
+    {
+    }
     Dictionary(Dictionary&&) = default;
     Dictionary& operator=(Dictionary&&) = default;
     Dictionary& operator=(Dictionary const&) = default;
@@ -116,7 +125,7 @@ public:
     std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_listeners;
 };
 
-template<typename T>
+template <typename T>
 struct DictionaryClass : ClassDefinition<T, realm::js::Dictionary<T>, CollectionClass<T>> {
     using Type = T;
     using ContextType = typename T::Context;
@@ -132,20 +141,20 @@ struct DictionaryClass : ClassDefinition<T, realm::js::Dictionary<T>, Collection
     static ObjectType create_instance(ContextType, realm::object_store::Dictionary);
 
     // methods
-    static void getter(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void setter(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void has(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void keys(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void set(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void getter(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void setter(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void has(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void keys(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void set(ContextType, ObjectType, Arguments&, ReturnValue&);
     // observables
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // helpers
-    static ValueType create_dictionary_change_set(ContextType, DictionaryChangeSet const &);
-    static void validate_value(ContextType, const realm::object_store::Dictionary &, ValueType);
+    static ValueType create_dictionary_change_set(ContextType, DictionaryChangeSet const&);
+    static void validate_value(ContextType, const realm::object_store::Dictionary&, ValueType);
 
     std::string const name = "Dictionary";
 
@@ -162,30 +171,36 @@ struct DictionaryClass : ClassDefinition<T, realm::js::Dictionary<T>, Collection
     };
 };
 
-template<typename T>
-typename T::Object DictionaryClass<T>::create_instance(ContextType ctx, realm::object_store::Dictionary dictionary) {
+template <typename T>
+typename T::Object DictionaryClass<T>::create_instance(ContextType ctx, realm::object_store::Dictionary dictionary)
+{
     auto object = create_object<T, DictionaryClass<T>>(ctx, new realm::js::Dictionary<T>(std::move(dictionary)));
 
     ObjectType realm_constructor = Value::validated_to_object(ctx, Object::get_global(ctx, "Realm"));
-    FunctionType realm_dictionary_proxy = Value::to_function(ctx, Object::get_property(ctx, realm_constructor, "DictionaryProxy"));
-    ValueType arguments [] = { object };
+    FunctionType realm_dictionary_proxy =
+        Value::to_function(ctx, Object::get_property(ctx, realm_constructor, "DictionaryProxy"));
+    ValueType arguments[] = {object};
     return Value::to_object(ctx, Function<T>::call(ctx, realm_dictionary_proxy, 1, arguments));
 }
 
-template<typename T>
-void DictionaryClass<T>::validate_value(ContextType ctx, const realm::object_store::Dictionary &dictionary, ValueType value) {
+template <typename T>
+void DictionaryClass<T>::validate_value(ContextType ctx, const realm::object_store::Dictionary& dictionary,
+                                        ValueType value)
+{
     auto type = dictionary.get_type();
     StringData object_type;
     if (type == realm::PropertyType::Object) {
         object_type = dictionary.get_object_schema().name;
     }
     if (!Value::is_valid_for_property_type(ctx, value, type, object_type)) {
-        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type), Value::to_string(ctx, value));
+        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type),
+                                 Value::to_string(ctx, value));
     }
 }
 
-template<typename T>
-void DictionaryClass<T>::setter(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::setter(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
@@ -199,8 +214,9 @@ void DictionaryClass<T>::setter(ContextType ctx, ObjectType this_object, Argumen
     return_value.set(this_object);
 }
 
-template<typename T>
-void DictionaryClass<T>::getter(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::getter(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
 
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
@@ -210,16 +226,19 @@ void DictionaryClass<T>::getter(ContextType ctx, ObjectType this_object, Argumen
         if (dictionary->contains(key)) {
             NativeAccessor<T> accessor(ctx, *dictionary);
             return_value.set(dictionary->get(accessor, key));
-        } else {
+        }
+        else {
             return_value.set_undefined();
         }
-    } else {
+    }
+    else {
         return_value.set_undefined();
     }
 }
 
-template<typename T>
-void DictionaryClass<T>::set(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::set(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
 
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
@@ -230,8 +249,9 @@ void DictionaryClass<T>::set(ContextType ctx, ObjectType this_object, Arguments 
     return_value.set(this_object);
 }
 
-template<typename T>
-void DictionaryClass<T>::remove(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::remove(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
     if (Value::is_string(ctx, args[0])) {
@@ -258,16 +278,18 @@ void DictionaryClass<T>::remove(ContextType ctx, ObjectType this_object, Argumen
     return_value.set(this_object);
 }
 
-template<typename T>
-void DictionaryClass<T>::has(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::has(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
     std::string key = Value::validated_to_string(ctx, args[0]);
     return_value.set(dictionary->contains(key));
 }
 
-template<typename T>
-void DictionaryClass<T>::keys(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::keys(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto dictionary = *get_internal<T, DictionaryClass<T>>(ctx, this_object);
 
@@ -282,12 +304,15 @@ void DictionaryClass<T>::keys(ContextType ctx, ObjectType this_object, Arguments
     return_value.set(keys);
 }
 
-template<typename T>
-typename T::Value DictionaryClass<T>::create_dictionary_change_set(ContextType ctx, DictionaryChangeSet const& change_set) {
+template <typename T>
+typename T::Value DictionaryClass<T>::create_dictionary_change_set(ContextType ctx,
+                                                                   DictionaryChangeSet const& change_set)
+{
     ObjectType object = Object::create_empty(ctx);
     std::vector<ValueType> scratch;
 
-    scratch.reserve(std::max({change_set.deletions.size(), change_set.insertions.size(), change_set.modifications.size()}));
+    scratch.reserve(
+        std::max({change_set.deletions.size(), change_set.insertions.size(), change_set.modifications.size()}));
     auto make_object_array = [&](auto const& keys) {
         scratch.clear();
         for (auto mixed_item : keys) {
@@ -297,14 +322,16 @@ typename T::Value DictionaryClass<T>::create_dictionary_change_set(ContextType c
     };
 
     return Object::create_obj(ctx, {
-        {"deletions", make_object_array(change_set.deletions)},
-        {"insertions", make_object_array(change_set.insertions)},
-        {"modifications", make_object_array(change_set.modifications)},
-    });
+                                       {"deletions", make_object_array(change_set.deletions)},
+                                       {"insertions", make_object_array(change_set.insertions)},
+                                       {"modifications", make_object_array(change_set.modifications)},
+                                   });
 }
 
-template<typename T>
-void DictionaryClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                      ReturnValue& return_value)
+{
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
 
     args.validate_maximum(1);
@@ -312,26 +339,28 @@ void DictionaryClass<T>::add_listener(ContextType ctx, ObjectType this_object, A
     Protected<FunctionType> protected_callback(ctx, callback);
     Protected<ObjectType> protected_this(ctx, this_object);
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
-    auto token = dictionary->add_key_based_notification_callback([=](DictionaryChangeSet const& change_set, std::exception_ptr exception) {
-        HANDLESCOPE(protected_ctx)
+    auto token = dictionary->add_key_based_notification_callback(
+        [=](DictionaryChangeSet const& change_set, std::exception_ptr exception) {
+            HANDLESCOPE(protected_ctx)
 
-        ValueType arguments[] {
-            DictionaryClass<T>::create_instance(protected_ctx, *dictionary),
-            DictionaryClass<T>::create_dictionary_change_set(protected_ctx, change_set)
-        };
+            ValueType arguments[]{DictionaryClass<T>::create_instance(protected_ctx, *dictionary),
+                                  DictionaryClass<T>::create_dictionary_change_set(protected_ctx, change_set)};
 
-        Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
-    });
+            Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
+        });
     dictionary->m_listeners.emplace_back(protected_callback, std::move(token));
 }
 
-template<typename T>
-void DictionaryClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
 
     args.validate_maximum(1);
     auto callback = Value::validated_to_function(ctx, args[0]);
-    auto protected_function = Protected<FunctionType>(ctx, callback); // Protecting for comparison, not to extend lifetime.
+    auto protected_function =
+        Protected<FunctionType>(ctx, callback); // Protecting for comparison, not to extend lifetime.
 
     auto& listeners = dictionary->m_listeners;
     auto compare = [&](auto&& func_and_tok) {
@@ -341,13 +370,15 @@ void DictionaryClass<T>::remove_listener(ContextType ctx, ObjectType this_object
 }
 
 
-template<typename T>
-void DictionaryClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void DictionaryClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                              ReturnValue& return_value)
+{
     auto dictionary = get_internal<T, DictionaryClass<T>>(ctx, this_object);
 
     args.validate_maximum(0);
     dictionary->m_listeners.clear();
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_email_password_auth.hpp
+++ b/src/js_email_password_auth.hpp
@@ -25,7 +25,7 @@
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 class EmailPasswordAuthClass : public ClassDefinition<T, app::App::UsernamePasswordProviderClient> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -46,13 +46,12 @@ public:
     static FunctionType create_constructor(ContextType);
     static ObjectType create_instance(ContextType, SharedApp);
 
-    PropertyMap<T> const properties = {
-    };
+    PropertyMap<T> const properties = {};
 
     static void register_user(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void confirm_user(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void resend_confirmation_email(ContextType, ObjectType, Arguments&, ReturnValue&);
-    static void retry_custom_confirmation(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void retry_custom_confirmation(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void send_reset_password_email(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void reset_password(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void call_reset_password_function(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -69,19 +68,25 @@ public:
     };
 };
 
-template<typename T>
-inline typename T::Function EmailPasswordAuthClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function EmailPasswordAuthClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType constructor = ObjectWrap<T, EmailPasswordAuthClass<T>>::create_constructor(ctx);
     return constructor;
 }
 
-template<typename T>
-typename T::Object EmailPasswordAuthClass<T>::create_instance(ContextType ctx, SharedApp app) {
-    return create_object<T, EmailPasswordAuthClass<T>>(ctx, new app::App::UsernamePasswordProviderClient(app->provider_client<realm::app::App::UsernamePasswordProviderClient>()));
+template <typename T>
+typename T::Object EmailPasswordAuthClass<T>::create_instance(ContextType ctx, SharedApp app)
+{
+    return create_object<T, EmailPasswordAuthClass<T>>(
+        ctx, new app::App::UsernamePasswordProviderClient(
+                 app->provider_client<realm::app::App::UsernamePasswordProviderClient>()));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::register_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::register_user(ContextType ctx, ObjectType this_object, Arguments& args,
+                                              ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -94,8 +99,10 @@ void EmailPasswordAuthClass<T>::register_user(ContextType ctx, ObjectType this_o
     client.register_email(email, password, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::confirm_user(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::confirm_user(ContextType ctx, ObjectType this_object, Arguments& args,
+                                             ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -108,8 +115,10 @@ void EmailPasswordAuthClass<T>::confirm_user(ContextType ctx, ObjectType this_ob
     client.confirm_user(token, token_id, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::resend_confirmation_email(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::resend_confirmation_email(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                          ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -127,11 +136,13 @@ void EmailPasswordAuthClass<T>::resend_confirmation_email(ContextType ctx, Objec
  * @param args Two arguments;  [0]:  email address of the user;  [1]:  callback to invoke upon completion
  * @param return_value void
  */
-template<typename T>
-void EmailPasswordAuthClass<T>::retry_custom_confirmation(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::retry_custom_confirmation(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                          ReturnValue& return_value)
+{
     args.validate_count(2);
 
-    auto &client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
+    auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
 
     auto details = Value::validated_to_object(ctx, args[0], "emailDetails");
     auto email = Object::validated_get_string(ctx, details, "email", "email");
@@ -140,8 +151,10 @@ void EmailPasswordAuthClass<T>::retry_custom_confirmation(ContextType ctx, Objec
     client.retry_custom_confirmation(email, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::send_reset_password_email(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::send_reset_password_email(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                          ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -153,8 +166,10 @@ void EmailPasswordAuthClass<T>::send_reset_password_email(ContextType ctx, Objec
     client.send_reset_password_email(email, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::reset_password(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::reset_password(ContextType ctx, ObjectType this_object, Arguments& args,
+                                               ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -168,8 +183,10 @@ void EmailPasswordAuthClass<T>::reset_password(ContextType ctx, ObjectType this_
     client.reset_password(password, token, token_id, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void EmailPasswordAuthClass<T>::call_reset_password_function(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value) {
+template <typename T>
+void EmailPasswordAuthClass<T>::call_reset_password_function(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                             ReturnValue& return_value)
+{
     args.validate_count(3);
 
     auto& client = *get_internal<T, EmailPasswordAuthClass<T>>(ctx, this_object);
@@ -182,8 +199,9 @@ void EmailPasswordAuthClass<T>::call_reset_password_function(ContextType ctx, Ob
 
     auto bson_args = String::to_bson(stringified_ejson_args);
 
-    client.call_reset_password_function(email, password, bson_args.operator const bson::BsonArray &(), Function::wrap_void_callback(ctx, this_object, callback));
+    client.call_reset_password_function(email, password, bson_args.operator const bson::BsonArray&(),
+                                        Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -31,18 +31,21 @@
 namespace realm {
 namespace js {
 
-template<typename JSEngine>
+template <typename JSEngine>
 class NativeAccessor;
 
-template<typename T>
+template <typename T>
 class List : public realm::List {
-  public:
-    List(const realm::List &l) : realm::List(l) {}
+public:
+    List(const realm::List& l)
+        : realm::List(l)
+    {
+    }
 
     std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
 };
 
-template<typename T>
+template <typename T>
 struct ListClass : ClassDefinition<T, realm::js::List<T>, CollectionClass<T>> {
     using Type = T;
     using ContextType = typename T::Context;
@@ -57,29 +60,29 @@ struct ListClass : ClassDefinition<T, realm::js::List<T>, CollectionClass<T>> {
     static ObjectType create_instance(ContextType, realm::List);
 
     // properties
-    static void get_length(ContextType, ObjectType, ReturnValue &);
-    static void get_type(ContextType, ObjectType, ReturnValue &);
-    static void get_optional(ContextType, ObjectType, ReturnValue &);
-    static void get_index(ContextType, ObjectType, uint32_t, ReturnValue &);
+    static void get_length(ContextType, ObjectType, ReturnValue&);
+    static void get_type(ContextType, ObjectType, ReturnValue&);
+    static void get_optional(ContextType, ObjectType, ReturnValue&);
+    static void get_index(ContextType, ObjectType, uint32_t, ReturnValue&);
     static bool set_index(ContextType, ObjectType, uint32_t, ValueType);
 
     // methods
-    static void push(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void pop(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void unshift(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void shift(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void splice(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void snapshot(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void filtered(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void sorted(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void is_valid(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void is_empty(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void index_of(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void push(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void pop(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void unshift(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void shift(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void splice(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void snapshot(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void filtered(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void sorted(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void is_valid(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void is_empty(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void index_of(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // observable
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     std::string const name = "List";
 
@@ -116,38 +119,44 @@ private:
     static void validate_value(ContextType, realm::List&, ValueType);
 };
 
-template<typename T>
-typename T::Object ListClass<T>::create_instance(ContextType ctx, realm::List list) {
+template <typename T>
+typename T::Object ListClass<T>::create_instance(ContextType ctx, realm::List list)
+{
     return create_object<T, ListClass<T>>(ctx, new realm::js::List<T>(std::move(list)));
 }
 
-template<typename T>
-void ListClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, object);
     return_value.set(static_cast<uint32_t>(list->size()));
 }
 
-template<typename T>
-void ListClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, object);
     return_value.set(local_string_for_property_type(list->get_type() & ~realm::PropertyType::Flags));
 }
 
-template<typename T>
-void ListClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, object);
     return_value.set(is_nullable(list->get_type()));
 }
 
-template<typename T>
-void ListClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t index, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t index, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, object);
     NativeAccessor<T> accessor(ctx, *list);
     return_value.set(list->get(accessor, index));
 }
 
-template<typename T>
-bool ListClass<T>::set_index(ContextType ctx, ObjectType object, uint32_t index, ValueType value) {
+template <typename T>
+bool ListClass<T>::set_index(ContextType ctx, ObjectType object, uint32_t index, ValueType value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, object);
     validate_value(ctx, *list, value);
     NativeAccessor<T> accessor(ctx, *list);
@@ -155,8 +164,9 @@ bool ListClass<T>::set_index(ContextType ctx, ObjectType object, uint32_t index,
     return true;
 }
 
-template<typename T>
-void ListClass<T>::push(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::push(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     for (size_t i = 0; i < args.count; i++) {
         validate_value(ctx, *list, args[i]);
@@ -170,8 +180,9 @@ void ListClass<T>::push(ContextType ctx, ObjectType this_object, Arguments &args
     return_value.set((uint32_t)list->size());
 }
 
-template<typename T>
-void ListClass<T>::pop(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::pop(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
@@ -186,8 +197,9 @@ void ListClass<T>::pop(ContextType ctx, ObjectType this_object, Arguments &args,
     }
 }
 
-template<typename T>
-void ListClass<T>::unshift(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::unshift(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     for (size_t i = 0; i < args.count; i++) {
         validate_value(ctx, *list, args[i]);
@@ -201,8 +213,9 @@ void ListClass<T>::unshift(ContextType ctx, ObjectType this_object, Arguments &a
     return_value.set((uint32_t)list->size());
 }
 
-template<typename T>
-void ListClass<T>::shift(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::shift(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
@@ -216,8 +229,9 @@ void ListClass<T>::shift(ContextType ctx, ObjectType this_object, Arguments &arg
     }
 }
 
-template<typename T>
-void ListClass<T>::splice(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::splice(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     size_t size = list->size();
     long index = std::min<long>(Value::to_number(ctx, args[0]), size);
@@ -249,37 +263,43 @@ void ListClass<T>::splice(ContextType ctx, ObjectType this_object, Arguments &ar
     return_value.set(Object::create_array(ctx, removed_objects));
 }
 
-template<typename T>
-void ListClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_instance(ctx, list->snapshot()));
 }
 
-template<typename T>
-void ListClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_filtered(ctx, *list, args));
 }
 
-template<typename T>
-void ListClass<T>::sorted(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::sorted(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_instance(ctx, list->sort(ResultsClass<T>::get_keypaths(ctx, args))));
 }
 
-template<typename T>
-void ListClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, ListClass<T>>(ctx, this_object)->is_valid());
 }
 
-template<typename T>
-void ListClass<T>::is_empty(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::is_empty(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, ListClass<T>>(ctx, this_object)->size() == 0);
 }
 
-template<typename T>
-void ListClass<T>::index_of(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::index_of(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto fn = [&](auto&& row) {
         auto list = get_internal<T, ListClass<T>>(ctx, this_object);
         NativeAccessor<T> accessor(ctx, *list);
@@ -288,36 +308,43 @@ void ListClass<T>::index_of(ContextType ctx, ObjectType this_object, Arguments &
     ResultsClass<T>::index_of(ctx, fn, args, return_value);
 }
 
-template<typename T>
-void ListClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     ResultsClass<T>::add_listener(ctx, *list, this_object, args);
 }
 
-template<typename T>
-void ListClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     ResultsClass<T>::remove_listener(ctx, *list, this_object, args);
 }
 
-template<typename T>
-void ListClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ListClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                        ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
     list->m_notification_tokens.clear();
 }
 
-template<typename T>
-void ListClass<T>::validate_value(ContextType ctx, realm::List& list, ValueType value) {
+template <typename T>
+void ListClass<T>::validate_value(ContextType ctx, realm::List& list, ValueType value)
+{
     auto type = list.get_type();
     StringData object_type;
     if (type == realm::PropertyType::Object) {
         object_type = list.get_object_schema().name;
     }
     if (!Value::is_valid_for_property_type(ctx, value, type, object_type)) {
-        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type), Value::to_string(ctx, value));
+        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type),
+                                 Value::to_string(ctx, value));
     }
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -39,11 +39,11 @@ struct Property;
 
 namespace js {
 namespace _impl {
-template<typename JSEngine, typename T>
+template <typename JSEngine, typename T>
 struct Unbox;
 }
 
-template<typename JSEngine>
+template <typename JSEngine>
 class NativeAccessor {
 public:
     using ContextType = typename JSEngine::Context;
@@ -54,50 +54,57 @@ public:
     using OptionalValue = util::Optional<ValueType>;
 
     NativeAccessor(ContextType ctx, std::shared_ptr<Realm> realm, const ObjectSchema& object_schema)
-    : m_ctx(ctx), m_realm(std::move(realm)), m_object_schema(&object_schema)
-    { }
+        : m_ctx(ctx)
+        , m_realm(std::move(realm))
+        , m_object_schema(&object_schema)
+    {
+    }
 
-    template<typename Collection>
+    template <typename Collection>
     NativeAccessor(ContextType ctx, Collection const& collection)
-    : m_ctx(ctx)
-    , m_realm(collection.get_realm())
-    , m_object_schema(collection.get_type() == realm::PropertyType::Object ? &collection.get_object_schema() : nullptr)
-    { }
+        : m_ctx(ctx)
+        , m_realm(collection.get_realm())
+        , m_object_schema(collection.get_type() == realm::PropertyType::Object ? &collection.get_object_schema()
+                                                                               : nullptr)
+    {
+    }
 
     NativeAccessor(NativeAccessor& na, Obj parent, Property const& prop)
         : m_ctx(na.m_ctx)
         , m_realm(na.m_realm)
         , m_parent(std::move(parent))
         , m_property(&prop)
-        , m_object_schema(nullptr) {
+        , m_object_schema(nullptr)
+    {
         if (prop.type == realm::PropertyType::Object) {
             auto schema = m_realm->schema().find(prop.object_type);
             if (schema != m_realm->schema().end()) {
-			    m_object_schema = &*schema;
+                m_object_schema = &*schema;
             }
         }
         else {
             m_object_schema = na.m_object_schema;
         }
-
     }
 
     NativeAccessor(NativeAccessor& parent, const Property& prop)
-		: m_ctx(parent.m_ctx)
-		, m_realm(parent.m_realm)
-		, m_object_schema(nullptr)
-	{
-		auto schema = m_realm->schema().find(prop.object_type);
-		if (schema != m_realm->schema().end()) {
-			m_object_schema = &*schema;
-		}
+        : m_ctx(parent.m_ctx)
+        , m_realm(parent.m_realm)
+        , m_object_schema(nullptr)
+    {
+        auto schema = m_realm->schema().find(prop.object_type);
+        if (schema != m_realm->schema().end()) {
+            m_object_schema = &*schema;
+        }
     }
 
-    ~NativeAccessor() { }
+    ~NativeAccessor() {}
 
-    OptionalValue value_for_property(ValueType dict, Property const& prop, size_t) {
+    OptionalValue value_for_property(ValueType dict, Property const& prop, size_t)
+    {
         ObjectType object = Value::validated_to_object(m_ctx, dict);
-        ValueType value = Object::get_property(m_ctx, object, !prop.public_name.empty() ? prop.public_name : prop.name);
+        ValueType value =
+            Object::get_property(m_ctx, object, !prop.public_name.empty() ? prop.public_name : prop.name);
         if (Value::is_undefined(m_ctx, value)) {
             return util::none;
         }
@@ -107,16 +114,18 @@ public:
         return value;
     }
 
-    OptionalValue default_value_for_property(const ObjectSchema &object_schema, const Property &prop) {
+    OptionalValue default_value_for_property(const ObjectSchema& object_schema, const Property& prop)
+    {
         auto defaults = get_delegate<JSEngine>(m_realm.get())->m_defaults[object_schema.name];
         auto it = defaults.find(prop.name);
         return it != defaults.end() ? util::make_optional(ValueType(it->second)) : util::none;
     }
 
-    template<typename T>
+    template <typename T>
     T unbox(ValueType value, realm::CreatePolicy policy = realm::CreatePolicy::Skip, ObjKey current_obj = ObjKey());
 
-    Obj create_embedded_object() {
+    Obj create_embedded_object()
+    {
         if (!m_parent) {
             throw std::runtime_error("Embedded objects cannot be created directly.");
         }
@@ -124,57 +133,100 @@ public:
         return m_parent.create_and_set_linked_object(m_property->column_key);
     }
 
-    template<typename T>
-    util::Optional<T> unbox_optional(ValueType value) {
+    template <typename T>
+    util::Optional<T> unbox_optional(ValueType value)
+    {
         return is_null(value) ? util::none : util::make_optional(unbox<T>(value));
     }
 
-    template<typename T>
-    ValueType box(util::Optional<T> v) { return v ? box(*v) : null_value(); }
-    ValueType box(bool boolean)      { return Value::from_boolean(m_ctx, boolean); }
-    ValueType box(int64_t number)    { return Value::from_number(m_ctx, number); }
-    ValueType box(float number)      { return Value::from_number(m_ctx, number); }
-    ValueType box(double number)     { return Value::from_number(m_ctx, number); }
-    ValueType box(StringData string) { return Value::from_string(m_ctx, string.data()); }
-    ValueType box(BinaryData data)   { return Value::from_binary(m_ctx, data); }
-    ValueType box(ObjectId objectId) { return Value::from_object_id(m_ctx, objectId); }
-    ValueType box(Decimal128 number) { return Value::from_decimal128(m_ctx, number); }
-    ValueType box(UUID uuid)         { return Value::from_uuid(m_ctx, uuid); }
-    ValueType box(Mixed mixed)       { return Value::from_mixed(m_ctx, m_realm, mixed); }
+    template <typename T>
+    ValueType box(util::Optional<T> v)
+    {
+        return v ? box(*v) : null_value();
+    }
+    ValueType box(bool boolean)
+    {
+        return Value::from_boolean(m_ctx, boolean);
+    }
+    ValueType box(int64_t number)
+    {
+        return Value::from_number(m_ctx, number);
+    }
+    ValueType box(float number)
+    {
+        return Value::from_number(m_ctx, number);
+    }
+    ValueType box(double number)
+    {
+        return Value::from_number(m_ctx, number);
+    }
+    ValueType box(StringData string)
+    {
+        return Value::from_string(m_ctx, string.data());
+    }
+    ValueType box(BinaryData data)
+    {
+        return Value::from_binary(m_ctx, data);
+    }
+    ValueType box(ObjectId objectId)
+    {
+        return Value::from_object_id(m_ctx, objectId);
+    }
+    ValueType box(Decimal128 number)
+    {
+        return Value::from_decimal128(m_ctx, number);
+    }
+    ValueType box(UUID uuid)
+    {
+        return Value::from_uuid(m_ctx, uuid);
+    }
+    ValueType box(Mixed mixed)
+    {
+        return Value::from_mixed(m_ctx, m_realm, mixed);
+    }
 
-    ValueType box(Timestamp ts) {
+    ValueType box(Timestamp ts)
+    {
         if (ts.is_null()) {
             return null_value();
         }
         return Object::create_date(m_ctx, ts.get_seconds() * 1000 + ts.get_nanoseconds() / 1000000);
     }
-    ValueType box(realm::Object realm_object) {
+    ValueType box(realm::Object realm_object)
+    {
         return RealmObjectClass<JSEngine>::create_instance(m_ctx, std::move(realm_object));
     }
-    ValueType box(Obj obj) {
+    ValueType box(Obj obj)
+    {
         if (!obj.is_valid()) {
             return Value::from_null(m_ctx);
         }
         return RealmObjectClass<JSEngine>::create_instance(m_ctx, realm::Object(m_realm, *m_object_schema, obj));
     }
-    ValueType box(realm::List list) {
+    ValueType box(realm::List list)
+    {
         return ListClass<JSEngine>::create_instance(m_ctx, std::move(list));
     }
-    ValueType box(realm::Results results) {
+    ValueType box(realm::Results results)
+    {
         return ResultsClass<JSEngine>::create_instance(m_ctx, std::move(results));
     }
-    ValueType box(realm::object_store::Set set) {
+    ValueType box(realm::object_store::Set set)
+    {
         return SetClass<JSEngine>::create_instance(m_ctx, std::move(set));
     }
-    ValueType box(realm::object_store::Dictionary dictionary) {
+    ValueType box(realm::object_store::Dictionary dictionary)
+    {
         return DictionaryClass<JSEngine>::create_instance(m_ctx, std::move(dictionary));
     }
 
-    bool is_null(ValueType const& value) {
+    bool is_null(ValueType const& value)
+    {
         return Value::is_null(m_ctx, value) || Value::is_undefined(m_ctx, value);
     }
 
-    DataType get_type_of(ValueType const& value) {
+    DataType get_type_of(ValueType const& value)
+    {
         if (Value::is_number(m_ctx, value)) {
             return type_Double;
         }
@@ -205,13 +257,15 @@ public:
         return DataType(-1);
     }
 
-    ValueType null_value() {
+    ValueType null_value()
+    {
         return Value::from_null(m_ctx);
     }
 
     // called when creating lists and sets
-    template<typename Fn>
-    void enumerate_collection(ValueType& value, Fn&& func) {
+    template <typename Fn>
+    void enumerate_collection(ValueType& value, Fn&& func)
+    {
         auto obj = Value::validated_to_object(m_ctx, value);
         uint32_t size = Object::validated_get_length(m_ctx, obj);
         for (uint32_t i = 0; i < size; ++i) {
@@ -220,8 +274,9 @@ public:
     }
 
     // called when creating dictionaries.
-    template<typename Fn>
-    void enumerate_dictionary(ValueType value, Fn&& func) {
+    template <typename Fn>
+    void enumerate_dictionary(ValueType value, Fn&& func)
+    {
         auto js_object = Value::validated_to_object(m_ctx, value);
         for (auto&& key : Object::get_property_names(m_ctx, js_object)) {
             ValueType val = Object::get_property(m_ctx, js_object, key);
@@ -229,7 +284,8 @@ public:
         }
     }
 
-    bool is_same_list(realm::List const& list, ValueType const& value) const noexcept {
+    bool is_same_list(realm::List const& list, ValueType const& value) const noexcept
+    {
         auto object = Value::validated_to_object(m_ctx, value);
         if (js::Object<JSEngine>::template is_instance<ListClass<JSEngine>>(m_ctx, object)) {
             return list == *get_internal<JSEngine, ListClass<JSEngine>>(m_ctx, object);
@@ -237,7 +293,8 @@ public:
         return false;
     }
 
-    bool is_same_set(realm::object_store::Set const &set, ValueType const &value) const {
+    bool is_same_set(realm::object_store::Set const& set, ValueType const& value) const
+    {
         auto object = Value::validated_to_object(m_ctx, value);
         if (js::Object<JSEngine>::template is_instance<SetClass<JSEngine>>(m_ctx, object)) {
             return set == *get_internal<JSEngine, SetClass<JSEngine>>(m_ctx, object);
@@ -245,7 +302,8 @@ public:
         return false;
     }
 
-    bool is_same_dictionary(realm::object_store::Dictionary const& dictionary, ValueType const& value) const {
+    bool is_same_dictionary(realm::object_store::Dictionary const& dictionary, ValueType const& value) const
+    {
         auto object = Value::validated_to_object(m_ctx, value);
         if (Object::template is_instance<DictionaryClass<JSEngine>>(m_ctx, object)) {
             return dictionary == *get_internal<JSEngine, DictionaryClass<JSEngine>>(m_ctx, object);
@@ -253,13 +311,19 @@ public:
         return false;
     }
 
-    bool allow_missing(ValueType const&) const noexcept { return false; }
-    void will_change(realm::Object&, realm::Property const&) { }
-    void did_change() { }
+    bool allow_missing(ValueType const&) const noexcept
+    {
+        return false;
+    }
+    void will_change(realm::Object&, realm::Property const&) {}
+    void did_change() {}
 
     std::string print(ValueType const&);
     void print(std::string&, ValueType const&);
-    const char *typeof(ValueType const& v) { return Value::typeof(m_ctx, v); }
+    const char* typeof(ValueType const& v)
+    {
+        return Value::typeof(m_ctx, v);
+    }
 
 private:
     ContextType m_ctx;
@@ -269,42 +333,52 @@ private:
     const ObjectSchema* m_object_schema;
     std::string m_string_buffer;
     OwnedBinaryData m_owned_binary_data;
-    template<typename, typename>
+    template <typename, typename>
     friend struct _impl::Unbox;
 };
 
 namespace _impl {
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, bool> {
-    static bool call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static bool call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                     ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_boolean(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, int64_t> {
-    static int64_t call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static int64_t call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                        ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_number(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, float> {
-    static float call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static float call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                      ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_number(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, double> {
-    static double call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static double call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                       ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_number(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, Decimal128> {
-    static Decimal128 call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static Decimal128 call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                           ObjKey)
+    {
         if (ctx->is_null(value)) {
             return Decimal128(realm::null());
         }
@@ -312,51 +386,65 @@ struct Unbox<JSEngine, Decimal128> {
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, ObjectId> {
-    static ObjectId call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static ObjectId call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                         ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_object_id(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<bool>> {
-    static util::Optional<bool> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<bool> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                     realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<bool>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<int64_t>> {
-    static util::Optional<int64_t> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<int64_t> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                        realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<int64_t>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<float>> {
-    static util::Optional<float> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<float> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                      realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<float>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<double>> {
-    static util::Optional<double> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<double> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                       realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<double>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<ObjectId>> {
-    static util::Optional<ObjectId> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<ObjectId> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                         realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<ObjectId>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, StringData> {
-    static StringData call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static StringData call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                           ObjKey)
+    {
         if (ctx->is_null(value)) {
             return StringData();
         }
@@ -365,9 +453,10 @@ struct Unbox<JSEngine, StringData> {
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, BinaryData> {
-    static BinaryData call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value value, realm::CreatePolicy, ObjKey) {
+    static BinaryData call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value value, realm::CreatePolicy, ObjKey)
+    {
         if (ctx->is_null(value)) {
             return BinaryData();
         }
@@ -381,7 +470,8 @@ struct Unbox<JSEngine, BinaryData> {
             if (auto size = util::base64_decode(str, data.get(), max_size)) {
                 ctx->m_owned_binary_data = OwnedBinaryData(std::move(data), *size);
                 return ctx->m_owned_binary_data.get();
-            } else {
+            }
+            else {
                 throw std::runtime_error("Attempting to populate BinaryData from string that is not valid base64");
             }
         }
@@ -392,37 +482,48 @@ struct Unbox<JSEngine, BinaryData> {
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, Mixed> {
-    static Mixed call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
-        return js::Value<JSEngine>::to_mixed(ctx->m_ctx, ctx->m_realm, value, ctx->m_string_buffer); // no need to validate type for a mixed value
+    static Mixed call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                      ObjKey)
+    {
+        return js::Value<JSEngine>::to_mixed(ctx->m_ctx, ctx->m_realm, value,
+                                             ctx->m_string_buffer); // no need to validate type for a mixed value
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, UUID> {
-    static UUID call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static UUID call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                     ObjKey)
+    {
         return js::Value<JSEngine>::validated_to_uuid(ctx->m_ctx, value, "Property");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, ObjLink> {
-    static ObjLink call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static ObjLink call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                        ObjKey)
+    {
         throw std::runtime_error("'ObjLink' type support is not implemented yet");
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, util::Optional<UUID>> {
-    static util::Optional<UUID> call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static util::Optional<UUID> call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                                     realm::CreatePolicy, ObjKey)
+    {
         return ctx->template unbox_optional<UUID>(value);
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, Timestamp> {
-    static Timestamp call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy, ObjKey) {
+    static Timestamp call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
+                          ObjKey)
+    {
         if (ctx->is_null(value)) {
             return Timestamp();
         }
@@ -430,7 +531,8 @@ struct Unbox<JSEngine, Timestamp> {
         if (js::Value<JSEngine>::is_string(ctx->m_ctx, value)) {
             // the incoming value might be a date string, so let the Date constructor have at it
             date = js::Value<JSEngine>::to_date(ctx->m_ctx, value);
-        } else {
+        }
+        else {
             date = js::Value<JSEngine>::validated_to_date(ctx->m_ctx, value);
         }
 
@@ -441,9 +543,11 @@ struct Unbox<JSEngine, Timestamp> {
     }
 };
 
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, Obj> {
-    static Obj call(NativeAccessor<JSEngine> *native_accessor, typename JSEngine::Value const& value, realm::CreatePolicy policy, ObjKey current_row) {
+    static Obj call(NativeAccessor<JSEngine>* native_accessor, typename JSEngine::Value const& value,
+                    realm::CreatePolicy policy, ObjKey current_row)
+    {
         using Value = js::Value<JSEngine>;
         using ValueType = typename JSEngine::Value;
         using Object = js::Object<JSEngine>;
@@ -452,7 +556,8 @@ struct Unbox<JSEngine, Obj> {
         auto js_object = Value::validated_to_object(native_accessor->m_ctx, value);
         auto realm_object = get_internal<JSEngine, RealmObjectClass<JSEngine>>(native_accessor->m_ctx, js_object);
 
-        auto is_ros_instance = Object::template is_instance<RealmObjectClass<JSEngine>>(native_accessor->m_ctx, js_object);
+        auto is_ros_instance =
+            Object::template is_instance<RealmObjectClass<JSEngine>>(native_accessor->m_ctx, js_object);
 
         if (is_ros_instance && realm_object && realm_object->realm() == current_realm) {
             return realm_object->obj();
@@ -473,20 +578,23 @@ struct Unbox<JSEngine, Obj> {
         }
 
         if (Value::is_array(native_accessor->m_ctx, js_object)) {
-            js_object = Schema<JSEngine>::dict_for_property_array(native_accessor->m_ctx, *native_accessor->m_object_schema, js_object);
+            js_object = Schema<JSEngine>::dict_for_property_array(native_accessor->m_ctx,
+                                                                  *native_accessor->m_object_schema, js_object);
         }
 
-        auto child = realm::Object::create<ValueType>
-            (*native_accessor, native_accessor->m_realm, *native_accessor->m_object_schema,
-                    static_cast<ValueType>(js_object), policy, current_row);
+        auto child = realm::Object::create<ValueType>(*native_accessor, native_accessor->m_realm,
+                                                      *native_accessor->m_object_schema,
+                                                      static_cast<ValueType>(js_object), policy, current_row);
         return child.obj();
     }
 };
 
 // FIXME: Why do we need this? It is required in order to compile and seems to be used by the query builder
-template<typename JSEngine>
+template <typename JSEngine>
 struct Unbox<JSEngine, ObjKey> {
-    static ObjKey call(NativeAccessor<JSEngine> *ctx, typename JSEngine::Value const& value, realm::CreatePolicy policy, ObjKey current_row) {
+    static ObjKey call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value,
+                       realm::CreatePolicy policy, ObjKey current_row)
+    {
         return Unbox<JSEngine, Obj>::call(ctx, value, policy, current_row).get_key();
     }
 };
@@ -494,21 +602,24 @@ struct Unbox<JSEngine, ObjKey> {
 
 } // namespace _impl
 
-template<typename T>
-template<typename U>
-U NativeAccessor<T>::unbox(ValueType value, realm::CreatePolicy policy, ObjKey current_row) {
+template <typename T>
+template <typename U>
+U NativeAccessor<T>::unbox(ValueType value, realm::CreatePolicy policy, ObjKey current_row)
+{
     return _impl::Unbox<T, U>::call(this, std::move(value), policy, current_row);
 }
 
-template<typename T>
-std::string NativeAccessor<T>::print(ValueType const& value) {
+template <typename T>
+std::string NativeAccessor<T>::print(ValueType const& value)
+{
     std::string ret;
     print(ret, value);
     return ret;
 }
 
-template<typename T>
-void NativeAccessor<T>::print(std::string& str, ValueType const& value) {
+template <typename T>
+void NativeAccessor<T>::print(std::string& str, ValueType const& value)
+{
     if (Value::is_null(m_ctx, value)) {
         str += "null";
     }
@@ -539,7 +650,8 @@ void NativeAccessor<T>::print(std::string& str, ValueType const& value) {
             str += object_schema.name;
             str += "{";
             for (size_t i = 0, count = object_schema.persisted_properties.size(); i < count; ++i) {
-                print(str, realm_object->template get_property_value<ValueType>(*this, object_schema.persisted_properties[i].name));
+                print(str, realm_object->template get_property_value<ValueType>(
+                               *this, object_schema.persisted_properties[i].name));
                 if (i + 1 < count) {
                     str += ", ";
                 }
@@ -560,5 +672,5 @@ void NativeAccessor<T>::print(std::string& str, ValueType const& value) {
     }
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_observable.hpp
+++ b/src/js_observable.hpp
@@ -24,12 +24,13 @@ namespace realm {
 namespace js {
 
 // Empty class that merely serves as useful type for now.
-class Observable {};
+class Observable {
+};
 
-template<typename T>
+template <typename T>
 struct ObservableClass : ClassDefinition<T, Observable> {
     std::string const name = "Observable";
 };
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -31,25 +31,28 @@ namespace js {
 
 static std::string s_default_path = "";
 
-std::string default_path() {
+std::string default_path()
+{
     if (s_default_path.empty()) {
         s_default_path = realm::default_realm_file_directory() +
 #if defined(WIN32) && WIN32
-            '\\'
+                         '\\'
 #else
-            '/'
+                         '/'
 #endif
-            + "default.realm";
+                         + "default.realm";
     }
     return s_default_path;
 }
 
-void set_default_path(std::string path) {
+void set_default_path(std::string path)
+{
     s_default_path = path;
 }
 
 static std::string s_test_files_path;
-void clear_test_state() {
+void clear_test_state()
+{
     realm::_impl::RealmCoordinator::clear_all_caches();
     realm::remove_realm_files_from_directory(realm::default_realm_file_directory());
 #if REALM_ENABLE_SYNC
@@ -134,5 +137,5 @@ std::string TypeErrorException::type_string(Property const& prop)
 }
 
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -65,7 +65,8 @@
 namespace realm {
 namespace js {
 
-static std::string normalize_realm_path(std::string path) {
+static std::string normalize_realm_path(std::string path)
+{
 #if defined(WIN32) && WIN32
     if (path.size() > 1 && path[0] != '\\' && path[1] != ':') {
         path = default_realm_file_directory() + "\\" + path;
@@ -79,24 +80,29 @@ static std::string normalize_realm_path(std::string path) {
     return path;
 }
 
-template<typename T> class RealmClass;
-template<typename T> class AsyncOpenTaskClass;
+template <typename T>
+class RealmClass;
+template <typename T>
+class AsyncOpenTaskClass;
 
-template<typename T>
+template <typename T>
 class RealmDelegate : public BindingContext {
 private:
-    void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override {
+    void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
+    {
         HANDLESCOPE(m_context)
         notify(m_notifications, "change");
     }
 
-    void schema_did_change(realm::Schema const& schema) override {
+    void schema_did_change(realm::Schema const& schema) override
+    {
         HANDLESCOPE(m_context)
         ObjectType schema_object = Schema<T>::object_for_schema(m_context, schema);
         notify(m_schema_notifications, "schema", schema_object);
     }
 
-    void before_notify() override {
+    void before_notify() override
+    {
         HANDLESCOPE(m_context)
         notify(m_before_notify_notifications, "beforenotify");
     }
@@ -112,14 +118,15 @@ public:
     using ConstructorMap = typename Schema<T>::ConstructorMap;
 
     RealmDelegate(std::weak_ptr<realm::Realm> realm, GlobalContextType ctx)
-        : m_context(ctx),
-          m_realm(realm)
+        : m_context(ctx)
+        , m_realm(realm)
     {
         SharedRealm sharedRealm = realm.lock();
         m_realm_path = sharedRealm->config().path;
     }
 
-    ~RealmDelegate() {
+    ~RealmDelegate()
+    {
         on_context_destroy<RealmObjectClass<T>>(m_context, m_realm_path);
         // All protected values need to be unprotected while the context is retained.
         m_defaults.clear();
@@ -129,49 +136,58 @@ public:
         m_before_notify_notifications.clear();
     }
 
-    void add_notification(FunctionType notification) {
+    void add_notification(FunctionType notification)
+    {
         add(m_notifications, notification);
     }
 
-    void remove_notification(FunctionType notification) {
+    void remove_notification(FunctionType notification)
+    {
         remove(m_notifications, notification);
     }
 
-    void remove_all_notifications() {
+    void remove_all_notifications()
+    {
         m_notifications.clear();
     }
 
-    void add_schema_notification(FunctionType notification) {
+    void add_schema_notification(FunctionType notification)
+    {
         SharedRealm realm = m_realm.lock();
         // schema change notifications only happen if the Realm has a read transaction active
         realm->read_group();
         add(m_schema_notifications, notification);
     }
 
-    void remove_schema_notification(FunctionType notification) {
+    void remove_schema_notification(FunctionType notification)
+    {
         remove(m_schema_notifications, notification);
     }
 
-    void remove_all_schema_notifications() {
+    void remove_all_schema_notifications()
+    {
         m_schema_notifications.clear();
     }
 
-    void add_before_notify_notification(FunctionType notification) {
+    void add_before_notify_notification(FunctionType notification)
+    {
         add(m_before_notify_notifications, notification);
     }
 
-    void remove_before_notify_notification(FunctionType notification) {
+    void remove_before_notify_notification(FunctionType notification)
+    {
         remove(m_before_notify_notifications, notification);
     }
 
-    void remove_all_before_notify_notification() {
+    void remove_all_before_notify_notification()
+    {
         m_before_notify_notifications.clear();
     }
 
     ObjectDefaultsMap m_defaults;
     ConstructorMap m_constructors;
 
-  private:
+private:
     Protected<GlobalContextType> m_context;
     std::list<Protected<FunctionType>> m_notifications;
     std::list<Protected<FunctionType>> m_schema_notifications;
@@ -179,23 +195,28 @@ public:
     std::weak_ptr<realm::Realm> m_realm;
     std::string m_realm_path;
 
-    void add(std::list<Protected<FunctionType>>& notifications, FunctionType fn) {
+    void add(std::list<Protected<FunctionType>>& notifications, FunctionType fn)
+    {
         if (std::find(notifications.begin(), notifications.end(), fn) != notifications.end()) {
             return;
         }
         notifications.emplace_back(m_context, std::move(fn));
     }
 
-    void remove(std::list<Protected<FunctionType>>& notifications, FunctionType fn) {
+    void remove(std::list<Protected<FunctionType>>& notifications, FunctionType fn)
+    {
         // This doesn't just call remove() because that would create a new Protected<FunctionType>
-        notifications.remove_if([&](auto& notification) { return notification == fn; });
+        notifications.remove_if([&](auto& notification) {
+            return notification == fn;
+        });
     }
 
     // Note that this intentionally copies the `notifications` argument as we
     // want to iterate over a copy in case the user adds/removes notifications
     // from inside the handler
-    template<typename... Args>
-    void notify(std::list<Protected<FunctionType>> notifications, const char *name, Args&&... args) {
+    template <typename... Args>
+    void notify(std::list<Protected<FunctionType>> notifications, const char* name, Args&&... args)
+    {
         if (notifications.empty()) {
             return;
         }
@@ -209,7 +230,7 @@ public:
         ValueType arguments[] = {realm_object, Value::from_string(m_context, name), args...};
         auto argc = std::distance(std::begin(arguments), std::end(arguments));
 
-        for (auto &callback : notifications) {
+        for (auto& callback : notifications) {
             Function<T>::callback(m_context, callback, realm_object, argc, arguments);
         }
     }
@@ -218,34 +239,39 @@ public:
 };
 
 
-template<typename T>
+template <typename T>
 class ShouldCompactOnLaunchFunctor {
 public:
     ShouldCompactOnLaunchFunctor(typename T::Context ctx, typename T::Function should_compact_on_launch_func)
-    : m_ctx(Context<T>::get_global_context(ctx))
-    , m_func(ctx, should_compact_on_launch_func)
-    , m_event_loop_dispatcher {ShouldCompactOnLaunchFunctor<T>::main_loop_handler}
-    , m_mutex{new std::mutex}
-    , m_cond_var{new std::condition_variable}
+        : m_ctx(Context<T>::get_global_context(ctx))
+        , m_func(ctx, should_compact_on_launch_func)
+        , m_event_loop_dispatcher{ShouldCompactOnLaunchFunctor<T>::main_loop_handler}
+        , m_mutex{new std::mutex}
+        , m_cond_var{new std::condition_variable}
     {
     }
 
-    bool operator ()(const uint64_t total_bytes, const uint64_t used_bytes) {
+    bool operator()(const uint64_t total_bytes, const uint64_t used_bytes)
+    {
         m_event_loop_dispatcher(this, total_bytes, used_bytes);
         std::unique_lock<std::mutex> lock(*m_mutex);
-        m_cond_var->wait(lock, [this] { return this->m_ready; });
+        m_cond_var->wait(lock, [this] {
+            return this->m_ready;
+        });
 
         return m_should_compact_on_launch;
     }
 
-    static void main_loop_handler(ShouldCompactOnLaunchFunctor<T>* this_object,
-                                  const uint64_t total_bytes,
-                                  const uint64_t used_bytes) {
+    static void main_loop_handler(ShouldCompactOnLaunchFunctor<T>* this_object, const uint64_t total_bytes,
+                                  const uint64_t used_bytes)
+    {
         HANDLESCOPE(this_object->m_ctx);
 
         const int argc = 2;
-        typename T::Value arguments[argc] = { Value<T>::from_number(this_object->m_ctx, total_bytes), Value<T>::from_number(this_object->m_ctx, used_bytes) };
-        typename T::Value ret_val = Function<T>::callback(this_object->m_ctx, this_object->m_func, Object<T>::create_empty(this_object->m_ctx), argc, arguments);
+        typename T::Value arguments[argc] = {Value<T>::from_number(this_object->m_ctx, total_bytes),
+                                             Value<T>::from_number(this_object->m_ctx, used_bytes)};
+        typename T::Value ret_val = Function<T>::callback(
+            this_object->m_ctx, this_object->m_func, Object<T>::create_empty(this_object->m_ctx), argc, arguments);
         this_object->m_should_compact_on_launch = Value<T>::validated_to_boolean(this_object->m_ctx, ret_val);
         this_object->m_ready = true;
         this_object->m_cond_var->notify_one();
@@ -254,9 +280,9 @@ public:
 private:
     const Protected<typename T::GlobalContext> m_ctx;
     const Protected<typename T::Function> m_func;
-    util::EventLoopDispatcher<void(ShouldCompactOnLaunchFunctor<T>* this_object,
-                                   uint64_t total_bytes,
-                                   uint64_t used_bytes)> m_event_loop_dispatcher;
+    util::EventLoopDispatcher<void(ShouldCompactOnLaunchFunctor<T>* this_object, uint64_t total_bytes,
+                                   uint64_t used_bytes)>
+        m_event_loop_dispatcher;
     bool m_ready = false;
     bool m_should_compact_on_launch = false;
     std::shared_ptr<std::mutex> m_mutex;
@@ -267,7 +293,7 @@ std::string default_path();
 void set_default_path(std::string path);
 void clear_test_state();
 
-template<typename T>
+template <typename T>
 class RealmClass : public ClassDefinition<T, SharedRealm, ObservableClass<T>> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -295,60 +321,63 @@ public:
     static FunctionType create_constructor(ContextType);
 
     // methods
-    static void objects(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void object_for_primary_key(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void create(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void delete_one(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void delete_all(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void write(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void begin_transaction(ContextType, ObjectType, Arguments &, ReturnValue&);
-    static void commit_transaction(ContextType, ObjectType, Arguments &, ReturnValue&);
-    static void cancel_transaction(ContextType, ObjectType, Arguments &, ReturnValue&);
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void wait_for_download_completion(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void close(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void compact(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void writeCopyTo(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void delete_model(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void object_for_object_id(ContextType, ObjectType, Arguments &, ReturnValue&);
-    static void get_schema_name_from_object(ContextType, ObjectType, Arguments &, ReturnValue&);
-    static void update_schema(ContextType, ObjectType, Arguments &, ReturnValue&);
+    static void objects(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void object_for_primary_key(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void create(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void delete_one(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void delete_all(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void write(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void begin_transaction(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void commit_transaction(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void cancel_transaction(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void wait_for_download_completion(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void close(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void compact(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void writeCopyTo(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void delete_model(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void object_for_object_id(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_schema_name_from_object(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void update_schema(ContextType, ObjectType, Arguments&, ReturnValue&);
 
 #if REALM_ENABLE_SYNC
-    static void async_open_realm(ContextType, ObjectType, Arguments &, ReturnValue&);
+    static void async_open_realm(ContextType, ObjectType, Arguments&, ReturnValue&);
 #endif
 
     // properties
-    static void get_empty(ContextType, ObjectType, ReturnValue &);
-    static void get_path(ContextType, ObjectType, ReturnValue &);
-    static void get_schema_version(ContextType, ObjectType, ReturnValue &);
-    static void get_schema(ContextType, ObjectType, ReturnValue &);
-    static void get_in_memory(ContextType, ObjectType, ReturnValue &);
-    static void get_read_only(ContextType, ObjectType, ReturnValue &);
-    static void get_is_in_transaction(ContextType, ObjectType, ReturnValue &);
-    static void get_is_closed(ContextType, ObjectType, ReturnValue &);
+    static void get_empty(ContextType, ObjectType, ReturnValue&);
+    static void get_path(ContextType, ObjectType, ReturnValue&);
+    static void get_schema_version(ContextType, ObjectType, ReturnValue&);
+    static void get_schema(ContextType, ObjectType, ReturnValue&);
+    static void get_in_memory(ContextType, ObjectType, ReturnValue&);
+    static void get_read_only(ContextType, ObjectType, ReturnValue&);
+    static void get_is_in_transaction(ContextType, ObjectType, ReturnValue&);
+    static void get_is_closed(ContextType, ObjectType, ReturnValue&);
 #if REALM_ENABLE_SYNC
-    static void get_sync_session(ContextType, ObjectType, ReturnValue &);
+    static void get_sync_session(ContextType, ObjectType, ReturnValue&);
 #endif
 
     // static methods
-    static void constructor(ContextType, ObjectType, Arguments &);
-    static SharedRealm create_shared_realm(ContextType, realm::Realm::Config, bool, ObjectDefaultsMap &&, ConstructorMap &&);
-    static bool get_realm_config(ContextType ctx, size_t argc, const ValueType arguments[], realm::Realm::Config &, ObjectDefaultsMap &, ConstructorMap &);
-    static void set_binding_context(ContextType ctx, std::shared_ptr<Realm> const& realm, bool schema_updated, ObjectDefaultsMap&& defaults, ConstructorMap&& constructors);
+    static void constructor(ContextType, ObjectType, Arguments&);
+    static SharedRealm create_shared_realm(ContextType, realm::Realm::Config, bool, ObjectDefaultsMap&&,
+                                           ConstructorMap&&);
+    static bool get_realm_config(ContextType ctx, size_t argc, const ValueType arguments[], realm::Realm::Config&,
+                                 ObjectDefaultsMap&, ConstructorMap&);
+    static void set_binding_context(ContextType ctx, std::shared_ptr<Realm> const& realm, bool schema_updated,
+                                    ObjectDefaultsMap&& defaults, ConstructorMap&& constructors);
 
-    static void schema_version(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void clear_test_state(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void copy_bundled_realm_files(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void delete_file(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void realm_file_exists(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void schema_version(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void clear_test_state(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void copy_bundled_realm_files(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void delete_file(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void realm_file_exists(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-    static void bson_parse_json(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void bson_parse_json(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // static properties
-    static void get_default_path(ContextType, ObjectType, ReturnValue &);
+    static void get_default_path(ContextType, ObjectType, ReturnValue&);
     static void set_default_path(ContextType, ObjectType, ValueType value);
 
     std::string const name = "Realm";
@@ -400,20 +429,25 @@ public:
         {"isInTransaction", {wrap<get_is_in_transaction>, nullptr}},
         {"isClosed", {wrap<get_is_closed>, nullptr}},
 #if REALM_ENABLE_SYNC
-        {"syncSession", {wrap<get_sync_session>, nullptr}},
+        {"syncSession",
+         { wrap<get_sync_session>,
+           nullptr }},
 #endif
     };
 
-  private:
-    static const ObjectSchema& validated_object_schema_for_value(ContextType ctx, const SharedRealm &realm, const ValueType &value) {
+private:
+    static const ObjectSchema& validated_object_schema_for_value(ContextType ctx, const SharedRealm& realm,
+                                                                 const ValueType& value)
+    {
         std::string object_type;
 
-        // If argument is a constructor function, expect that the same constructor was used when specifying the schema.
+        // If argument is a constructor function, expect that the same constructor was used when specifying the
+        // schema.
         if (Value::is_constructor(ctx, value)) {
             FunctionType constructor = Value::to_constructor(ctx, value);
 
             auto delegate = get_delegate<T>(realm.get());
-            for (auto &pair : delegate->m_constructors) {
+            for (auto& pair : delegate->m_constructors) {
                 if (FunctionType(pair.second) == constructor) {
                     object_type = pair.first;
                     break;
@@ -438,7 +472,7 @@ public:
         // read transaction before we search the schema.
         realm->read_group();
 
-        auto &schema = realm->schema();
+        auto& schema = realm->schema();
         auto object_schema = schema.find(object_type);
 
         if (object_schema == schema.end()) {
@@ -447,7 +481,8 @@ public:
         return *object_schema;
     }
 
-    static realm::Realm::Config validate_and_normalize_config(ContextType ctx, ValueType value) {
+    static realm::Realm::Config validate_and_normalize_config(ContextType ctx, ValueType value)
+    {
         if (!Value::is_object(ctx, value)) {
             throw std::runtime_error("Invalid argument, expected a Realm configuration object");
         }
@@ -464,7 +499,8 @@ public:
 #if REALM_ENABLE_SYNC
             ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
             if (!Value::is_undefined(ctx, sync_config_value)) {
-                SyncClass<T>::populate_sync_config(ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")), config_object, config);
+                SyncClass<T>::populate_sync_config(
+                    ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")), config_object, config);
             }
 #endif
 
@@ -478,8 +514,9 @@ public:
     }
 };
 
-template<typename T>
-inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType realm_constructor = ObjectWrap<T, RealmClass<T>>::create_constructor(ctx);
     FunctionType collection_constructor = ObjectWrap<T, CollectionClass<T>>::create_constructor(ctx);
     FunctionType list_constructor = ObjectWrap<T, ListClass<T>>::create_constructor(ctx);
@@ -513,7 +550,8 @@ inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx) {
     Object::set_property(ctx, realm_constructor, "Auth", auth_constructor, attributes);
 
     FunctionType email_password_provider_client_constructor = EmailPasswordAuthClass<T>::create_constructor(ctx);
-    Object::set_property(ctx, auth_constructor, "EmailPasswordAuth", email_password_provider_client_constructor, attributes);
+    Object::set_property(ctx, auth_constructor, "EmailPasswordAuth", email_password_provider_client_constructor,
+                         attributes);
 
     FunctionType user_apikey_provider_client_constructor = ApiKeyAuthClass<T>::create_constructor(ctx);
     Object::set_property(ctx, auth_constructor, "ApiKeyAuth", user_apikey_provider_client_constructor, attributes);
@@ -532,8 +570,11 @@ inline typename T::Function RealmClass<T>::create_constructor(ContextType ctx) {
     return realm_constructor;
 }
 
-template<typename T>
-bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueType arguments[], realm::Realm::Config& config, ObjectDefaultsMap& defaults, ConstructorMap& constructors) {
+template <typename T>
+bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueType arguments[],
+                                     realm::Realm::Config& config, ObjectDefaultsMap& defaults,
+                                     ConstructorMap& constructors)
+{
     bool schema_updated = false;
 
     if (argc > 1) {
@@ -559,7 +600,8 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
             }
 
 #if REALM_ENABLE_SYNC
-            SyncClass<T>::populate_sync_config(ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")), object, config);
+            SyncClass<T>::populate_sync_config(ctx, Value::validated_to_object(ctx, Object::get_global(ctx, "Realm")),
+                                               object, config);
 #endif
 
             static const String path_string = "path";
@@ -573,12 +615,14 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
             static const String fifo_fallback_path_string = "fifoFilesFallbackPath";
             ValueType fallback_path_value = Object::get_property(ctx, object, fifo_fallback_path_string);
             if (!Value::is_undefined(ctx, fallback_path_value)) {
-                config.fifo_files_fallback_path = Value::validated_to_string(ctx, fallback_path_value, "fifoFilesFallbackPath");
+                config.fifo_files_fallback_path =
+                    Value::validated_to_string(ctx, fallback_path_value, "fifoFilesFallbackPath");
             }
 
             static const String in_memory_string = "inMemory";
             ValueType in_memory_value = Object::get_property(ctx, object, in_memory_string);
-            if (!Value::is_undefined(ctx, in_memory_value) && Value::validated_to_boolean(ctx, in_memory_value, "inMemory")) {
+            if (!Value::is_undefined(ctx, in_memory_value) &&
+                Value::validated_to_boolean(ctx, in_memory_value, "inMemory")) {
                 if (config.force_sync_history || config.sync_config) {
                     throw std::invalid_argument("Options 'inMemory' and 'sync' are mutual exclusive.");
                 }
@@ -587,18 +631,23 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
 
             static const String read_only_string = "readOnly";
             ValueType read_only_value = Object::get_property(ctx, object, read_only_string);
-            if (!Value::is_undefined(ctx, read_only_value) && Value::validated_to_boolean(ctx, read_only_value, "readOnly")) {
+            if (!Value::is_undefined(ctx, read_only_value) &&
+                Value::validated_to_boolean(ctx, read_only_value, "readOnly")) {
                 config.schema_mode = SchemaMode::Immutable;
             }
 
             static const String delete_realm_if_migration_needed_string = "deleteRealmIfMigrationNeeded";
-            ValueType delete_realm_if_migration_needed_value = Object::get_property(ctx, object, delete_realm_if_migration_needed_string);
-            if (!Value::is_undefined(ctx, delete_realm_if_migration_needed_value) && Value::validated_to_boolean(ctx, delete_realm_if_migration_needed_value, "deleteRealmIfMigrationNeeded")) {
+            ValueType delete_realm_if_migration_needed_value =
+                Object::get_property(ctx, object, delete_realm_if_migration_needed_string);
+            if (!Value::is_undefined(ctx, delete_realm_if_migration_needed_value) &&
+                Value::validated_to_boolean(ctx, delete_realm_if_migration_needed_value,
+                                            "deleteRealmIfMigrationNeeded")) {
                 if (config.schema_mode == SchemaMode::Immutable) {
                     throw std::invalid_argument("Cannot set 'deleteRealmIfMigrationNeeded' when 'readOnly' is set.");
                 }
                 if (config.sync_config && config.sync_config->partition_value != "") {
-                    throw std::invalid_argument("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('sync.partitionValue' is set).");
+                    throw std::invalid_argument("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled "
+                                                "('sync.partitionValue' is set).");
                 }
 
                 config.schema_mode = SchemaMode::ResetFile;
@@ -628,8 +677,10 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                     throw std::invalid_argument("Cannot set 'shouldCompactOnLaunch' when 'readOnly' is set.");
                 }
 
-                FunctionType should_compact_on_launch_function = Value::validated_to_function(ctx, compact_value, "shouldCompactOnLaunch");
-                ShouldCompactOnLaunchFunctor<T> should_compact_on_launch_functor {ctx, should_compact_on_launch_function};
+                FunctionType should_compact_on_launch_function =
+                    Value::validated_to_function(ctx, compact_value, "shouldCompactOnLaunch");
+                ShouldCompactOnLaunchFunctor<T> should_compact_on_launch_functor{ctx,
+                                                                                 should_compact_on_launch_function};
                 config.should_compact_on_launch_function = std::move(should_compact_on_launch_functor);
             }
 
@@ -643,21 +694,21 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 FunctionType migration_function = Value::validated_to_function(ctx, migration_value, "migration");
 
                 if (config.schema_mode == SchemaMode::ResetFile) {
-                    throw std::invalid_argument("Cannot include 'migration' when 'deleteRealmIfMigrationNeeded' is set.");
+                    throw std::invalid_argument(
+                        "Cannot include 'migration' when 'deleteRealmIfMigrationNeeded' is set.");
                 }
 
                 config.migration_function = [=](SharedRealm old_realm, SharedRealm realm, realm::Schema&) {
                     // the migration function called early so the binding context might not be set
                     if (!realm->m_binding_context) {
-                        realm->m_binding_context.reset(new RealmDelegate<T>(realm, Context<T>::get_global_context(ctx)));
+                        realm->m_binding_context.reset(
+                            new RealmDelegate<T>(realm, Context<T>::get_global_context(ctx)));
                     }
 
                     auto old_realm_ptr = new SharedRealm(old_realm);
                     auto realm_ptr = new SharedRealm(realm);
-                    ValueType arguments[2] = {
-                        create_object<T, RealmClass<T>>(ctx, old_realm_ptr),
-                        create_object<T, RealmClass<T>>(ctx, realm_ptr)
-                    };
+                    ValueType arguments[2] = {create_object<T, RealmClass<T>>(ctx, old_realm_ptr),
+                                              create_object<T, RealmClass<T>>(ctx, realm_ptr)};
 
                     try {
                         Function<T>::call(ctx, migration_function, 2, arguments);
@@ -676,15 +727,18 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
             }
 
             static const String automatic_change_notifications_string = "_automaticChangeNotifications";
-            ValueType automatic_change_notifications_value = Object::get_property(ctx, object, automatic_change_notifications_string);
+            ValueType automatic_change_notifications_value =
+                Object::get_property(ctx, object, automatic_change_notifications_string);
             if (!Value::is_undefined(ctx, automatic_change_notifications_value)) {
-                config.automatic_change_notifications = Value::validated_to_boolean(ctx, automatic_change_notifications_value, "_automaticChangeNotifications");
+                config.automatic_change_notifications = Value::validated_to_boolean(
+                    ctx, automatic_change_notifications_value, "_automaticChangeNotifications");
             }
 
             static const String disable_format_upgrade_string = "disableFormatUpgrade";
             ValueType disable_format_upgrade_value = Object::get_property(ctx, object, disable_format_upgrade_string);
             if (!Value::is_undefined(ctx, disable_format_upgrade_value)) {
-                config.disable_format_upgrade = Value::validated_to_boolean(ctx, disable_format_upgrade_value, "disableFormatUpgrade");
+                config.disable_format_upgrade =
+                    Value::validated_to_boolean(ctx, disable_format_upgrade_value, "disableFormatUpgrade");
             }
         }
     }
@@ -695,8 +749,9 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
     return schema_updated;
 }
 
-template<typename T>
-void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args) {
+template <typename T>
+void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args)
+{
     set_internal<T, RealmClass<T>>(ctx, this_object, nullptr);
     realm::Realm::Config config;
     ObjectDefaultsMap defaults;
@@ -707,9 +762,10 @@ void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Argumen
     set_internal<T, RealmClass<T>>(ctx, this_object, new SharedRealm(realm));
 }
 
-template<typename T>
+template <typename T>
 SharedRealm RealmClass<T>::create_shared_realm(ContextType ctx, realm::Realm::Config config, bool schema_updated,
-                                               ObjectDefaultsMap&& defaults, ConstructorMap&& constructors) {
+                                               ObjectDefaultsMap&& defaults, ConstructorMap&& constructors)
+{
     config.scheduler = realm::util::Scheduler::make_default();
 
     SharedRealm realm;
@@ -719,15 +775,16 @@ SharedRealm RealmClass<T>::create_shared_realm(ContextType ctx, realm::Realm::Co
     return realm;
 }
 
-template<typename T>
+template <typename T>
 void RealmClass<T>::set_binding_context(ContextType ctx, std::shared_ptr<Realm> const& realm, bool schema_updated,
-                                        ObjectDefaultsMap&& defaults, ConstructorMap&& constructors) {
+                                        ObjectDefaultsMap&& defaults, ConstructorMap&& constructors)
+{
     GlobalContextType global_context = Context<T>::get_global_context(ctx);
     if (!realm->m_binding_context) {
         realm->m_binding_context.reset(new RealmDelegate<T>(realm, global_context));
     }
 
-    RealmDelegate<T> *js_binding_context = dynamic_cast<RealmDelegate<T> *>(realm->m_binding_context.get());
+    RealmDelegate<T>* js_binding_context = dynamic_cast<RealmDelegate<T>*>(realm->m_binding_context.get());
     REALM_ASSERT(js_binding_context);
     REALM_ASSERT(js_binding_context->m_context == global_context);
 
@@ -738,8 +795,10 @@ void RealmClass<T>::set_binding_context(ContextType ctx, std::shared_ptr<Realm> 
     }
 }
 
-template<typename T>
-void RealmClass<T>::schema_version(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::schema_version(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     realm::Realm::Config config;
@@ -759,8 +818,10 @@ void RealmClass<T>::schema_version(ContextType ctx, ObjectType this_object, Argu
 }
 
 
-template<typename T>
-void RealmClass<T>::clear_test_state(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::clear_test_state(ContextType ctx, ObjectType this_object, Arguments& args,
+                                     ReturnValue& return_value)
+{
     args.validate_maximum(0);
     js::clear_test_state();
 #if REALM_ENABLE_SYNC
@@ -768,14 +829,17 @@ void RealmClass<T>::clear_test_state(ContextType ctx, ObjectType this_object, Ar
 #endif
 }
 
-template<typename T>
-void RealmClass<T>::copy_bundled_realm_files(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::copy_bundled_realm_files(ContextType ctx, ObjectType this_object, Arguments& args,
+                                             ReturnValue& return_value)
+{
     args.validate_maximum(0);
     realm::copy_bundled_realm_files();
 }
 
-template<typename T>
-void RealmClass<T>::delete_file(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::delete_file(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
     ValueType value = args[0];
     std::string realm_file_path = validate_and_normalize_config(ctx, value).path;
@@ -785,23 +849,27 @@ void RealmClass<T>::delete_file(ContextType ctx, ObjectType this_object, Argumen
     realm::remove_directory(realm_file_path + ".management");
 }
 
-template<typename T>
-void RealmClass<T>::realm_file_exists(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::realm_file_exists(ContextType ctx, ObjectType this_object, Arguments& args,
+                                      ReturnValue& return_value)
+{
     args.validate_maximum(1);
     ValueType value = args[0];
     std::string realm_file_path = validate_and_normalize_config(ctx, value).path;
     return_value.set(realm::util::File::exists(realm_file_path));
 }
 
-template<typename T>
-void RealmClass<T>::delete_model(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::delete_model(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
     ValueType value = args[0];
 
     SharedRealm& realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
 
     auto& config = realm->config();
-    if (config.schema_mode == SchemaMode::Immutable || config.schema_mode == SchemaMode::AdditiveExplicit || config.schema_mode == SchemaMode::ReadOnlyAlternative) {
+    if (config.schema_mode == SchemaMode::Immutable || config.schema_mode == SchemaMode::AdditiveExplicit ||
+        config.schema_mode == SchemaMode::ReadOnlyAlternative) {
         throw std::runtime_error("Cannot delete model for a read-only or a synced Realm.");
     }
 
@@ -816,79 +884,87 @@ void RealmClass<T>::delete_model(ContextType ctx, ObjectType this_object, Argume
     ObjectStore::delete_data_for_object(group, model_name);
     if (!realm->is_in_migration()) {
         realm::Schema new_schema = ObjectStore::schema_from_group(group);
-        realm->update_schema(new_schema,
-                             realm->schema_version() + 1,
-                             nullptr,
-                             nullptr,
-                             true);
+        realm->update_schema(new_schema, realm->schema_version() + 1, nullptr, nullptr, true);
     }
 }
 
-template<typename T>
-void RealmClass<T>::get_default_path(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_default_path(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(realm::js::default_path());
 }
 
-template<typename T>
-void RealmClass<T>::set_default_path(ContextType ctx, ObjectType object, ValueType value) {
+template <typename T>
+void RealmClass<T>::set_default_path(ContextType ctx, ObjectType object, ValueType value)
+{
     js::set_default_path(Value::validated_to_string(ctx, value, "defaultPath"));
 }
 
-template<typename T>
-void RealmClass<T>::get_empty(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_empty(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     SharedRealm& realm = *get_internal<T, RealmClass<T>>(ctx, object);
     bool is_empty = ObjectStore::is_empty(realm->read_group());
     return_value.set(is_empty);
 }
 
-template<typename T>
-void RealmClass<T>::get_path(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_path(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::string path = get_internal<T, RealmClass<T>>(ctx, object)->get()->config().path;
     return_value.set(path);
 }
 
-template<typename T>
-void RealmClass<T>::get_schema_version(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_schema_version(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     double version = get_internal<T, RealmClass<T>>(ctx, object)->get()->schema_version();
     return_value.set(version);
 }
 
-template<typename T>
-void RealmClass<T>::get_schema(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_schema(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto& schema = get_internal<T, RealmClass<T>>(ctx, object)->get()->schema();
     ObjectType schema_object = Schema<T>::object_for_schema(ctx, schema);
     return_value.set(schema_object);
 }
 
-template<typename T>
-void RealmClass<T>::get_in_memory(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_in_memory(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, RealmClass<T>>(ctx, object)->get()->config().in_memory);
 }
 
-template<typename T>
-void RealmClass<T>::get_read_only(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_read_only(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, RealmClass<T>>(ctx, object)->get()->config().immutable());
 }
 
-template<typename T>
-void RealmClass<T>::get_is_in_transaction(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_is_in_transaction(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, RealmClass<T>>(ctx, object)->get()->is_in_transaction());
 }
 
-template<typename T>
-void RealmClass<T>::get_is_closed(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_is_closed(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, RealmClass<T>>(ctx, object)->get()->is_closed());
 }
 
 #if REALM_ENABLE_SYNC
-template<typename T>
-void RealmClass<T>::get_sync_session(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::get_sync_session(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto realm = *get_internal<T, RealmClass<T>>(ctx, object);
     auto config = realm->config();
     if (config.sync_config) {
         auto user = config.sync_config->user;
         if (user) {
-            if (std::shared_ptr<SyncSession>session = user->sync_manager()->get_existing_active_session(config.path)) {
+            if (std::shared_ptr<SyncSession> session =
+                    user->sync_manager()->get_existing_active_session(config.path)) {
                 return return_value.set(create_object<T, SessionClass<T>>(ctx, new WeakSession(session)));
             }
         }
@@ -898,8 +974,10 @@ void RealmClass<T>::get_sync_session(ContextType ctx, ObjectType object, ReturnV
 #endif
 
 #if REALM_ENABLE_SYNC
-template<typename T>
-void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Arguments& args,
+                                     ReturnValue& return_value)
+{
     args.validate_maximum(2);
     auto callback_function = Value::validated_to_function(ctx, args[0 + (args.count == 2)]);
     Realm::Config config;
@@ -919,7 +997,9 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
     if (user && user->state() == SyncUser::State::Removed) {
         ObjectType object = Object::create_empty(protected_ctx);
         Object::set_property(protected_ctx, object, "message",
-                             Value::from_string(protected_ctx, "Cannot asynchronously open synced Realm because the associated session previously experienced a fatal error"));
+                             Value::from_string(protected_ctx,
+                                                "Cannot asynchronously open synced Realm because the associated "
+                                                "session previously experienced a fatal error"));
         Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
 
         ValueType callback_arguments[] = {
@@ -931,47 +1011,51 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
     std::shared_ptr<AsyncOpenTask> task;
     task = Realm::get_synchronized_realm(config);
 
-    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, defaults = std::move(defaults), constructors = std::move(constructors)]
-                                                               (ThreadSafeReference&& realm_ref, std::exception_ptr error) {
-        HANDLESCOPE(protected_ctx)
+    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler(
+        [=, defaults = std::move(defaults), constructors = std::move(constructors)](ThreadSafeReference&& realm_ref,
+                                                                                    std::exception_ptr error) {
+            HANDLESCOPE(protected_ctx)
 
-        if (error) {
-            try {
-                std::rethrow_exception(error);
-            } catch (const std::exception& e) {
-                ObjectType object = Object::create_empty(protected_ctx);
-                Object::set_property(protected_ctx, object, "message", Value::from_string(protected_ctx, e.what()));
-                Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
+            if (error) {
+                try {
+                    std::rethrow_exception(error);
+                }
+                catch (const std::exception& e) {
+                    ObjectType object = Object::create_empty(protected_ctx);
+                    Object::set_property(protected_ctx, object, "message",
+                                         Value::from_string(protected_ctx, e.what()));
+                    Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
 
-                ValueType callback_arguments[2] =  {
-                    Value::from_undefined(protected_ctx),
-                    object,
-                };
-                Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, callback_arguments);
-                return;
+                    ValueType callback_arguments[2] = {
+                        Value::from_undefined(protected_ctx),
+                        object,
+                    };
+                    Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, callback_arguments);
+                    return;
+                }
             }
-        }
 
-        auto def = std::move(defaults);
-        auto ctor = std::move(constructors);
-        const SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref), util::Scheduler::make_default());
-        set_binding_context(protected_ctx, realm, schema_updated, std::move(def), std::move(ctor));
-        ObjectType object = create_object<T, RealmClass<T>>(protected_ctx, new SharedRealm(realm));
+            auto def = std::move(defaults);
+            auto ctor = std::move(constructors);
+            const SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref), util::Scheduler::make_default());
+            set_binding_context(protected_ctx, realm, schema_updated, std::move(def), std::move(ctor));
+            ObjectType object = create_object<T, RealmClass<T>>(protected_ctx, new SharedRealm(realm));
 
-        ValueType callback_arguments[2] = {
-            object,
-            Value::from_null(protected_ctx),
-        };
-        Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
-    });
+            ValueType callback_arguments[2] = {
+                object,
+                Value::from_null(protected_ctx),
+            };
+            Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
+        });
 
     task->start(callback_handler);
     return_value.set(create_object<T, AsyncOpenTaskClass<T>>(ctx, new std::shared_ptr<AsyncOpenTask>(task)));
 }
 #endif
 
-template<typename T>
-void RealmClass<T>::objects(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::objects(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
@@ -984,13 +1068,15 @@ void RealmClass<T>::objects(ContextType ctx, ObjectType this_object, Arguments &
     return_value.set(ResultsClass<T>::create_instance(ctx, realm, object_schema.name));
 }
 
-template<typename T>
-void RealmClass<T>::object_for_primary_key(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::object_for_primary_key(ContextType ctx, ObjectType this_object, Arguments& args,
+                                           ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     std::string object_type;
-    auto &object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
+    auto& object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
     NativeAccessor accessor(ctx, realm, object_schema);
     auto realm_object = realm::Object::get_for_primary_key(accessor, realm, object_schema, args[1]);
 
@@ -1002,8 +1088,9 @@ void RealmClass<T>::object_for_primary_key(ContextType ctx, ObjectType this_obje
     }
 }
 
-template<typename T>
-void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(3);
     realm::CreatePolicy policy = realm::CreatePolicy::ForceCreate;
     if (args.count == 3) {
@@ -1027,18 +1114,20 @@ void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments &a
             }
             else if (mode == "all") {
                 policy = realm::CreatePolicy::UpdateAll;
-            } else {
+            }
+            else {
                 throw std::runtime_error("Unsupported 'updateMode'. Only 'never', 'modified' or 'all' is supported.");
             }
         }
         else {
-            throw std::runtime_error("Unsupported 'updateMode'. Only the strings 'never', 'modified' or 'all' is supported.");
+            throw std::runtime_error(
+                "Unsupported 'updateMode'. Only the strings 'never', 'modified' or 'all' is supported.");
         }
     }
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     realm->verify_open();
-    auto &object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
+    auto& object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
 
     ObjectType object = Value::validated_to_object(ctx, args[1], "properties");
     if (Value::is_array(ctx, args[1])) {
@@ -1057,8 +1146,9 @@ void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments &a
     return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
 }
 
-template<typename T>
-void RealmClass<T>::delete_one(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::delete_one(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
@@ -1076,10 +1166,12 @@ void RealmClass<T>::delete_one(ContextType ctx, ObjectType this_object, Argument
         }
 
         if (!realm_object->is_valid()) {
-            throw std::runtime_error("Object is invalid. Either it has been previously deleted or the Realm it belongs to has been closed.");
+            throw std::runtime_error("Object is invalid. Either it has been previously deleted or the Realm it "
+                                     "belongs to has been closed.");
         }
 
-        realm::TableRef table = ObjectStore::table_for_object_type(realm->read_group(), realm_object->get_object_schema().name);
+        realm::TableRef table =
+            ObjectStore::table_for_object_type(realm->read_group(), realm_object->get_object_schema().name);
         table->remove_object(realm_object->obj().get_key());
     }
     else if (Value::is_array(ctx, arg)) {
@@ -1088,15 +1180,17 @@ void RealmClass<T>::delete_one(ContextType ctx, ObjectType this_object, Argument
             ObjectType object = Object::validated_get_object(ctx, arg, i);
 
             if (!Object::template is_instance<RealmObjectClass<T>>(ctx, object)) {
-                throw std::runtime_error("Argument to 'delete' must be a Realm object or a collection of Realm objects.");
+                throw std::runtime_error(
+                    "Argument to 'delete' must be a Realm object or a collection of Realm objects.");
             }
 
             auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
             if (!realm_object) {
-               throw std::runtime_error(util::format("Invalid argument at index %1", i));
+                throw std::runtime_error(util::format("Invalid argument at index %1", i));
             }
 
-            realm::TableRef table = ObjectStore::table_for_object_type(realm->read_group(), realm_object->get_object_schema().name);
+            realm::TableRef table =
+                ObjectStore::table_for_object_type(realm->read_group(), realm_object->get_object_schema().name);
             table->remove_object(realm_object->obj().get_key());
         }
     }
@@ -1113,8 +1207,9 @@ void RealmClass<T>::delete_one(ContextType ctx, ObjectType this_object, Argument
     }
 }
 
-template<typename T>
-void RealmClass<T>::delete_all(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::delete_all(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
@@ -1130,8 +1225,9 @@ void RealmClass<T>::delete_all(ContextType ctx, ObjectType this_object, Argument
     }
 }
 
-template<typename T>
-void RealmClass<T>::write(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::write(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
@@ -1140,7 +1236,7 @@ void RealmClass<T>::write(ContextType ctx, ObjectType this_object, Arguments &ar
     realm->begin_transaction();
 
     try {
-        auto const &callback_return = Function<T>::call(ctx, callback, this_object, 0, nullptr);
+        auto const& callback_return = Function<T>::call(ctx, callback, this_object, 0, nullptr);
         return_value.set(callback_return);
     }
     catch (...) {
@@ -1151,32 +1247,39 @@ void RealmClass<T>::write(ContextType ctx, ObjectType this_object, Arguments &ar
     realm->commit_transaction();
 }
 
-template<typename T>
-void RealmClass<T>::begin_transaction(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::begin_transaction(ContextType ctx, ObjectType this_object, Arguments& args,
+                                      ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     realm->begin_transaction();
 }
 
-template<typename T>
-void RealmClass<T>::commit_transaction(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::commit_transaction(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     realm->commit_transaction();
 }
 
-template<typename T>
-void RealmClass<T>::cancel_transaction(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::cancel_transaction(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     realm->cancel_transaction();
 }
 
-template<typename T>
-void RealmClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     std::string name = Value::validated_to_string(ctx, args[0], "notification name");
@@ -1194,12 +1297,15 @@ void RealmClass<T>::add_listener(ContextType ctx, ObjectType this_object, Argume
         get_delegate<T>(realm.get())->add_schema_notification(callback);
     }
     else {
-        throw std::runtime_error(util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported.", name));
+        throw std::runtime_error(
+            util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported.", name));
     }
 }
 
-template<typename T>
-void RealmClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                    ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     std::string name = Value::validated_to_string(ctx, args[0], "notification name");
@@ -1217,12 +1323,15 @@ void RealmClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arg
         get_delegate<T>(realm.get())->remove_schema_notification(callback);
     }
     else {
-        throw std::runtime_error(util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported", name));
+        throw std::runtime_error(
+            util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported", name));
     }
 }
 
-template<typename T>
-void RealmClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_maximum(1);
     std::string name = "change";
     if (args.count) {
@@ -1241,20 +1350,23 @@ void RealmClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object
         get_delegate<T>(realm.get())->remove_all_schema_notifications();
     }
     else {
-        throw std::runtime_error(util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported", name));
+        throw std::runtime_error(
+            util::format("Unknown event name '%1': only 'change', 'schema' and 'beforenotify' are supported", name));
     }
 }
 
-template<typename T>
-void RealmClass<T>::close(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::close(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     realm->close();
 }
 
-template<typename T>
-void RealmClass<T>::compact(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::compact(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
@@ -1265,8 +1377,9 @@ void RealmClass<T>::compact(ContextType ctx, ObjectType this_object, Arguments &
     return_value.set(realm->compact());
 }
 
-template<typename T>
-void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     if (args.count == 0) {
@@ -1301,14 +1414,16 @@ void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Argumen
     realm->write_copy(path, encryption_key.get());
 }
 
-template<typename T>
-void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue& return_value) {
+template <typename T>
+void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                ReturnValue& return_value)
+{
     args.validate_count(1);
 
     // Try to map the input to the internal schema name for the given input. This should work for managed objects and
     // schema objects. Pure strings and functions are expected to return a correct value.
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
-    auto &object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
+    auto& object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
     return_value.set(object_schema.name);
 }
 
@@ -1318,8 +1433,9 @@ void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this
  * TODO: This is exposed as an internal `_updateSchema` API because this should eventually be published as
  * `Realm.schema.update`.
  */
-template<typename T>
-void RealmClass<T>::update_schema(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::update_schema(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     ObjectType schema = Value::validated_to_array(ctx, args[0], "schema");
 
@@ -1335,17 +1451,12 @@ void RealmClass<T>::update_schema(ContextType ctx, ObjectType this_object, Argum
     }
 
     // Perform the schema update
-    realm->update_schema(
-        parsed_schema,
-        realm->schema_version() + 1,
-        nullptr,
-        nullptr,
-        true
-    );
+    realm->update_schema(parsed_schema, realm->schema_version() + 1, nullptr, nullptr, true);
 }
 
-template<typename T>
-void RealmClass<T>::bson_parse_json(ContextType ctx, ObjectType, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void RealmClass<T>::bson_parse_json(ContextType ctx, ObjectType, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     auto json = std::string(Value::validated_to_string(ctx, args[0]));
     auto parsed = bson::parse(json);
@@ -1353,7 +1464,7 @@ void RealmClass<T>::bson_parse_json(ContextType ctx, ObjectType, Arguments& args
 }
 
 #if REALM_ENABLE_SYNC
-template<typename T>
+template <typename T>
 class AsyncOpenTaskClass : public ClassDefinition<T, std::shared_ptr<AsyncOpenTask>> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -1375,8 +1486,8 @@ public:
 
     static FunctionType create_constructor(ContextType);
 
-    static void add_download_notification(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void cancel(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add_download_notification(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void cancel(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const methods = {
         {"addDownloadNotification", wrap<add_download_notification>},
@@ -1384,19 +1495,24 @@ public:
     };
 };
 
-template<typename T>
-typename T::Function AsyncOpenTaskClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+typename T::Function AsyncOpenTaskClass<T>::create_constructor(ContextType ctx)
+{
     return ObjectWrap<T, AsyncOpenTaskClass<T>>::create_constructor(ctx);
 }
 
-template<typename T>
-void AsyncOpenTaskClass<T>::cancel(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue & return_value) {
+template <typename T>
+void AsyncOpenTaskClass<T>::cancel(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     std::shared_ptr<AsyncOpenTask> task = *get_internal<T, AsyncOpenTaskClass<T>>(ctx, this_object);
     task->cancel();
 }
 
-template<typename T>
-void AsyncOpenTaskClass<T>::add_download_notification(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue & return_value) {
+template <typename T>
+void AsyncOpenTaskClass<T>::add_download_notification(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                      ReturnValue& return_value)
+{
     args.validate_maximum(1);
     auto callback_function = Value::validated_to_function(ctx, args[0]);
 
@@ -1404,19 +1520,20 @@ void AsyncOpenTaskClass<T>::add_download_notification(ContextType ctx, ObjectTyp
     Protected<ObjectType> protected_this(ctx, this_object);
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
 
-    realm::util::EventLoopDispatcher<SyncProgressHandler> callback_handler([=](uint64_t transferred_bytes, uint64_t transferrable_bytes) mutable {
-        HANDLESCOPE(protected_ctx)
-        ValueType callback_arguments[2] = {
-            Value::from_number(protected_ctx, transferred_bytes),
-            Value::from_number(protected_ctx, transferrable_bytes),
-        };
-        Function::callback(protected_ctx, protected_callback, 2, callback_arguments);
-    });
+    realm::util::EventLoopDispatcher<SyncProgressHandler> callback_handler(
+        [=](uint64_t transferred_bytes, uint64_t transferrable_bytes) mutable {
+            HANDLESCOPE(protected_ctx)
+            ValueType callback_arguments[2] = {
+                Value::from_number(protected_ctx, transferred_bytes),
+                Value::from_number(protected_ctx, transferrable_bytes),
+            };
+            Function::callback(protected_ctx, protected_callback, 2, callback_arguments);
+        });
 
     std::shared_ptr<AsyncOpenTask> task = *get_internal<T, AsyncOpenTaskClass<T>>(ctx, this_object);
     task->register_download_progress_notifier(callback_handler); // Ignore token as we don't want to unregister.
 }
 #endif
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -20,9 +20,10 @@
 
 namespace realm {
 namespace js {
-    template<typename> struct RealmObjectClass;
+template <typename>
+struct RealmObjectClass;
 }
-}
+} // namespace realm
 
 #include <realm/object-store/object_accessor.hpp>
 #include <realm/object-store/object_store.hpp>
@@ -36,13 +37,16 @@ namespace js {
 namespace realm {
 namespace js {
 
-template<typename> class NativeAccessor;
+template <typename>
+class NativeAccessor;
 
-template<typename T>
+template <typename T>
 class RealmObject : public realm::Object {
 public:
-    RealmObject(RealmObject const& obj) : realm::Object(obj) {};
-    RealmObject(realm::Object const& obj) : realm::Object(obj) {};
+    RealmObject(RealmObject const& obj)
+        : realm::Object(obj){};
+    RealmObject(realm::Object const& obj)
+        : realm::Object(obj){};
     RealmObject(RealmObject&&) = default;
     RealmObject& operator=(RealmObject&&) = default;
     RealmObject& operator=(RealmObject const&) = default;
@@ -50,7 +54,7 @@ public:
     std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
 };
 
-template<typename T>
+template <typename T>
 struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -65,23 +69,23 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
 
     static ObjectType create_instance(ContextType, realm::js::RealmObject<T>);
 
-    static void get_property(ContextType, ObjectType, const String &, ReturnValue &);
-    static bool set_property(ContextType, ObjectType, const String &, ValueType);
+    static void get_property(ContextType, ObjectType, const String&, ReturnValue&);
+    static bool set_property(ContextType, ObjectType, const String&, ValueType);
     static std::vector<String> get_property_names(ContextType, ObjectType);
 
-    static void is_valid(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get_object_schema(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void linking_objects(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void linking_objects_count(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get_object_id(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void is_same_object(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void set_link(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get_property_type(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void is_valid(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_object_schema(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void linking_objects(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void linking_objects_count(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_object_id(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void is_same_object(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void set_link(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_property_type(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-    static void get_realm(ContextType, ObjectType, ReturnValue &);
+    static void get_realm(ContextType, ObjectType, ReturnValue&);
 
     const std::string name = "RealmObject";
 
@@ -110,8 +114,9 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
     };
 };
 
-template<typename T>
-void RealmObjectClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue& return_value)
+{
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, this_object);
     if (!realm_object) {
         throw std::runtime_error("Invalid 'this' object");
@@ -119,8 +124,10 @@ void RealmObjectClass<T>::is_valid(ContextType ctx, ObjectType this_object, Argu
     return_value.set(realm_object->is_valid());
 }
 
-template<typename T>
-void RealmObjectClass<T>::get_object_schema(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::get_object_schema(ContextType ctx, ObjectType this_object, Arguments&,
+                                            ReturnValue& return_value)
+{
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, this_object);
     if (!realm_object) {
         throw std::runtime_error("Invalid 'this' object");
@@ -128,8 +135,9 @@ void RealmObjectClass<T>::get_object_schema(ContextType ctx, ObjectType this_obj
     return_value.set(Schema<T>::object_for_object_schema(ctx, realm_object->get_object_schema()));
 }
 
-template<typename T>
-typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::js::RealmObject<T> realm_object) {
+template <typename T>
+typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::js::RealmObject<T> realm_object)
+{
     static String prototype_string = "prototype";
 
     auto delegate = get_delegate<T>(realm_object.realm().get());
@@ -154,8 +162,10 @@ typename T::Object RealmObjectClass<T>::create_instance(ContextType ctx, realm::
     }
 }
 
-template<typename T>
-void RealmObjectClass<T>::get_property(ContextType ctx, ObjectType object, const String &property_name, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::get_property(ContextType ctx, ObjectType object, const String& property_name,
+                                       ReturnValue& return_value)
+{
     std::string prop_name = property_name;
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
     if (!realm_object) {
@@ -170,8 +180,10 @@ void RealmObjectClass<T>::get_property(ContextType ctx, ObjectType object, const
     }
 }
 
-template<typename T>
-bool RealmObjectClass<T>::set_property(ContextType ctx, ObjectType object, const String &property_name, ValueType value) {
+template <typename T>
+bool RealmObjectClass<T>::set_property(ContextType ctx, ObjectType object, const String& property_name,
+                                       ValueType value)
+{
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
     if (!realm_object) {
         return false;
@@ -192,8 +204,9 @@ bool RealmObjectClass<T>::set_property(ContextType ctx, ObjectType object, const
     return true;
 }
 
-template<typename T>
-void RealmObjectClass<T>::set_link(ContextType ctx, ObjectType object, Arguments &args, ReturnValue& return_value) {
+template <typename T>
+void RealmObjectClass<T>::set_link(ContextType ctx, ObjectType object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
@@ -223,16 +236,14 @@ void RealmObjectClass<T>::set_link(ContextType ctx, ObjectType object, Arguments
 
     ObjKey obj_key = {};
     if (linked_pk->type == realm::PropertyType::String) {
-        obj_key = linked_table->find_first(linked_pk->column_key,
-                                           accessor.template unbox<StringData>(args[1]));
+        obj_key = linked_table->find_first(linked_pk->column_key, accessor.template unbox<StringData>(args[1]));
     }
     else if (is_nullable(linked_pk->type)) {
         obj_key = linked_table->find_first(linked_pk->column_key,
                                            accessor.template unbox<util::Optional<int64_t>>(args[1]));
     }
     else {
-        obj_key = linked_table->find_first(linked_pk->column_key,
-                                           accessor.template unbox<int64_t>(args[1]));
+        obj_key = linked_table->find_first(linked_pk->column_key, accessor.template unbox<int64_t>(args[1]));
     }
 
     if (obj_key) {
@@ -243,8 +254,9 @@ void RealmObjectClass<T>::set_link(ContextType ctx, ObjectType object, Arguments
     }
 }
 
-template<typename T>
-void RealmObjectClass<T>::get_realm(ContextType ctx, ObjectType object, ReturnValue& return_value) {
+template <typename T>
+void RealmObjectClass<T>::get_realm(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set_undefined();
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
     if (realm_object) {
@@ -256,30 +268,33 @@ void RealmObjectClass<T>::get_realm(ContextType ctx, ObjectType object, ReturnVa
     return_value.set(realm_obj);
 }
 
-template<typename T>
-std::vector<String<T>> RealmObjectClass<T>::get_property_names(ContextType ctx, ObjectType object) {
+template <typename T>
+std::vector<String<T>> RealmObjectClass<T>::get_property_names(ContextType ctx, ObjectType object)
+{
     std::vector<String> names;
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
     if (!realm_object) {
         return names;
     }
 
-    auto &object_schema = realm_object->get_object_schema();
+    auto& object_schema = realm_object->get_object_schema();
 
     names.reserve(object_schema.persisted_properties.size() + object_schema.computed_properties.size());
 
-    for (auto &prop : object_schema.persisted_properties) {
+    for (auto& prop : object_schema.persisted_properties) {
         names.push_back(!prop.public_name.empty() ? prop.public_name : prop.name);
     }
-    for (auto &prop : object_schema.computed_properties) {
+    for (auto& prop : object_schema.computed_properties) {
         names.push_back(!prop.public_name.empty() ? prop.public_name : prop.name);
     }
 
     return names;
 }
 
-template<typename T>
-void RealmObjectClass<T>::get_object_id(ContextType ctx, ObjectType object, Arguments &args, ReturnValue& return_value) {
+template <typename T>
+void RealmObjectClass<T>::get_object_id(ContextType ctx, ObjectType object, Arguments& args,
+                                        ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
@@ -292,8 +307,10 @@ void RealmObjectClass<T>::get_object_id(ContextType ctx, ObjectType object, Argu
     return_value.set(obj_id.to_string());
 }
 
-template<typename T>
-void RealmObjectClass<T>::is_same_object(ContextType ctx, ObjectType object, Arguments &args, ReturnValue& return_value) {
+template <typename T>
+void RealmObjectClass<T>::is_same_object(ContextType ctx, ObjectType object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_count(1);
 
     ObjectType otherObject = Value::validated_to_object(ctx, args[0]);
@@ -323,12 +340,14 @@ void RealmObjectClass<T>::is_same_object(ContextType ctx, ObjectType object, Arg
     }
 
     // FIXME: is self == other good enough?
-    return_value.set(self->obj().get_table() == other->obj().get_table()
-                     && self->obj().get_key() == other->obj().get_key());
+    return_value.set(self->obj().get_table() == other->obj().get_table() &&
+                     self->obj().get_key() == other->obj().get_key());
 }
 
-template<typename T>
-void RealmObjectClass<T>::linking_objects_count(ContextType ctx, ObjectType object, Arguments &, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::linking_objects_count(ContextType ctx, ObjectType object, Arguments&,
+                                                ReturnValue& return_value)
+{
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
     if (!realm_object) {
         throw std::runtime_error("Invalid 'this' object");
@@ -339,8 +358,10 @@ void RealmObjectClass<T>::linking_objects_count(ContextType ctx, ObjectType obje
 }
 
 
-template<typename T>
-void RealmObjectClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue& return_value) {
+template <typename T>
+void RealmObjectClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, this_object);
@@ -353,41 +374,42 @@ void RealmObjectClass<T>::add_listener(ContextType ctx, ObjectType this_object, 
     Protected<ObjectType> protected_this(ctx, this_object);
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
 
-    auto token = realm_object->add_notification_callback([=](CollectionChangeSet const& change_set, std::exception_ptr exception) {
-            HANDLESCOPE(protected_ctx)
+    auto token = realm_object->add_notification_callback([=](CollectionChangeSet const& change_set,
+                                                             std::exception_ptr exception) {
+        HANDLESCOPE(protected_ctx)
 
-            bool deleted = false;
-            std::vector<ValueType> scratch;
+        bool deleted = false;
+        std::vector<ValueType> scratch;
 
-            if (!change_set.deletions.empty()) {
-                deleted = true;
-            }
-            else {
-                auto table = realm_object->obj().get_table();
-                for (const auto &col : change_set.columns) {
-                    if (col.second.empty()) {
-                        continue;
-                    }
-                    ColKey col_key(col.first);
-                    scratch.push_back(Value::from_string(protected_ctx, std::string(table->get_column_name(col_key))));
+        if (!change_set.deletions.empty()) {
+            deleted = true;
+        }
+        else {
+            auto table = realm_object->obj().get_table();
+            for (const auto& col : change_set.columns) {
+                if (col.second.empty()) {
+                    continue;
                 }
+                ColKey col_key(col.first);
+                scratch.push_back(Value::from_string(protected_ctx, std::string(table->get_column_name(col_key))));
             }
+        }
 
-            ObjectType object = Object::create_empty(protected_ctx);
-            Object::set_property(protected_ctx, object, "deleted", Value::from_boolean(protected_ctx, deleted));
-            Object::set_property(protected_ctx, object, "changedProperties", Object::create_array(protected_ctx, scratch));
+        ObjectType object = Object::create_empty(protected_ctx);
+        Object::set_property(protected_ctx, object, "deleted", Value::from_boolean(protected_ctx, deleted));
+        Object::set_property(protected_ctx, object, "changedProperties",
+                             Object::create_array(protected_ctx, scratch));
 
-            ValueType arguments[] {
-                static_cast<ObjectType>(protected_this),
-                object
-            };
-            Function::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
-        });
+        ValueType arguments[]{static_cast<ObjectType>(protected_this), object};
+        Function::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
+    });
     realm_object->m_notification_tokens.emplace_back(protected_callback, std::move(token));
 }
 
-template<typename T>
-void RealmObjectClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                          ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     auto callback = Value::validated_to_function(ctx, args[0]);
@@ -405,8 +427,10 @@ void RealmObjectClass<T>::remove_listener(ContextType ctx, ObjectType this_objec
     tokens.erase(std::remove_if(tokens.begin(), tokens.end(), compare), tokens.end());
 }
 
-template<typename T>
-void RealmObjectClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                               ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, this_object);
@@ -417,8 +441,10 @@ void RealmObjectClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_
     realm_object->m_notification_tokens.clear();
 }
 
-template<typename T>
-void RealmObjectClass<T>::get_property_type(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void RealmObjectClass<T>::get_property_type(ContextType ctx, ObjectType this_object, Arguments& args,
+                                            ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     std::string property_name = Value::validated_to_string(ctx, args[0], "propertyName");
@@ -441,19 +467,21 @@ void RealmObjectClass<T>::get_property_type(ContextType ctx, ObjectType this_obj
         return_value.set(type_deduction.javascript_type(type));
     }
     else {
-    	return_value.set(prop->type_string());
+        return_value.set(prop->type_string());
     }
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm
 
 // move this all the way here because it needs to include "js_results.hpp" which in turn includes this file
 
 #include "js_results.hpp"
 
-template<typename T>
-void realm::js::RealmObjectClass<T>::linking_objects(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void realm::js::RealmObjectClass<T>::linking_objects(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                     ReturnValue& return_value)
+{
     args.validate_count(2);
 
     std::string object_type = Value::validated_to_string(ctx, args[0], "objectType");
@@ -475,10 +503,12 @@ void realm::js::RealmObjectClass<T>::linking_objects(ContextType ctx, ObjectType
     }
 
     if (link_property->object_type != realm_object->get_object_schema().name) {
-        throw std::logic_error(util::format("'%1.%2' is not a relationship to '%3'", object_type, property_name, realm_object->get_object_schema().name));
+        throw std::logic_error(util::format("'%1.%2' is not a relationship to '%3'", object_type, property_name,
+                                            realm_object->get_object_schema().name));
     }
 
-    realm::TableRef table = ObjectStore::table_for_object_type(realm_object->realm()->read_group(), target_object_schema->name);
+    realm::TableRef table =
+        ObjectStore::table_for_object_type(realm_object->realm()->read_group(), target_object_schema->name);
     auto obj = realm_object->obj();
     auto tv = obj.get_backlink_view(table, link_property->column_key);
 

--- a/src/js_results.hpp
+++ b/src/js_results.hpp
@@ -36,18 +36,23 @@
 namespace realm {
 namespace js {
 
-template<typename>
+template <typename>
 class NativeAccessor;
 
 struct NonRealmObjectException : public std::logic_error {
-    NonRealmObjectException() : std::logic_error("Object is not a Realm object") { }
+    NonRealmObjectException()
+        : std::logic_error("Object is not a Realm object")
+    {
+    }
 };
 
-template<typename T>
+template <typename T>
 class Results : public realm::Results {
-  public:
-    Results(Results const& r) : realm::Results(r) {};
-    Results(realm::Results const& r) : realm::Results(r) {};
+public:
+    Results(Results const& r)
+        : realm::Results(r){};
+    Results(realm::Results const& r)
+        : realm::Results(r){};
     Results(Results&&) = default;
     Results& operator=(Results&&) = default;
     Results& operator=(Results const&) = default;
@@ -57,7 +62,7 @@ class Results : public realm::Results {
     std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
 };
 
-template<typename T>
+template <typename T>
 struct ResultsClass : ClassDefinition<T, realm::js::Results<T>, CollectionClass<T>> {
     using Type = T;
     using ContextType = typename T::Context;
@@ -70,41 +75,41 @@ struct ResultsClass : ClassDefinition<T, realm::js::Results<T>, CollectionClass<
     using Arguments = js::Arguments<T>;
 
     static ObjectType create_instance(ContextType, realm::Results);
-    static ObjectType create_instance(ContextType, SharedRealm, const std::string &object_type);
+    static ObjectType create_instance(ContextType, SharedRealm, const std::string& object_type);
 
-    template<typename U>
-    static ObjectType create_filtered(ContextType, const U &, Arguments &);
+    template <typename U>
+    static ObjectType create_filtered(ContextType, const U&, Arguments&);
 
-    static std::vector<std::pair<std::string, bool>> get_keypaths(ContextType, Arguments &);
+    static std::vector<std::pair<std::string, bool>> get_keypaths(ContextType, Arguments&);
 
-    static void get_length(ContextType, ObjectType, ReturnValue &);
-    static void get_type(ContextType, ObjectType, ReturnValue &);
-    static void get_optional(ContextType, ObjectType, ReturnValue &);
-    static void get_index(ContextType, ObjectType, uint32_t, ReturnValue &);
+    static void get_length(ContextType, ObjectType, ReturnValue&);
+    static void get_type(ContextType, ObjectType, ReturnValue&);
+    static void get_optional(ContextType, ObjectType, ReturnValue&);
+    static void get_index(ContextType, ObjectType, uint32_t, ReturnValue&);
 
-    static void description(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void snapshot(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void filtered(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void sorted(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void is_valid(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void is_empty(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void description(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void snapshot(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void filtered(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void sorted(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void is_valid(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void is_empty(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-    static void index_of(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void index_of(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-    template<typename Fn>
-    static void index_of(ContextType, Fn&, Arguments &, ReturnValue &);
+    template <typename Fn>
+    static void index_of(ContextType, Fn&, Arguments&, ReturnValue&);
 
-    static void update(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void update(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // observable
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-    template<typename U>
-    static void add_listener(ContextType, U&, ObjectType, Arguments &);
-    template<typename U>
-    static void remove_listener(ContextType, U&, ObjectType, Arguments &);
+    template <typename U>
+    static void add_listener(ContextType, U&, ObjectType, Arguments&);
+    template <typename U>
+    static void remove_listener(ContextType, U&, ObjectType, Arguments&);
 
     std::string const name = "Results";
 
@@ -135,13 +140,16 @@ struct ResultsClass : ClassDefinition<T, realm::js::Results<T>, CollectionClass<
     IndexPropertyType<T> const index_accessor = {wrap<get_index>, nullptr};
 };
 
-template<typename T>
-typename T::Object ResultsClass<T>::create_instance(ContextType ctx, realm::Results results) {
+template <typename T>
+typename T::Object ResultsClass<T>::create_instance(ContextType ctx, realm::Results results)
+{
     return create_object<T, ResultsClass<T>>(ctx, new realm::js::Results<T>(std::move(results)));
 }
 
-template<typename T>
-typename T::Object ResultsClass<T>::create_instance(ContextType ctx, SharedRealm realm, const std::string &object_type) {
+template <typename T>
+typename T::Object ResultsClass<T>::create_instance(ContextType ctx, SharedRealm realm,
+                                                    const std::string& object_type)
+{
     auto table = ObjectStore::table_for_object_type(realm->read_group(), object_type);
     if (!table) {
         throw std::runtime_error("Table does not exist. Object type: " + object_type);
@@ -149,17 +157,18 @@ typename T::Object ResultsClass<T>::create_instance(ContextType ctx, SharedRealm
     return create_object<T, ResultsClass<T>>(ctx, new realm::js::Results<T>(realm, table));
 }
 
-template<typename T>
-template<typename U>
-typename T::Object ResultsClass<T>::create_filtered(ContextType ctx, const U &collection, Arguments &args) {
+template <typename T>
+template <typename U>
+typename T::Object ResultsClass<T>::create_filtered(ContextType ctx, const U& collection, Arguments& args)
+{
     if (collection.get_type() != realm::PropertyType::Object) {
         throw std::runtime_error("Filtering non-object Lists and Results is not yet implemented.");
     }
 
     auto query_string = Value::validated_to_string(ctx, args[0], "predicate");
 
-    auto const &realm = collection.get_realm();
-    auto const &object_schema = collection.get_object_schema();
+    auto const& realm = collection.get_realm();
+    auto const& object_schema = collection.get_object_schema();
 
     query_parser::KeyPathMapping mapping;
     realm::populate_keypath_mapping(mapping, *realm);
@@ -175,9 +184,9 @@ typename T::Object ResultsClass<T>::create_filtered(ContextType ctx, const U &co
         return create_instance(ctx, collection.filter(std::move(query)));
 }
 
-template<typename T>
-std::vector<std::pair<std::string, bool>>
-ResultsClass<T>::get_keypaths(ContextType ctx, Arguments &args) {
+template <typename T>
+std::vector<std::pair<std::string, bool>> ResultsClass<T>::get_keypaths(ContextType ctx, Arguments& args)
+{
     args.validate_maximum(2);
 
     std::vector<std::pair<std::string, bool>> sort_order;
@@ -186,7 +195,8 @@ ResultsClass<T>::get_keypaths(ContextType ctx, Arguments &args) {
         return sort_order;
     }
     else if (Value::is_array(ctx, args[0])) {
-        validate_argument_count(args.count, 1, "Second argument is not allowed if passed an array of sort descriptors");
+        validate_argument_count(args.count, 1,
+                                "Second argument is not allowed if passed an array of sort descriptors");
 
         ObjectType js_prop_names = Value::validated_to_object(ctx, args[0]);
         size_t prop_count = Object::validated_get_length(ctx, js_prop_names);
@@ -217,33 +227,38 @@ ResultsClass<T>::get_keypaths(ContextType ctx, Arguments &args) {
     return sort_order;
 }
 
-template<typename T>
-void ResultsClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::get_length(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, object);
     return_value.set((uint32_t)results->size());
 }
 
-template<typename T>
-void ResultsClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, object);
     return_value.set(local_string_for_property_type(results->get_type() & ~realm::PropertyType::Flags));
 }
 
-template<typename T>
-void ResultsClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, object);
     return_value.set(is_nullable(results->get_type()));
 }
 
-template<typename T>
-void ResultsClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t index, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::get_index(ContextType ctx, ObjectType object, uint32_t index, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, object);
     NativeAccessor<T> accessor(ctx, *results);
     return_value.set(results->get(accessor, index));
 }
 
-template<typename T>
-void ResultsClass<T>::description(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::description(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     auto query = results->get_query();
@@ -252,45 +267,51 @@ void ResultsClass<T>::description(ContextType ctx, ObjectType this_object, Argum
     return_value.set(Value::from_string(ctx, serialized_query));
 }
 
-template<typename T>
-void ResultsClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_instance(ctx, results->snapshot()));
 }
 
-template<typename T>
-void ResultsClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     return_value.set(create_filtered(ctx, *results, args));
 }
 
-template<typename T>
-void ResultsClass<T>::sorted(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::sorted(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_instance(ctx, results->sort(ResultsClass<T>::get_keypaths(ctx, args))));
 }
 
-template<typename T>
-void ResultsClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::is_valid(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, ResultsClass<T>>(ctx, this_object)->is_valid());
 }
 
-template<typename T>
-void ResultsClass<T>::is_empty(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::is_empty(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     return_value.set(get_internal<T, ResultsClass<T>>(ctx, this_object)->size() == 0);
 }
 
-template<typename T>
-template<typename Fn>
-void ResultsClass<T>::index_of(ContextType ctx, Fn& fn, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+template <typename Fn>
+void ResultsClass<T>::index_of(ContextType ctx, Fn& fn, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     size_t ndx;
     try {
         ndx = fn(args[0]);
     }
-    catch (realm::Results::IncorrectTableException &) {
+    catch (realm::Results::IncorrectTableException&) {
         throw std::runtime_error("Object type does not match the type contained in result");
     }
     catch (NonRealmObjectException&) {
@@ -305,8 +326,9 @@ void ResultsClass<T>::index_of(ContextType ctx, Fn& fn, Arguments &args, ReturnV
     }
 }
 
-template<typename T>
-void ResultsClass<T>::update(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::update(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(2);
 
     std::string property = Value::validated_to_string(ctx, args[0], "property");
@@ -331,9 +353,9 @@ void ResultsClass<T>::update(ContextType ctx, ObjectType this_object, Arguments 
     }
 }
 
-template<typename T>
-void ResultsClass<T>::index_of(ContextType ctx, ObjectType this_object,
-                               Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::index_of(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto fn = [&](auto&& row) {
         auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
         NativeAccessor<T> accessor(ctx, *results);
@@ -342,9 +364,10 @@ void ResultsClass<T>::index_of(ContextType ctx, ObjectType this_object,
     index_of(ctx, fn, args, return_value);
 }
 
-template<typename T>
-template<typename U>
-void ResultsClass<T>::add_listener(ContextType ctx, U& collection, ObjectType this_object, Arguments &args) {
+template <typename T>
+template <typename U>
+void ResultsClass<T>::add_listener(ContextType ctx, U& collection, ObjectType this_object, Arguments& args)
+{
     args.validate_maximum(1);
 
     auto callback = Value::validated_to_function(ctx, args[0]);
@@ -352,26 +375,28 @@ void ResultsClass<T>::add_listener(ContextType ctx, U& collection, ObjectType th
     Protected<ObjectType> protected_this(ctx, this_object);
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
 
-    auto token = collection.add_notification_callback([=](CollectionChangeSet const& change_set, std::exception_ptr exception) {
+    auto token = collection.add_notification_callback(
+        [=](CollectionChangeSet const& change_set, std::exception_ptr exception) {
             HANDLESCOPE(protected_ctx)
-            ValueType arguments[] {
-                static_cast<ObjectType>(protected_this),
-                CollectionClass<T>::create_collection_change_set(protected_ctx, change_set)
-            };
+            ValueType arguments[]{static_cast<ObjectType>(protected_this),
+                                  CollectionClass<T>::create_collection_change_set(protected_ctx, change_set)};
             Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, arguments);
         });
     collection.m_notification_tokens.emplace_back(protected_callback, std::move(token));
 }
 
-template<typename T>
-void ResultsClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     add_listener(ctx, *results, this_object, args);
 }
 
-template<typename T>
-template<typename U>
-void ResultsClass<T>::remove_listener(ContextType ctx, U& collection, ObjectType this_object, Arguments &args) {
+template <typename T>
+template <typename U>
+void ResultsClass<T>::remove_listener(ContextType ctx, U& collection, ObjectType this_object, Arguments& args)
+{
     args.validate_maximum(1);
 
     auto callback = Value::validated_to_function(ctx, args[0]);
@@ -384,19 +409,23 @@ void ResultsClass<T>::remove_listener(ContextType ctx, U& collection, ObjectType
     tokens.erase(std::remove_if(tokens.begin(), tokens.end(), compare), tokens.end());
 }
 
-template<typename T>
-void ResultsClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args,
+                                      ReturnValue& return_value)
+{
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     remove_listener(ctx, *results, this_object, args);
 }
 
-template<typename T>
-void ResultsClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void ResultsClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                           ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto results = get_internal<T, ResultsClass<T>>(ctx, this_object);
     results->m_notification_tokens.clear();
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -26,7 +26,7 @@
 namespace realm {
 namespace js {
 
-template<typename T>
+template <typename T>
 struct Schema {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -40,18 +40,20 @@ struct Schema {
     using ObjectDefaultsMap = std::map<std::string, ObjectDefaults>;
     using ConstructorMap = std::map<std::string, Protected<FunctionType>>;
 
-    static ObjectType dict_for_property_array(ContextType, const ObjectSchema &, ObjectType);
-    static Property parse_property(ContextType, ValueType, StringData, std::string, ObjectDefaults &);
-    static ObjectSchema parse_object_schema(ContextType, ObjectType, ObjectDefaultsMap &, ConstructorMap &);
-    static realm::Schema parse_schema(ContextType, ObjectType, ObjectDefaultsMap &, ConstructorMap &);
+    static ObjectType dict_for_property_array(ContextType, const ObjectSchema&, ObjectType);
+    static Property parse_property(ContextType, ValueType, StringData, std::string, ObjectDefaults&);
+    static ObjectSchema parse_object_schema(ContextType, ObjectType, ObjectDefaultsMap&, ConstructorMap&);
+    static realm::Schema parse_schema(ContextType, ObjectType, ObjectDefaultsMap&, ConstructorMap&);
 
-    static ObjectType object_for_schema(ContextType, const realm::Schema &);
-    static ObjectType object_for_object_schema(ContextType, const ObjectSchema &);
-    static ObjectType object_for_property(ContextType, const Property &);
+    static ObjectType object_for_schema(ContextType, const realm::Schema&);
+    static ObjectType object_for_object_schema(ContextType, const ObjectSchema&);
+    static ObjectType object_for_property(ContextType, const Property&);
 };
 
-template<typename T>
-typename T::Object Schema<T>::dict_for_property_array(ContextType ctx, const ObjectSchema &object_schema, ObjectType array) {
+template <typename T>
+typename T::Object Schema<T>::dict_for_property_array(ContextType ctx, const ObjectSchema& object_schema,
+                                                      ObjectType array)
+{
     size_t count = object_schema.persisted_properties.size();
 
     if (count != Object::validated_get_length(ctx, array)) {
@@ -178,21 +180,23 @@ static inline void parse_property_type(StringData object_name, Property& prop, S
 
         else {
             if (is_nullable(prop.type)) {
-                throw std::logic_error(util::format("List property '%1.%2' cannot be optional", object_name, prop.name));
+                throw std::logic_error(
+                    util::format("List property '%1.%2' cannot be optional", object_name, prop.name));
             }
             if (is_array(prop.type)) {
-                throw std::logic_error(util::format("List property '%1.%2' must have a non-list value type", object_name, prop.name));
+                throw std::logic_error(
+                    util::format("List property '%1.%2' must have a non-list value type", object_name, prop.name));
             }
             prop.type |= PropertyType::Object | PropertyType::Array;
         }
     }
     else if (type == "set") {
         // apply the correct properties for sets
-        realm::js::set::derive_property_type(object_name, prop);  // may throw std::logic_error
+        realm::js::set::derive_property_type(object_name, prop); // may throw std::logic_error
     }
     else if (type == "dictionary") {
         // apply the correct properties for dictionaries
-        realm::js::dictionary::derive_property_type(object_name, prop);  // may throw std::logic_error
+        realm::js::dictionary::derive_property_type(object_name, prop); // may throw std::logic_error
     }
     else if (type == "linkingObjects") {
         prop.type |= PropertyType::LinkingObjects | PropertyType::Array;
@@ -217,9 +221,10 @@ static inline void parse_property_type(StringData object_name, Property& prop, S
 }
 
 
-template<typename T>
+template <typename T>
 Property Schema<T>::parse_property(ContextType ctx, ValueType attributes, StringData object_name,
-                                   std::string property_name, ObjectDefaults &object_defaults) {
+                                   std::string property_name, ObjectDefaults& object_defaults)
+{
     static const String default_string = "default";
     static const String indexed_string = "indexed";
     static const String type_string = "type";
@@ -246,7 +251,8 @@ Property Schema<T>::parse_property(ContextType ctx, ValueType attributes, String
         parse_property_type(object_name, prop, property_type);
 
         ValueType optional_value = Object::get_property(ctx, *property_object, optional_string);
-        if (!Value::is_undefined(ctx, optional_value) && Value::validated_to_boolean(ctx, optional_value, "optional")) {
+        if (!Value::is_undefined(ctx, optional_value) &&
+            Value::validated_to_boolean(ctx, optional_value, "optional")) {
             prop.type |= PropertyType::Nullable;
         }
 
@@ -284,8 +290,8 @@ Property Schema<T>::parse_property(ContextType ctx, ValueType attributes, String
 
     if (prop.type == PropertyType::LinkingObjects) {
         if (!property_object) {
-            throw std::logic_error(util::format("Linking objects property %1.%2 must specify 'objectType'",
-                                                object_name, prop.name));
+            throw std::logic_error(
+                util::format("Linking objects property %1.%2 must specify 'objectType'", object_name, prop.name));
         }
         prop.object_type = Object::validated_get_string(ctx, *property_object, object_type_string);
         prop.link_origin_property_name = Object::validated_get_string(ctx, *property_object, property_string);
@@ -294,8 +300,10 @@ Property Schema<T>::parse_property(ContextType ctx, ValueType attributes, String
     return prop;
 }
 
-template<typename T>
-ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_schema_object, ObjectDefaultsMap &defaults, ConstructorMap &constructors) {
+template <typename T>
+ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_schema_object,
+                                            ObjectDefaultsMap& defaults, ConstructorMap& constructors)
+{
     static const String name_string = "name";
     static const String primary_string = "primaryKey";
     static const String properties_string = "properties";
@@ -305,14 +313,16 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
     std::optional<FunctionType> object_constructor = {};
     if (Value::is_constructor(ctx, object_schema_object)) {
         object_constructor = Value::to_constructor(ctx, object_schema_object);
-        object_schema_object = Object::validated_get_object(ctx, *object_constructor, schema_string, "Realm object constructor must have a 'schema' property.");
+        object_schema_object = Object::validated_get_object(
+            ctx, *object_constructor, schema_string, "Realm object constructor must have a 'schema' property.");
     }
 
     ObjectDefaults object_defaults;
     ObjectSchema object_schema;
     object_schema.name = Object::validated_get_string(ctx, object_schema_object, name_string, "ObjectSchema");
 
-    ObjectType properties_object = Object::validated_get_object(ctx, object_schema_object, properties_string, "ObjectSchema");
+    ObjectType properties_object =
+        Object::validated_get_object(ctx, object_schema_object, properties_string, "ObjectSchema");
     if (Value::is_array(ctx, properties_object)) {
         uint32_t length = Object::validated_get_length(ctx, properties_object);
         for (uint32_t i = 0; i < length; i++) {
@@ -323,7 +333,9 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
                 property = parse_property(ctx, property_object, object_schema.name, property_name, object_defaults);
             }
             catch (std::invalid_argument& ex) {
-                std::string message = util::format("Error while parsing property '%1' of object with name '%2'. Error: %3", std::string(property_name), object_schema.name, ex.what());
+                std::string message =
+                    util::format("Error while parsing property '%1' of object with name '%2'. Error: %3",
+                                 std::string(property_name), object_schema.name, ex.what());
                 throw std::logic_error(message);
             }
 
@@ -333,7 +345,6 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
             else {
                 object_schema.persisted_properties.emplace_back(std::move(property));
             }
-
         }
     }
     else {
@@ -345,7 +356,9 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
                 property = parse_property(ctx, property_value, object_schema.name, property_name, object_defaults);
             }
             catch (std::invalid_argument& ex) {
-                std::string message = util::format("Error while parsing property '%1' of object with name '%2'. Error: %3", std::string(property_name), object_schema.name, ex.what());
+                std::string message =
+                    util::format("Error while parsing property '%1' of object with name '%2'. Error: %3",
+                                 std::string(property_name), object_schema.name, ex.what());
                 throw std::logic_error(message);
             }
             if (property.type == realm::PropertyType::LinkingObjects) {
@@ -360,9 +373,10 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
     ValueType primary_value = Object::get_property(ctx, object_schema_object, primary_string);
     if (!Value::is_undefined(ctx, primary_value)) {
         object_schema.primary_key = Value::validated_to_string(ctx, primary_value);
-        Property *property = object_schema.primary_key_property();
+        Property* property = object_schema.primary_key_property();
         if (!property) {
-            throw std::runtime_error("Schema named '" + object_schema.name + "' specifies primary key of '" + object_schema.primary_key + "' but does not declare a property of that name.");
+            throw std::runtime_error("Schema named '" + object_schema.name + "' specifies primary key of '" +
+                                     object_schema.primary_key + "' but does not declare a property of that name.");
         }
         property->is_primary = true;
     }
@@ -385,9 +399,10 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
     return object_schema;
 }
 
-template<typename T>
-realm::Schema Schema<T>::parse_schema(ContextType ctx, ObjectType schema_object,
-                                      ObjectDefaultsMap &defaults, ConstructorMap &constructors) {
+template <typename T>
+realm::Schema Schema<T>::parse_schema(ContextType ctx, ObjectType schema_object, ObjectDefaultsMap& defaults,
+                                      ConstructorMap& constructors)
+{
     std::vector<ObjectSchema> schema;
     uint32_t length = Object::validated_get_length(ctx, schema_object);
 
@@ -400,8 +415,9 @@ realm::Schema Schema<T>::parse_schema(ContextType ctx, ObjectType schema_object,
     return realm::Schema(schema);
 }
 
-template<typename T>
-typename T::Object Schema<T>::object_for_schema(ContextType ctx, const realm::Schema &schema) {
+template <typename T>
+typename T::Object Schema<T>::object_for_schema(ContextType ctx, const realm::Schema& schema)
+{
     ObjectType object = Object::create_array(ctx);
     uint32_t count = 0;
     for (auto& object_schema : schema) {
@@ -410,8 +426,9 @@ typename T::Object Schema<T>::object_for_schema(ContextType ctx, const realm::Sc
     return object;
 }
 
-template<typename T>
-typename T::Object Schema<T>::object_for_object_schema(ContextType ctx, const ObjectSchema &object_schema) {
+template <typename T>
+typename T::Object Schema<T>::object_for_object_schema(ContextType ctx, const ObjectSchema& object_schema)
+{
     ObjectType object = Object::create_empty(ctx);
 
     static const String name_string = "name";
@@ -441,16 +458,19 @@ typename T::Object Schema<T>::object_for_object_schema(ContextType ctx, const Ob
     return object;
 }
 
-template<typename T>
-typename T::Object Schema<T>::object_for_property(ContextType ctx, const Property &property) {
+template <typename T>
+typename T::Object Schema<T>::object_for_property(ContextType ctx, const Property& property)
+{
     ObjectType object = Object::create_empty(ctx);
 
     static const String name_string = "name";
-    Object::set_property(ctx, object, name_string, Value::from_string(ctx, property.public_name.empty() ? property.name : property.public_name));
+    Object::set_property(
+        ctx, object, name_string,
+        Value::from_string(ctx, property.public_name.empty() ? property.name : property.public_name));
 
     static const String type_string = "type";
     if (is_array(property.type)) {
-        if  (property.type == realm::PropertyType::LinkingObjects) {
+        if (property.type == realm::PropertyType::LinkingObjects) {
             Object::set_property(ctx, object, type_string, Value::from_string(ctx, "linkingObjects"));
         }
         else {
@@ -458,7 +478,8 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         }
     }
     else {
-        Object::set_property(ctx, object, type_string, Value::from_string(ctx, local_string_for_property_type(property.type)));
+        Object::set_property(ctx, object, type_string,
+                             Value::from_string(ctx, local_string_for_property_type(property.type)));
     }
 
     static const String object_type_string = "objectType";
@@ -466,12 +487,15 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
         Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, property.object_type));
     }
     else if (is_array(property.type) || is_dictionary(property.type) || is_set(property.type)) {
-        Object::set_property(ctx, object, object_type_string, Value::from_string(ctx, local_string_for_property_type(property.type & ~realm::PropertyType::Flags)));
+        Object::set_property(
+            ctx, object, object_type_string,
+            Value::from_string(ctx, local_string_for_property_type(property.type & ~realm::PropertyType::Flags)));
     }
 
     static const String property_string = "property";
     if (property.type == realm::PropertyType::LinkingObjects) {
-        Object::set_property(ctx, object, property_string, Value::from_string(ctx, property.link_origin_property_name));
+        Object::set_property(ctx, object, property_string,
+                             Value::from_string(ctx, property.link_origin_property_name));
     }
 
     static const String indexed_string = "indexed";
@@ -480,11 +504,11 @@ typename T::Object Schema<T>::object_for_property(ContextType ctx, const Propert
     static const String optional_string = "optional";
     Object::set_property(ctx, object, optional_string, Value::from_boolean(ctx, is_nullable(property.type)));
 
-    static const String map_to_string =  "mapTo";
+    static const String map_to_string = "mapTo";
     Object::set_property(ctx, object, map_to_string, Value::from_string(ctx, property.name));
 
     return object;
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_set.hpp
+++ b/src/js_set.hpp
@@ -31,18 +31,19 @@
 namespace realm {
 namespace js {
 
-template<typename JSEngine>
+template <typename JSEngine>
 class NativeAccessor;
 
 namespace set {
-    /**
+/**
  * @brief Derive and apply property flags for \ref Set.
  *
  * @param object_name Name of the Set object (for error reporting purposes)
  * @param prop (mutable) Property object that will be changed to be correct for \ref Set
  * @exception std::logic_error Thrown if the the prop argument contains an invalid property configuration
  */
-inline static void derive_property_type(StringData const &object_name, Property &prop) {
+inline static void derive_property_type(StringData const& object_name, Property& prop)
+{
     using realm::PropertyType;
 
     if (prop.object_type == "bool") {
@@ -90,13 +91,14 @@ inline static void derive_property_type(StringData const &object_name, Property 
             throw std::logic_error(util::format("Set property '%1.%2' cannot be optional", object_name, prop.name));
         }
         if (is_array(prop.type)) {
-            throw std::logic_error(util::format("Set property '%1.%2' must have a non-list value type", object_name, prop.name));
+            throw std::logic_error(
+                util::format("Set property '%1.%2' must have a non-list value type", object_name, prop.name));
         }
         prop.type |= PropertyType::Object | PropertyType::Set;
     }
-}  // validated_property_type()
+} // validated_property_type()
 
-};  // set namespace
+}; // namespace set
 
 /**
  * @brief Glue class that provides an interface between \ref SetClass and \ref realm::object_store::Set
@@ -107,25 +109,29 @@ inline static void derive_property_type(StringData const &object_name, Property 
  *
  * @tparam T The type of the elements that the Set will hold.  Inherited from \ref SetClass
  */
-template<typename T>
+template <typename T>
 class Set : public realm::object_store::Set {
-  public:
-    Set(const realm::object_store::Set &set) : realm::object_store::Set(set) {}
-    void derive_property_type(StringData const &object_name, Property &prop) const;
+public:
+    Set(const realm::object_store::Set& set)
+        : realm::object_store::Set(set)
+    {
+    }
+    void derive_property_type(StringData const& object_name, Property& prop) const;
 
     std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
 };
 
 
 /**
- * @brief Implementation class for JavaScript's [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) class
+ * @brief Implementation class for JavaScript's
+ * [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) class
  *
  * @tparam T The type of the elements that the SetClass will hold.
  */
-template<typename T>
+template <typename T>
 struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
-    using Type = T;                                                 ///< type of the elements that the SetClass holds
-    using ContextType = typename T::Context;                        ///< JS context type
+    using Type = T;                          ///< type of the elements that the SetClass holds
+    using ContextType = typename T::Context; ///< JS context type
     using ObjectType = typename T::Object;
     using ValueType = typename T::Value;
     using FunctionType = typename T::Function;
@@ -137,30 +143,30 @@ struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
     static ObjectType create_instance(ContextType, realm::object_store::Set);
 
     // properties
-    static void get_size(ContextType, ObjectType, ReturnValue &);
-     static void get_optional(ContextType, ObjectType, ReturnValue &);
-     static void get_indexed(ContextType, ObjectType, uint32_t, ReturnValue &);
-     static void get_type(ContextType, ObjectType, ReturnValue &);
+    static void get_size(ContextType, ObjectType, ReturnValue&);
+    static void get_optional(ContextType, ObjectType, ReturnValue&);
+    static void get_indexed(ContextType, ObjectType, uint32_t, ReturnValue&);
+    static void get_type(ContextType, ObjectType, ReturnValue&);
 
     // methods
-    static void add(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void clear(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void delete_element(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void has(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void clear(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void delete_element(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void has(ContextType, ObjectType, Arguments&, ReturnValue&);
 
 
-    static void filtered(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void snapshot(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void filtered(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void snapshot(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // observable
-    static void add_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_listener(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void remove_all_listeners(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void add_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_listener(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void remove_all_listeners(ContextType, ObjectType, Arguments&, ReturnValue&);
 
-     std::string const name = "Set";
+    std::string const name = "Set";
 
-     MethodMap<T> const methods = {
+    MethodMap<T> const methods = {
         {"add", wrap<add>},
         {"clear", wrap<clear>},
         {"delete", wrap<delete_element>},
@@ -177,22 +183,23 @@ struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
         {"addListener", wrap<add_listener>},
         {"removeListener", wrap<remove_listener>},
         {"removeAllListeners", wrap<remove_all_listeners>},
-     };
+    };
 
-     PropertyMap<T> const properties = {
-         {"size", {wrap<get_size>, nullptr}},
-         {"type", {wrap<get_type>, nullptr}},
-         {"optional", {wrap<get_optional>, nullptr}},
-     };
+    PropertyMap<T> const properties = {
+        {"size", {wrap<get_size>, nullptr}},
+        {"type", {wrap<get_type>, nullptr}},
+        {"optional", {wrap<get_optional>, nullptr}},
+    };
 
-     IndexPropertyType<T> const index_accessor = {nullptr, nullptr};
+    IndexPropertyType<T> const index_accessor = {nullptr, nullptr};
 
 private:
-    static void validate_value(ContextType, realm::object_store::Set &, ValueType);
+    static void validate_value(ContextType, realm::object_store::Set&, ValueType);
 };
 
-template<typename T>
-typename T::Object SetClass<T>::create_instance(ContextType ctx, realm::object_store::Set set) {
+template <typename T>
+typename T::Object SetClass<T>::create_instance(ContextType ctx, realm::object_store::Set set)
+{
     return create_object<T, SetClass<T>>(ctx, new realm::js::Set<T>(std::move(set)));
 }
 
@@ -201,14 +208,17 @@ typename T::Object SetClass<T>::create_instance(ContextType ctx, realm::object_s
  * @brief Implements JavaScript Set's `.size` property
  *
  *  Returns the number of elements in the SetClass.
- *  See [MDN's reference documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/size)
+ *  See [MDN's reference
+ * documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/size)
  *
  * @param ctx JS context
  * @param object \ref ObjectType wrapping the SetClass itself
- * @param return_value \ref ReturnValue wrapping an integer that gives the number of elements in the set to return to the JS context
+ * @param return_value \ref ReturnValue wrapping an integer that gives the number of elements in the set to return to
+ * the JS context
  */
-template<typename T>
-void SetClass<T>::get_size(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::get_size(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto set = get_internal<T, SetClass<T>>(ctx, object);
     return_value.set(static_cast<uint32_t>(set->size()));
 }
@@ -222,10 +232,12 @@ void SetClass<T>::get_size(ContextType ctx, ObjectType object, ReturnValue &retu
  * @param ctx JS context
  * @param object \ref ObjectType wrapping the SetClass itself
  * @param index Index of the element to retrieve
- * @param return_value \ref ReturnValue wrapping an integer that gives the number of elements in the set to return to the JS context
+ * @param return_value \ref ReturnValue wrapping an integer that gives the number of elements in the set to return to
+ * the JS context
  */
-template<typename T>
-void SetClass<T>::get_indexed(ContextType ctx, ObjectType object, uint32_t index, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::get_indexed(ContextType ctx, ObjectType object, uint32_t index, ReturnValue& return_value)
+{
     auto set = get_internal<T, SetClass<T>>(ctx, object);
     NativeAccessor<T> accessor(ctx, *set);
     return_value.set(set->get(accessor, index));
@@ -237,10 +249,12 @@ void SetClass<T>::get_indexed(ContextType ctx, ObjectType object, uint32_t index
  *
  * @param ctx JS context
  * @param object \ref ObjectType wrapping the SetClass itself
- * @param return_value \ref ReturnValue wrapping a boolean that is true if the Set's element type is nullable, false otherwise
+ * @param return_value \ref ReturnValue wrapping a boolean that is true if the Set's element type is nullable, false
+ * otherwise
  */
-template<typename T>
-void SetClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto set = get_internal<T, SetClass<T>>(ctx, object);
     return_value.set(is_nullable(set->get_type()));
 }
@@ -251,15 +265,18 @@ void SetClass<T>::get_optional(ContextType ctx, ObjectType object, ReturnValue &
  *
  *  Adds a single element, `A`, of type `T` to the set.  `A` will not be added if it
  *  already exists within the SetClass.
- *  See [MDN's reference documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add).
+ *  See [MDN's reference
+ * documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add).
  *
  * @param ctx JS context
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args \ref Arguments structure containing a single new element of type `T` to add to the Set
- * @param return_value \ref ReturnValue wrapping the Set itself, including the newly added element to return to the JS context
+ * @param return_value \ref ReturnValue wrapping the Set itself, including the newly added element to return to the JS
+ * context
  */
-template<typename T>
-void SetClass<T>::add(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::add(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
@@ -286,10 +303,12 @@ void SetClass<T>::add(ContextType ctx, ObjectType this_object, Arguments &args, 
  * @param ctx JS context
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args \ref Arguments structure containing a single integer
- * @param return_value \ref ReturnValue wrapping a `Mixed<T>` object, wrapping the found element to return to the JS context
+ * @param return_value \ref ReturnValue wrapping a `Mixed<T>` object, wrapping the found element to return to the JS
+ * context
  */
-template<typename T>
-void SetClass<T>::get(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::get(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     if (!Value::is_number(ctx, args[0])) {
@@ -303,7 +322,8 @@ void SetClass<T>::get(ContextType ctx, ObjectType this_object, Arguments &args, 
     switch_on_type(value_type, [&](auto const type_indicator) -> void {
         using element_type = std::remove_pointer_t<decltype(type_indicator)>;
         int requested_index = Value::validated_to_number(ctx, args[0]);
-        realm::Mixed element_value = set->template get<std::remove_pointer_t<decltype(type_indicator)>>(requested_index);
+        realm::Mixed element_value =
+            set->template get<std::remove_pointer_t<decltype(type_indicator)>>(requested_index);
         return_value.set(element_value);
     });
 }
@@ -314,15 +334,17 @@ void SetClass<T>::get(ContextType ctx, ObjectType this_object, Arguments &args, 
  *
  *  Empties the set, removing all elements.
  *  Returns `undefined` to the JS context.
- *  See [MDN's reference documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear).
+ *  See [MDN's reference
+ * documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear).
  *
  * @param ctx JS context
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args Empty \ref Arguments structure
  * @param return_value \ref ReturnValue wrapping `undefined` to return to the JS context
  */
-template<typename T>
-void SetClass<T>::clear(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::clear(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
 
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
@@ -336,15 +358,17 @@ void SetClass<T>::clear(ContextType ctx, ObjectType this_object, Arguments &args
  *
  *  Attempts to remove the given element from the set.
  *  Returns `true` if the element was present, `false` otherwise.
- *  See [MDN's reference documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete).
+ *  See [MDN's reference
+ * documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete).
  *
  * @param ctx JS context
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args \ref Arguments structure containing a single element to remove
  * @param return_value \ref ReturnValue wrapping the value to return to the JS context
  */
-template<typename T>
-void SetClass<T>::delete_element(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::delete_element(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     auto const set = get_internal<T, SetClass<T>>(ctx, this_object);
@@ -363,15 +387,17 @@ void SetClass<T>::delete_element(ContextType ctx, ObjectType this_object, Argume
  *
  *   has() checks whether the given element exists in the set.
  *   Sets return_value to true if the element is found, false otherwise.
- *   See [MDN's reference documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has).
+ *   See [MDN's reference
+ * documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has).
  *
  * @param ctx JS context
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args \ref Arguments structure containing a single element of type `T` to search for
  * @param return_value \ref ReturnValue wrapping the value to return to the JS context
  */
-template<typename T>
-void SetClass<T>::has(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::has(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(1);
 
     auto const set = get_internal<T, SetClass<T>>(ctx, this_object);
@@ -395,11 +421,13 @@ void SetClass<T>::has(ContextType ctx, ObjectType this_object, Arguments &args, 
  *
  * @param this_object \ref ObjectType wrapping the SetClass itself
  * @param args \ref Arguments structure containing the filter that will be applied to the SetClass
- * @param return_value \ref ReturnValue wrapping a \ref ResultClass containing matching objects to return to the JS context
+ * @param return_value \ref ReturnValue wrapping a \ref ResultClass containing matching objects to return to the JS
+ * context
  * @exception std::runtime_error Thrown if the \ref SetClass does not contain objects
  */
-template<typename T>
-void SetClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     auto const set = get_internal<T, SetClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_filtered(ctx, *set, args));
 }
@@ -412,8 +440,9 @@ void SetClass<T>::filtered(ContextType ctx, ObjectType this_object, Arguments &a
  * @param object \ref ObjectType wrapping the SetClass itself
  * @param return_value \ref ReturnValue wrapping a static `const char *` descriping the set's element type
  */
-template<typename T>
-void SetClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto const set = get_internal<T, ListClass<T>>(ctx, object);
     return_value.set(local_string_for_property_type(set->get_type() & ~realm::PropertyType::Flags));
 }
@@ -430,15 +459,17 @@ void SetClass<T>::get_type(ContextType ctx, ObjectType object, ReturnValue &retu
  * @param value \ref ValueType that is to be checked whether it is valid for the set
  * @exception TypeErrorException Thrown if `value` is not valid for the set
  */
-template<typename T>
-void SetClass<T>::validate_value(ContextType ctx, realm::object_store::Set &set, ValueType value) {
+template <typename T>
+void SetClass<T>::validate_value(ContextType ctx, realm::object_store::Set& set, ValueType value)
+{
     auto type = set.get_type();
     StringData object_type;
     if (type == realm::PropertyType::Object) {
         object_type = set.get_object_schema().name;
     }
     if (!Value::is_valid_for_property_type(ctx, value, type, object_type)) {
-        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type), Value::to_string(ctx, value));
+        throw TypeErrorException("Property", object_type ? object_type : local_string_for_property_type(type),
+                                 Value::to_string(ctx, value));
     }
 }
 
@@ -452,8 +483,9 @@ void SetClass<T>::validate_value(ContextType ctx, realm::object_store::Set &set,
  * @param args None -- must be empty
  * @param return_value \ref ReturnValue wrapping a a new Set instance created by the snapshot
  */
-template<typename T>
-void SetClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
     return_value.set(ResultsClass<T>::create_instance(ctx, set->snapshot()));
@@ -468,8 +500,9 @@ void SetClass<T>::snapshot(ContextType ctx, ObjectType this_object, Arguments &a
  * @param args A single argument containing a callback function
  * @param return_value None
  */
-template<typename T>
-void SetClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::add_listener(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     // args is validated by ResultClass
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
     ResultsClass<T>::add_listener(ctx, *set, this_object, args);
@@ -484,8 +517,9 @@ void SetClass<T>::add_listener(ContextType ctx, ObjectType this_object, Argument
  * @param args A single argument containing the callback function of the previously-registered listener
  * @param return_value None
  */
-template<typename T>
-void SetClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     // args is validated by ResultClass
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
     ResultsClass<T>::remove_listener(ctx, *set, this_object, args);
@@ -500,12 +534,14 @@ void SetClass<T>::remove_listener(ContextType ctx, ObjectType this_object, Argum
  * @param args None
  * @param return_value None
  */
-template<typename T>
-void SetClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SetClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_maximum(0);
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
     set->m_notification_tokens.clear();
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -58,8 +58,9 @@ namespace realm {
 namespace js {
 
 // simple utility method
-template<typename T>
-static std::string partition_value_bson_to_string(typename T::Context ctx, typename T::Value partition_value_value) {
+template <typename T>
+static std::string partition_value_bson_to_string(typename T::Context ctx, typename T::Value partition_value_value)
+{
     bson::Bson partition_bson;
     if (Value<T>::is_string(ctx, partition_value_value)) {
         std::string pv = Value<T>::validated_to_string(ctx, partition_value_value);
@@ -69,8 +70,9 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
         double pv = Value<T>::validated_to_number(ctx, partition_value_value);
         double integerPart;
         double fractionalPart = modf(pv, &integerPart);
-        if (pv > JS_MAX_SAFE_INTEGER  || pv < -JS_MAX_SAFE_INTEGER || fabs(fractionalPart) > 0.0) {
-            throw std::runtime_error("partitionValue of type 'number' must be an integer in the range: Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER.");
+        if (pv > JS_MAX_SAFE_INTEGER || pv < -JS_MAX_SAFE_INTEGER || fabs(fractionalPart) > 0.0) {
+            throw std::runtime_error("partitionValue of type 'number' must be an integer in the range: "
+                                     "Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER.");
         }
         partition_bson = bson::Bson(static_cast<int64_t>(integerPart));
     }
@@ -98,7 +100,7 @@ static std::string partition_value_bson_to_string(typename T::Context ctx, typen
 
 using WeakSession = std::weak_ptr<realm::SyncSession>;
 
-template<typename T>
+template <typename T>
 class SessionClass : public ClassDefinition<T, WeakSession> {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
@@ -119,24 +121,24 @@ public:
 
     static FunctionType create_constructor(ContextType);
 
-    static void get_config(ContextType, ObjectType, ReturnValue &);
-    static void get_user(ContextType, ObjectType, ReturnValue &);
-    static void get_state(ContextType, ObjectType, ReturnValue &);
-    static void get_connection_state(ContextType, ObjectType, ReturnValue &);
+    static void get_config(ContextType, ObjectType, ReturnValue&);
+    static void get_user(ContextType, ObjectType, ReturnValue&);
+    static void get_state(ContextType, ObjectType, ReturnValue&);
+    static void get_connection_state(ContextType, ObjectType, ReturnValue&);
 
-    static void simulate_error(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void add_progress_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void remove_progress_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void add_state_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void remove_state_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void add_connection_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void remove_connection_notification(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void is_connected(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void resume(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-    static void pause(ContextType ctx, ObjectType this_object, Arguments &, ReturnValue &);
-//    static void override_server(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void wait_for_download_completion(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void wait_for_upload_completion(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void simulate_error(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void add_progress_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void remove_progress_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void add_state_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void remove_state_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void add_connection_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void remove_connection_notification(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void is_connected(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void resume(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    static void pause(ContextType ctx, ObjectType this_object, Arguments&, ReturnValue&);
+    //    static void override_server(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void wait_for_download_completion(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void wait_for_upload_completion(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // TODO: add app or appId property
     PropertyMap<T> const properties = {
@@ -166,17 +168,22 @@ private:
     static void wait_for_completion(Direction direction, ContextType ctx, ObjectType this_object, Arguments& args);
 };
 
-template<typename T>
+template <typename T>
 class SyncSessionErrorHandlerFunctor {
 public:
     SyncSessionErrorHandlerFunctor(typename T::Context ctx, typename T::Function error_func)
-    : m_ctx(Context<T>::get_global_context(ctx))
-    , m_func(ctx, error_func)
-    { }
+        : m_ctx(Context<T>::get_global_context(ctx))
+        , m_func(ctx, error_func)
+    {
+    }
 
-    typename T::Function func() const { return m_func; }
+    typename T::Function func() const
+    {
+        return m_func;
+    }
 
-    void operator()(std::shared_ptr<SyncSession> session, SyncError error) {
+    void operator()(std::shared_ptr<SyncSession> session, SyncError error)
+    {
         HANDLESCOPE(m_ctx)
 
         std::string name = "Error";
@@ -184,7 +191,9 @@ public:
 
         if (error.is_client_reset_requested()) {
             auto config_object = Object<T>::create_empty(m_ctx);
-            Object<T>::set_property(m_ctx, config_object, "path", Value<T>::from_string(m_ctx, error.user_info[SyncError::c_recovery_file_path_key]));
+            Object<T>::set_property(
+                m_ctx, config_object, "path",
+                Value<T>::from_string(m_ctx, error.user_info[SyncError::c_recovery_file_path_key]));
             Object<T>::set_property(m_ctx, config_object, "readOnly", Value<T>::from_boolean(m_ctx, true));
             Object<T>::set_property(m_ctx, error_object, "config", config_object);
             name = "ClientReset";
@@ -193,7 +202,8 @@ public:
         Object<T>::set_property(m_ctx, error_object, "name", Value<T>::from_string(m_ctx, name));
         Object<T>::set_property(m_ctx, error_object, "message", Value<T>::from_string(m_ctx, error.message));
         Object<T>::set_property(m_ctx, error_object, "isFatal", Value<T>::from_boolean(m_ctx, error.is_fatal));
-        Object<T>::set_property(m_ctx, error_object, "category", Value<T>::from_string(m_ctx, error.error_code.category().name()));
+        Object<T>::set_property(m_ctx, error_object, "category",
+                                Value<T>::from_string(m_ctx, error.error_code.category().name()));
         Object<T>::set_property(m_ctx, error_object, "code", Value<T>::from_number(m_ctx, error.error_code.value()));
 
         auto user_info = Object<T>::create_empty(m_ctx);
@@ -209,6 +219,7 @@ public:
 
         Function<T>::callback(m_ctx, m_func, 2, arguments);
     }
+
 private:
     const Protected<typename T::GlobalContext> m_ctx;
     const Protected<typename T::Function> m_func;
@@ -222,20 +233,21 @@ template <typename T>
 class SSLVerifyCallbackSyncThreadFunctor {
 public:
     SSLVerifyCallbackSyncThreadFunctor(typename T::Context ctx, typename T::Function ssl_verify_func)
-    : m_ctx(Context<T>::get_global_context(ctx))
-    , m_func(ctx, ssl_verify_func)
-    , m_event_loop_dispatcher {SSLVerifyCallbackSyncThreadFunctor<T>::main_loop_handler}
-    , m_mutex{new std::mutex}
-    , m_cond_var{new std::condition_variable}
+        : m_ctx(Context<T>::get_global_context(ctx))
+        , m_func(ctx, ssl_verify_func)
+        , m_event_loop_dispatcher{SSLVerifyCallbackSyncThreadFunctor<T>::main_loop_handler}
+        , m_mutex{new std::mutex}
+        , m_cond_var{new std::condition_variable}
     {
     }
 
     // This function is called on the sync client's event loop thread.
-    bool operator ()(const std::string& server_address, util::network::Endpoint::port_type server_port, const char* pem_data, size_t pem_size, int preverify_ok, int depth)
+    bool operator()(const std::string& server_address, util::network::Endpoint::port_type server_port,
+                    const char* pem_data, size_t pem_size, int preverify_ok, int depth)
     {
-        const std::string pem_certificate {pem_data, pem_size};
+        const std::string pem_certificate{pem_data, pem_size};
         {
-            std::lock_guard<std::mutex> lock {*m_mutex};
+            std::lock_guard<std::mutex> lock{*m_mutex};
             m_ssl_certificate_callback_done = false;
         }
 
@@ -247,7 +259,9 @@ public:
             // Wait for the return value of the callback function on the node.js main thread.
             // The sync client blocks during this wait.
             std::unique_lock<std::mutex> lock(*m_mutex);
-            m_cond_var->wait(lock, [this] { return this->m_ssl_certificate_callback_done; });
+            m_cond_var->wait(lock, [this] {
+                return this->m_ssl_certificate_callback_done;
+            });
             ssl_certificate_accepted = m_ssl_certificate_accepted;
         }
 
@@ -258,30 +272,31 @@ public:
     // main_loop_handler calls the user callback (m_func) and sends the return value
     // back to the sync client's event loop thread through a condition variable.
     static void main_loop_handler(SSLVerifyCallbackSyncThreadFunctor<T>* this_object,
-                                  const std::string& server_address,
-                                  util::network::Endpoint::port_type server_port,
-                                  const std::string& pem_certificate,
-                                  int preverify_ok,
-                                  int depth)
+                                  const std::string& server_address, util::network::Endpoint::port_type server_port,
+                                  const std::string& pem_certificate, int preverify_ok, int depth)
     {
         const Protected<typename T::GlobalContext>& ctx = this_object->m_ctx;
-		HANDLESCOPE(ctx)
+        HANDLESCOPE(ctx)
 
 
         typename T::Object ssl_certificate_object = Object<T>::create_empty(ctx);
-        Object<T>::set_property(ctx, ssl_certificate_object, "serverAddress", Value<T>::from_string(ctx, server_address));
-        Object<T>::set_property(ctx, ssl_certificate_object, "serverPort", Value<T>::from_number(ctx, double(server_port)));
-        Object<T>::set_property(ctx, ssl_certificate_object, "pemCertificate", Value<T>::from_string(ctx, pem_certificate));
-        Object<T>::set_property(ctx, ssl_certificate_object, "acceptedByOpenSSL", Value<T>::from_boolean(ctx, preverify_ok != 0));
+        Object<T>::set_property(ctx, ssl_certificate_object, "serverAddress",
+                                Value<T>::from_string(ctx, server_address));
+        Object<T>::set_property(ctx, ssl_certificate_object, "serverPort",
+                                Value<T>::from_number(ctx, double(server_port)));
+        Object<T>::set_property(ctx, ssl_certificate_object, "pemCertificate",
+                                Value<T>::from_string(ctx, pem_certificate));
+        Object<T>::set_property(ctx, ssl_certificate_object, "acceptedByOpenSSL",
+                                Value<T>::from_boolean(ctx, preverify_ok != 0));
         Object<T>::set_property(ctx, ssl_certificate_object, "depth", Value<T>::from_number(ctx, double(depth)));
 
         const int argc = 1;
-        typename T::Value arguments[argc] = { ssl_certificate_object };
+        typename T::Value arguments[argc] = {ssl_certificate_object};
         typename T::Value ret_val = Function<T>::callback(ctx, this_object->m_func, 1, arguments);
         bool ret_val_bool = Value<T>::to_boolean(ctx, ret_val);
 
         {
-            std::lock_guard<std::mutex> lock {*this_object->m_mutex};
+            std::lock_guard<std::mutex> lock{*this_object->m_mutex};
             this_object->m_ssl_certificate_callback_done = true;
             this_object->m_ssl_certificate_accepted = ret_val_bool;
         }
@@ -294,11 +309,9 @@ private:
     const Protected<typename T::GlobalContext> m_ctx;
     const Protected<typename T::Function> m_func;
     util::EventLoopDispatcher<void(SSLVerifyCallbackSyncThreadFunctor<T>* this_object,
-                                   const std::string& server_address,
-                                   util::network::Endpoint::port_type server_port,
-                                   const std::string& pem_certificate,
-                                   int preverify_ok,
-                                   int depth)> m_event_loop_dispatcher;
+                                   const std::string& server_address, util::network::Endpoint::port_type server_port,
+                                   const std::string& pem_certificate, int preverify_ok, int depth)>
+        m_event_loop_dispatcher;
     bool m_ssl_certificate_callback_done = false;
     bool m_ssl_certificate_accepted = false;
     std::shared_ptr<std::mutex> m_mutex;
@@ -306,8 +319,10 @@ private:
 };
 
 // TODO: We should move this function to js_user.hpp but hard due to circular dependency
-template<typename T>
-void UserClass<T>::session_for_on_disk_path(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::session_for_on_disk_path(ContextType ctx, ObjectType this_object, Arguments& args,
+                                            ReturnValue& return_value)
+{
     args.validate_count(1);
 
     User<T>* internal = get_internal<T, UserClass<T>>(ctx, this_object);
@@ -316,51 +331,65 @@ void UserClass<T>::session_for_on_disk_path(ContextType ctx, ObjectType this_obj
     }
 
     auto user = internal->get();
-    //user.get();
+    // user.get();
     if (auto session = user->session_for_on_disk_path(Value::validated_to_string(ctx, args[0]))) {
         return_value.set(create_object<T, SessionClass<T>>(ctx, new WeakSession(session)));
-    } else {
+    }
+    else {
         return_value.set_undefined();
     }
 }
 
-template<typename T>
-void SessionClass<T>::get_config(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::get_config(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
         ObjectType config = Object::create_empty(ctx);
-        Object::set_property(ctx, config, "user", create_object<T, UserClass<T>>(ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
+        Object::set_property(
+            ctx, config, "user",
+            create_object<T, UserClass<T>>(
+                ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
         // TODO: add app id
         bson::Bson partition_value_bson = bson::parse(session->config().partition_value);
-        Object::set_property(ctx, config, "partitionValue", Value::from_string(ctx, String::from_bson(partition_value_bson)));
-        if (auto dispatcher = session->config().error_handler.template target<util::EventLoopDispatcher<SyncSessionErrorHandler>>()) {
+        Object::set_property(ctx, config, "partitionValue",
+                             Value::from_string(ctx, String::from_bson(partition_value_bson)));
+        if (auto dispatcher =
+                session->config()
+                    .error_handler.template target<util::EventLoopDispatcher<SyncSessionErrorHandler>>()) {
             if (auto handler = dispatcher->func().template target<SyncSessionErrorHandlerFunctor<T>>()) {
                 Object::set_property(ctx, config, "error", handler->func());
             }
         }
         if (!session->config().custom_http_headers.empty()) {
             ObjectType custom_http_headers_object = Object::create_empty(ctx);
-            for (auto it = session->config().custom_http_headers.begin(); it != session->config().custom_http_headers.end(); ++it) {
+            for (auto it = session->config().custom_http_headers.begin();
+                 it != session->config().custom_http_headers.end(); ++it) {
                 Object::set_property(ctx, custom_http_headers_object, it->first, Value::from_string(ctx, it->second));
             }
             Object::set_property(ctx, config, "custom_http_headers", custom_http_headers_object);
         }
         return_value.set(config);
-    } else {
+    }
+    else {
         return_value.set_undefined();
     }
 }
 
-template<typename T>
-void SessionClass<T>::get_user(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::get_user(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
-        return_value.set(create_object<T, UserClass<T>>(ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
-    } else {
+        return_value.set(create_object<T, UserClass<T>>(
+            ctx, new User<T>(session->config().user, nullptr))); // FIXME: nullptr is not an app object
+    }
+    else {
         return_value.set_undefined();
     }
 }
 
-template<typename T>
-void SessionClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     static const std::string invalid("invalid");
     static const std::string inactive("inactive");
     static const std::string active("active");
@@ -370,33 +399,40 @@ void SessionClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue 
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
         if (session->state() == SyncSession::State::Inactive) {
             return_value.set(inactive);
-        } else {
+        }
+        else {
             return_value.set(active);
         }
     }
 }
 
-template<typename T>
-std::string SessionClass<T>::get_connection_state_value(SyncSession::ConnectionState state) {
-    switch(state) {
-        case SyncSession::ConnectionState::Disconnected: return "disconnected";
-        case SyncSession::ConnectionState::Connecting: return "connecting";
-        case SyncSession::ConnectionState::Connected: return "connected";
-		default:
-			REALM_UNREACHABLE();
+template <typename T>
+std::string SessionClass<T>::get_connection_state_value(SyncSession::ConnectionState state)
+{
+    switch (state) {
+        case SyncSession::ConnectionState::Disconnected:
+            return "disconnected";
+        case SyncSession::ConnectionState::Connecting:
+            return "connecting";
+        case SyncSession::ConnectionState::Connected:
+            return "connected";
+        default:
+            REALM_UNREACHABLE();
     }
 }
 
-template<typename T>
-void SessionClass<T>::get_connection_state(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::get_connection_state(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     return_value.set(get_connection_state_value(SyncSession::ConnectionState::Disconnected));
     if (auto session = get_internal<T, SessionClass<T>>(ctx, object)->lock()) {
         return_value.set(get_connection_state_value(session->connection_state()));
     }
 }
 
-template<typename T>
-void SessionClass<T>::simulate_error(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &) {
+template <typename T>
+void SessionClass<T>::simulate_error(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue&)
+{
     args.validate_count(2);
 
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
@@ -406,8 +442,10 @@ void SessionClass<T>::simulate_error(ContextType ctx, ObjectType this_object, Ar
     }
 }
 
-template<typename T>
-void SessionClass<T>::add_progress_notification(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::add_progress_notification(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                ReturnValue& return_value)
+{
     args.validate_count(3);
 
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
@@ -422,7 +460,8 @@ void SessionClass<T>::add_progress_notification(ContextType ctx, ObjectType this
             direction = SyncSession::ProgressDirection::upload;
         }
         else {
-            throw std::invalid_argument("Invalid argument 'direction'. Only 'download' and 'upload' progress notification directions are supported");
+            throw std::invalid_argument("Invalid argument 'direction'. Only 'download' and 'upload' progress "
+                                        "notification directions are supported");
         }
 
         bool is_streaming = false;
@@ -433,7 +472,8 @@ void SessionClass<T>::add_progress_notification(ContextType ctx, ObjectType this
             is_streaming = false;
         }
         else {
-            throw std::invalid_argument("Invalid argument 'mode'. Only 'reportIndefinitely' and 'forCurrentlyOutstandingWork' progress notification modes are supported");
+            throw std::invalid_argument("Invalid argument 'mode'. Only 'reportIndefinitely' and "
+                                        "'forCurrentlyOutstandingWork' progress notification modes are supported");
         }
 
         auto callback_function = Value::validated_to_function(ctx, args[2], "callback");
@@ -443,28 +483,33 @@ void SessionClass<T>::add_progress_notification(ContextType ctx, ObjectType this
         Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
         std::function<ProgressHandler> progressFunc;
 
-        util::EventLoopDispatcher<ProgressHandler> progress_handler([=](uint64_t transferred_bytes, uint64_t transferrable_bytes) {
-            HANDLESCOPE(protected_ctx)
-            ValueType callback_arguments[2] = {
-                Value::from_number(protected_ctx, transferred_bytes),
-                Value::from_number(protected_ctx, transferrable_bytes),
-            };
+        util::EventLoopDispatcher<ProgressHandler> progress_handler(
+            [=](uint64_t transferred_bytes, uint64_t transferrable_bytes) {
+                HANDLESCOPE(protected_ctx)
+                ValueType callback_arguments[2] = {
+                    Value::from_number(protected_ctx, transferred_bytes),
+                    Value::from_number(protected_ctx, transferrable_bytes),
+                };
 
-            Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
-        });
+                Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
+            });
 
         progressFunc = std::move(progress_handler);
 
-        auto registrationToken = session->register_progress_notifier(std::move(progressFunc), direction, is_streaming);
+        auto registrationToken =
+            session->register_progress_notifier(std::move(progressFunc), direction, is_streaming);
         auto syncSession = create_object<T, SessionClass<T>>(ctx, new WeakSession(session));
         PropertyAttributes attributes = ReadOnly | DontEnum | DontDelete;
         Object::set_property(ctx, callback_function, "_syncSession", syncSession, attributes);
-        Object::set_property(ctx, callback_function, "_registrationToken", Value::from_number(protected_ctx, registrationToken), attributes);
+        Object::set_property(ctx, callback_function, "_registrationToken",
+                             Value::from_number(protected_ctx, registrationToken), attributes);
     }
 }
 
-template<typename T>
-void SessionClass<T>::remove_progress_notification(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::remove_progress_notification(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                   ReturnValue& return_value)
+{
     args.validate_count(1);
     auto callback_function = Value::validated_to_function(ctx, args[0], "callback");
     auto syncSessionProp = Object::get_property(ctx, callback_function, "_syncSession");
@@ -481,8 +526,10 @@ void SessionClass<T>::remove_progress_notification(ContextType ctx, ObjectType t
     }
 }
 
-template<typename T>
-void SessionClass<T>::add_connection_notification(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::add_connection_notification(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                  ReturnValue& return_value)
+{
     args.validate_count(1);
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
         auto callback_function = Value::validated_to_function(ctx, args[0], "callback");
@@ -492,14 +539,15 @@ void SessionClass<T>::add_connection_notification(ContextType ctx, ObjectType th
 
         std::function<ConnectionHandler> connectionFunc;
 
-        util::EventLoopDispatcher<ConnectionHandler> connection_handler([=](SyncSession::ConnectionState old_state, SyncSession::ConnectionState new_state) {
-            HANDLESCOPE(protected_ctx)
-            ValueType callback_arguments[2] = {
-                Value::from_string(protected_ctx, get_connection_state_value(new_state)),
-                Value::from_string(protected_ctx, get_connection_state_value(old_state)),
-            };
-            Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
-        });
+        util::EventLoopDispatcher<ConnectionHandler> connection_handler(
+            [=](SyncSession::ConnectionState old_state, SyncSession::ConnectionState new_state) {
+                HANDLESCOPE(protected_ctx)
+                ValueType callback_arguments[2] = {
+                    Value::from_string(protected_ctx, get_connection_state_value(new_state)),
+                    Value::from_string(protected_ctx, get_connection_state_value(old_state)),
+                };
+                Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
+            });
 
         connectionFunc = std::move(connection_handler);
 
@@ -507,12 +555,15 @@ void SessionClass<T>::add_connection_notification(ContextType ctx, ObjectType th
         auto syncSession = create_object<T, SessionClass<T>>(ctx, new WeakSession(session));
         PropertyAttributes attributes = ReadOnly | DontEnum | DontDelete;
         Object::set_property(ctx, callback_function, "_syncSession", syncSession, attributes);
-        Object::set_property(ctx, callback_function, "_connectionNotificationToken", Value::from_number(protected_ctx, notificationToken), attributes);
+        Object::set_property(ctx, callback_function, "_connectionNotificationToken",
+                             Value::from_number(protected_ctx, notificationToken), attributes);
     }
 }
 
-template<typename T>
-void SessionClass<T>::remove_connection_notification(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::remove_connection_notification(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                     ReturnValue& return_value)
+{
     args.validate_count(1);
     auto callback_function = Value::validated_to_function(ctx, args[0], "callback");
     auto syncSessionProp = Object::get_property(ctx, callback_function, "_syncSession");
@@ -528,22 +579,25 @@ void SessionClass<T>::remove_connection_notification(ContextType ctx, ObjectType
     }
 }
 
-template<typename T>
-void SessionClass<T>::is_connected(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::is_connected(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     args.validate_count(0);
     return_value.set(false);
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
         auto state = session->state();
         auto connection_state = session->connection_state();
-        if (connection_state == SyncSession::ConnectionState::Connected
-            && (state == SyncSession::State::Active || state == SyncSession::State::Dying)) {
+        if (connection_state == SyncSession::ConnectionState::Connected &&
+            (state == SyncSession::State::Active || state == SyncSession::State::Dying)) {
             return_value.set(true);
         }
     }
 }
 
-template<typename T>
-void SessionClass<T>::resume(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::resume(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(0);
     return_value.set(false);
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
@@ -551,8 +605,9 @@ void SessionClass<T>::resume(ContextType ctx, ObjectType this_object, Arguments&
     }
 }
 
-template<typename T>
-void SessionClass<T>::pause(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SessionClass<T>::pause(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(0);
     return_value.set(false);
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
@@ -577,26 +632,28 @@ void SessionClass<T>::override_server(ContextType ctx, ObjectType this_object, A
     }
 }*/
 
-template<typename T>
-void SessionClass<T>::wait_for_completion(Direction direction, ContextType ctx, ObjectType this_object, Arguments &args) {
+template <typename T>
+void SessionClass<T>::wait_for_completion(Direction direction, ContextType ctx, ObjectType this_object,
+                                          Arguments& args)
+{
     args.validate_count(1);
     if (auto session = get_internal<T, SessionClass<T>>(ctx, this_object)->lock()) {
         auto callback = Value::validated_to_function(ctx, args[0]);
 
-        util::EventLoopDispatcher<DownloadUploadCompletionHandler> completion_handler([
-            ctx=Protected(Context<T>::get_global_context(ctx)),
-            callback=Protected(ctx, callback)
-        ](std::error_code error) {
-            HANDLESCOPE(ctx);
-            Function<T>::callback(ctx, callback, {
-                !error ? Value::from_undefined(ctx) : Object::create_obj(ctx, {
-                    {"message", Value::from_string(ctx, error.message())},
-                    {"errorCode", Value::from_number(ctx, error.value())},
-                })
+        util::EventLoopDispatcher<DownloadUploadCompletionHandler> completion_handler(
+            [ctx = Protected(Context<T>::get_global_context(ctx)),
+             callback = Protected(ctx, callback)](std::error_code error) {
+                HANDLESCOPE(ctx);
+                Function<T>::callback(
+                    ctx, callback,
+                    {!error ? Value::from_undefined(ctx)
+                            : Object::create_obj(ctx, {
+                                                          {"message", Value::from_string(ctx, error.message())},
+                                                          {"errorCode", Value::from_number(ctx, error.value())},
+                                                      })});
             });
-        });
 
-        switch(direction) {
+        switch (direction) {
             case Upload:
                 session->wait_for_upload_completion(std::move(completion_handler));
                 break;
@@ -610,17 +667,21 @@ void SessionClass<T>::wait_for_completion(Direction direction, ContextType ctx, 
     }
 }
 
-template<typename T>
-void SessionClass<T>::wait_for_upload_completion(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue&) {
+template <typename T>
+void SessionClass<T>::wait_for_upload_completion(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                 ReturnValue&)
+{
     wait_for_completion(Direction::Upload, ctx, this_object, args);
 }
 
-template<typename T>
-void SessionClass<T>::wait_for_download_completion(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue&) {
+template <typename T>
+void SessionClass<T>::wait_for_download_completion(ContextType ctx, ObjectType this_object, Arguments& args,
+                                                   ReturnValue&)
+{
     wait_for_completion(Direction::Download, ctx, this_object, args);
 }
 
-template<typename T>
+template <typename T>
 class SyncClass : public ClassDefinition<T, void*> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -639,19 +700,20 @@ public:
 
     static FunctionType create_constructor(ContextType);
 
-    static void set_sync_log_level(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void set_sync_logger(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void set_sync_user_agent(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void initiate_client_reset(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void reconnect(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void has_existing_sessions(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void enable_multiplexing(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void deserialize_change_set(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get_all_sync_sessions(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void get_sync_session(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void set_sync_log_level(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void set_sync_logger(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void set_sync_user_agent(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void initiate_client_reset(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void reconnect(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void has_existing_sessions(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void enable_multiplexing(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void deserialize_change_set(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_all_sync_sessions(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_sync_session(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     // private
-    static void populate_sync_config(ContextType, ObjectType realm_constructor, ObjectType config_object, Realm::Config&);
+    static void populate_sync_config(ContextType, ObjectType realm_constructor, ObjectType config_object,
+                                     Realm::Config&);
     static void populate_sync_config_for_ssl(ContextType, ObjectType, SyncConfig&);
 
     MethodMap<T> const static_methods = {
@@ -668,19 +730,24 @@ public:
     };
 };
 
-template<typename T>
-inline typename T::Function SyncClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function SyncClass<T>::create_constructor(ContextType ctx)
+{
     FunctionType sync_constructor = ObjectWrap<T, SyncClass<T>>::create_constructor(ctx);
 
     PropertyAttributes attributes = ReadOnly | DontEnum | DontDelete;
-    Object::set_property(ctx, sync_constructor, "User", ObjectWrap<T, UserClass<T>>::create_constructor(ctx), attributes);
-    Object::set_property(ctx, sync_constructor, "Session", ObjectWrap<T, SessionClass<T>>::create_constructor(ctx), attributes);
+    Object::set_property(ctx, sync_constructor, "User", ObjectWrap<T, UserClass<T>>::create_constructor(ctx),
+                         attributes);
+    Object::set_property(ctx, sync_constructor, "Session", ObjectWrap<T, SessionClass<T>>::create_constructor(ctx),
+                         attributes);
 
     return sync_constructor;
 }
 
-template<typename T>
-void SyncClass<T>::get_sync_session(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::get_sync_session(ContextType ctx, ObjectType this_object, Arguments& args,
+                                    ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto user_object = Value::validated_to_object(ctx, args[0], "user");
@@ -698,8 +765,10 @@ void SyncClass<T>::get_sync_session(ContextType ctx, ObjectType this_object, Arg
     return_value.set_null();
 }
 
-template<typename T>
-void SyncClass<T>::get_all_sync_sessions(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::get_all_sync_sessions(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_count(1);
 
     auto user_object = Value::validated_to_object(ctx, args[0], "user");
@@ -712,18 +781,23 @@ void SyncClass<T>::get_all_sync_sessions(ContextType ctx, ObjectType this_object
     return_value.set(Object::create_array(ctx, session_objects));
 }
 
-template<typename T>
-void SyncClass<T>::initiate_client_reset(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue & return_value) {
+template <typename T>
+void SyncClass<T>::initiate_client_reset(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_count(2);
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
     std::string path = Value::validated_to_string(ctx, args[1]);
     if (!app->sync_manager()->immediately_run_file_actions(std::string(path))) {
-        throw std::runtime_error(util::format("Realm was not configured correctly. Client Reset could not be run for Realm at: %1", path));
+        throw std::runtime_error(
+            util::format("Realm was not configured correctly. Client Reset could not be run for Realm at: %1", path));
     }
 }
 
-template<typename T>
-void SyncClass<T>::set_sync_log_level(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::set_sync_log_level(ContextType ctx, ObjectType this_object, Arguments& args,
+                                      ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
@@ -733,8 +807,10 @@ void SyncClass<T>::set_sync_log_level(ContextType ctx, ObjectType this_object, A
     app->sync_manager()->set_log_level(level);
 }
 
-template<typename T>
-void SyncClass<T>::set_sync_logger(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::set_sync_logger(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     args.validate_count(2);
 
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
@@ -746,10 +822,8 @@ void SyncClass<T>::set_sync_logger(ContextType ctx, ObjectType this_object, Argu
     common::logger::Delegated show_logs = [=](int level, std::string message) {
         HANDLESCOPE(protected_ctx)
 
-        ValueType arguments[2] = {
-            Value::from_number(protected_ctx, level),
-            Value::from_string(protected_ctx, message)
-        };
+        ValueType arguments[2] = {Value::from_number(protected_ctx, level),
+                                  Value::from_string(protected_ctx, message)};
 
         Function::callback(protected_ctx, protected_callback, 2, arguments);
     };
@@ -758,30 +832,36 @@ void SyncClass<T>::set_sync_logger(ContextType ctx, ObjectType this_object, Argu
     app->sync_manager()->set_logger_factory(sync_logger);
 }
 
-template<typename T>
-void SyncClass<T>::set_sync_user_agent(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::set_sync_user_agent(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_count(2);
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
     std::string application_user_agent = Value::validated_to_string(ctx, args[1], "user agent");
     app->sync_manager()->set_user_agent(application_user_agent);
 }
 
-template<typename T>
-void SyncClass<T>::reconnect(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::reconnect(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
     app->sync_manager()->reconnect();
 }
 
-template<typename T>
-void SyncClass<T>::has_existing_sessions(ContextType ctx, ObjectType this_object, Arguments &args, ReturnValue & return_value) {
+template <typename T>
+void SyncClass<T>::has_existing_sessions(ContextType ctx, ObjectType this_object, Arguments& args,
+                                         ReturnValue& return_value)
+{
     args.validate_count(1);
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
     return_value.set(app->sync_manager()->has_existing_sessions());
 }
 
-template<typename T>
-void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constructor, ObjectType config_object, Realm::Config& config)
+template <typename T>
+void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constructor, ObjectType config_object,
+                                        Realm::Config& config)
 {
     ValueType sync_config_value = Object::get_property(ctx, config_object, "sync");
     if (Value::is_boolean(ctx, sync_config_value)) {
@@ -789,13 +869,15 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         if (config.force_sync_history) {
             config.schema_mode = SchemaMode::AdditiveExplicit;
         }
-    } else if (!Value::is_undefined(ctx, sync_config_value)) {
+    }
+    else if (!Value::is_undefined(ctx, sync_config_value)) {
         auto sync_config_object = Value::validated_to_object(ctx, sync_config_value);
 
         std::function<SyncSessionErrorHandler> error_handler;
         ValueType error_func = Object::get_property(ctx, sync_config_object, "error");
         if (!Value::is_undefined(ctx, error_func)) {
-            error_handler = util::EventLoopDispatcher<SyncSessionErrorHandler>(SyncSessionErrorHandlerFunctor<T>(ctx, Value::validated_to_function(ctx, error_func)));
+            error_handler = util::EventLoopDispatcher<SyncSessionErrorHandler>(
+                SyncSessionErrorHandlerFunctor<T>(ctx, Value::validated_to_function(ctx, error_func)));
         }
 
         ObjectType user_object = Object::validated_get_object(ctx, sync_config_object, "user");
@@ -813,14 +895,18 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         SyncSessionStopPolicy session_stop_policy = SyncSessionStopPolicy::AfterChangesUploaded;
         ValueType session_stop_policy_value = Object::get_property(ctx, sync_config_object, "_sessionStopPolicy");
         if (!Value::is_undefined(ctx, session_stop_policy_value)) {
-            std::string stop_session = Value::validated_to_string(ctx, session_stop_policy_value, "_sessionStopPolicy");
+            std::string stop_session =
+                Value::validated_to_string(ctx, session_stop_policy_value, "_sessionStopPolicy");
             if (stop_session == std::string("immediately")) {
                 session_stop_policy = SyncSessionStopPolicy::Immediately;
-            } else if (stop_session == std::string("never")) {
+            }
+            else if (stop_session == std::string("never")) {
                 session_stop_policy = SyncSessionStopPolicy::LiveIndefinitely;
-            } else if (stop_session == std::string("after-upload")) {
+            }
+            else if (stop_session == std::string("after-upload")) {
                 session_stop_policy = SyncSessionStopPolicy::AfterChangesUploaded;
-            } else {
+            }
+            else {
                 throw std::invalid_argument("Unknown argument for _sessionStopPolicy: " + stop_session);
             }
         }
@@ -844,9 +930,9 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         // HTTP proxy: only node is supported
 #ifdef REALM_PLATFORM_NODE
         SyncConfig::ProxyConfig proxy_config;
-        std::vector<std::string> env_vars = { "https_proxy", "HTTPS_PROXY" };
+        std::vector<std::string> env_vars = {"https_proxy", "HTTPS_PROXY"};
         for (auto env_var : env_vars) {
-            char *http_proxy = std::getenv(env_var.c_str());
+            char* http_proxy = std::getenv(env_var.c_str());
             if (http_proxy != NULL) {
                 // https://stackoverflow.com/questions/43906956/split-url-into-host-port-and-resource-c
                 std::string url(http_proxy);
@@ -863,10 +949,13 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
 
                 if (protocol == "http") {
                     proxy_config.type = SyncConfig::ProxyConfig::Type::HTTP;
-                } else if (protocol == "https") {
+                }
+                else if (protocol == "https") {
                     proxy_config.type = SyncConfig::ProxyConfig::Type::HTTPS;
-                } else {
-                    throw std::runtime_error("Expected either 'http' or 'https' as protocol for " + env_var + " (got " + protocol + ")");
+                }
+                else {
+                    throw std::runtime_error("Expected either 'http' or 'https' as protocol for " + env_var +
+                                             " (got " + protocol + ")");
                 }
                 proxy_config.address = std::move(host);
                 proxy_config.port = static_cast<std::uint_fast16_t>(atoi(port.c_str()));
@@ -890,7 +979,7 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
     }
 }
 
-template<typename T>
+template <typename T>
 void SyncClass<T>::populate_sync_config_for_ssl(ContextType ctx, ObjectType config_object, SyncConfig& config)
 {
     ValueType validate_ssl = Object::get_property(ctx, config_object, "validate");
@@ -905,16 +994,19 @@ void SyncClass<T>::populate_sync_config_for_ssl(ContextType ctx, ObjectType conf
 
     ValueType validate_callback = Object::get_property(ctx, config_object, "validateCallback");
     if (Value::is_function(ctx, validate_callback)) {
-        config.ssl_verify_callback = SSLVerifyCallbackSyncThreadFunctor<T> { ctx, Value::to_function(ctx, validate_callback) };
+        config.ssl_verify_callback =
+            SSLVerifyCallbackSyncThreadFunctor<T>{ctx, Value::to_function(ctx, validate_callback)};
     }
 }
 
-template<typename T>
-void SyncClass<T>::enable_multiplexing(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void SyncClass<T>::enable_multiplexing(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_count(1);
     auto app = *get_internal<T, AppClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "app"));
     app->sync_manager()->enable_session_multiplexing();
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -39,52 +39,48 @@
 #include <realm/object-store/sync/generic_network_transport.hpp>
 
 #if defined(__GNUC__) && !(defined(DEBUG) && DEBUG)
-# define REALM_JS_INLINE inline __attribute__((always_inline))
+#define REALM_JS_INLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER) && !(defined(DEBUG) && DEBUG)
-# define REALM_JS_INLINE __forceinline
+#define REALM_JS_INLINE __forceinline
 #else
-# define REALM_JS_INLINE inline
+#define REALM_JS_INLINE inline
 #endif
 
 namespace realm {
-    class ObjectSchema;
+class ObjectSchema;
 }
 
 namespace realm {
 namespace js {
 
-template<typename>
+template <typename>
 struct RealmObjectClass;
 
-template<typename>
+template <typename>
 struct ResultsClass;
-template<typename>
+template <typename>
 struct ListClass;
 
-template<typename>
+template <typename>
 struct SetClass;
 
-template<typename>
+template <typename>
 struct DictionaryClass;
 
-enum PropertyAttributes : unsigned {
-    None       = 0,
-    ReadOnly   = 1 << 0,
-    DontEnum   = 1 << 1,
-    DontDelete = 1 << 2
-};
+enum PropertyAttributes : unsigned { None = 0, ReadOnly = 1 << 0, DontEnum = 1 << 1, DontDelete = 1 << 2 };
 
-template<typename>
+template <typename>
 struct Object;
 
 // JS: Number.MAX_SAFE_INTEGER === Math.pow(2, 53)-1;
 constexpr static int64_t JS_MAX_SAFE_INTEGER = (1ll << 53) - 1;
 
-inline PropertyAttributes operator|(PropertyAttributes a, PropertyAttributes b) {
+inline PropertyAttributes operator|(PropertyAttributes a, PropertyAttributes b)
+{
     return PropertyAttributes(static_cast<unsigned>(a) | static_cast<unsigned>(b));
 }
 
-template<typename T>
+template <typename T>
 struct String {
     using ContextType = typename T::Context;
     using StringType = typename T::String;
@@ -92,18 +88,18 @@ struct String {
     /** Build a BSON structure from a stringified EJSON representation */
     static bson::Bson to_bson(String);
     /** Build a stringified EJSON representation of a BSON structure */
-    static String from_bson(const bson::Bson &);
+    static String from_bson(const bson::Bson&);
 
-    String(const char *);
-    String(const StringType &);
-    String(StringType &&);
+    String(const char*);
+    String(const StringType&);
+    String(StringType&&);
     String(StringData);
 
     operator StringType() const;
     operator std::string() const;
 };
 
-template<typename T>
+template <typename T>
 struct Context {
     using ContextType = typename T::Context;
     using GlobalContextType = typename T::GlobalContext;
@@ -113,64 +109,76 @@ struct Context {
 
 class TypeErrorException : public std::invalid_argument {
 public:
-    template<typename NativeAccessor, typename ValueType>
-    TypeErrorException(NativeAccessor& accessor, StringData object_type,
-                       Property const& prop, ValueType value)
-    : std::invalid_argument(util::format("%1.%2 must be of type '%3', got '%4' (%5)",
-                                         object_type, prop.name, type_string(prop),
-                                         accessor.typeof(value),
-                                         accessor.print(value)))
-    {}
+    template <typename NativeAccessor, typename ValueType>
+    TypeErrorException(NativeAccessor& accessor, StringData object_type, Property const& prop, ValueType value)
+        : std::invalid_argument(util::format("%1.%2 must be of type '%3', got '%4' (%5)", object_type, prop.name,
+                                             type_string(prop), accessor.typeof(value), accessor.print(value)))
+    {
+    }
 
-    TypeErrorException(const char *name, std::string const& type, std::string const& value)
-    : std::invalid_argument(util::format("%1 must be of type '%2', got (%3)",
-                                         name ? name : "JS value", type, value))
-    {}
+    TypeErrorException(const char* name, std::string const& type, std::string const& value)
+        : std::invalid_argument(
+              util::format("%1 must be of type '%2', got (%3)", name ? name : "JS value", type, value))
+    {
+    }
 
     static std::string type_string(Property const& prop);
 };
 
-template<typename T>
+template <typename T>
 struct Value {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
     using ObjectType = typename T::Object;
     using ValueType = typename T::Value;
 
-    static const char *typeof(ContextType, const ValueType &);
+    static const char* typeof(ContextType, const ValueType&);
 
-    static bool is_array(ContextType, const ValueType &);
-    static bool is_array_buffer(ContextType, const ValueType &);
-    static bool is_array_buffer_view(ContextType, const ValueType &);
-    static bool is_boolean(ContextType, const ValueType &);
-    static bool is_constructor(ContextType, const ValueType &);
-    static bool is_date(ContextType, const ValueType &);
-    static bool is_error(ContextType, const ValueType &);
-    static bool is_function(ContextType, const ValueType &);
-    static bool is_null(ContextType, const ValueType &);
-    static bool is_number(ContextType, const ValueType &);
-    static bool is_decimal128(ContextType, const ValueType &);
-    static bool is_object_id(ContextType, const ValueType &);
-    static bool is_object(ContextType, const ValueType &);
-    static bool is_string(ContextType, const ValueType &);
-    static bool is_undefined(ContextType, const ValueType &);
-    static bool is_binary(ContextType, const ValueType &);
-    static bool is_valid(const ValueType &);
-    static bool is_bson(ContextType, const ValueType &);
-    static bool is_uuid(ContextType, const ValueType &);
+    static bool is_array(ContextType, const ValueType&);
+    static bool is_array_buffer(ContextType, const ValueType&);
+    static bool is_array_buffer_view(ContextType, const ValueType&);
+    static bool is_boolean(ContextType, const ValueType&);
+    static bool is_constructor(ContextType, const ValueType&);
+    static bool is_date(ContextType, const ValueType&);
+    static bool is_error(ContextType, const ValueType&);
+    static bool is_function(ContextType, const ValueType&);
+    static bool is_null(ContextType, const ValueType&);
+    static bool is_number(ContextType, const ValueType&);
+    static bool is_decimal128(ContextType, const ValueType&);
+    static bool is_object_id(ContextType, const ValueType&);
+    static bool is_object(ContextType, const ValueType&);
+    static bool is_string(ContextType, const ValueType&);
+    static bool is_undefined(ContextType, const ValueType&);
+    static bool is_binary(ContextType, const ValueType&);
+    static bool is_valid(const ValueType&);
+    static bool is_bson(ContextType, const ValueType&);
+    static bool is_uuid(ContextType, const ValueType&);
 
     static bool is_valid_for_property(ContextType, const ValueType&, const Property&);
-    static bool is_valid_for_property_type(ContextType, const ValueType&, realm::PropertyType type, StringData object_type);
+    static bool is_valid_for_property_type(ContextType, const ValueType&, realm::PropertyType type,
+                                           StringData object_type);
 
     static ValueType from_boolean(ContextType, bool);
     static ValueType from_null(ContextType);
     static ValueType from_number(ContextType, double);
     static ValueType from_decimal128(ContextType, const Decimal128&);
     static ValueType from_object_id(ContextType, const ObjectId&);
-    static ValueType from_string(ContextType ctx, const char *s) { return s ? from_nonnull_string(ctx, s) : from_null(ctx); }
-    static ValueType from_string(ContextType ctx, StringData s) { return s ? from_nonnull_string(ctx, String<T>(s)) : from_null(ctx); }
-    static ValueType from_string(ContextType ctx, const std::string& s) { return from_nonnull_string(ctx, s.c_str()); }
-    static ValueType from_binary(ContextType ctx, BinaryData b) { return b ? from_nonnull_binary(ctx, b) : from_null(ctx); }
+    static ValueType from_string(ContextType ctx, const char* s)
+    {
+        return s ? from_nonnull_string(ctx, s) : from_null(ctx);
+    }
+    static ValueType from_string(ContextType ctx, StringData s)
+    {
+        return s ? from_nonnull_string(ctx, String<T>(s)) : from_null(ctx);
+    }
+    static ValueType from_string(ContextType ctx, const std::string& s)
+    {
+        return from_nonnull_string(ctx, s.c_str());
+    }
+    static ValueType from_binary(ContextType ctx, BinaryData b)
+    {
+        return b ? from_nonnull_binary(ctx, b) : from_null(ctx);
+    }
     static ValueType from_nonnull_string(ContextType, const String<T>&);
     static ValueType from_nonnull_binary(ContextType, BinaryData);
     static ValueType from_undefined(ContextType);
@@ -178,31 +186,33 @@ struct Value {
     static ValueType from_uuid(ContextType, const UUID&);
     static ValueType from_objkey(ContextType, const ObjKey&);
     static ValueType from_objlink(ContextType, const ObjLink&);
-    static ValueType from_bson(ContextType, const bson::Bson &);
-    static ObjectType from_bson(ContextType, const bson::BsonDocument &);
-    static ValueType from_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const Mixed &mixed);
+    static ValueType from_bson(ContextType, const bson::Bson&);
+    static ObjectType from_bson(ContextType, const bson::BsonDocument&);
+    static ValueType from_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const Mixed& mixed);
 
-    static ObjectType to_array(ContextType, const ValueType &);
-    static bool to_boolean(ContextType, const ValueType &);
-    static FunctionType to_constructor(ContextType, const ValueType &);
-    static ObjectType to_date(ContextType, const ValueType &);
-    static FunctionType to_function(ContextType, const ValueType &);
-    static double to_number(ContextType, const ValueType &);
-    static Decimal128 to_decimal128(ContextType, const ValueType &);
-    static ObjectId to_object_id(ContextType, const ValueType &);
-    static UUID to_uuid(ContextType, const ValueType &);
-    static ObjectType to_object(ContextType, const ValueType &);
-    static String<T> to_string(ContextType, const ValueType &);
+    static ObjectType to_array(ContextType, const ValueType&);
+    static bool to_boolean(ContextType, const ValueType&);
+    static FunctionType to_constructor(ContextType, const ValueType&);
+    static ObjectType to_date(ContextType, const ValueType&);
+    static FunctionType to_function(ContextType, const ValueType&);
+    static double to_number(ContextType, const ValueType&);
+    static Decimal128 to_decimal128(ContextType, const ValueType&);
+    static ObjectId to_object_id(ContextType, const ValueType&);
+    static UUID to_uuid(ContextType, const ValueType&);
+    static ObjectType to_object(ContextType, const ValueType&);
+    static String<T> to_string(ContextType, const ValueType&);
     static OwnedBinaryData to_binary(ContextType, const ValueType&);
     static bson::Bson to_bson(ContextType, ValueType);
-    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value, std::string &string_buffer);
+    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
+                          std::string& string_buffer);
 
-#define VALIDATED(return_t, type) \
-    static return_t validated_to_##type(ContextType ctx, const ValueType &value, const char *name = nullptr) { \
-        if (!is_##type(ctx, value)) { \
-            throw TypeErrorException(name, #type, to_string(ctx, value)); \
-        } \
-        return to_##type(ctx, value); \
+#define VALIDATED(return_t, type)                                                                                    \
+    static return_t validated_to_##type(ContextType ctx, const ValueType& value, const char* name = nullptr)         \
+    {                                                                                                                \
+        if (!is_##type(ctx, value)) {                                                                                \
+            throw TypeErrorException(name, #type, to_string(ctx, value));                                            \
+        }                                                                                                            \
+        return to_##type(ctx, value);                                                                                \
     }
 
     VALIDATED(ObjectType, array)
@@ -221,41 +231,53 @@ struct Value {
 #undef VALIDATED
 };
 
-template<typename T>
+template <typename T>
 struct Function {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
     using ObjectType = typename T::Object;
     using ValueType = typename T::Value;
 
-    static ValueType callback(ContextType, const FunctionType &, const ObjectType &, size_t, const ValueType[]);
-    static ValueType callback(ContextType ctx, const FunctionType & f, const ObjectType& o, std::initializer_list<ValueType> args) {
+    static ValueType callback(ContextType, const FunctionType&, const ObjectType&, size_t, const ValueType[]);
+    static ValueType callback(ContextType ctx, const FunctionType& f, const ObjectType& o,
+                              std::initializer_list<ValueType> args)
+    {
         return callback(ctx, f, o, args.size(), args.begin());
     }
-    static ValueType callback(ContextType ctx, const FunctionType& f, size_t count, const ValueType args[]) {
+    static ValueType callback(ContextType ctx, const FunctionType& f, size_t count, const ValueType args[])
+    {
         return callback(ctx, f, {}, count, args);
     }
-    static ValueType callback(ContextType ctx, const FunctionType & f, std::initializer_list<ValueType> args) {
+    static ValueType callback(ContextType ctx, const FunctionType& f, std::initializer_list<ValueType> args)
+    {
         return callback(ctx, f, args.size(), args.begin());
     }
-    static ValueType call(ContextType, const FunctionType &, const ObjectType &, size_t, const ValueType[]);
-    template<size_t N> static ValueType call(ContextType ctx, const FunctionType &function,
-                                             const ObjectType &this_object, const ValueType (&arguments)[N])
+    static ValueType call(ContextType, const FunctionType&, const ObjectType&, size_t, const ValueType[]);
+    template <size_t N>
+    static ValueType call(ContextType ctx, const FunctionType& function, const ObjectType& this_object,
+                          const ValueType (&arguments)[N])
     {
         return call(ctx, function, this_object, N, arguments);
     }
-    static ValueType call(ContextType ctx, const FunctionType &function, size_t argument_count, const ValueType arguments[]) {
+    static ValueType call(ContextType ctx, const FunctionType& function, size_t argument_count,
+                          const ValueType arguments[])
+    {
         return call(ctx, function, {}, argument_count, arguments);
     }
-    static ValueType call(ContextType ctx, const FunctionType &function, const ObjectType &this_object, const std::vector<ValueType> &arguments) {
+    static ValueType call(ContextType ctx, const FunctionType& function, const ObjectType& this_object,
+                          const std::vector<ValueType>& arguments)
+    {
         return call(ctx, function, this_object, arguments.size(), arguments.data());
     }
 
-    static ObjectType construct(ContextType ctx, const FunctionType & f, std::initializer_list<ValueType> args) {
+    static ObjectType construct(ContextType ctx, const FunctionType& f, std::initializer_list<ValueType> args)
+    {
         return construct(ctx, f, args.size(), args.begin());
     }
-    static ObjectType construct(ContextType, const FunctionType &, size_t, const ValueType[]);
-    static ObjectType construct(ContextType ctx, const FunctionType &function, const std::vector<ValueType> &arguments) {
+    static ObjectType construct(ContextType, const FunctionType&, size_t, const ValueType[]);
+    static ObjectType construct(ContextType ctx, const FunctionType& function,
+                                const std::vector<ValueType>& arguments)
+    {
         return construct(ctx, function, arguments.size(), arguments.data());
     }
 
@@ -268,75 +290,95 @@ struct Function {
      * wrap_callback_error_first  - void(const util::Optional<app::AppError>& error, auto&& result)
      * wrap_callback_result_first - void(auto&& result, const util::Optional<app::AppError>& error)
      *
-     * In all cases, the converter should have a signature like JsResultType(ContextType, CppResultType), possibly with
-     * const and reference qualifiers on CppResultType. The converter will only be called when there is no error.
+     * In all cases, the converter should have a signature like JsResultType(ContextType, CppResultType), possibly
+     * with const and reference qualifiers on CppResultType. The converter will only be called when there is no error.
      */
     static auto wrap_void_callback(ContextType, const ObjectType& this_object, const FunctionType& callback);
-    template<typename Converter>
-    static auto wrap_callback_error_first(ContextType, const ObjectType& this_object, const FunctionType& callback, Converter&& converter);
-    template<typename Converter>
-    static auto wrap_callback_result_first(ContextType, const ObjectType& this_object, const FunctionType& callback, Converter&& converter);
+    template <typename Converter>
+    static auto wrap_callback_error_first(ContextType, const ObjectType& this_object, const FunctionType& callback,
+                                          Converter&& converter);
+    template <typename Converter>
+    static auto wrap_callback_result_first(ContextType, const ObjectType& this_object, const FunctionType& callback,
+                                           Converter&& converter);
 };
 
-template<typename T>
+template <typename T>
 struct Object {
     using ContextType = typename T::Context;
     using FunctionType = typename T::Function;
     using ObjectType = typename T::Object;
     using ValueType = typename T::Value;
 
-  public:
-    static ValueType get_prototype(ContextType, const ObjectType &);
-    static void set_prototype(ContextType, const ObjectType &, const ValueType &);
+public:
+    static ValueType get_prototype(ContextType, const ObjectType&);
+    static void set_prototype(ContextType, const ObjectType&, const ValueType&);
 
-    static ValueType get_property(ContextType, const ObjectType &, StringData);
-    static ValueType get_property(ContextType c, const ObjectType &o, const char *s) { return get_property(c, o, StringData(s)); }
-    static ValueType get_property(ContextType c, const ObjectType &o, const std::string &s) { return get_property(c, o, StringData(s)); }
-    static ValueType get_property(ContextType, const ObjectType &, const String<T> &);
-    static ValueType get_property(ContextType, const ObjectType &, uint32_t);
-    static void set_property(ContextType ctx, ObjectType&& obj, const String<T>& field, const ValueType& val, PropertyAttributes attributes = None) {
+    static ValueType get_property(ContextType, const ObjectType&, StringData);
+    static ValueType get_property(ContextType c, const ObjectType& o, const char* s)
+    {
+        return get_property(c, o, StringData(s));
+    }
+    static ValueType get_property(ContextType c, const ObjectType& o, const std::string& s)
+    {
+        return get_property(c, o, StringData(s));
+    }
+    static ValueType get_property(ContextType, const ObjectType&, const String<T>&);
+    static ValueType get_property(ContextType, const ObjectType&, uint32_t);
+    static void set_property(ContextType ctx, ObjectType&& obj, const String<T>& field, const ValueType& val,
+                             PropertyAttributes attributes = None)
+    {
         set_property(ctx, obj, field, val, attributes);
     }
-    static void set_property(ContextType ctx, ObjectType&& obj, uint32_t field, const ValueType& val) {
+    static void set_property(ContextType ctx, ObjectType&& obj, uint32_t field, const ValueType& val)
+    {
         set_property(ctx, obj, field, val);
     }
-    static void set_property(ContextType, ObjectType &, const String<T> &, const ValueType &, PropertyAttributes attributes = None);
-    static void set_property(ContextType, ObjectType &, uint32_t, const ValueType &);
-    static std::vector<String<T>> get_property_names(ContextType, const ObjectType &);
+    static void set_property(ContextType, ObjectType&, const String<T>&, const ValueType&,
+                             PropertyAttributes attributes = None);
+    static void set_property(ContextType, ObjectType&, uint32_t, const ValueType&);
+    static std::vector<String<T>> get_property_names(ContextType, const ObjectType&);
 
-    static void set_global(ContextType, const String<T> &, const ValueType &);
-    static ValueType get_global(ContextType, const String<T> &);
+    static void set_global(ContextType, const String<T>&, const ValueType&);
+    static ValueType get_global(ContextType, const String<T>&);
 
-    template<typename P>
-    static ValueType validated_get_property(ContextType ctx, const ObjectType &object, const P &property, const char *message = nullptr) {
+    template <typename P>
+    static ValueType validated_get_property(ContextType ctx, const ObjectType& object, const P& property,
+                                            const char* message = nullptr)
+    {
         auto value = get_property(ctx, object, property);
         if (Value<T>::is_undefined(ctx, value)) {
-            throw std::out_of_range(message ? message : "Object missing expected property: " + util::to_string(property));
+            throw std::out_of_range(message ? message
+                                            : "Object missing expected property: " + util::to_string(property));
         }
         return value;
     }
 
-    static uint32_t validated_get_length(ContextType ctx, const ObjectType &object) {
+    static uint32_t validated_get_length(ContextType ctx, const ObjectType& object)
+    {
         static const String<T> length_string = "length";
         return Value<T>::validated_to_number(ctx, get_property(ctx, object, length_string));
     }
 
-#define VALIDATED(return_t, type) \
-    static return_t validated_get_##type(ContextType ctx, const ObjectType &object, const String<T> &key, const char *message = nullptr) { \
-        try { \
-            return Value<T>::validated_to_##type(ctx, get_property(ctx, object, key), std::string(key).c_str()); \
-        } \
-        catch (std::invalid_argument &e) { \
-            throw message ? std::invalid_argument(util::format("Failed to read %1: %2", message, e.what())) : e; \
-        } \
-    } \
-    static return_t validated_get_##type(ContextType ctx, const ObjectType &object, uint32_t index, const char *message = nullptr) { \
-        try { \
-            return Value<T>::validated_to_##type(ctx, get_property(ctx, object, index)); \
-        } \
-        catch (std::invalid_argument &e) { \
-            throw message ? std::invalid_argument(util::format("Failed to read %1: %2", message, e.what())) : e; \
-        } \
+#define VALIDATED(return_t, type)                                                                                    \
+    static return_t validated_get_##type(ContextType ctx, const ObjectType& object, const String<T>& key,            \
+                                         const char* message = nullptr)                                              \
+    {                                                                                                                \
+        try {                                                                                                        \
+            return Value<T>::validated_to_##type(ctx, get_property(ctx, object, key), std::string(key).c_str());     \
+        }                                                                                                            \
+        catch (std::invalid_argument & e) {                                                                          \
+            throw message ? std::invalid_argument(util::format("Failed to read %1: %2", message, e.what())) : e;     \
+        }                                                                                                            \
+    }                                                                                                                \
+    static return_t validated_get_##type(ContextType ctx, const ObjectType& object, uint32_t index,                  \
+                                         const char* message = nullptr)                                              \
+    {                                                                                                                \
+        try {                                                                                                        \
+            return Value<T>::validated_to_##type(ctx, get_property(ctx, object, index));                             \
+        }                                                                                                            \
+        catch (std::invalid_argument & e) {                                                                          \
+            throw message ? std::invalid_argument(util::format("Failed to read %1: %2", message, e.what())) : e;     \
+        }                                                                                                            \
     }
 
     VALIDATED(ObjectType, array)
@@ -353,19 +395,26 @@ struct Object {
 
 #undef VALIDATED
 
-    static ValueType call_method(ContextType ctx, const ObjectType &object, const String<T> &name, uint32_t argc, const ValueType arguments[]) {
+    static ValueType call_method(ContextType ctx, const ObjectType& object, const String<T>& name, uint32_t argc,
+                                 const ValueType arguments[])
+    {
         FunctionType method = validated_get_function(ctx, object, name);
         return Function<T>::call(ctx, method, object, argc, arguments);
     }
-    static ValueType call_method(ContextType ctx, const ObjectType &object, const String<T> &name, const std::vector<ValueType> &arguments) {
+    static ValueType call_method(ContextType ctx, const ObjectType& object, const String<T>& name,
+                                 const std::vector<ValueType>& arguments)
+    {
         return call_method(ctx, object, name, (uint32_t)arguments.size(), arguments.data());
     }
-    static ValueType call_method(ContextType ctx, const ObjectType &object, const String<T> &name, const std::initializer_list<ValueType> &arguments) {
+    static ValueType call_method(ContextType ctx, const ObjectType& object, const String<T>& name,
+                                 const std::initializer_list<ValueType>& arguments)
+    {
         return call_method(ctx, object, name, (uint32_t)arguments.size(), arguments.begin());
     }
 
     static ObjectType create_empty(ContextType);
-    static ObjectType create_obj(ContextType ctx, std::initializer_list<std::pair<String<T>, ValueType>> values) {
+    static ObjectType create_obj(ContextType ctx, std::initializer_list<std::pair<String<T>, ValueType>> values)
+    {
         auto obj = create_empty(ctx);
         for (auto&& [name, val] : values) {
             set_property(ctx, obj, name, val);
@@ -374,52 +423,57 @@ struct Object {
     }
 
     static ObjectType create_array(ContextType, uint32_t, const ValueType[]);
-    static ObjectType create_array(ContextType ctx, const std::vector<ValueType> &values) {
+    static ObjectType create_array(ContextType ctx, const std::vector<ValueType>& values)
+    {
         return create_array(ctx, (uint32_t)values.size(), values.data());
     }
-    static ObjectType create_array(ContextType ctx, std::initializer_list<ValueType> values) {
+    static ObjectType create_array(ContextType ctx, std::initializer_list<ValueType> values)
+    {
         return create_array(ctx, (uint32_t)values.size(), values.begin());
     }
-    static ObjectType create_array(ContextType ctx) {
+    static ObjectType create_array(ContextType ctx)
+    {
         return create_array(ctx, 0, nullptr);
     }
 
     static ObjectType create_date(ContextType, double);
 
-    template<typename ClassType>
+    template <typename ClassType>
     static ObjectType create_instance(ContextType, typename ClassType::Internal*);
 
     static ObjectType create_bson_type(ContextType, StringData type, std::initializer_list<ValueType> args);
 
-    template<typename ClassType>
-    static ObjectType create_instance_by_schema(ContextType, typename T::Function& constructor, const realm::ObjectSchema& schema, typename ClassType::Internal*);
+    template <typename ClassType>
+    static ObjectType create_instance_by_schema(ContextType, typename T::Function& constructor,
+                                                const realm::ObjectSchema& schema, typename ClassType::Internal*);
 
-    template<typename ClassType>
-    static ObjectType create_instance_by_schema(ContextType, const realm::ObjectSchema& schema, typename ClassType::Internal*);
+    template <typename ClassType>
+    static ObjectType create_instance_by_schema(ContextType, const realm::ObjectSchema& schema,
+                                                typename ClassType::Internal*);
 
-    template<typename ClassType>
-    static bool is_instance(ContextType, const ObjectType &);
+    template <typename ClassType>
+    static bool is_instance(ContextType, const ObjectType&);
 
-    template<typename ClassType>
-    static typename ClassType::Internal* get_internal(const ObjectType &);
+    template <typename ClassType>
+    static typename ClassType::Internal* get_internal(const ObjectType&);
 
-    template<typename ClassType>
-    static typename ClassType::Internal* get_internal(ContextType ctx, const ObjectType &);
+    template <typename ClassType>
+    static typename ClassType::Internal* get_internal(ContextType ctx, const ObjectType&);
 
-    template<typename ClassType>
-    static void set_internal(ContextType ctx, const ObjectType &, typename ClassType::Internal*);
+    template <typename ClassType>
+    static void set_internal(ContextType ctx, const ObjectType&, typename ClassType::Internal*);
 
     static ObjectType create_from_app_error(ContextType, const app::AppError&);
     static ValueType create_from_optional_app_error(ContextType, const util::Optional<app::AppError>&);
 };
 
-template<typename ValueType>
+template <typename ValueType>
 class Protected {
     operator ValueType() const;
-    bool operator==(const ValueType &) const;
-    bool operator!=(const ValueType &) const;
-    bool operator==(const Protected<ValueType> &) const;
-    bool operator!=(const Protected<ValueType> &) const;
+    bool operator==(const ValueType&) const;
+    bool operator!=(const ValueType&) const;
+    bool operator==(const Protected<ValueType>&) const;
+    bool operator!=(const Protected<ValueType>&) const;
 
     struct Comparator {
         bool operator()(const Protected<ValueType>& a, const Protected<ValueType>& b) const;
@@ -431,38 +485,46 @@ template <typename Ctx, typename T>
 Protected(Ctx, T) -> Protected<T>;
 
 
-template<typename T>
+template <typename T>
 struct Exception : public std::runtime_error {
     using ContextType = typename T::Context;
     using ValueType = typename T::Value;
 
     const Protected<ValueType> m_value;
 
-    Exception(ContextType ctx, const std::string &message)
-        : std::runtime_error(message), m_value(ctx, value(ctx, message)) {}
-    Exception(ContextType ctx, const ValueType &val)
-        : std::runtime_error(std::string(Value<T>::to_string(ctx, val))), m_value(ctx, val) {}
+    Exception(ContextType ctx, const std::string& message)
+        : std::runtime_error(message)
+        , m_value(ctx, value(ctx, message))
+    {
+    }
+    Exception(ContextType ctx, const ValueType& val)
+        : std::runtime_error(std::string(Value<T>::to_string(ctx, val)))
+        , m_value(ctx, val)
+    {
+    }
 
-    operator ValueType() const {
+    operator ValueType() const
+    {
         return m_value;
     }
 
-    static ValueType value(ContextType ctx, const std::string &message);
+    static ValueType value(ContextType ctx, const std::string& message);
 
-    static ValueType value(ContextType ctx, const std::exception &exp) {
-        if (const Exception<T> *js_exp = dynamic_cast<const Exception<T> *>(&exp)) {
+    static ValueType value(ContextType ctx, const std::exception& exp)
+    {
+        if (const Exception<T>* js_exp = dynamic_cast<const Exception<T>*>(&exp)) {
             return *js_exp;
         }
         return value(ctx, exp.what());
     }
 };
 
-template<typename T>
+template <typename T>
 struct ReturnValue {
     using ValueType = typename T::Value;
 
-    void set(const ValueType &);
-    void set(const std::string &);
+    void set(const ValueType&);
+    void set(const std::string&);
     void set(bool);
     void set(double);
     void set(Decimal128);
@@ -473,39 +535,52 @@ struct ReturnValue {
     void set_undefined();
 };
 
-template<typename T, typename ClassType>
-REALM_JS_INLINE typename T::Object create_object(typename T::Context ctx, typename ClassType::Internal* internal = nullptr) {
+template <typename T, typename ClassType>
+REALM_JS_INLINE typename T::Object create_object(typename T::Context ctx,
+                                                 typename ClassType::Internal* internal = nullptr)
+{
     return Object<T>::template create_instance<ClassType>(ctx, internal);
 }
 
-template<typename T, typename ClassType>
-REALM_JS_INLINE typename T::Object create_instance_by_schema(typename T::Context ctx, typename T::Function& constructor, const realm::ObjectSchema& schema, typename ClassType::Internal* internal = nullptr) {
+template <typename T, typename ClassType>
+REALM_JS_INLINE typename T::Object
+create_instance_by_schema(typename T::Context ctx, typename T::Function& constructor,
+                          const realm::ObjectSchema& schema, typename ClassType::Internal* internal = nullptr)
+{
     return Object<T>::template create_instance_by_schema<ClassType>(ctx, constructor, schema, internal);
 }
 
-template<typename T, typename ClassType>
-REALM_JS_INLINE typename T::Object create_instance_by_schema(typename T::Context ctx, const realm::ObjectSchema& schema, typename ClassType::Internal* internal = nullptr) {
+template <typename T, typename ClassType>
+REALM_JS_INLINE typename T::Object create_instance_by_schema(typename T::Context ctx,
+                                                             const realm::ObjectSchema& schema,
+                                                             typename ClassType::Internal* internal = nullptr)
+{
     return Object<T>::template create_instance_by_schema<ClassType>(ctx, schema, internal);
 }
 
-template<typename T, typename ClassType>
-REALM_JS_INLINE typename ClassType::Internal* get_internal(typename T::Context ctx, const typename T::Object &object) {
+template <typename T, typename ClassType>
+REALM_JS_INLINE typename ClassType::Internal* get_internal(typename T::Context ctx, const typename T::Object& object)
+{
     return Object<T>::template get_internal<ClassType>(ctx, object);
 }
 
-template<typename T, typename ClassType>
-REALM_JS_INLINE void set_internal(typename T::Context ctx, const typename T::Object &object, typename ClassType::Internal* ptr) {
+template <typename T, typename ClassType>
+REALM_JS_INLINE void set_internal(typename T::Context ctx, const typename T::Object& object,
+                                  typename ClassType::Internal* ptr)
+{
     Object<T>::template set_internal<ClassType>(ctx, object, ptr);
 }
 
-template<typename T>
-inline bool Value<T>::is_valid_for_property(ContextType context, const ValueType &value, const Property& prop)
+template <typename T>
+inline bool Value<T>::is_valid_for_property(ContextType context, const ValueType& value, const Property& prop)
 {
     return is_valid_for_property_type(context, value, prop.type, prop.object_type);
 }
 
-template<typename T>
-inline bool Value<T>::is_valid_for_property_type(ContextType context, const ValueType &value, realm::PropertyType type, StringData object_type) {
+template <typename T>
+inline bool Value<T>::is_valid_for_property_type(ContextType context, const ValueType& value,
+                                                 realm::PropertyType type, StringData object_type)
+{
     using realm::PropertyType;
 
     auto check_value = [&](auto&& value) {
@@ -543,9 +618,8 @@ inline bool Value<T>::is_valid_for_property_type(ContextType context, const Valu
 
     auto check_collection_type = [&](auto&& list) {
         auto list_type = list->get_type();
-        return list_type == type
-            && is_nullable(list_type) == is_nullable(type)
-            && (type != PropertyType::Object || list->get_object_schema().name == object_type);
+        return list_type == type && is_nullable(list_type) == is_nullable(type) &&
+               (type != PropertyType::Object || list->get_object_schema().name == object_type);
     };
 
 
@@ -565,7 +639,7 @@ inline bool Value<T>::is_valid_for_property_type(ContextType context, const Valu
             return check_collection_type(get_internal<T, SetClass<T>>(context, object));
         }
         if (realm::is_dictionary(type)) { // FIXME: check type of `value`
-            return true; // dictionary place-holder
+            return true;                  // dictionary place-holder
         }
     }
 
@@ -588,133 +662,149 @@ inline bool Value<T>::is_valid_for_property_type(ContextType context, const Valu
     return true;
 }
 
-template<typename T>
-inline typename T::Value Value<T>::from_timestamp(typename T::Context ctx, Timestamp ts) {
+template <typename T>
+inline typename T::Value Value<T>::from_timestamp(typename T::Context ctx, Timestamp ts)
+{
     return Object<T>::create_date(ctx, ts.get_seconds() * 1000 + ts.get_nanoseconds() / 1000000);
 }
 
-template<typename T>
-inline typename T::Object Object<T>::create_from_app_error(ContextType ctx, const app::AppError& error) {
+template <typename T>
+inline typename T::Object Object<T>::create_from_app_error(ContextType ctx, const app::AppError& error)
+{
     return Object::create_obj(ctx, {
-        {"message", Value<T>::from_string(ctx, error.message)},
-        {"code", Value<T>::from_number(ctx, error.error_code.value())},
-    });
+                                       {"message", Value<T>::from_string(ctx, error.message)},
+                                       {"code", Value<T>::from_number(ctx, error.error_code.value())},
+                                   });
 }
 
-template<typename T>
-inline typename T::Object Object<T>::create_bson_type(ContextType ctx, StringData type, std::initializer_list<ValueType> args) {
+template <typename T>
+inline typename T::Object Object<T>::create_bson_type(ContextType ctx, StringData type,
+                                                      std::initializer_list<ValueType> args)
+{
     auto realm = Value<T>::validated_to_object(ctx, Object<T>::get_global(ctx, "Realm"));
     auto bson = Value<T>::validated_to_object(ctx, Object<T>::get_property(ctx, realm, "BSON"));
     auto ctor = Value<T>::to_constructor(ctx, Object<T>::get_property(ctx, bson, type));
     return Function<T>::construct(ctx, ctor, args);
 }
 
-template<typename T>
-inline typename T::Value Object<T>::create_from_optional_app_error(ContextType ctx, const util::Optional<app::AppError>& error) {
+template <typename T>
+inline typename T::Value Object<T>::create_from_optional_app_error(ContextType ctx,
+                                                                   const util::Optional<app::AppError>& error)
+{
     if (!error)
         return Value<T>::from_undefined(ctx);
     return create_from_app_error(ctx, *error);
 }
 
-template<typename T>
-inline typename T::Value Value<T>::from_objkey(typename T::Context ctx, const ObjKey& value) {
+template <typename T>
+inline typename T::Value Value<T>::from_objkey(typename T::Context ctx, const ObjKey& value)
+{
     throw std::runtime_error("'Mixed' type support is not implemented yet");
 }
 
-template<typename T>
-inline typename T::Value Value<T>::from_objlink(typename T::Context ctx, const ObjLink& value) {
+template <typename T>
+inline typename T::Value Value<T>::from_objlink(typename T::Context ctx, const ObjLink& value)
+{
     throw std::runtime_error("'Mixed' type support is not implemented yet");
 }
 
-template<typename T>
-inline typename T::Value Value<T>::from_bson(typename T::Context ctx, const bson::Bson& value) {
+template <typename T>
+inline typename T::Value Value<T>::from_bson(typename T::Context ctx, const bson::Bson& value)
+{
     using Type = bson::Bson::Type;
 
     switch (value.type()) {
-    case Type::Uuid:
-        return from_uuid(ctx, value.operator UUID());
-    case Type::MinKey:
-        return Object<T>::create_bson_type(ctx, "MinKey", {});
-    case Type::MaxKey:
-        return Object<T>::create_bson_type(ctx, "MaxKey", {});
-    case Type::Null:
-        return from_null(ctx);
-    case Type::Bool:
-        return from_boolean(ctx, value.operator bool());
-    case Type::Double:
-        return from_number(ctx, value.operator double());
-    case Type::Int32:
-        // All int32 values can be precisely represented as a double
-        return from_number(ctx, double(value.operator int32_t()));
-    case Type::Int64: {
-        // int64 needs special handling. The server uses it for all intish numbers, even 1.0, so we map
-        // it to a plain js number if it is in the range where it can be done precisely, otherwise
-        // we map to the bson.Long type which preserves the value, but is harder to use.
-        const auto i64_val = value.operator int64_t();
-        if (-JS_MAX_SAFE_INTEGER <= i64_val && i64_val <= JS_MAX_SAFE_INTEGER)
-            return Value<T>::from_number(ctx, double(i64_val));
+        case Type::Uuid:
+            return from_uuid(ctx, value.operator UUID());
+        case Type::MinKey:
+            return Object<T>::create_bson_type(ctx, "MinKey", {});
+        case Type::MaxKey:
+            return Object<T>::create_bson_type(ctx, "MaxKey", {});
+        case Type::Null:
+            return from_null(ctx);
+        case Type::Bool:
+            return from_boolean(ctx, value.operator bool());
+        case Type::Double:
+            return from_number(ctx, value.operator double());
+        case Type::Int32:
+            // All int32 values can be precisely represented as a double
+            return from_number(ctx, double(value.operator int32_t()));
+        case Type::Int64: {
+            // int64 needs special handling. The server uses it for all intish numbers, even 1.0, so we map
+            // it to a plain js number if it is in the range where it can be done precisely, otherwise
+            // we map to the bson.Long type which preserves the value, but is harder to use.
+            const auto i64_val = value.operator int64_t();
+            if (-JS_MAX_SAFE_INTEGER <= i64_val && i64_val <= JS_MAX_SAFE_INTEGER)
+                return Value<T>::from_number(ctx, double(i64_val));
 
-        return Object<T>::create_bson_type(ctx, "Long", {
-            Value<T>::from_number(ctx, int32_t(i64_val)), // low
-            Value<T>::from_number(ctx, int32_t(i64_val >> 32)), // high
-        });
-    }
-    case Type::Decimal128:
-        return from_decimal128(ctx, value.operator Decimal128());
-    case Type::ObjectId:
-        return from_object_id(ctx, value.operator ObjectId());
-    case Type::Datetime:
-        return from_timestamp(ctx, value.operator Timestamp());
-    case Type::Timestamp: {
-        auto mts = value.operator bson::MongoTimestamp();
-        return Object<T>::create_bson_type(ctx, "Timestamp", {
-            // The constructor takes the arguments "backwards" from standard order.
-            Value<T>::from_number(ctx, mts.increment),
-            Value<T>::from_number(ctx, mts.seconds),
-        });
-    }
-    case Type::String:
-        return from_string(ctx, value.operator const std::string&());
-    case Type::Binary: {
-        const auto& vec = value.operator const std::vector<char>&();
-        const auto decoded = realm::util::base64_decode_to_vector(StringData(vec.data(), vec.size()));
-        if (!decoded)
-            throw std::invalid_argument("invalid base64 in binary data");
-        auto Uint8Array = Value<T>::to_function(ctx, Object<T>::get_global(ctx, "Uint8Array"));
-        auto array = Function<T>::construct(ctx, Uint8Array, {
-            from_nonnull_binary(ctx, {decoded->data(), decoded->size()}),
-        });
-        return Object<T>::create_bson_type(ctx, "Binary", {
-            array,
-            Value<T>::from_number(ctx, 0), // TODO get subtype from `value` once it is possible.
-        });
-    }
-    case Type::Document:
-        return from_bson(ctx, value.operator const bson::BsonDocument&());
-    case Type::Array: {
-        auto&& in_vec = value.operator const std::vector<bson::Bson>&();
-        std::vector<ValueType> out_vec;
-        out_vec.reserve(in_vec.size());
-        for (auto&& elem : in_vec) {
-            out_vec.push_back(from_bson(ctx, elem));
+            return Object<T>::create_bson_type(ctx, "Long",
+                                               {
+                                                   Value<T>::from_number(ctx, int32_t(i64_val)),       // low
+                                                   Value<T>::from_number(ctx, int32_t(i64_val >> 32)), // high
+                                               });
         }
-        return Object<T>::create_array(ctx, out_vec);
-    }
-    case Type::RegularExpression: {
-        auto&& re = value.operator const bson::RegularExpression&();
-        std::ostringstream oss;
-        oss << re.options();
-        return Object<T>::create_bson_type(ctx, "BSONRegExp", {
-            Value<T>::from_string(ctx, re.pattern()),
-            Value<T>::from_string(ctx, oss.str()),
-        });
-    }
+        case Type::Decimal128:
+            return from_decimal128(ctx, value.operator Decimal128());
+        case Type::ObjectId:
+            return from_object_id(ctx, value.operator ObjectId());
+        case Type::Datetime:
+            return from_timestamp(ctx, value.operator Timestamp());
+        case Type::Timestamp: {
+            auto mts = value.operator bson::MongoTimestamp();
+            return Object<T>::create_bson_type(
+                ctx, "Timestamp",
+                {
+                    // The constructor takes the arguments "backwards" from standard order.
+                    Value<T>::from_number(ctx, mts.increment),
+                    Value<T>::from_number(ctx, mts.seconds),
+                });
+        }
+        case Type::String:
+            return from_string(ctx, value.operator const std::string&());
+        case Type::Binary: {
+            const auto& vec = value.operator const std::vector<char>&();
+            const auto decoded = realm::util::base64_decode_to_vector(StringData(vec.data(), vec.size()));
+            if (!decoded)
+                throw std::invalid_argument("invalid base64 in binary data");
+            auto Uint8Array = Value<T>::to_function(ctx, Object<T>::get_global(ctx, "Uint8Array"));
+            auto array = Function<T>::construct(ctx, Uint8Array,
+                                                {
+                                                    from_nonnull_binary(ctx, {decoded->data(), decoded->size()}),
+                                                });
+            return Object<T>::create_bson_type(
+                ctx, "Binary",
+                {
+                    array, Value<T>::from_number(ctx, 0), // TODO get subtype from `value` once it is possible.
+                });
+        }
+        case Type::Document:
+            return from_bson(ctx, value.operator const bson::BsonDocument&());
+        case Type::Array: {
+            auto&& in_vec = value.operator const std::vector<bson::Bson>&();
+            std::vector<ValueType> out_vec;
+            out_vec.reserve(in_vec.size());
+            for (auto&& elem : in_vec) {
+                out_vec.push_back(from_bson(ctx, elem));
+            }
+            return Object<T>::create_array(ctx, out_vec);
+        }
+        case Type::RegularExpression: {
+            auto&& re = value.operator const bson::RegularExpression&();
+            std::ostringstream oss;
+            oss << re.options();
+            return Object<T>::create_bson_type(ctx, "BSONRegExp",
+                                               {
+                                                   Value<T>::from_string(ctx, re.pattern()),
+                                                   Value<T>::from_string(ctx, oss.str()),
+                                               });
+        }
     }
     throw std::invalid_argument("Value not convertible.");
 }
 
-template<typename T>
-inline typename T::Object Value<T>::from_bson(typename T::Context ctx, const bson::BsonDocument& doc) {
+template <typename T>
+inline typename T::Object Value<T>::from_bson(typename T::Context ctx, const bson::BsonDocument& doc)
+{
     auto out = Object<T>::create_empty(ctx);
     for (auto&& [k, v] : doc) {
         Object<T>::set_property(ctx, out, k, from_bson(ctx, v));
@@ -722,56 +812,71 @@ inline typename T::Object Value<T>::from_bson(typename T::Context ctx, const bso
     return out;
 }
 
-template<typename T>
-typename T::Value Value<T>::from_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const Mixed &mixed) {
+template <typename T>
+typename T::Value Value<T>::from_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const Mixed& mixed)
+{
     if (mixed.is_null()) {
         return from_null(ctx);
     }
 
     switch (mixed.get_type()) {
-        case DataType::Type::Int: return from_number(ctx, mixed.get_int());
-        case DataType::Type::Bool: return from_boolean(ctx, mixed.get_bool());
+        case DataType::Type::Int:
+            return from_number(ctx, mixed.get_int());
+        case DataType::Type::Bool:
+            return from_boolean(ctx, mixed.get_bool());
         case DataType::Type::String: {
             auto str = std::string(mixed.get<StringData>());
             return from_string(ctx, str);
         }
-        case DataType::Type::Binary: return from_binary(ctx, mixed.get<BinaryData>());
-        case DataType::Type::Timestamp: return from_timestamp(ctx, mixed.get_timestamp());
-        case DataType::Type::Float: return from_number(ctx, mixed.get_float());
-        case DataType::Type::Double: return from_number(ctx, mixed.get_double());
-        case DataType::Type::Decimal: return from_decimal128(ctx, mixed.get_decimal());
+        case DataType::Type::Binary:
+            return from_binary(ctx, mixed.get<BinaryData>());
+        case DataType::Type::Timestamp:
+            return from_timestamp(ctx, mixed.get_timestamp());
+        case DataType::Type::Float:
+            return from_number(ctx, mixed.get_float());
+        case DataType::Type::Double:
+            return from_number(ctx, mixed.get_double());
+        case DataType::Type::Decimal:
+            return from_decimal128(ctx, mixed.get_decimal());
         case DataType::Type::Link: {
             realm::Object realm_object(realm, mixed.get_link());
             return RealmObjectClass<T>::create_instance(ctx, realm_object);
         };
-        case DataType::Type::ObjectId: return from_object_id(ctx, mixed.get_object_id());
+        case DataType::Type::ObjectId:
+            return from_object_id(ctx, mixed.get_object_id());
         case DataType::Type::TypedLink: {
             realm::Object realm_object(realm, mixed.get_link());
             return RealmObjectClass<T>::create_instance(ctx, realm_object);
         };
-        case DataType::Type::UUID: return from_uuid(ctx, mixed.get_uuid());
+        case DataType::Type::UUID:
+            return from_uuid(ctx, mixed.get_uuid());
         default:
             REALM_UNREACHABLE();
     }
 }
 
 
-template<typename T>
-inline bson::Bson Value<T>::to_bson(typename T::Context ctx, ValueType value) {
+template <typename T>
+inline bson::Bson Value<T>::to_bson(typename T::Context ctx, ValueType value)
+{
     // For now going through the bson.EJSON.stringify() since it will correctly handle the special JS types.
     // Consider directly converting to Bson if we need more control or there are performance issues.
     auto realm = Value::validated_to_object(ctx, Object<T>::get_global(ctx, "Realm"));
     auto bson = Value::validated_to_object(ctx, Object<T>::get_property(ctx, realm, "_bson"));
     auto ejson = Value::validated_to_object(ctx, Object<T>::get_property(ctx, bson, "EJSON"));
-    auto call_args_json = Object<T>::call_method(ctx, ejson, "stringify", {
-        value,
-        Object<T>::create_obj(ctx, {{"relaxed", Value::from_boolean(ctx, false)}}),
-    });
+    auto call_args_json =
+        Object<T>::call_method(ctx, ejson, "stringify",
+                               {
+                                   value,
+                                   Object<T>::create_obj(ctx, {{"relaxed", Value::from_boolean(ctx, false)}}),
+                               });
     return bson::parse(std::string(Value::to_string(ctx, call_args_json)));
 }
 
-template<typename T>
-typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value, std::string &string_buffer) {
+template <typename T>
+typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
+                                         std::string& string_buffer)
+{
     if (is_null(ctx, value) || is_undefined(ctx, value)) {
         return Mixed(realm::null());
     }
@@ -829,41 +934,45 @@ typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm>
 }
 
 template <typename T>
-auto Function<T>::wrap_void_callback(ContextType ctx, const ObjectType& this_object, const FunctionType& callback) {
-    return [ctx = Protected(Context<T>::get_global_context(ctx)),
-            callback = Protected(ctx, callback),
-            this_object = Protected(ctx, this_object)]
-        (const util::Optional<app::AppError>& error) {
-            HANDLESCOPE(ctx);
-            Function::callback(ctx, callback, this_object, {
-                Object<T>::create_from_optional_app_error(ctx, error),
-            });
-        };
+auto Function<T>::wrap_void_callback(ContextType ctx, const ObjectType& this_object, const FunctionType& callback)
+{
+    return [ctx = Protected(Context<T>::get_global_context(ctx)), callback = Protected(ctx, callback),
+            this_object = Protected(ctx, this_object)](const util::Optional<app::AppError>& error) {
+        HANDLESCOPE(ctx);
+        Function::callback(ctx, callback, this_object,
+                           {
+                               Object<T>::create_from_optional_app_error(ctx, error),
+                           });
+    };
 }
 
 template <typename T>
 template <typename Converter>
-auto Function<T>::wrap_callback_error_first(ContextType ctx, const ObjectType& this_object, const FunctionType& callback, Converter&& converter) {
-    return [ctx = Protected(Context<T>::get_global_context(ctx)),
-            callback = Protected(ctx, callback),
-            this_object = Protected(ctx, this_object),
-            converter = std::forward<Converter>(converter)]
-        (const util::Optional<app::AppError>& error, auto&& result) {
-            HANDLESCOPE(ctx);
-            Function::callback(ctx, callback, this_object, {
+auto Function<T>::wrap_callback_error_first(ContextType ctx, const ObjectType& this_object,
+                                            const FunctionType& callback, Converter&& converter)
+{
+    return [ctx = Protected(Context<T>::get_global_context(ctx)), callback = Protected(ctx, callback),
+            this_object = Protected(ctx, this_object), converter = std::forward<Converter>(converter)](
+               const util::Optional<app::AppError>& error, auto&& result) {
+        HANDLESCOPE(ctx);
+        Function::callback(
+            ctx, callback, this_object,
+            {
                 error ? Value<T>::from_undefined(ctx) : converter(ctx, std::forward<decltype(result)>(result)),
                 Object<T>::create_from_optional_app_error(ctx, error),
             });
-        };
+    };
 }
 
 template <typename T>
 template <typename Converter>
-auto Function<T>::wrap_callback_result_first(ContextType ctx, const ObjectType& this_object, const FunctionType& callback, Converter&& converter) {
-    return [callback = wrap_callback_error_first(ctx, this_object, callback, std::forward<Converter>(converter))]
-            (auto&& result, const util::Optional<app::AppError>& error) -> decltype(auto) {
-                return callback(error, std::forward<decltype(result)>(result));
-            };
+auto Function<T>::wrap_callback_result_first(ContextType ctx, const ObjectType& this_object,
+                                             const FunctionType& callback, Converter&& converter)
+{
+    return [callback = wrap_callback_error_first(ctx, this_object, callback, std::forward<Converter>(converter))](
+               auto&& result, const util::Optional<app::AppError>& error) -> decltype(auto) {
+        return callback(error, std::forward<decltype(result)>(result));
+    };
 }
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/js_user.hpp
+++ b/src/js_user.hpp
@@ -39,7 +39,7 @@ using SharedUser = std::shared_ptr<realm::SyncUser>;
 using SharedApp = std::shared_ptr<realm::app::App>;
 using WatchStream = realm::app::WatchStream;
 
-template<typename T>
+template <typename T>
 class WatchStreamClass : public ClassDefinition<T, WatchStream> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -56,16 +56,15 @@ class WatchStreamClass : public ClassDefinition<T, WatchStream> {
 public:
     std::string const name = "WatchStream";
 
-    static void get_state(ContextType, ObjectType, ReturnValue &);
-    static void get_error(ContextType, ObjectType, ReturnValue &);
+    static void get_state(ContextType, ObjectType, ReturnValue&);
+    static void get_error(ContextType, ObjectType, ReturnValue&);
 
     PropertyMap<T> const properties = {
         {"state", {wrap<get_state>, nullptr}},
         {"error", {wrap<get_error>, nullptr}},
     };
 
-    MethodMap<T> const static_methods = {
-    };
+    MethodMap<T> const static_methods = {};
 
     static void feed_buffer(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void next_event(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -76,55 +75,67 @@ public:
     };
 };
 
-template<typename T>
-void WatchStreamClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void WatchStreamClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     WatchStream* ws = get_internal<T, WatchStreamClass<T>>(ctx, object);
     switch (ws->state()) {
-    case WatchStream::HAVE_ERROR:
-        return return_value.set(Value::from_string(ctx, "HAVE_ERROR"));
-    case WatchStream::HAVE_EVENT:
-        return return_value.set(Value::from_string(ctx, "HAVE_EVENT"));
-    case WatchStream::NEED_DATA:
-        return return_value.set(Value::from_string(ctx, "NEED_DATA"));
+        case WatchStream::HAVE_ERROR:
+            return return_value.set(Value::from_string(ctx, "HAVE_ERROR"));
+        case WatchStream::HAVE_EVENT:
+            return return_value.set(Value::from_string(ctx, "HAVE_EVENT"));
+        case WatchStream::NEED_DATA:
+            return return_value.set(Value::from_string(ctx, "NEED_DATA"));
     }
     REALM_UNREACHABLE();
 }
 
-template<typename T>
-void WatchStreamClass<T>::get_error(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void WatchStreamClass<T>::get_error(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     WatchStream* ws = get_internal<T, WatchStreamClass<T>>(ctx, object);
     return return_value.set(Object::create_from_app_error(ctx, ws->error()));
 }
 
-template<typename T>
-void WatchStreamClass<T>::feed_buffer(ContextType ctx, ObjectType object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void WatchStreamClass<T>::feed_buffer(ContextType ctx, ObjectType object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(1);
     WatchStream* ws = get_internal<T, WatchStreamClass<T>>(ctx, object);
     auto buffer = Value::validated_to_binary(ctx, args[0], "buffer");
     ws->feed_buffer({buffer.data(), buffer.size()});
 }
 
-template<typename T>
-void WatchStreamClass<T>::next_event(ContextType ctx, ObjectType object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void WatchStreamClass<T>::next_event(ContextType ctx, ObjectType object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(0);
     WatchStream* ws = get_internal<T, WatchStreamClass<T>>(ctx, object);
     return return_value.set(Value::from_string(ctx, String::from_bson(ws->next_event())));
 }
 
-template<typename T>
+template <typename T>
 class User : public SharedUser {
 public:
-    User(SharedUser user, SharedApp app) : SharedUser(std::move(user)), m_app(std::move(app)) {}
-    User(SharedUser user) : SharedUser(std::move(user)), m_app(nullptr) {}
-    User(User &&) = default;
+    User(SharedUser user, SharedApp app)
+        : SharedUser(std::move(user))
+        , m_app(std::move(app))
+    {
+    }
+    User(SharedUser user)
+        : SharedUser(std::move(user))
+        , m_app(nullptr)
+    {
+    }
+    User(User&&) = default;
 
-    User& operator=(User &&) = default;
+    User& operator=(User&&) = default;
     User& operator=(User const&) = default;
 
     SharedApp m_app;
 };
 
-template<typename T>
+template <typename T>
 class UserClass : public ClassDefinition<T, User<T>> {
     using GlobalContextType = typename T::GlobalContext;
     using ContextType = typename T::Context;
@@ -145,17 +156,17 @@ public:
     static FunctionType create_constructor(ContextType);
     static ObjectType create_instance(ContextType, SharedUser, SharedApp);
 
-    static void get_id(ContextType, ObjectType, ReturnValue &);
-    static void get_identities(ContextType, ObjectType, ReturnValue &);
-    static void get_access_token(ContextType, ObjectType, ReturnValue &);
-    static void get_refresh_token(ContextType, ObjectType, ReturnValue &);
-    static void get_profile(ContextType, ObjectType, ReturnValue &);
-    static void is_logged_in(ContextType, ObjectType, ReturnValue &);
-    static void get_state(ContextType, ObjectType, ReturnValue &);
-    static void get_custom_data(ContextType, ObjectType, ReturnValue &);
-    static void get_api_keys(ContextType, ObjectType, ReturnValue &);
-    static void get_device_id(ContextType, ObjectType, ReturnValue &);
-    static void get_provider_type(ContextType, ObjectType, ReturnValue &);
+    static void get_id(ContextType, ObjectType, ReturnValue&);
+    static void get_identities(ContextType, ObjectType, ReturnValue&);
+    static void get_access_token(ContextType, ObjectType, ReturnValue&);
+    static void get_refresh_token(ContextType, ObjectType, ReturnValue&);
+    static void get_profile(ContextType, ObjectType, ReturnValue&);
+    static void is_logged_in(ContextType, ObjectType, ReturnValue&);
+    static void get_state(ContextType, ObjectType, ReturnValue&);
+    static void get_custom_data(ContextType, ObjectType, ReturnValue&);
+    static void get_api_keys(ContextType, ObjectType, ReturnValue&);
+    static void get_device_id(ContextType, ObjectType, ReturnValue&);
+    static void get_provider_type(ContextType, ObjectType, ReturnValue&);
 
     PropertyMap<T> const properties = {
         {"id", {wrap<get_id>, nullptr}},
@@ -171,8 +182,7 @@ public:
         {"providerType", {wrap<get_provider_type>, nullptr}},
     };
 
-    MethodMap<T> const static_methods = {
-    };
+    MethodMap<T> const static_methods = {};
 
     static void logout(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void session_for_on_disk_path(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -198,8 +208,9 @@ public:
     };
 };
 
-template<typename T>
-inline typename T::Function UserClass<T>::create_constructor(ContextType ctx) {
+template <typename T>
+inline typename T::Function UserClass<T>::create_constructor(ContextType ctx)
+{
     // WatchStream isn't directly nameable from JS, so we don't need to do anything with the returned function object,
     // but we still need to initialize it here.
     ObjectWrap<T, WatchStreamClass<T>>::create_constructor(ctx);
@@ -207,19 +218,22 @@ inline typename T::Function UserClass<T>::create_constructor(ContextType ctx) {
     return ObjectWrap<T, UserClass<T>>::create_constructor(ctx);
 }
 
-template<typename T>
-typename T::Object UserClass<T>::create_instance(ContextType ctx, SharedUser user, SharedApp app) {
+template <typename T>
+typename T::Object UserClass<T>::create_instance(ContextType ctx, SharedUser user, SharedApp app)
+{
     return create_object<T, UserClass<T>>(ctx, new User<T>(std::move(user), std::move(app)));
 }
 
-template<typename T>
-void UserClass<T>::get_id(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_id(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::string id = get_internal<T, UserClass<T>>(ctx, object)->get()->identity();
     return_value.set(id);
 }
 
-template<typename T>
-void UserClass<T>::get_identities(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_identities(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::vector<SyncUserIdentity> identities = get_internal<T, UserClass<T>>(ctx, object)->get()->identities();
 
     std::vector<ValueType> identity_objects;
@@ -232,8 +246,9 @@ void UserClass<T>::get_identities(ContextType ctx, ObjectType object, ReturnValu
     return_value.set(Object::create_array(ctx, identity_objects));
 }
 
-template<typename T>
-void UserClass<T>::get_device_id(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_device_id(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto user = get_internal<T, UserClass<T>>(ctx, object)->get();
     if (user->has_device_id()) {
         return_value.set(user->device_id());
@@ -242,50 +257,56 @@ void UserClass<T>::get_device_id(ContextType ctx, ObjectType object, ReturnValue
     return_value.set_null();
 }
 
-template<typename T>
-void UserClass<T>::get_provider_type(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_provider_type(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::string provider_type = get_internal<T, UserClass<T>>(ctx, object)->get()->provider_type();
     return_value.set(provider_type);
 }
 
-template<typename T>
-void UserClass<T>::get_access_token(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_access_token(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::string token = get_internal<T, UserClass<T>>(ctx, object)->get()->access_token();
     return_value.set(token);
 }
 
-template<typename T>
-void UserClass<T>::get_refresh_token(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_refresh_token(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     std::string token = get_internal<T, UserClass<T>>(ctx, object)->get()->refresh_token();
     return_value.set(token);
 }
 
 
-template<typename T>
-void UserClass<T>::is_logged_in(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::is_logged_in(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto logged_in = get_internal<T, UserClass<T>>(ctx, object)->get()->is_logged_in();
     return_value.set(logged_in);
 }
 
-template<typename T>
-void UserClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_state(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto state = get_internal<T, UserClass<T>>(ctx, object)->get()->state();
 
     switch (state) {
-    case SyncUser::State::LoggedOut:
-        return_value.set("LoggedOut");
-        break;
-    case SyncUser::State::LoggedIn:
-        return_value.set("LoggedIn");
-        break;
-    case SyncUser::State::Removed:
-        return_value.set("Removed");
-        break;
+        case SyncUser::State::LoggedOut:
+            return_value.set("LoggedOut");
+            break;
+        case SyncUser::State::LoggedIn:
+            return_value.set("LoggedIn");
+            break;
+        case SyncUser::State::Removed:
+            return_value.set("Removed");
+            break;
     }
 }
 
-template<typename T>
-void UserClass<T>::get_custom_data(ContextType ctx, ObjectType object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_custom_data(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
     auto custom_data = get_internal<T, UserClass<T>>(ctx, object)->get()->custom_data();
     if (!custom_data)
         return return_value.set_null();
@@ -293,24 +314,25 @@ void UserClass<T>::get_custom_data(ContextType ctx, ObjectType object, ReturnVal
     return_value.set(Value::from_string(ctx, String::from_bson(*custom_data)));
 }
 
-template<typename T>
-void UserClass<T>::get_profile(ContextType ctx, ObjectType object, ReturnValue& return_value) {
-    static const String string_name        = "name";
-    static const String string_email       = "email";
+template <typename T>
+void UserClass<T>::get_profile(ContextType ctx, ObjectType object, ReturnValue& return_value)
+{
+    static const String string_name = "name";
+    static const String string_email = "email";
     static const String string_picture_url = "pictureUrl";
-    static const String string_first_name  = "firstName";
-    static const String string_last_name   = "lastName";
-    static const String string_gender      = "gender";
-    static const String string_birthday    = "birthday";
-    static const String string_min_age     = "minAge";
-    static const String string_max_age     = "maxAge";
+    static const String string_first_name = "firstName";
+    static const String string_last_name = "lastName";
+    static const String string_gender = "gender";
+    static const String string_birthday = "birthday";
+    static const String string_min_age = "minAge";
+    static const String string_max_age = "maxAge";
 
     auto user_profile = get_internal<T, UserClass<T>>(ctx, object)->get()->user_profile();
 
     auto profile_object = Object::create_empty(ctx);
-#define STRING_TO_PROP(propname) \
-    util::Optional<std::string> optional_##propname = user_profile.propname(); \
-    if (optional_##propname ) { \
+#define STRING_TO_PROP(propname)                                                                                     \
+    util::Optional<std::string> optional_##propname = user_profile.propname();                                       \
+    if (optional_##propname) {                                                                                       \
         Object::set_property(ctx, profile_object, string_##propname, Value::from_string(ctx, *optional_##propname)); \
     }
 
@@ -328,8 +350,9 @@ void UserClass<T>::get_profile(ContextType ctx, ObjectType object, ReturnValue& 
     return_value.set(profile_object);
 }
 
-template<typename T>
-void UserClass<T>::logout(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &) {
+template <typename T>
+void UserClass<T>::logout(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue&)
+{
     args.validate_count(1);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
 
@@ -337,66 +360,70 @@ void UserClass<T>::logout(ContextType ctx, ObjectType this_object, Arguments& ar
     user->m_app->log_out(*user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void UserClass<T>::link_credentials(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &) {
+template <typename T>
+void UserClass<T>::link_credentials(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue&)
+{
     args.validate_count(2);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
 
-    auto credentials = *get_internal<T, CredentialsClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "credentials"));
+    auto credentials =
+        *get_internal<T, CredentialsClass<T>>(ctx, Value::validated_to_object(ctx, args[0], "credentials"));
     auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
-    user->m_app->link_user(*user, credentials, Function::wrap_callback_result_first(ctx, this_object, callback,
-        [user] (ContextType ctx, SharedUser shared_user) {
-            REALM_ASSERT_RELEASE(shared_user);
-            return create_object<T, UserClass<T>>(ctx, new User<T>(std::move(shared_user), user->m_app));
-        }));
+    user->m_app->link_user(*user, credentials,
+                           Function::wrap_callback_result_first(
+                               ctx, this_object, callback, [user](ContextType ctx, SharedUser shared_user) {
+                                   REALM_ASSERT_RELEASE(shared_user);
+                                   return create_object<T, UserClass<T>>(
+                                       ctx, new User<T>(std::move(shared_user), user->m_app));
+                               }));
 }
 
-template<typename T>
-void UserClass<T>::call_function(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &) {
+template <typename T>
+void UserClass<T>::call_function(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue&)
+{
     args.validate_count(4);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
 
     auto name = Value::validated_to_string(ctx, args[0], "name");
     auto stringified_ejson_args = Value::validated_to_string(ctx, args[1], "args");
     auto service = Value::is_undefined(ctx, args[2])
-            ? util::none
-            : util::Optional<std::string>(Value::validated_to_string(ctx, args[2], "service"));
+                       ? util::none
+                       : util::Optional<std::string>(Value::validated_to_string(ctx, args[2], "service"));
     auto callback = Value::validated_to_function(ctx, args[3], "callback");
 
     auto bson_args = String::to_bson(stringified_ejson_args);
 
     user->m_app->call_function(
-        *user,
-        name,
-        bson_args.operator const bson::BsonArray&(),
-        service,
+        *user, name, bson_args.operator const bson::BsonArray&(), service,
         Function::wrap_callback_error_first(ctx, this_object, callback,
-            [] (ContextType ctx, const util::Optional<bson::Bson>& result) {
-                REALM_ASSERT_RELEASE(result);
-                return Value::from_string(ctx, String::from_bson(*result));
-            }));
+                                            [](ContextType ctx, const util::Optional<bson::Bson>& result) {
+                                                REALM_ASSERT_RELEASE(result);
+                                                return Value::from_string(ctx, String::from_bson(*result));
+                                            }));
 }
 
-template<typename T>
-void UserClass<T>::get_api_keys(ContextType ctx, ObjectType this_object, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::get_api_keys(ContextType ctx, ObjectType this_object, ReturnValue& return_value)
+{
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
     return_value.set(ApiKeyAuthClass<T>::create_instance(ctx, user->m_app, *user));
 }
 
-template<typename T>
-void UserClass<T>::refresh_custom_data(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::refresh_custom_data(ContextType ctx, ObjectType this_object, Arguments& args,
+                                       ReturnValue& return_value)
+{
     args.validate_count(1);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
     auto callback = Value::validated_to_function(ctx, args[0], "callback");
 
-    user->m_app->refresh_custom_data(
-        *user,
-        Function::wrap_void_callback(ctx, this_object, callback));
+    user->m_app->refresh_custom_data(*user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void UserClass<T>::push_register(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::push_register(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
+{
     args.validate_count(3);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
     auto service = Value::validated_to_string(ctx, args[0], "service");
@@ -404,25 +431,26 @@ void UserClass<T>::push_register(ContextType ctx, ObjectType this_object, Argume
     auto callback = Value::validated_to_function(ctx, args[2], "callback");
 
     user->m_app->push_notification_client(service).register_device(
-        token,
-        *user,
-        Function::wrap_void_callback(ctx, this_object, callback));
+        token, *user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void UserClass<T>::push_deregister(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::push_deregister(ContextType ctx, ObjectType this_object, Arguments& args,
+                                   ReturnValue& return_value)
+{
     args.validate_count(2);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
     auto service = Value::validated_to_string(ctx, args[0], "service");
     auto callback = Value::validated_to_function(ctx, args[1], "callback");
 
     user->m_app->push_notification_client(service).deregister_device(
-        *user,
-        Function::wrap_void_callback(ctx, this_object, callback));
+        *user, Function::wrap_void_callback(ctx, this_object, callback));
 }
 
-template<typename T>
-void UserClass<T>::make_streaming_request(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::make_streaming_request(ContextType ctx, ObjectType this_object, Arguments& args,
+                                          ReturnValue& return_value)
+{
     args.validate_between(2, 3);
     auto user = get_internal<T, UserClass<T>>(ctx, this_object);
 
@@ -431,18 +459,17 @@ void UserClass<T>::make_streaming_request(ContextType ctx, ObjectType this_objec
     auto stringified_ejson_args = Value::validated_to_string(ctx, args[2], "args");
     auto bson_args = String::to_bson(stringified_ejson_args);
 
-    auto req = user->m_app->make_streaming_request(
-        *user,
-        name,
-        bson_args.operator const bson::BsonArray &(),
-        std::string(service));
+    auto req = user->m_app->make_streaming_request(*user, name, bson_args.operator const bson::BsonArray&(),
+                                                   std::string(service));
     return return_value.set(JavaScriptNetworkTransport<T>::makeRequest(ctx, req));
 }
 
-template<typename T>
-void UserClass<T>::new_watch_stream(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue &return_value) {
+template <typename T>
+void UserClass<T>::new_watch_stream(ContextType ctx, ObjectType this_object, Arguments& args,
+                                    ReturnValue& return_value)
+{
     args.validate_count(0);
     return return_value.set(create_object<T, WatchStreamClass<T>>(ctx, new WatchStream()));
 }
-}
-}
+} // namespace js
+} // namespace realm

--- a/src/js_util.hpp
+++ b/src/js_util.hpp
@@ -28,34 +28,34 @@
 namespace realm {
 namespace js {
 
-enum class AggregateFunc {
-    Min,
-    Max,
-    Sum,
-    Avg
-};
+enum class AggregateFunc { Min, Max, Sum, Avg };
 
-template<typename T>
+template <typename T>
 class RealmDelegate;
 
-template<typename T>
-static inline RealmDelegate<T> *get_delegate(realm::Realm *realm) {
-    return static_cast<RealmDelegate<T> *>(realm->m_binding_context.get());
+template <typename T>
+static inline RealmDelegate<T>* get_delegate(realm::Realm* realm)
+{
+    return static_cast<RealmDelegate<T>*>(realm->m_binding_context.get());
 }
 
-static const char *local_string_for_property_type(realm::PropertyType type)
+static const char* local_string_for_property_type(realm::PropertyType type)
 {
     switch (type & ~realm::PropertyType::Flags) {
         // Override naming given by ObjectStore
-        case realm::PropertyType::ObjectId: return "objectId";
-        case realm::PropertyType::Decimal: return "decimal128";
+        case realm::PropertyType::ObjectId:
+            return "objectId";
+        case realm::PropertyType::Decimal:
+            return "decimal128";
 
-        default: return string_for_property_type(type);
+        default:
+            return string_for_property_type(type);
     }
 }
 
-template<typename T>
-static inline T stot(const std::string &s) {
+template <typename T>
+static inline T stot(const std::string& s)
+{
     std::istringstream iss(s);
     T value;
     iss >> value;
@@ -65,7 +65,8 @@ static inline T stot(const std::string &s) {
     return value;
 }
 
-static inline uint32_t validated_positive_index(std::string string) {
+static inline uint32_t validated_positive_index(std::string string)
+{
     int64_t index = stot<int64_t>(string);
     if (index < 0) {
         throw std::out_of_range(std::string("Index ") + string + " cannot be less than zero.");
@@ -76,27 +77,31 @@ static inline uint32_t validated_positive_index(std::string string) {
     return static_cast<uint32_t>(index);
 }
 
-static inline void validate_argument_count(size_t count, size_t expected, const char *message = nullptr) {
+static inline void validate_argument_count(size_t count, size_t expected, const char* message = nullptr)
+{
     if (count != expected) {
         throw std::invalid_argument(message ? message : "Invalid arguments");
     }
 }
 
-static inline void validate_argument_count(size_t count, size_t min, size_t max, const char *message = nullptr) {
+static inline void validate_argument_count(size_t count, size_t min, size_t max, const char* message = nullptr)
+{
     if (count < min || count > max) {
         throw std::invalid_argument(message ? message : "Invalid arguments");
     }
 }
 
-static inline void validate_argument_count_at_least(size_t count, size_t expected, const char *message = nullptr) {
+static inline void validate_argument_count_at_least(size_t count, size_t expected, const char* message = nullptr)
+{
     if (count < expected) {
         throw std::invalid_argument(message ? message : "Invalid arguments");
     }
 }
 
-template<typename T, AggregateFunc func>
+template <typename T, AggregateFunc func>
 void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::ObjectType this_object,
-                                     typename T::Arguments &args, typename T::ReturnValue &return_value) {
+                                     typename T::Arguments& args, typename T::ReturnValue& return_value)
+{
 
     auto list = get_internal<typename T::Type, T>(ctx, this_object);
 
@@ -106,8 +111,8 @@ void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::Ob
         std::string property_name = T::Value::validated_to_string(ctx, args[0]);
         const Property* property = object_schema.property_for_name(property_name);
         if (!property) {
-            throw std::invalid_argument(util::format("Property '%1' does not exist on object '%2'",
-                                                     property_name, object_schema.name));
+            throw std::invalid_argument(
+                util::format("Property '%1' does not exist on object '%2'", property_name, object_schema.name));
         }
         column = property->column_key;
     }
@@ -132,5 +137,5 @@ void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::Ob
     }
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_context.hpp
+++ b/src/jsc/jsc_context.hpp
@@ -23,10 +23,11 @@
 namespace realm {
 namespace js {
 
-template<>
-inline JSGlobalContextRef jsc::Context::get_global_context(JSContextRef ctx) {
+template <>
+inline JSGlobalContextRef jsc::Context::get_global_context(JSContextRef ctx)
+{
     return JSContextGetGlobalContext(ctx);
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_exception.hpp
+++ b/src/jsc/jsc_exception.hpp
@@ -23,11 +23,12 @@
 namespace realm {
 namespace js {
 
-template<>
-inline JSValueRef jsc::Exception::value(JSContextRef ctx, const std::string &message) {
+template <>
+inline JSValueRef jsc::Exception::value(JSContextRef ctx, const std::string& message)
+{
     JSValueRef value = jsc::Value::from_string(ctx, message);
     return JSObjectMakeError(ctx, 1, &value, NULL);
 }
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_function.hpp
+++ b/src/jsc/jsc_function.hpp
@@ -23,8 +23,10 @@
 namespace realm {
 namespace js {
 
-template<>
-inline JSValueRef jsc::Function::call(JSContextRef ctx, const JSObjectRef &function, const JSObjectRef &this_object, size_t argc, const JSValueRef arguments[]) {
+template <>
+inline JSValueRef jsc::Function::call(JSContextRef ctx, const JSObjectRef& function, const JSObjectRef& this_object,
+                                      size_t argc, const JSValueRef arguments[])
+{
     JSValueRef exception = nullptr;
     JSValueRef result = JSObjectCallAsFunction(ctx, function, this_object, argc, arguments, &exception);
     if (exception) {
@@ -33,13 +35,17 @@ inline JSValueRef jsc::Function::call(JSContextRef ctx, const JSObjectRef &funct
     return result;
 }
 
-template<>
-inline JSValueRef jsc::Function::callback(JSContextRef ctx, const JSObjectRef &function, const JSObjectRef &this_object, size_t argc, const JSValueRef arguments[]) {
-   return jsc::Function::call(ctx, function, this_object, argc, arguments);
+template <>
+inline JSValueRef jsc::Function::callback(JSContextRef ctx, const JSObjectRef& function,
+                                          const JSObjectRef& this_object, size_t argc, const JSValueRef arguments[])
+{
+    return jsc::Function::call(ctx, function, this_object, argc, arguments);
 }
 
-template<>
-inline JSObjectRef jsc::Function::construct(JSContextRef ctx, const JSObjectRef &function, size_t argc, const JSValueRef arguments[]) {
+template <>
+inline JSObjectRef jsc::Function::construct(JSContextRef ctx, const JSObjectRef& function, size_t argc,
+                                            const JSValueRef arguments[])
+{
     JSValueRef exception = nullptr;
     JSObjectRef result = JSObjectCallAsConstructor(ctx, function, argc, arguments, &exception);
     if (exception) {
@@ -47,6 +53,6 @@ inline JSObjectRef jsc::Function::construct(JSContextRef ctx, const JSObjectRef 
     }
     return result;
 }
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_init.cpp
+++ b/src/jsc/jsc_init.cpp
@@ -26,23 +26,25 @@
 #include "platform.hpp"
 namespace realm {
 namespace jsc {
-    js::Protected<JSObjectRef> ObjectDefineProperty;
-    js::Protected<JSObjectRef> FunctionPrototype;
-    js::Protected<JSObjectRef> RealmObjectClassConstructor;
-    js::Protected<JSObjectRef> RealmObjectClassConstructorPrototype;
-}
-}
+js::Protected<JSObjectRef> ObjectDefineProperty;
+js::Protected<JSObjectRef> FunctionPrototype;
+js::Protected<JSObjectRef> RealmObjectClassConstructor;
+js::Protected<JSObjectRef> RealmObjectClassConstructorPrototype;
+} // namespace jsc
+} // namespace realm
 
 extern "C" {
 
 using namespace realm;
 using namespace realm::jsc;
 
-JSObjectRef RJSConstructorCreate(JSContextRef ctx) {
+JSObjectRef RJSConstructorCreate(JSContextRef ctx)
+{
     return js::RealmClass<Types>::create_constructor(ctx);
 }
 
-void RJSInitializeInContext(JSContextRef ctx) {
+void RJSInitializeInContext(JSContextRef ctx)
+{
     static const jsc::String realm_string = "Realm";
 
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
@@ -51,10 +53,12 @@ void RJSInitializeInContext(JSContextRef ctx) {
 
     JSObjectRef realm_constructor = RJSConstructorCreate(ctx);
 
-    jsc::Object::set_property(ctx, global_object, realm_string, realm_constructor, js::ReadOnly | js::DontEnum | js::DontDelete);
+    jsc::Object::set_property(ctx, global_object, realm_string, realm_constructor,
+                              js::ReadOnly | js::DontEnum | js::DontDelete);
 }
 
-void RJSInvalidateCaches() {
+void RJSInvalidateCaches()
+{
     // Close all cached Realms
     realm::_impl::RealmCoordinator::clear_all_caches();
     // Clear the Object Store App cache, to prevent instances from using a context that was released

--- a/src/jsc/jsc_object.hpp
+++ b/src/jsc/jsc_object.hpp
@@ -23,8 +23,9 @@
 namespace realm {
 namespace js {
 
-template<>
-inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, const jsc::String &key) {
+template <>
+inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef& object, const jsc::String& key)
+{
     JSValueRef exception = nullptr;
     JSValueRef value = JSObjectGetProperty(ctx, object, key, &exception);
     if (exception) {
@@ -33,13 +34,15 @@ inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef 
     return value;
 }
 
-template<>
-inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, StringData key) {
+template <>
+inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef& object, StringData key)
+{
     return get_property(ctx, object, jsc::String(key));
 }
 
-template<>
-inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef &object, uint32_t index) {
+template <>
+inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef& object, uint32_t index)
+{
     JSValueRef exception = nullptr;
     JSValueRef value = JSObjectGetPropertyAtIndex(ctx, object, index, &exception);
     if (exception) {
@@ -48,8 +51,10 @@ inline JSValueRef jsc::Object::get_property(JSContextRef ctx, const JSObjectRef 
     return value;
 }
 
-template<>
-inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef &object, const jsc::String &key, const JSValueRef &value, PropertyAttributes attributes) {
+template <>
+inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef& object, const jsc::String& key,
+                                      const JSValueRef& value, PropertyAttributes attributes)
+{
     JSValueRef exception = nullptr;
     JSObjectSetProperty(ctx, object, key, value, attributes << 1, &exception);
     if (exception) {
@@ -57,8 +62,9 @@ inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef &object, con
     }
 }
 
-template<>
-inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef &object, uint32_t index, const JSValueRef &value) {
+template <>
+inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef& object, uint32_t index, const JSValueRef& value)
+{
     JSValueRef exception = nullptr;
     JSObjectSetPropertyAtIndex(ctx, object, index, value, &exception);
     if (exception) {
@@ -66,8 +72,9 @@ inline void jsc::Object::set_property(JSContextRef ctx, JSObjectRef &object, uin
     }
 }
 
-template<>
-inline std::vector<jsc::String> jsc::Object::get_property_names(JSContextRef ctx, const JSObjectRef &object) {
+template <>
+inline std::vector<jsc::String> jsc::Object::get_property_names(JSContextRef ctx, const JSObjectRef& object)
+{
     JSPropertyNameArrayRef property_names = JSObjectCopyPropertyNames(ctx, object);
     size_t property_count = JSPropertyNameArrayGetCount(property_names);
 
@@ -82,23 +89,27 @@ inline std::vector<jsc::String> jsc::Object::get_property_names(JSContextRef ctx
     return names;
 }
 
-template<>
-inline JSValueRef jsc::Object::get_prototype(JSContextRef ctx, const JSObjectRef &object) {
+template <>
+inline JSValueRef jsc::Object::get_prototype(JSContextRef ctx, const JSObjectRef& object)
+{
     return JSObjectGetPrototype(ctx, object);
 }
 
-template<>
-inline void jsc::Object::set_prototype(JSContextRef ctx, const JSObjectRef &object, const JSValueRef &prototype) {
+template <>
+inline void jsc::Object::set_prototype(JSContextRef ctx, const JSObjectRef& object, const JSValueRef& prototype)
+{
     JSObjectSetPrototype(ctx, object, prototype);
 }
 
-template<>
-inline JSObjectRef jsc::Object::create_empty(JSContextRef ctx) {
+template <>
+inline JSObjectRef jsc::Object::create_empty(JSContextRef ctx)
+{
     return JSObjectMake(ctx, nullptr, nullptr);
 }
 
-template<>
-inline JSObjectRef jsc::Object::create_array(JSContextRef ctx, uint32_t length, const JSValueRef values[]) {
+template <>
+inline JSObjectRef jsc::Object::create_array(JSContextRef ctx, uint32_t length, const JSValueRef values[])
+{
     JSValueRef exception = nullptr;
     JSObjectRef array = JSObjectMakeArray(ctx, length, values, &exception);
     if (exception) {
@@ -107,65 +118,78 @@ inline JSObjectRef jsc::Object::create_array(JSContextRef ctx, uint32_t length, 
     return array;
 }
 
-template<>
-inline JSObjectRef jsc::Object::create_date(JSContextRef ctx, double time) {
+template <>
+inline JSObjectRef jsc::Object::create_date(JSContextRef ctx, double time)
+{
     JSValueRef number = jsc::Value::from_number(ctx, time);
     return JSObjectMakeDate(ctx, 1, &number, nullptr);
 }
 
-template<>
-template<typename ClassType>
-inline JSObjectRef jsc::Object::create_instance(JSContextRef ctx, typename ClassType::Internal* internal) {
+template <>
+template <typename ClassType>
+inline JSObjectRef jsc::Object::create_instance(JSContextRef ctx, typename ClassType::Internal* internal)
+{
     return jsc::ObjectWrap<ClassType>::create_instance(ctx, internal);
 }
 
-template<>
-template<typename ClassType>
-inline JSObjectRef jsc::Object::create_instance_by_schema(JSContextRef ctx, JSObjectRef& constructor, const realm::ObjectSchema& schema, typename ClassType::Internal* internal) {
-	return jsc::ObjectWrap<ClassType>::create_instance_by_schema(ctx, constructor, schema, internal);
+template <>
+template <typename ClassType>
+inline JSObjectRef jsc::Object::create_instance_by_schema(JSContextRef ctx, JSObjectRef& constructor,
+                                                          const realm::ObjectSchema& schema,
+                                                          typename ClassType::Internal* internal)
+{
+    return jsc::ObjectWrap<ClassType>::create_instance_by_schema(ctx, constructor, schema, internal);
 }
 
-template<>
-template<typename ClassType>
-inline JSObjectRef jsc::Object::create_instance_by_schema(JSContextRef ctx, const realm::ObjectSchema& schema, typename ClassType::Internal* internal) {
-	return jsc::ObjectWrap<ClassType>::create_instance_by_schema(ctx, schema, internal);
+template <>
+template <typename ClassType>
+inline JSObjectRef jsc::Object::create_instance_by_schema(JSContextRef ctx, const realm::ObjectSchema& schema,
+                                                          typename ClassType::Internal* internal)
+{
+    return jsc::ObjectWrap<ClassType>::create_instance_by_schema(ctx, schema, internal);
 }
 
-template<typename ClassType>
-inline void on_context_destroy(JSContextRef ctx, std::string realmPath) {
+template <typename ClassType>
+inline void on_context_destroy(JSContextRef ctx, std::string realmPath)
+{
     jsc::ObjectWrap<ClassType>::on_context_destroy(ctx, realmPath);
 }
 
-template<>
-template<typename ClassType>
-inline bool jsc::Object::is_instance(JSContextRef ctx, const JSObjectRef &object) {
+template <>
+template <typename ClassType>
+inline bool jsc::Object::is_instance(JSContextRef ctx, const JSObjectRef& object)
+{
     return jsc::ObjectWrap<ClassType>::has_instance(ctx, object);
 }
 
-template<>
-template<typename ClassType>
-inline typename ClassType::Internal* jsc::Object::get_internal(JSContextRef ctx, const JSObjectRef &object) {
+template <>
+template <typename ClassType>
+inline typename ClassType::Internal* jsc::Object::get_internal(JSContextRef ctx, const JSObjectRef& object)
+{
     return jsc::ObjectWrap<ClassType>::get_internal(ctx, object);
 }
 
-template<>
-template<typename ClassType>
-inline void jsc::Object::set_internal(JSContextRef ctx, const JSObjectRef &object, typename ClassType::Internal* ptr) {
-    auto wrap = static_cast<jsc::ObjectWrap<ClassType> *>(JSObjectGetPrivate(object));
+template <>
+template <typename ClassType>
+inline void jsc::Object::set_internal(JSContextRef ctx, const JSObjectRef& object, typename ClassType::Internal* ptr)
+{
+    auto wrap = static_cast<jsc::ObjectWrap<ClassType>*>(JSObjectGetPrivate(object));
     *wrap = ptr;
 }
 
-template<>
-inline void jsc::Object::set_global(JSContextRef ctx, const jsc::String &key, const JSValueRef &value) {
+template <>
+inline void jsc::Object::set_global(JSContextRef ctx, const jsc::String& key, const JSValueRef& value)
+{
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
     jsc::Object::set_property(ctx, global_object, key, value, js::ReadOnly | js::DontEnum | js::DontDelete);
 }
 
-template<>
-inline JSValueRef jsc::Object::get_global(JSContextRef ctx, const jsc::String &key) {
+template <>
+inline JSValueRef jsc::Object::get_global(JSContextRef ctx, const jsc::String& key)
+{
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
     return jsc::Object::get_property(ctx, global_object, key);
 }
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_protected.hpp
+++ b/src/jsc/jsc_protected.hpp
@@ -23,60 +23,84 @@
 namespace realm {
 namespace js {
 
-template<>
+template <>
 class Protected<JSGlobalContextRef> {
     JSGlobalContextRef m_context;
 
-  public:
-    Protected() : m_context(nullptr) {}
-    Protected(const Protected<JSGlobalContextRef> &other) : Protected(other.m_context) {}
-    Protected(Protected<JSGlobalContextRef> &&other) : m_context(other.m_context) {
+public:
+    Protected()
+        : m_context(nullptr)
+    {
+    }
+    Protected(const Protected<JSGlobalContextRef>& other)
+        : Protected(other.m_context)
+    {
+    }
+    Protected(Protected<JSGlobalContextRef>&& other)
+        : m_context(other.m_context)
+    {
         other.m_context = nullptr;
     }
-    explicit Protected(JSGlobalContextRef ctx) : m_context(ctx) {
+    explicit Protected(JSGlobalContextRef ctx)
+        : m_context(ctx)
+    {
         JSGlobalContextRetain(m_context);
     }
-    ~Protected() {
+    ~Protected()
+    {
         if (m_context) {
             JSGlobalContextRelease(m_context);
         }
     }
-    operator JSGlobalContextRef() const {
+    operator JSGlobalContextRef() const
+    {
         return m_context;
     }
-    operator bool() const {
+    operator bool() const
+    {
         return m_context != nullptr;
     }
-    
+
     struct Comparator {
-        bool operator() (const Protected<JSGlobalContextRef>& a, const Protected<JSGlobalContextRef>& b) const {
+        bool operator()(const Protected<JSGlobalContextRef>& a, const Protected<JSGlobalContextRef>& b) const
+        {
             return a.m_context == b.m_context;
         }
     };
 };
 
-template<>
+template <>
 class Protected<JSValueRef> {
-  protected:
+protected:
     JSGlobalContextRef m_context = nullptr;
     JSValueRef m_value = nullptr;
 
-  public:
+public:
     Protected() {}
 
-    Protected(const Protected<JSValueRef> &other) : Protected(other.m_context, other.m_value) {}
-    
-    Protected(Protected<JSValueRef> &&other) : m_context(other.m_context), m_value(other.m_value) {
+    Protected(const Protected<JSValueRef>& other)
+        : Protected(other.m_context, other.m_value)
+    {
+    }
+
+    Protected(Protected<JSValueRef>&& other)
+        : m_context(other.m_context)
+        , m_value(other.m_value)
+    {
         other.m_context = nullptr;
         other.m_value = nullptr;
     }
 
-    Protected(JSContextRef ctx, JSValueRef value) : m_context(JSContextGetGlobalContext(ctx)), m_value(value) {
+    Protected(JSContextRef ctx, JSValueRef value)
+        : m_context(JSContextGetGlobalContext(ctx))
+        , m_value(value)
+    {
         JSGlobalContextRetain(m_context);
         JSValueProtect(m_context, m_value);
     }
 
-    ~Protected() {
+    ~Protected()
+    {
         if (m_value) {
             JSValueUnprotect(m_context, m_value);
         }
@@ -85,48 +109,66 @@ class Protected<JSValueRef> {
             JSGlobalContextRelease(m_context);
         }
     }
-    operator JSValueRef() const {
+    operator JSValueRef() const
+    {
         return m_value;
     }
-    operator bool() const {
+    operator bool() const
+    {
         return m_value != nullptr;
     }
-    
+
     struct Comparator {
-        bool operator() (const Protected<JSValueRef>& a, const Protected<JSValueRef>& b) const {
+        bool operator()(const Protected<JSValueRef>& a, const Protected<JSValueRef>& b) const
+        {
             if (a.m_context != b.m_context) {
                 return false;
             }
             return JSValueIsStrictEqual(a.m_context, a.m_value, b.m_value);
         }
     };
-    
-    Protected<JSValueRef>& operator=(Protected<JSValueRef> other) {
+
+    Protected<JSValueRef>& operator=(Protected<JSValueRef> other)
+    {
         std::swap(m_context, other.m_context);
         std::swap(m_value, other.m_value);
         return *this;
     }
 };
 
-template<>
+template <>
 class Protected<JSObjectRef> : public Protected<JSValueRef> {
-  public:
-    Protected() : Protected<JSValueRef>() {}
-    Protected(const Protected<JSObjectRef> &other) : Protected<JSValueRef>(other) {}
-    Protected(Protected<JSObjectRef> &&other) : Protected<JSValueRef>(std::move(other)) {}
-    Protected(JSContextRef ctx, JSObjectRef value) : Protected<JSValueRef>(ctx, value) {}
+public:
+    Protected()
+        : Protected<JSValueRef>()
+    {
+    }
+    Protected(const Protected<JSObjectRef>& other)
+        : Protected<JSValueRef>(other)
+    {
+    }
+    Protected(Protected<JSObjectRef>&& other)
+        : Protected<JSValueRef>(std::move(other))
+    {
+    }
+    Protected(JSContextRef ctx, JSObjectRef value)
+        : Protected<JSValueRef>(ctx, value)
+    {
+    }
 
-    operator JSObjectRef() const {
+    operator JSObjectRef() const
+    {
         JSValueRef value = static_cast<JSValueRef>(*this);
         return (JSObjectRef)value;
     }
-    
-    Protected<JSObjectRef>& operator=(Protected<JSObjectRef> other) {
+
+    Protected<JSObjectRef>& operator=(Protected<JSObjectRef> other)
+    {
         std::swap(m_context, other.m_context);
         std::swap(m_value, other.m_value);
         return *this;
     }
 };
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_return_value.hpp
+++ b/src/jsc/jsc_return_value.hpp
@@ -24,47 +24,61 @@
 namespace realm {
 namespace js {
 
-template<>
+template <>
 class ReturnValue<jsc::Types> {
     const JSContextRef m_context;
     JSValueRef m_value = nullptr;
 
-  public:
-    ReturnValue(JSContextRef ctx) : m_context(ctx) {}
+public:
+    ReturnValue(JSContextRef ctx)
+        : m_context(ctx)
+    {
+    }
 
-    void set(const JSValueRef &value) {
+    void set(const JSValueRef& value)
+    {
         m_value = value;
     }
-    void set(const std::string &string) {
+    void set(const std::string& string)
+    {
         m_value = JSValueMakeString(m_context, jsc::String(string));
     }
-    void set(const char *string) {
+    void set(const char* string)
+    {
         m_value = JSValueMakeString(m_context, jsc::String(string));
     }
-    void set(bool boolean) {
+    void set(bool boolean)
+    {
         m_value = JSValueMakeBoolean(m_context, boolean);
     }
-    void set(double number) {
+    void set(double number)
+    {
         m_value = JSValueMakeNumber(m_context, number);
     }
-    void set(int32_t number) {
+    void set(int32_t number)
+    {
         m_value = JSValueMakeNumber(m_context, number);
     }
-    void set(uint32_t number) {
+    void set(uint32_t number)
+    {
         m_value = JSValueMakeNumber(m_context, number);
     }
-    void set(realm::Mixed mixed) {
+    void set(realm::Mixed mixed)
+    {
         m_value = Value<jsc::Types>::from_mixed(m_context, nullptr, mixed);
     }
-    void set_null() {
+    void set_null()
+    {
         m_value = JSValueMakeNull(m_context);
     }
-    void set_undefined() {
+    void set_undefined()
+    {
         m_value = JSValueMakeUndefined(m_context);
     }
 
-    template<typename T>
-    void set(const util::Optional<T>& value) {
+    template <typename T>
+    void set(const util::Optional<T>& value)
+    {
         if (value) {
             set(*value);
         }
@@ -73,10 +87,11 @@ class ReturnValue<jsc::Types> {
         }
     }
 
-    operator JSValueRef() const {
+    operator JSValueRef() const
+    {
         return m_value;
     }
 };
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_rpc_network_transport.hpp
+++ b/src/jsc/jsc_rpc_network_transport.hpp
@@ -33,8 +33,9 @@ struct RPCFetchRef {
 */
 
 /**
- * Provides an implementation of GenericNetworkTransport for use when the library is loaded in a runtime which doesn't provide the APIs required to perform network requests directly.
- * Instead it uses the RPC server to ask the RPC client to perform network requests on its behalf.
+ * Provides an implementation of GenericNetworkTransport for use when the library is loaded in a runtime which doesn't
+ * provide the APIs required to perform network requests directly. Instead it uses the RPC server to ask the RPC
+ * client to perform network requests on its behalf.
  */
 struct RPCNetworkTransport : public app::GenericNetworkTransport {
     using T = jsc::Types;
@@ -47,25 +48,32 @@ struct RPCNetworkTransport : public app::GenericNetworkTransport {
     using Value = js::Value<T>;
     using Function = js::Function<T>;
 
-    using SendRequestHandler = void(ContextType m_ctx, const app::Request request, std::function<void(const app::Response)> completion_callback);
-    
+    using SendRequestHandler = void(ContextType m_ctx, const app::Request request,
+                                    std::function<void(const app::Response)> completion_callback);
+
     static inline js::Protected<FunctionType> fetch_function;
 
-    RPCNetworkTransport(ContextType ctx) : m_ctx(ctx) {}
+    RPCNetworkTransport(ContextType ctx)
+        : m_ctx(ctx)
+    {
+    }
 
-    void send_request_to_server(const app::Request request, std::function<void(const app::Response)> completion_callback) override {
+    void send_request_to_server(const app::Request request,
+                                std::function<void(const app::Response)> completion_callback) override
+    {
         // Build up a JS request object
         auto request_object = js::JavaScriptNetworkTransport<T>::makeRequest(m_ctx, request);
         // Ask the RPC layer to enqueue a call to the client-side fetch function
-        Function::call(m_ctx, fetch_function, nullptr, {
-            request_object,
-            js::ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
-        });
+        Function::call(m_ctx, fetch_function, nullptr,
+                       {
+                           request_object,
+                           js::ResponseHandlerClass<T>::create_instance(m_ctx, std::move(completion_callback)),
+                       });
     }
 
 private:
     ContextType m_ctx;
 };
 
-}
-}
+} // namespace rpc
+} // namespace realm

--- a/src/jsc/jsc_string.hpp
+++ b/src/jsc/jsc_string.hpp
@@ -23,39 +23,61 @@
 namespace realm {
 namespace js {
 
-template<>
+template <>
 class String<jsc::Types> {
     using StringType = String<jsc::Types>;
 
     JSStringRef m_str;
 
-  public:
-    static bson::Bson to_bson(StringType stringified_ejson) {
+public:
+    static bson::Bson to_bson(StringType stringified_ejson)
+    {
         return bson::parse(std::string(stringified_ejson));
     }
 
-    static String from_bson(const bson::Bson& bson) {
+    static String from_bson(const bson::Bson& bson)
+    {
         return String(bson.to_string());
     }
 
-    String(const char *s) : m_str(JSStringCreateWithUTF8CString(s)) {}
-    String(const JSStringRef &s) : m_str(JSStringRetain(s)) {}
-    String(StringData str) : String(str.data()) {}
-    String(const std::string& str) : String(str.c_str()) {}
-    String(const StringType &o) : String(o.m_str) {}
-    String(StringType &&o) : m_str(o.m_str) {
+    String(const char* s)
+        : m_str(JSStringCreateWithUTF8CString(s))
+    {
+    }
+    String(const JSStringRef& s)
+        : m_str(JSStringRetain(s))
+    {
+    }
+    String(StringData str)
+        : String(str.data())
+    {
+    }
+    String(const std::string& str)
+        : String(str.c_str())
+    {
+    }
+    String(const StringType& o)
+        : String(o.m_str)
+    {
+    }
+    String(StringType&& o)
+        : m_str(o.m_str)
+    {
         o.m_str = nullptr;
     }
-    ~String() {
+    ~String()
+    {
         if (m_str) {
             JSStringRelease(m_str);
         }
     }
 
-    operator JSStringRef() const {
+    operator JSStringRef() const
+    {
         return m_str;
     }
-    operator std::string() const {
+    operator std::string() const
+    {
         size_t max_size = JSStringGetMaximumUTF8CStringSize(m_str);
         std::string string;
         string.resize(max_size);
@@ -63,6 +85,6 @@ class String<jsc::Types> {
         return string;
     }
 };
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/jsc/jsc_types.hpp
+++ b/src/jsc/jsc_types.hpp
@@ -49,7 +49,7 @@ struct Types {
     using StringPropertyEnumeratorCallback = JSObjectGetPropertyNamesCallback;
 };
 
-template<typename ClassType>
+template <typename ClassType>
 class ObjectWrap;
 
 using String = js::String<Types>;
@@ -60,5 +60,5 @@ using Object = js::Object<Types>;
 using Exception = js::Exception<Types>;
 using ReturnValue = js::ReturnValue<Types>;
 
-} // jsc
-} // realm
+} // namespace jsc
+} // namespace realm

--- a/src/jsc/jsc_value.cpp
+++ b/src/jsc/jsc_value.cpp
@@ -24,8 +24,8 @@
 namespace realm {
 namespace js {
 
-template<>
-bool jsc::Value::is_binary(JSContextRef ctx, const JSValueRef &value)
+template <>
+bool jsc::Value::is_binary(JSContextRef ctx, const JSValueRef& value)
 {
     static jsc::String s_array_buffer = "ArrayBuffer";
     static jsc::String s_is_view = "isView";
@@ -46,7 +46,7 @@ bool jsc::Value::is_binary(JSContextRef ctx, const JSValueRef &value)
     return false;
 }
 
-template<>
+template <>
 JSValueRef jsc::Value::from_nonnull_binary(JSContextRef ctx, BinaryData data)
 {
     static jsc::String s_buffer = "buffer";
@@ -54,7 +54,8 @@ JSValueRef jsc::Value::from_nonnull_binary(JSContextRef ctx, BinaryData data)
 
     size_t byte_count = data.size();
     JSValueRef byte_count_value = jsc::Value::from_number(ctx, byte_count);
-    JSObjectRef uint8_array_constructor = jsc::Object::validated_get_constructor(ctx, JSContextGetGlobalObject(ctx), s_uint8_array);
+    JSObjectRef uint8_array_constructor =
+        jsc::Object::validated_get_constructor(ctx, JSContextGetGlobalObject(ctx), s_uint8_array);
     JSObjectRef uint8_array = jsc::Function::construct(ctx, uint8_array_constructor, 1, &byte_count_value);
 
     for (uint32_t i = 0; i < byte_count; i++) {
@@ -65,7 +66,7 @@ JSValueRef jsc::Value::from_nonnull_binary(JSContextRef ctx, BinaryData data)
     return jsc::Object::validated_get_object(ctx, uint8_array, s_buffer);
 }
 
-template<>
+template <>
 JSValueRef jsc::Value::from_decimal128(JSContextRef ctx, const Decimal128& value)
 {
     static jsc::String s_realm = "Realm";
@@ -80,12 +81,12 @@ JSValueRef jsc::Value::from_decimal128(JSContextRef ctx, const Decimal128& value
     JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(ctx, global_object, s_realm);
     JSObjectRef decimal_constructor = jsc::Object::validated_get_constructor(ctx, realm_constructor, s_decimal);
 
-    std::array<JSValueRef, 1> args = { {jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string()))} };
+    std::array<JSValueRef, 1> args = {{jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string()))}};
 
     return jsc::Object::call_method(ctx, decimal_constructor, s_from_string, args.size(), args.data());
 }
 
-template<>
+template <>
 JSValueRef jsc::Value::from_object_id(JSContextRef ctx, const ObjectId& value)
 {
     static jsc::String s_realm = "Realm";
@@ -95,11 +96,11 @@ JSValueRef jsc::Value::from_object_id(JSContextRef ctx, const ObjectId& value)
     JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(ctx, global_object, s_realm);
     JSObjectRef object_id_constructor = jsc::Object::validated_get_constructor(ctx, realm_constructor, s_object_id);
 
-    std::array<JSValueRef, 1> args { {jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string())) } };
+    std::array<JSValueRef, 1> args{{jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string()))}};
     return jsc::Function::construct(ctx, object_id_constructor, args.size(), args.data());
 }
 
-template<>
+template <>
 JSValueRef jsc::Value::from_uuid(JSContextRef ctx, const UUID& value)
 {
     static jsc::String s_realm = "Realm";
@@ -109,12 +110,12 @@ JSValueRef jsc::Value::from_uuid(JSContextRef ctx, const UUID& value)
     JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(ctx, global_object, s_realm);
     JSObjectRef uuid_constructor = jsc::Object::validated_get_constructor(ctx, realm_constructor, s_uuid);
 
-    std::array<JSValueRef, 1> args { {jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string())) } };
+    std::array<JSValueRef, 1> args{{jsc::Value::from_nonnull_string(ctx, jsc::String(value.to_string()))}};
     return jsc::Function::construct(ctx, uuid_constructor, args.size(), args.data());
 }
 
-template<>
-OwnedBinaryData jsc::Value::to_binary(JSContextRef ctx, const JSValueRef &value)
+template <>
+OwnedBinaryData jsc::Value::to_binary(JSContextRef ctx, const JSValueRef& value)
 {
     static jsc::String s_array_buffer = "ArrayBuffer";
     static jsc::String s_buffer = "buffer";
@@ -150,7 +151,8 @@ OwnedBinaryData jsc::Value::to_binary(JSContextRef ctx, const JSValueRef &value)
         throw std::runtime_error("Can only convert ArrayBuffer and TypedArray objects to binary");
     }
 
-    JSObjectRef uint8_array = jsc::Function::construct(ctx, uint8_array_constructor, uint8_array_argc, uint8_array_arguments);
+    JSObjectRef uint8_array =
+        jsc::Function::construct(ctx, uint8_array_constructor, uint8_array_argc, uint8_array_arguments);
     uint32_t byte_count = jsc::Object::validated_get_length(ctx, uint8_array);
     auto buffer = std::make_unique<char[]>(byte_count);
 
@@ -162,7 +164,7 @@ OwnedBinaryData jsc::Value::to_binary(JSContextRef ctx, const JSValueRef &value)
     return OwnedBinaryData(std::move(buffer), byte_count);
 }
 
-template<>
+template <>
 Decimal128 jsc::Value::to_decimal128(JSContextRef ctx, const JSValueRef& value)
 {
     auto object = to_object(ctx, value);
@@ -175,13 +177,14 @@ Decimal128 jsc::Value::to_decimal128(JSContextRef ctx, const JSValueRef& value)
         JSValueRef as_string = jsc::Object::call_method(ctx, to_object(ctx, value), s_to_string, 0, args);
         std::string str = to_string(ctx, as_string);
         return Decimal128(StringData(str));
-    } else {
+    }
+    else {
         std::string str = to_string(ctx, ejson_property);
         return Decimal128(StringData(str));
     }
 }
 
-template<>
+template <>
 ObjectId jsc::Value::to_object_id(JSContextRef ctx, const JSValueRef& value)
 {
     auto object = to_object(ctx, value);
@@ -193,12 +196,13 @@ ObjectId jsc::Value::to_object_id(JSContextRef ctx, const JSValueRef& value)
         JSValueRef args[] = {};
         JSValueRef as_string = jsc::Object::call_method(ctx, to_object(ctx, value), s_to_hex_string, 0, args);
         return ObjectId(std::string(to_string(ctx, as_string)).c_str());
-    } else {
+    }
+    else {
         return ObjectId(std::string(to_string(ctx, ejson_property)).c_str());
     }
 }
 
-template<>
+template <>
 UUID jsc::Value::to_uuid(JSContextRef ctx, const JSValueRef& value)
 {
     auto object = to_object(ctx, value);
@@ -210,7 +214,8 @@ UUID jsc::Value::to_uuid(JSContextRef ctx, const JSValueRef& value)
         JSValueRef args[] = {};
         JSValueRef as_string = jsc::Object::call_method(ctx, to_object(ctx, value), s_to_hex_string, 0, args);
         return UUID(std::string(to_string(ctx, as_string)).c_str());
-    } else {
+    }
+    else {
         return UUID(std::string(to_string(ctx, ejson_property)).c_str());
     }
 }

--- a/src/jsc/jsc_value.hpp
+++ b/src/jsc/jsc_value.hpp
@@ -25,7 +25,8 @@
 namespace realm {
 namespace js {
 
-static inline bool is_object_of_type(JSContextRef ctx, JSValueRef value, jsc::String type) {
+static inline bool is_object_of_type(JSContextRef ctx, JSValueRef value, jsc::String type)
+{
     JSObjectRef global_object = JSContextGetGlobalObject(ctx);
     JSValueRef exception = nullptr;
     JSValueRef constructor = JSObjectGetProperty(ctx, global_object, type, &exception);
@@ -33,7 +34,8 @@ static inline bool is_object_of_type(JSContextRef ctx, JSValueRef value, jsc::St
         throw jsc::Exception(ctx, exception);
     }
 
-    bool result = JSValueIsInstanceOfConstructor(ctx, value, jsc::Value::validated_to_constructor(ctx, constructor), &exception);
+    bool result = JSValueIsInstanceOfConstructor(ctx, value, jsc::Value::validated_to_constructor(ctx, constructor),
+                                                 &exception);
     if (exception) {
         throw jsc::Exception(ctx, exception);
     }
@@ -41,95 +43,117 @@ static inline bool is_object_of_type(JSContextRef ctx, JSValueRef value, jsc::St
     return result;
 }
 
-template<>
-inline const char *jsc::Value::typeof(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline const char* jsc::Value::typeof(JSContextRef ctx, const JSValueRef& value)
+{
     switch (JSValueGetType(ctx, value)) {
-        case kJSTypeNull: return "null";
-        case kJSTypeNumber: return "number";
-        case kJSTypeObject: return "object";
-        case kJSTypeString: return "string";
-        case kJSTypeBoolean: return "boolean";
-        case kJSTypeUndefined: return "undefined";
-        #if defined __IPHONE_12_2 || defined __MAC_10_14_4
-            case kJSTypeSymbol: return "symbol";
-        #endif
+        case kJSTypeNull:
+            return "null";
+        case kJSTypeNumber:
+            return "number";
+        case kJSTypeObject:
+            return "object";
+        case kJSTypeString:
+            return "string";
+        case kJSTypeBoolean:
+            return "boolean";
+        case kJSTypeUndefined:
+            return "undefined";
+#if defined __IPHONE_12_2 || defined __MAC_10_14_4
+        case kJSTypeSymbol:
+            return "symbol";
+#endif
     }
 }
 
-template<>
-inline bool jsc::Value::is_array(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_array(JSContextRef ctx, const JSValueRef& value)
+{
     // JSValueIsArray() is not available until iOS 9.
     static const jsc::String type = "Array";
     return is_object_of_type(ctx, value, type);
 }
 
-template<>
-inline bool jsc::Value::is_array_buffer(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_array_buffer(JSContextRef ctx, const JSValueRef& value)
+{
     static const jsc::String type = "ArrayBuffer";
     return is_object_of_type(ctx, value, type);
 }
 
-template<>
-inline bool jsc::Value::is_date(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_date(JSContextRef ctx, const JSValueRef& value)
+{
     static const jsc::String type = "Date";
     return is_object_of_type(ctx, value, type);
 }
 
-template<>
-inline bool jsc::Value::is_boolean(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_boolean(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsBoolean(ctx, value);
 }
 
-template<>
-inline bool jsc::Value::is_constructor(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_constructor(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsObject(ctx, value) && JSObjectIsConstructor(ctx, (JSObjectRef)value);
 }
 
-template<>
-inline bool jsc::Value::is_error(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_error(JSContextRef ctx, const JSValueRef& value)
+{
     static const jsc::String type = "Error";
     return is_object_of_type(ctx, value, type);
 }
 
-template<>
-inline bool jsc::Value::is_function(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_function(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsObject(ctx, value) && JSObjectIsFunction(ctx, (JSObjectRef)value);
 }
 
-template<>
-inline bool jsc::Value::is_null(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_null(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsNull(ctx, value);
 }
 
-template<>
-inline bool jsc::Value::is_number(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_number(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsNumber(ctx, value);
 }
 
-template<>
-inline bool jsc::Value::is_object(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_object(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsObject(ctx, value);
 }
 
-template<>
-inline bool jsc::Value::is_string(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_string(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsString(ctx, value);
 }
 
-template<>
-bool jsc::Value::is_binary(JSContextRef ctx, const JSValueRef &value);
+template <>
+bool jsc::Value::is_binary(JSContextRef ctx, const JSValueRef& value);
 
-template<>
-inline bool jsc::Value::is_undefined(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_undefined(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueIsUndefined(ctx, value);
 }
 
-template<>
-inline bool jsc::Value::is_valid(const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_valid(const JSValueRef& value)
+{
     return value != nullptr;
 }
 
-inline bool is_bson_type(JSContextRef ctx, const JSValueRef &value, std::string type) {
+inline bool is_bson_type(JSContextRef ctx, const JSValueRef& value, std::string type)
+{
     if (JSValueIsNull(ctx, value) || JSValueIsUndefined(ctx, value) || !JSValueIsObject(ctx, value)) {
         return false;
     }
@@ -161,9 +185,11 @@ inline bool is_bson_type(JSContextRef ctx, const JSValueRef &value, std::string 
 }
 
 /**
- * Checks if a `value` is an EJSON representation of a particular type (determined by the existance of a particular property).
+ * Checks if a `value` is an EJSON representation of a particular type (determined by the existance of a particular
+ * property).
  */
-inline bool is_ejson_type(JSContextRef ctx, const JSValueRef &value, std::string property_name) {
+inline bool is_ejson_type(JSContextRef ctx, const JSValueRef& value, std::string property_name)
+{
     if (JSValueIsNull(ctx, value) || JSValueIsUndefined(ctx, value) || !JSValueIsObject(ctx, value)) {
         return false;
     }
@@ -183,65 +209,75 @@ inline bool is_ejson_type(JSContextRef ctx, const JSValueRef &value, std::string
     return JSValueIsUndefined(ctx, property) == false;
 }
 
-template<>
-inline bool jsc::Value::is_decimal128(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_decimal128(JSContextRef ctx, const JSValueRef& value)
+{
     return is_bson_type(ctx, value, "Decimal128") || is_ejson_type(ctx, value, "$numberDecimal");
 }
 
-template<>
-inline bool jsc::Value::is_object_id(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_object_id(JSContextRef ctx, const JSValueRef& value)
+{
     return is_bson_type(ctx, value, "ObjectID") || is_ejson_type(ctx, value, "$oid");
 }
 
-template<>
-inline bool jsc::Value::is_uuid(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::is_uuid(JSContextRef ctx, const JSValueRef& value)
+{
     // TODO: is_ejson_type won't work for binary EJSON
     return is_bson_type(ctx, value, "UUID") || is_ejson_type(ctx, value, "$uuid");
 }
 
-template<>
-inline JSValueRef jsc::Value::from_boolean(JSContextRef ctx, bool boolean) {
+template <>
+inline JSValueRef jsc::Value::from_boolean(JSContextRef ctx, bool boolean)
+{
     return JSValueMakeBoolean(ctx, boolean);
 }
 
-template<>
-inline JSValueRef jsc::Value::from_null(JSContextRef ctx) {
+template <>
+inline JSValueRef jsc::Value::from_null(JSContextRef ctx)
+{
     return JSValueMakeNull(ctx);
 }
 
-template<>
-inline JSValueRef jsc::Value::from_number(JSContextRef ctx, double number) {
+template <>
+inline JSValueRef jsc::Value::from_number(JSContextRef ctx, double number)
+{
     return JSValueMakeNumber(ctx, number);
 }
 
-template<>
-inline JSValueRef jsc::Value::from_nonnull_string(JSContextRef ctx, const jsc::String &string) {
+template <>
+inline JSValueRef jsc::Value::from_nonnull_string(JSContextRef ctx, const jsc::String& string)
+{
     return JSValueMakeString(ctx, string);
 }
 
-template<>
-inline JSValueRef jsc::Value::from_undefined(JSContextRef ctx) {
+template <>
+inline JSValueRef jsc::Value::from_undefined(JSContextRef ctx)
+{
     return JSValueMakeUndefined(ctx);
 }
 
-template<>
+template <>
 JSValueRef jsc::Value::from_nonnull_binary(JSContextRef ctx, BinaryData data);
 
-template<>
+template <>
 JSValueRef jsc::Value::from_decimal128(JSContextRef ctx, const Decimal128& value);
 
-template<>
+template <>
 JSValueRef jsc::Value::from_object_id(JSContextRef ctx, const ObjectId& value);
 
-template<>
+template <>
 JSValueRef jsc::Value::from_uuid(JSContextRef ctx, const UUID& value);
 
-template<>
-inline bool jsc::Value::to_boolean(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline bool jsc::Value::to_boolean(JSContextRef ctx, const JSValueRef& value)
+{
     return JSValueToBoolean(ctx, value);
 }
-template<>
-inline jsc::String jsc::Value::to_string(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline jsc::String jsc::Value::to_string(JSContextRef ctx, const JSValueRef& value)
+{
     JSValueRef exception = nullptr;
     jsc::String string = JSValueToStringCopy(ctx, value, &exception);
 
@@ -254,23 +290,25 @@ inline jsc::String jsc::Value::to_string(JSContextRef ctx, const JSValueRef &val
     return string;
 }
 
-template<>
-inline double jsc::Value::to_number(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline double jsc::Value::to_number(JSContextRef ctx, const JSValueRef& value)
+{
     JSValueRef exception = nullptr;
     double number = JSValueToNumber(ctx, value, &exception);
     if (exception) {
         throw jsc::Exception(ctx, exception);
     }
     if (isnan(number)) {
-        throw std::invalid_argument(util::format("Value '%1' not convertible to a number.",
-                                                 (std::string)to_string(ctx, value)));
+        throw std::invalid_argument(
+            util::format("Value '%1' not convertible to a number.", (std::string)to_string(ctx, value)));
     }
     return number;
 }
 
 
-template<>
-inline JSObjectRef jsc::Value::to_object(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline JSObjectRef jsc::Value::to_object(JSContextRef ctx, const JSValueRef& value)
+{
     JSValueRef exception = nullptr;
     JSObjectRef object = JSValueToObject(ctx, value, &exception);
     if (exception) {
@@ -279,46 +317,51 @@ inline JSObjectRef jsc::Value::to_object(JSContextRef ctx, const JSValueRef &val
     return object;
 }
 
-template<>
-inline JSObjectRef jsc::Value::to_array(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline JSObjectRef jsc::Value::to_array(JSContextRef ctx, const JSValueRef& value)
+{
     return to_object(ctx, value);
 }
 
-template<>
-inline JSObjectRef jsc::Value::to_constructor(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline JSObjectRef jsc::Value::to_constructor(JSContextRef ctx, const JSValueRef& value)
+{
     return to_object(ctx, value);
 }
 
-template<>
-inline JSObjectRef jsc::Value::to_date(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline JSObjectRef jsc::Value::to_date(JSContextRef ctx, const JSValueRef& value)
+{
     if (JSValueIsString(ctx, value)) {
         JSValueRef error;
-        std::array<JSValueRef, 1> args { value };
+        std::array<JSValueRef, 1> args{value};
         if (JSObjectRef result = JSObjectMakeDate(ctx, args.size(), args.data(), &error)) {
             return result;
-        } else {
+        }
+        else {
             throw jsc::Exception(ctx, error);
         }
     }
     return to_object(ctx, value);
 }
 
-template<>
-inline JSObjectRef jsc::Value::to_function(JSContextRef ctx, const JSValueRef &value) {
+template <>
+inline JSObjectRef jsc::Value::to_function(JSContextRef ctx, const JSValueRef& value)
+{
     return to_object(ctx, value);
 }
 
-template<>
+template <>
 OwnedBinaryData jsc::Value::to_binary(JSContextRef ctx, const JSValueRef& value);
 
-template<>
+template <>
 Decimal128 jsc::Value::to_decimal128(JSContextRef ctx, const JSValueRef& value);
 
-template<>
+template <>
 ObjectId jsc::Value::to_object_id(JSContextRef ctx, const JSValueRef& value);
 
-template<>
+template <>
 UUID jsc::Value::to_uuid(JSContextRef ctx, const JSValueRef& value);
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/jsc/rpc.hpp
+++ b/src/jsc/rpc.hpp
@@ -26,14 +26,15 @@ namespace rpc {
 
 class RPCServerImpl;
 class RPCServer {
-  public:
+public:
     RPCServer();
     ~RPCServer();
     std::string perform_request(std::string const& name, std::string const& json_args);
     bool try_run_task();
-  private:
+
+private:
     std::unique_ptr<RPCServerImpl> m_impl;
 };
 
-} // rpc
-} // realm
+} // namespace rpc
+} // namespace realm

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -33,19 +33,19 @@
 #include <unordered_map>
 #include <exception>
 
-//forward declare the types for gcc to compile correctly
+// forward declare the types for gcc to compile correctly
 namespace realm {
-	namespace js {
-		template<typename T>
-		struct RealmObjectClass;
-		
-		template<typename T>
-		class RealmClass;
-	}
-	namespace node {
-		struct Types;
-	}
+namespace js {
+template <typename T>
+struct RealmObjectClass;
+
+template <typename T>
+class RealmClass;
+} // namespace js
+namespace node {
+struct Types;
 }
+} // namespace realm
 
 namespace realm {
 namespace node {
@@ -57,30 +57,38 @@ Napi::FunctionReference GlobalProxy;
 Napi::FunctionReference FunctionBind;
 Napi::FunctionReference RealmClassConstructor;
 
-static void node_class_init(Napi::Env env) {
-	auto setPrototypeOf = env.Global().Get("Object").As<Napi::Object>().Get("setPrototypeOf").As<Napi::Function>();
-	ObjectSetPrototypeOf = Napi::Persistent(setPrototypeOf);
-	ObjectSetPrototypeOf.SuppressDestruct();
+static void node_class_init(Napi::Env env)
+{
+    auto setPrototypeOf = env.Global().Get("Object").As<Napi::Object>().Get("setPrototypeOf").As<Napi::Function>();
+    ObjectSetPrototypeOf = Napi::Persistent(setPrototypeOf);
+    ObjectSetPrototypeOf.SuppressDestruct();
 
-	auto getOwnPropertyDescriptor = env.Global().Get("Object").As<Napi::Object>().Get("getOwnPropertyDescriptor").As<Napi::Function>();
-	ObjectGetOwnPropertyDescriptor = Napi::Persistent(getOwnPropertyDescriptor);
-	ObjectGetOwnPropertyDescriptor.SuppressDestruct();
+    auto getOwnPropertyDescriptor =
+        env.Global().Get("Object").As<Napi::Object>().Get("getOwnPropertyDescriptor").As<Napi::Function>();
+    ObjectGetOwnPropertyDescriptor = Napi::Persistent(getOwnPropertyDescriptor);
+    ObjectGetOwnPropertyDescriptor.SuppressDestruct();
 
-	auto proxy = env.Global().Get("Proxy").As<Napi::Function>();
-	GlobalProxy = Napi::Persistent(proxy);
-	GlobalProxy.SuppressDestruct();
+    auto proxy = env.Global().Get("Proxy").As<Napi::Function>();
+    GlobalProxy = Napi::Persistent(proxy);
+    GlobalProxy.SuppressDestruct();
 
 
-	auto bind = env.Global().Get("Function").As<Napi::Function>().Get("prototype").As<Napi::Object>().Get("bind").As<Napi::Function>();
-	FunctionBind = Napi::Persistent(bind);
-	FunctionBind.SuppressDestruct();
+    auto bind = env.Global()
+                    .Get("Function")
+                    .As<Napi::Function>()
+                    .Get("prototype")
+                    .As<Napi::Object>()
+                    .Get("bind")
+                    .As<Napi::Function>();
+    FunctionBind = Napi::Persistent(bind);
+    FunctionBind.SuppressDestruct();
 
-	Napi::Symbol ext = Napi::Symbol::New(env, "_external");
-	ExternalSymbol = node::Protected<Napi::Symbol>(env, ext);
-	ExternalSymbol.SuppressDestruct();
+    Napi::Symbol ext = Napi::Symbol::New(env, "_external");
+    ExternalSymbol = node::Protected<Napi::Symbol>(env, ext);
+    ExternalSymbol.SuppressDestruct();
 }
 
-template<typename T>
+template <typename T>
 using ClassDefinition = js::ClassDefinition<Types, T>;
 
 using ConstructorType = js::ConstructorType<Types>;
@@ -90,1425 +98,1577 @@ using PropertyType = js::PropertyType<Types>;
 using IndexPropertyType = js::IndexPropertyType<Types>;
 using StringPropertyType = js::StringPropertyType<Types>;
 
-template<typename ClassType>
+template <typename ClassType>
 class WrappedObject : public Napi::ObjectWrap<WrappedObject<ClassType>> {
-	using Internal = typename ClassType::Internal;
+    using Internal = typename ClassType::Internal;
+
 public:
-	WrappedObject(const Napi::CallbackInfo& info);
+    WrappedObject(const Napi::CallbackInfo& info);
 
-	static Napi::Value create_instance_with_proxy(const Napi::CallbackInfo& info);
+    static Napi::Value create_instance_with_proxy(const Napi::CallbackInfo& info);
 
-	static Napi::Function init(Napi::Env env, 
-		const std::string& name, 
-		node::Types::FunctionCallback constructor_callback, 
-		std::function<bool(const std::string&)> has_native_method_callback,
-		const std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>>& properties, 
-		const IndexPropertyType* indexPropertyHandlers = nullptr);
+    static Napi::Function init(Napi::Env env, const std::string& name,
+                               node::Types::FunctionCallback constructor_callback,
+                               std::function<bool(const std::string&)> has_native_method_callback,
+                               const std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>>& properties,
+                               const IndexPropertyType* indexPropertyHandlers = nullptr);
 
-	static Napi::Object create_instance(Napi::Env env, Internal* internal = nullptr);
-	
-	static bool is_instance(Napi::Env env, const Napi::Object& object);
+    static Napi::Object create_instance(Napi::Env env, Internal* internal = nullptr);
 
-	static WrappedObject<ClassType>* try_unwrap(const Napi::Object& object);
+    static bool is_instance(Napi::Env env, const Napi::Object& object);
 
-	Internal* get_internal();
-	void set_internal(Internal* internal);
-	static void set_factory_constructor(const Napi::Function& factoryConstructor);
-	static Napi::Function get_constructor(Napi::Env env);
+    static WrappedObject<ClassType>* try_unwrap(const Napi::Object& object);
 
-	Napi::Value method_callback(const Napi::CallbackInfo& info);
-	Napi::Value getter_callback(const Napi::CallbackInfo& info);
-	void setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
-	void readonly_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
-	static void readonly_static_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
+    Internal* get_internal();
+    void set_internal(Internal* internal);
+    static void set_factory_constructor(const Napi::Function& factoryConstructor);
+    static Napi::Function get_constructor(Napi::Env env);
+
+    Napi::Value method_callback(const Napi::CallbackInfo& info);
+    Napi::Value getter_callback(const Napi::CallbackInfo& info);
+    void setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
+    void readonly_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
+    static void readonly_static_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value);
 
 private:
-	std::unique_ptr<Internal> m_internal;
-	static Napi::FunctionReference constructor;
-	static Napi::FunctionReference factory_constructor;
-	static IndexPropertyType* m_indexPropertyHandlers;
-	static std::string m_name;
-	static std::function<bool(const std::string&)> m_has_native_methodFunc;
-	static Napi::Reference<Napi::External<Internal>> m_nullExternal;
+    std::unique_ptr<Internal> m_internal;
+    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference factory_constructor;
+    static IndexPropertyType* m_indexPropertyHandlers;
+    static std::string m_name;
+    static std::function<bool(const std::string&)> m_has_native_methodFunc;
+    static Napi::Reference<Napi::External<Internal>> m_nullExternal;
 
-	class ProxyHandler {
-		public:
-			static Napi::Value get_instance_proxy_handler(Napi::Env env);
-		
-		private:
-			static Napi::Value bind_native_function(Napi::Env env, const std::string& functionName, const Napi::Function& function, const Napi::Object& thisObject);
-			static Napi::ObjectReference m_proxyHandler;
-			
+    class ProxyHandler {
+    public:
+        static Napi::Value get_instance_proxy_handler(Napi::Env env);
 
-			static Napi::Value get_proxy_trap(const Napi::CallbackInfo& info);
-			static Napi::Value set_proxy_trap(const Napi::CallbackInfo& info);
-			static Napi::Value own_keys_proxy_trap(const Napi::CallbackInfo& info);
-			static Napi::Value has_proxy_trap(const Napi::CallbackInfo& info);
-			static Napi::Value get_own_property_descriptor_trap(const Napi::CallbackInfo& info);
-			static Napi::Value get_prototype_of_proxy_trap(const Napi::CallbackInfo& info);
-			static Napi::Value set_prototype_of_proxy_trap(const Napi::CallbackInfo& info);
-		};
+    private:
+        static Napi::Value bind_native_function(Napi::Env env, const std::string& functionName,
+                                                const Napi::Function& function, const Napi::Object& thisObject);
+        static Napi::ObjectReference m_proxyHandler;
+
+
+        static Napi::Value get_proxy_trap(const Napi::CallbackInfo& info);
+        static Napi::Value set_proxy_trap(const Napi::CallbackInfo& info);
+        static Napi::Value own_keys_proxy_trap(const Napi::CallbackInfo& info);
+        static Napi::Value has_proxy_trap(const Napi::CallbackInfo& info);
+        static Napi::Value get_own_property_descriptor_trap(const Napi::CallbackInfo& info);
+        static Napi::Value get_prototype_of_proxy_trap(const Napi::CallbackInfo& info);
+        static Napi::Value set_prototype_of_proxy_trap(const Napi::CallbackInfo& info);
+    };
 };
 
-template<typename ClassType>
+template <typename ClassType>
 Napi::FunctionReference WrappedObject<ClassType>::constructor;
 
-template<typename ClassType>
+template <typename ClassType>
 Napi::FunctionReference WrappedObject<ClassType>::factory_constructor;
 
-template<typename ClassType>
+template <typename ClassType>
 IndexPropertyType* WrappedObject<ClassType>::m_indexPropertyHandlers;
 
-template<typename ClassType>
+template <typename ClassType>
 std::string WrappedObject<ClassType>::m_name;
 
-template<typename ClassType>
+template <typename ClassType>
 std::function<bool(const std::string&)> WrappedObject<ClassType>::m_has_native_methodFunc;
 
-template<typename ClassType>
+template <typename ClassType>
 Napi::Reference<Napi::External<typename ClassType::Internal>> WrappedObject<ClassType>::m_nullExternal;
 
 
 struct SchemaObjectType {
-	Napi::FunctionReference constructor;
+    Napi::FunctionReference constructor;
 };
 
-template<typename ClassType>
+template <typename ClassType>
 class ObjectWrap {
     using Internal = typename ClassType::Internal;
     using ParentClassType = typename ClassType::Parent;
 
-  public:
+public:
     static Napi::Function create_constructor(Napi::Env env);
 
-	static Napi::Object create_instance(Napi::Env env, Internal* = nullptr);
-	static Napi::Object create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, Internal* internal = nullptr);
-	static Napi::Object create_instance_by_schema(Napi::Env env, const realm::ObjectSchema& schema, Internal* internal = nullptr) {
-            Napi::Function constructor;
-            return create_instance_by_schema(env, constructor, schema, internal);
-        }
-	static void internal_finalizer(Napi::Env, typename ClassType::Internal* internal);
+    static Napi::Object create_instance(Napi::Env env, Internal* = nullptr);
+    static Napi::Object create_instance_by_schema(Napi::Env env, Napi::Function& constructor,
+                                                  const realm::ObjectSchema& schema, Internal* internal = nullptr);
+    static Napi::Object create_instance_by_schema(Napi::Env env, const realm::ObjectSchema& schema,
+                                                  Internal* internal = nullptr)
+    {
+        Napi::Function constructor;
+        return create_instance_by_schema(env, constructor, schema, internal);
+    }
+    static void internal_finalizer(Napi::Env, typename ClassType::Internal* internal);
 
-	static void on_context_destroy(Napi::Env env, std::string realmPath);
-	static bool is_instance(Napi::Env env, const Napi::Object& object);
-	
-	static Internal* get_internal(Napi::Env env, const Napi::Object& object);
-	static void set_internal(Napi::Env env, const Napi::Object& object, Internal* data);
+    static void on_context_destroy(Napi::Env env, std::string realmPath);
+    static bool is_instance(Napi::Env env, const Napi::Object& object);
 
-	static Napi::Value constructor_callback(const Napi::CallbackInfo& info);
-	static bool has_native_method(const std::string& name);
+    static Internal* get_internal(Napi::Env env, const Napi::Object& object);
+    static void set_internal(Napi::Env env, const Napi::Object& object, Internal* data);
 
-  private:
-	static auto& get_class();
-	static auto& get_nativeMethods();
-	static auto& get_schemaObjectTypes();
-	
-	//Gives access to ObjectWrap<ClassType> init_class private static member. See https://stackoverflow.com/a/40937193
-	template<typename T>
-	friend struct ObjectWrapAccessor;
-	
-	static Napi::Function init_class(Napi::Env env);
+    static Napi::Value constructor_callback(const Napi::CallbackInfo& info);
+    static bool has_native_method(const std::string& name);
 
-	static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback);
-	static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_static_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback);
-    static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_property(Napi::Env env, const std::string& name, const PropertyType&);
-	static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> setup_static_property(Napi::Env env, const std::string& name, const PropertyType&);
-	
-	static Napi::Value property_getter(const Napi::CallbackInfo& info);
-	static void property_setter(const Napi::CallbackInfo& info);
-	static std::vector<Napi::PropertyDescriptor> create_napi_property_descriptors(Napi::Env env, const Napi::Object& constructorPrototype, const realm::ObjectSchema& schema, bool redefine = true);
+private:
+    static auto& get_class();
+    static auto& get_nativeMethods();
+    static auto& get_schemaObjectTypes();
+
+    // Gives access to ObjectWrap<ClassType> init_class private static member. See
+    // https://stackoverflow.com/a/40937193
+    template <typename T>
+    friend struct ObjectWrapAccessor;
+
+    static Napi::Function init_class(Napi::Env env);
+
+    static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+    setup_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback);
+    static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+    setup_static_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback);
+    static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+    setup_property(Napi::Env env, const std::string& name, const PropertyType&);
+    static Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+    setup_static_property(Napi::Env env, const std::string& name, const PropertyType&);
+
+    static Napi::Value property_getter(const Napi::CallbackInfo& info);
+    static void property_setter(const Napi::CallbackInfo& info);
+    static std::vector<Napi::PropertyDescriptor>
+    create_napi_property_descriptors(Napi::Env env, const Napi::Object& constructorPrototype,
+                                     const realm::ObjectSchema& schema, bool redefine = true);
 };
 
-template<>
+template <>
 class ObjectWrap<void> {
-  public:
+public:
     using Internal = void;
 
-	static Napi::Function create_constructor(Napi::Env env) {
-		return Napi::Function();
-	}
+    static Napi::Function create_constructor(Napi::Env env)
+    {
+        return Napi::Function();
+    }
 
-	static Napi::Function init_class(Napi::Env env) {
-		return Napi::Function();
-	}
+    static Napi::Function init_class(Napi::Env env)
+    {
+        return Napi::Function();
+    }
 
-	static bool has_native_method(const std::string& name) {
-		return false;
-	}
+    static bool has_native_method(const std::string& name)
+    {
+        return false;
+    }
 };
 
-//Gives access to ObjectWrap<ClassType> init_class private static member. See https://stackoverflow.com/a/40937193
-template<typename T>
+// Gives access to ObjectWrap<ClassType> init_class private static member. See https://stackoverflow.com/a/40937193
+template <typename T>
 struct ObjectWrapAccessor {
-	inline static Napi::Function init_class(Napi::Env env) {
-		return ObjectWrap<T>::init_class(env);
-	}
+    inline static Napi::Function init_class(Napi::Env env)
+    {
+        return ObjectWrap<T>::init_class(env);
+    }
 };
 
-static inline std::vector<Napi::Value> get_arguments(const Napi::CallbackInfo& info) {
-	size_t count = info.Length();
-	std::vector<Napi::Value> arguments;
-	arguments.reserve(count);
+static inline std::vector<Napi::Value> get_arguments(const Napi::CallbackInfo& info)
+{
+    size_t count = info.Length();
+    std::vector<Napi::Value> arguments;
+    arguments.reserve(count);
 
-	for (u_int i = 0; i < count; i++) {
-		arguments.push_back(info[i]);
-	}
+    for (u_int i = 0; i < count; i++) {
+        arguments.push_back(info[i]);
+    }
 
-	return arguments;
+    return arguments;
 }
 
-static inline std::vector<napi_value> napi_get_arguments(const Napi::CallbackInfo& info) {
-	size_t count = info.Length();
-	std::vector<napi_value> arguments;
-	arguments.reserve(count);
+static inline std::vector<napi_value> napi_get_arguments(const Napi::CallbackInfo& info)
+{
+    size_t count = info.Length();
+    std::vector<napi_value> arguments;
+    arguments.reserve(count);
 
-	for (u_int i = 0; i < count; i++) {
-		arguments.push_back(info[i]);
-	}
+    for (u_int i = 0; i < count; i++) {
+        arguments.push_back(info[i]);
+    }
 
-	return arguments;
+    return arguments;
 }
 
-template<typename ClassType>
-inline auto& ObjectWrap<ClassType>::get_class() {
-	static ClassType s_class;
-	return s_class;
-}
- 
-template<typename ClassType>
-inline auto& ObjectWrap<ClassType>::get_nativeMethods() {
-	static std::unordered_set<std::string> s_nativeMethods;
-	return s_nativeMethods;
+template <typename ClassType>
+inline auto& ObjectWrap<ClassType>::get_class()
+{
+    static ClassType s_class;
+    return s_class;
 }
 
- 
-template<typename ClassType>
-inline auto& ObjectWrap<ClassType>::get_schemaObjectTypes() {
-	static std::unordered_map<std::string, std::unordered_map<std::string, SchemaObjectType*>*> s_schemaObjectTypes;
-	return s_schemaObjectTypes;
+template <typename ClassType>
+inline auto& ObjectWrap<ClassType>::get_nativeMethods()
+{
+    static std::unordered_set<std::string> s_nativeMethods;
+    return s_nativeMethods;
 }
 
-//A cache for property names. The pair is property name and a node::String* to the same string representation.
-//The cache is persisted throughout the process life time to preseve property names between constructor cache invalidations (on_destory_context is called) 
-//Since RealmObjectClass instances may be used after context is destroyed, their property names should be valid
+
+template <typename ClassType>
+inline auto& ObjectWrap<ClassType>::get_schemaObjectTypes()
+{
+    static std::unordered_map<std::string, std::unordered_map<std::string, SchemaObjectType*>*> s_schemaObjectTypes;
+    return s_schemaObjectTypes;
+}
+
+// A cache for property names. The pair is property name and a node::String* to the same string representation.
+// The cache is persisted throughout the process life time to preseve property names between constructor cache
+// invalidations (on_destory_context is called) Since RealmObjectClass instances may be used after context is
+// destroyed, their property names should be valid
 static std::unordered_map<std::string, node::String*> propertyNamesCache;
 
-static node::String* get_cached_property_name(const std::string& name) {
-	if (propertyNamesCache.count(name)) {
-		node::String* cachedName = propertyNamesCache.at(name);
-		return cachedName;
-	}
+static node::String* get_cached_property_name(const std::string& name)
+{
+    if (propertyNamesCache.count(name)) {
+        node::String* cachedName = propertyNamesCache.at(name);
+        return cachedName;
+    }
 
-	node::String* result = new node::String(name);
-	propertyNamesCache.emplace(name, result);
-	return result;
+    node::String* result = new node::String(name);
+    propertyNamesCache.emplace(name, result);
+    return result;
 }
 
 
-inline static void copy_object(Napi::Env env, const Napi::Value& source, const Napi::Error& target) {
-	Napi::HandleScope scope(env);
+inline static void copy_object(Napi::Env env, const Napi::Value& source, const Napi::Error& target)
+{
+    Napi::HandleScope scope(env);
 
-	if (source.IsEmpty() || source.IsNull() || source.IsUndefined()) {
-		return;
-	}
+    if (source.IsEmpty() || source.IsNull() || source.IsUndefined()) {
+        return;
+    }
 
-	Napi::Function objectFunc = env.Global().Get("Object").As<Napi::Function>();
-	Napi::Function assignFunc = objectFunc.Get("assign").As<Napi::Function>();
-	assignFunc.Call({ target.Value(), source });
+    Napi::Function objectFunc = env.Global().Get("Object").As<Napi::Function>();
+    Napi::Function assignFunc = objectFunc.Get("assign").As<Napi::Function>();
+    assignFunc.Call({target.Value(), source});
 }
 
-template<typename ClassType>
-WrappedObject<ClassType>::WrappedObject(const Napi::CallbackInfo& info) : Napi::ObjectWrap<WrappedObject<ClassType>>(info) {
-	Napi::Env env = info.Env();
+template <typename ClassType>
+WrappedObject<ClassType>::WrappedObject(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<WrappedObject<ClassType>>(info)
+{
+    Napi::Env env = info.Env();
 
-	//skip the constructor_callback if create_instance is creating a JS instance only
-	if (info.Length() == 1 && info[0].IsExternal())	{
-		Napi::External<Internal> external = info[0].As<Napi::External<Internal>>();
-		if (!external.Data()) {
-			return;
-		}
+    // skip the constructor_callback if create_instance is creating a JS instance only
+    if (info.Length() == 1 && info[0].IsExternal()) {
+        Napi::External<Internal> external = info[0].As<Napi::External<Internal>>();
+        if (!external.Data()) {
+            return;
+        }
 
-		Internal* internal = external.Data();
-		set_internal(internal);
-		return;
-	}
+        Internal* internal = external.Data();
+        set_internal(internal);
+        return;
+    }
 
-	try {
-		node::Types::FunctionCallback constructor_callback = (node::Types::FunctionCallback)info.Data();
-		constructor_callback(info);
-	}
-	catch (const node::Exception& e) {
-		Napi::Error error = Napi::Error::New(info.Env(), e.what());
-		copy_object(env, e.m_value, error);
-		throw error;
-	}
-	catch (const std::exception& e) {
-		throw Napi::Error::New(env, e.what());
-	}
+    try {
+        node::Types::FunctionCallback constructor_callback = (node::Types::FunctionCallback)info.Data();
+        constructor_callback(info);
+    }
+    catch (const node::Exception& e) {
+        Napi::Error error = Napi::Error::New(info.Env(), e.what());
+        copy_object(env, e.m_value, error);
+        throw error;
+    }
+    catch (const std::exception& e) {
+        throw Napi::Error::New(env, e.what());
+    }
 }
 
-template<typename ClassType>
-Napi::Function WrappedObject<ClassType>::init(Napi::Env env, 
-	const std::string& name, 
-	node::Types::FunctionCallback constructor_callback, 
-	std::function<bool(const std::string&)> has_native_method_callback,
-	const std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>>& properties, 
-	const IndexPropertyType* indexPropertyHandlers) {
+template <typename ClassType>
+Napi::Function
+WrappedObject<ClassType>::init(Napi::Env env, const std::string& name,
+                               node::Types::FunctionCallback constructor_callback,
+                               std::function<bool(const std::string&)> has_native_method_callback,
+                               const std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>>& properties,
+                               const IndexPropertyType* indexPropertyHandlers)
+{
 
-	m_name = name;
-	m_has_native_methodFunc = has_native_method_callback;
-	WrappedObject<ClassType>::m_nullExternal = Napi::Persistent(Napi::External<Internal>::New(env, nullptr));
-	WrappedObject<ClassType>::m_nullExternal.SuppressDestruct();
+    m_name = name;
+    m_has_native_methodFunc = has_native_method_callback;
+    WrappedObject<ClassType>::m_nullExternal = Napi::Persistent(Napi::External<Internal>::New(env, nullptr));
+    WrappedObject<ClassType>::m_nullExternal.SuppressDestruct();
 
-	Napi::Function ctor = Napi::ObjectWrap<WrappedObject<ClassType>>::DefineClass(env, name.c_str(), properties, (void*)constructor_callback);
-	
-	constructor = Napi::Persistent(ctor);
-	constructor.SuppressDestruct();
+    Napi::Function ctor = Napi::ObjectWrap<WrappedObject<ClassType>>::DefineClass(env, name.c_str(), properties,
+                                                                                  (void*)constructor_callback);
 
-	m_indexPropertyHandlers = const_cast<IndexPropertyType*>(indexPropertyHandlers);
-	return ctor;
+    constructor = Napi::Persistent(ctor);
+    constructor.SuppressDestruct();
+
+    m_indexPropertyHandlers = const_cast<IndexPropertyType*>(indexPropertyHandlers);
+    return ctor;
 }
 
-//This creates the required JS instance with a Proxy parent to support get and set handlers and returns a proxy created on the JS instance to support property enumeration handler
-//the returned JS Proxy has only ownKeys trap setup so that all other member accesses skip the Proxy and go directly to the JS instance
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::create_instance_with_proxy(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
+// This creates the required JS instance with a Proxy parent to support get and set handlers and returns a proxy
+// created on the JS instance to support property enumeration handler the returned JS Proxy has only ownKeys trap
+// setup so that all other member accesses skip the Proxy and go directly to the JS instance
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::create_instance_with_proxy(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
 
-	if (constructor.IsEmpty()) {
-		std::string typeName(typeid(ClassType).name());
-		std::string errorMessage = util::format("create_instance_with_proxy: Class %s not initialized. Call init() first", typeName);
-		throw Napi::Error::New(env, errorMessage);
-	}
+    if (constructor.IsEmpty()) {
+        std::string typeName(typeid(ClassType).name());
+        std::string errorMessage =
+            util::format("create_instance_with_proxy: Class %s not initialized. Call init() first", typeName);
+        throw Napi::Error::New(env, errorMessage);
+    }
 
-	if (!info.IsConstructCall()) {
-		throw Napi::Error::New(env, "This function should be called as a constructor");
-	}
+    if (!info.IsConstructCall()) {
+        throw Napi::Error::New(env, "This function should be called as a constructor");
+    }
 
-	Napi::EscapableHandleScope scope(env);
+    Napi::EscapableHandleScope scope(env);
 
-	try {
+    try {
 
-		auto arguments = napi_get_arguments(info);
-		Napi::Object instance = constructor.New(arguments);
+        auto arguments = napi_get_arguments(info);
+        Napi::Object instance = constructor.New(arguments);
 
-		//using DefineProperty to make it non enumerable and non configurable and non writable
-		instance.DefineProperty(Napi::PropertyDescriptor::Value("_instance", instance, napi_default));
-		
-		info.This().As<Napi::Object>().DefineProperty(Napi::PropertyDescriptor::Value("isRealmCtor", Napi::Boolean::New(env, true), napi_configurable)); 
-		
-		ObjectSetPrototypeOf.Call({ info.This(), instance });
-		Napi::Object instanceProxy = GlobalProxy.New({ info.This(), ProxyHandler::get_instance_proxy_handler(env) });
-		
-		instance.DefineProperty(Napi::PropertyDescriptor::Value("_instanceProxy", instanceProxy, napi_default));
-		return scope.Escape(instanceProxy);
-	}
-	catch (const Napi::Error & e) {
-		throw e;
-	}
-	catch (const std::exception& e) {
-		throw Napi::Error::New(info.Env(), e.what());
-	}
+        // using DefineProperty to make it non enumerable and non configurable and non writable
+        instance.DefineProperty(Napi::PropertyDescriptor::Value("_instance", instance, napi_default));
+
+        info.This().As<Napi::Object>().DefineProperty(
+            Napi::PropertyDescriptor::Value("isRealmCtor", Napi::Boolean::New(env, true), napi_configurable));
+
+        ObjectSetPrototypeOf.Call({info.This(), instance});
+        Napi::Object instanceProxy = GlobalProxy.New({info.This(), ProxyHandler::get_instance_proxy_handler(env)});
+
+        instance.DefineProperty(Napi::PropertyDescriptor::Value("_instanceProxy", instanceProxy, napi_default));
+        return scope.Escape(instanceProxy);
+    }
+    catch (const Napi::Error& e) {
+        throw e;
+    }
+    catch (const std::exception& e) {
+        throw Napi::Error::New(info.Env(), e.what());
+    }
 }
 
-template<typename ClassType>
-Napi::Object WrappedObject<ClassType>::create_instance(Napi::Env env, Internal* internal) {
-	if (constructor.IsEmpty() || factory_constructor.IsEmpty()) {
-		std::string typeName(typeid(ClassType).name());
-		std::string errorMessage = util::format("create_instance: Class %s not initialized. Call init() first", typeName);
-		throw Napi::Error::New(env, errorMessage);
-	}
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Object WrappedObject<ClassType>::create_instance(Napi::Env env, Internal* internal)
+{
+    if (constructor.IsEmpty() || factory_constructor.IsEmpty()) {
+        std::string typeName(typeid(ClassType).name());
+        std::string errorMessage =
+            util::format("create_instance: Class %s not initialized. Call init() first", typeName);
+        throw Napi::Error::New(env, errorMessage);
+    }
+    Napi::EscapableHandleScope scope(env);
 
-	//creating a JS instance only. pass null as first and single argument
-	//Internal intern = &std::shared_ptr<Internal>(internal);
-	Napi::External<Internal> external;
-	if (internal) {
-		external = Napi::External<Internal>::New(env, internal);
-	}
-	else {
-		external = WrappedObject<ClassType>::m_nullExternal.Value();
-	}
+    // creating a JS instance only. pass null as first and single argument
+    // Internal intern = &std::shared_ptr<Internal>(internal);
+    Napi::External<Internal> external;
+    if (internal) {
+        external = Napi::External<Internal>::New(env, internal);
+    }
+    else {
+        external = WrappedObject<ClassType>::m_nullExternal.Value();
+    }
 
-	Napi::Object instance = factory_constructor.New({ external });
-	return scope.Escape(instance).As<Napi::Object>();
+    Napi::Object instance = factory_constructor.New({external});
+    return scope.Escape(instance).As<Napi::Object>();
 }
 
-template<typename ClassType>
-WrappedObject<ClassType>* WrappedObject<ClassType>::try_unwrap(const Napi::Object& object) {
-	Napi::Env env = object.Env();
+template <typename ClassType>
+WrappedObject<ClassType>* WrappedObject<ClassType>::try_unwrap(const Napi::Object& object)
+{
+    Napi::Env env = object.Env();
 
-	WrappedObject<ClassType>* unwrapped;
-	napi_status status = napi_unwrap(env, object, reinterpret_cast<void**>(&unwrapped));
-	if ((status) != napi_ok) {
-		Napi::Object instance = object.Get("_instance").As<Napi::Object>();
-		if (instance.IsUndefined() || instance.IsNull()) {
-			throw Napi::Error::New(env, "Invalid object. No _instance member");
-		}
+    WrappedObject<ClassType>* unwrapped;
+    napi_status status = napi_unwrap(env, object, reinterpret_cast<void**>(&unwrapped));
+    if ((status) != napi_ok) {
+        Napi::Object instance = object.Get("_instance").As<Napi::Object>();
+        if (instance.IsUndefined() || instance.IsNull()) {
+            throw Napi::Error::New(env, "Invalid object. No _instance member");
+        }
 
-		status = napi_unwrap(env, instance, reinterpret_cast<void**>(&unwrapped));
-	}
+        status = napi_unwrap(env, instance, reinterpret_cast<void**>(&unwrapped));
+    }
 
-	NAPI_THROW_IF_FAILED(env, status, nullptr);
-	return unwrapped;
+    NAPI_THROW_IF_FAILED(env, status, nullptr);
+    return unwrapped;
 }
 
-template<typename ClassType>
-inline typename ClassType::Internal* WrappedObject<ClassType>::get_internal() {
-	return m_internal.get();
+template <typename ClassType>
+inline typename ClassType::Internal* WrappedObject<ClassType>::get_internal()
+{
+    return m_internal.get();
 }
 
-template<typename ClassType>
-inline void WrappedObject<ClassType>::set_internal(Internal* internal) {
-	m_internal = std::unique_ptr<Internal>(internal);
+template <typename ClassType>
+inline void WrappedObject<ClassType>::set_internal(Internal* internal)
+{
+    m_internal = std::unique_ptr<Internal>(internal);
 }
 
-template<typename ClassType>
-void WrappedObject<ClassType>::set_factory_constructor(const Napi::Function& factoryConstructor) {
-	factory_constructor = Napi::Persistent(factoryConstructor);
-	factory_constructor.SuppressDestruct();
+template <typename ClassType>
+void WrappedObject<ClassType>::set_factory_constructor(const Napi::Function& factoryConstructor)
+{
+    factory_constructor = Napi::Persistent(factoryConstructor);
+    factory_constructor.SuppressDestruct();
 }
 
-template<typename ClassType>
-Napi::Function WrappedObject<ClassType>::get_constructor(Napi::Env env) {
-	if (!constructor.IsEmpty()) {
-		return constructor.Value();
-	}
+template <typename ClassType>
+Napi::Function WrappedObject<ClassType>::get_constructor(Napi::Env env)
+{
+    if (!constructor.IsEmpty()) {
+        return constructor.Value();
+    }
 
-	return Napi::Function(env, env.Null());
+    return Napi::Function(env, env.Null());
 }
 
-template<typename ClassType>
-inline bool WrappedObject<ClassType>::is_instance(Napi::Env env, const Napi::Object& object) {
-	if (constructor.IsEmpty()) {
-		std::string typeName(typeid(ClassType).name());
-		std::string errorMessage = util::format("is_instance: Class %s not initialized. Call init() first", typeName);
-		throw Napi::Error::New(env, errorMessage);
-	}
+template <typename ClassType>
+inline bool WrappedObject<ClassType>::is_instance(Napi::Env env, const Napi::Object& object)
+{
+    if (constructor.IsEmpty()) {
+        std::string typeName(typeid(ClassType).name());
+        std::string errorMessage = util::format("is_instance: Class %s not initialized. Call init() first", typeName);
+        throw Napi::Error::New(env, errorMessage);
+    }
 
-	Napi::HandleScope scope(env);
+    Napi::HandleScope scope(env);
 
-	//Check the object is instance of the constructor. This will be true when the object have it's prototype set with setPrototypeOf. 
-	//This is true for objects configured in the schema with a function type.
-	Napi::Function ctor  = constructor.Value();
-	bool isInstanceOf = object.InstanceOf(ctor);
-	if (isInstanceOf) {
-		return true;
-	}
+    // Check the object is instance of the constructor. This will be true when the object have it's prototype set with
+    // setPrototypeOf. This is true for objects configured in the schema with a function type.
+    Napi::Function ctor = constructor.Value();
+    bool isInstanceOf = object.InstanceOf(ctor);
+    if (isInstanceOf) {
+        return true;
+    }
 
-	//Object store needs is_instance to return true when called with RealmObject instance even if the prototype was changed with setPrototypeOf
-	Napi::Object instance = object.Get("_instance").As<Napi::Object>();
-	if (!instance.IsUndefined()) {
-		isInstanceOf = instance.InstanceOf(ctor);
-	}
+    // Object store needs is_instance to return true when called with RealmObject instance even if the prototype was
+    // changed with setPrototypeOf
+    Napi::Object instance = object.Get("_instance").As<Napi::Object>();
+    if (!instance.IsUndefined()) {
+        isInstanceOf = instance.InstanceOf(ctor);
+    }
 
-	//handle RealmObjects with user defined ctors without extending RealmObject
-	//In this case we just check for existing internal value to identify RealmObject instances
-	if (!isInstanceOf) {
-		bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
-		if (isRealmObjectClass) {
-			Napi::External<typename ClassType::Internal> external = object.Get(ExternalSymbol).As<Napi::External<typename ClassType::Internal>>();
-			if (!external.IsUndefined()) {
-				return true;
-			}
-		}
-	}
+    // handle RealmObjects with user defined ctors without extending RealmObject
+    // In this case we just check for existing internal value to identify RealmObject instances
+    if (!isInstanceOf) {
+        bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+        if (isRealmObjectClass) {
+            Napi::External<typename ClassType::Internal> external =
+                object.Get(ExternalSymbol).As<Napi::External<typename ClassType::Internal>>();
+            if (!external.IsUndefined()) {
+                return true;
+            }
+        }
+    }
 
-	return isInstanceOf;
+    return isInstanceOf;
 }
 
 
-static inline Napi::Value method_callback(const Napi::CallbackInfo& info) {
-	node::Types::FunctionCallback method = (node::Types::FunctionCallback)info.Data();
-	return method(info);
+static inline Napi::Value method_callback(const Napi::CallbackInfo& info)
+{
+    node::Types::FunctionCallback method = (node::Types::FunctionCallback)info.Data();
+    return method(info);
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::method_callback(const Napi::CallbackInfo& info) {
-	node::Types::FunctionCallback method = (node::Types::FunctionCallback)info.Data();
-	return method(info);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::method_callback(const Napi::CallbackInfo& info)
+{
+    node::Types::FunctionCallback method = (node::Types::FunctionCallback)info.Data();
+    return method(info);
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::getter_callback(const Napi::CallbackInfo& info) {
-	PropertyType* propertyType = (PropertyType*)info.Data();
-	return propertyType->getter(info);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::getter_callback(const Napi::CallbackInfo& info)
+{
+    PropertyType* propertyType = (PropertyType*)info.Data();
+    return propertyType->getter(info);
 }
 
-template<typename ClassType>
-void WrappedObject<ClassType>::setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value) {
-	PropertyType* propertyType = (PropertyType*)info.Data();
-	propertyType->setter(info, value);
+template <typename ClassType>
+void WrappedObject<ClassType>::setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value)
+{
+    PropertyType* propertyType = (PropertyType*)info.Data();
+    propertyType->setter(info, value);
 }
 
-template<typename ClassType>
-void WrappedObject<ClassType>::readonly_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value) {
-	Napi::Error error = Napi::Error::New(info.Env(), "Cannot assign to read only property");
-	error.Set("readOnly", true);
-	throw error;
+template <typename ClassType>
+void WrappedObject<ClassType>::readonly_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value)
+{
+    Napi::Error error = Napi::Error::New(info.Env(), "Cannot assign to read only property");
+    error.Set("readOnly", true);
+    throw error;
 }
 
-template<typename ClassType>
-void WrappedObject<ClassType>::readonly_static_setter_callback(const Napi::CallbackInfo& info, const Napi::Value& value) {
-	Napi::Error error = Napi::Error::New(info.Env(), "Cannot assign to read only static property");
-	error.Set("readOnly", true);
-	throw error;
+template <typename ClassType>
+void WrappedObject<ClassType>::readonly_static_setter_callback(const Napi::CallbackInfo& info,
+                                                               const Napi::Value& value)
+{
+    Napi::Error error = Napi::Error::New(info.Env(), "Cannot assign to read only static property");
+    error.Set("readOnly", true);
+    throw error;
 }
 
-template<typename ClassType>
+template <typename ClassType>
 Napi::ObjectReference WrappedObject<ClassType>::ProxyHandler::m_proxyHandler;
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::get_instance_proxy_handler(Napi::Env env) {
-	if (!m_proxyHandler.IsEmpty()) {
-		return m_proxyHandler.Value();
-	}
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::get_instance_proxy_handler(Napi::Env env)
+{
+    if (!m_proxyHandler.IsEmpty()) {
+        return m_proxyHandler.Value();
+    }
 
-	Napi::Object proxyObject = Napi::Object::New(env);
-	Napi::PropertyDescriptor instanceGetTrapFunc = Napi::PropertyDescriptor::Function("get", &WrappedObject<ClassType>::ProxyHandler::get_proxy_trap);
-	Napi::PropertyDescriptor instanceSetTrapFunc = Napi::PropertyDescriptor::Function("set", &WrappedObject<ClassType>::ProxyHandler::set_proxy_trap);
-	Napi::PropertyDescriptor ownKeysTrapFunc = Napi::PropertyDescriptor::Function("ownKeys", &WrappedObject<ClassType>::ProxyHandler::own_keys_proxy_trap);
-	Napi::PropertyDescriptor hasTrapFunc = Napi::PropertyDescriptor::Function("has", &WrappedObject<ClassType>::ProxyHandler::has_proxy_trap);
-	Napi::PropertyDescriptor getOwnPropertyDescriptorTrapFunc = Napi::PropertyDescriptor::Function("getOwnPropertyDescriptor", &WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_trap);
-	Napi::PropertyDescriptor getPrototypeOfFunc = Napi::PropertyDescriptor::Function("getPrototypeOf", &WrappedObject<ClassType>::ProxyHandler::get_prototype_of_proxy_trap);
-	Napi::PropertyDescriptor setPrototypeOfFunc = Napi::PropertyDescriptor::Function("setPrototypeOf", &WrappedObject<ClassType>::ProxyHandler::set_prototype_of_proxy_trap);
-	
-	proxyObject.DefineProperties({ instanceGetTrapFunc, instanceSetTrapFunc, ownKeysTrapFunc, hasTrapFunc, getOwnPropertyDescriptorTrapFunc, getPrototypeOfFunc, setPrototypeOfFunc });
-	
-	m_proxyHandler = Napi::Persistent(proxyObject);
-	m_proxyHandler.SuppressDestruct();
-	return proxyObject;
+    Napi::Object proxyObject = Napi::Object::New(env);
+    Napi::PropertyDescriptor instanceGetTrapFunc =
+        Napi::PropertyDescriptor::Function("get", &WrappedObject<ClassType>::ProxyHandler::get_proxy_trap);
+    Napi::PropertyDescriptor instanceSetTrapFunc =
+        Napi::PropertyDescriptor::Function("set", &WrappedObject<ClassType>::ProxyHandler::set_proxy_trap);
+    Napi::PropertyDescriptor ownKeysTrapFunc =
+        Napi::PropertyDescriptor::Function("ownKeys", &WrappedObject<ClassType>::ProxyHandler::own_keys_proxy_trap);
+    Napi::PropertyDescriptor hasTrapFunc =
+        Napi::PropertyDescriptor::Function("has", &WrappedObject<ClassType>::ProxyHandler::has_proxy_trap);
+    Napi::PropertyDescriptor getOwnPropertyDescriptorTrapFunc = Napi::PropertyDescriptor::Function(
+        "getOwnPropertyDescriptor", &WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_trap);
+    Napi::PropertyDescriptor getPrototypeOfFunc = Napi::PropertyDescriptor::Function(
+        "getPrototypeOf", &WrappedObject<ClassType>::ProxyHandler::get_prototype_of_proxy_trap);
+    Napi::PropertyDescriptor setPrototypeOfFunc = Napi::PropertyDescriptor::Function(
+        "setPrototypeOf", &WrappedObject<ClassType>::ProxyHandler::set_prototype_of_proxy_trap);
+
+    proxyObject.DefineProperties({instanceGetTrapFunc, instanceSetTrapFunc, ownKeysTrapFunc, hasTrapFunc,
+                                  getOwnPropertyDescriptorTrapFunc, getPrototypeOfFunc, setPrototypeOfFunc});
+
+    m_proxyHandler = Napi::Persistent(proxyObject);
+    m_proxyHandler.SuppressDestruct();
+    return proxyObject;
 }
 
-static Napi::Value bind_function(Napi::Env env, const std::string& functionName, const Napi::Function& function, const Napi::Object& thisObject) {
-	Napi::Function boundFunc = FunctionBind.Call(function, { thisObject }).As<Napi::Function>();
-	return boundFunc;
+static Napi::Value bind_function(Napi::Env env, const std::string& functionName, const Napi::Function& function,
+                                 const Napi::Object& thisObject)
+{
+    Napi::Function boundFunc = FunctionBind.Call(function, {thisObject}).As<Napi::Function>();
+    return boundFunc;
 }
 
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::bind_native_function(Napi::Env env, const std::string& functionName, const Napi::Function& function, const Napi::Object& thisObject) {
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::bind_native_function(Napi::Env env,
+                                                                         const std::string& functionName,
+                                                                         const Napi::Function& function,
+                                                                         const Napi::Object& thisObject)
+{
+    Napi::EscapableHandleScope scope(env);
 
-	//do not bind the non native functions. These are attached from extensions.js and should be called on the instanceProxy.
-	if (!m_has_native_methodFunc(functionName)) {
-		//return undefined to indicate this is not a native function
-		return scope.Escape(env.Undefined());
-	}
+    // do not bind the non native functions. These are attached from extensions.js and should be called on the
+    // instanceProxy.
+    if (!m_has_native_methodFunc(functionName)) {
+        // return undefined to indicate this is not a native function
+        return scope.Escape(env.Undefined());
+    }
 
-	Napi::Value result = bind_function(env, functionName, function, thisObject);
-	return scope.Escape(result);
+    Napi::Value result = bind_function(env, functionName, function, thisObject);
+    return scope.Escape(result);
 }
 
-static inline Napi::Object get_prototype(Napi::Env env, const Napi::Object& object) {
-	napi_value napi_proto;
-	napi_status status = napi_get_prototype(env, object, &napi_proto);
-	if (status != napi_ok) {
-		throw Napi::Error::New(env, "Invalid object. Couldn't get prototype of object");
-	}
-	Napi::Object prototypeObject = Napi::Object(env, napi_proto);
-	return prototypeObject;
+static inline Napi::Object get_prototype(Napi::Env env, const Napi::Object& object)
+{
+    napi_value napi_proto;
+    napi_status status = napi_get_prototype(env, object, &napi_proto);
+    if (status != napi_ok) {
+        throw Napi::Error::New(env, "Invalid object. Couldn't get prototype of object");
+    }
+    Napi::Object prototypeObject = Napi::Object(env, napi_proto);
+    return prototypeObject;
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::get_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::get_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object target = info[0].As<Napi::Object>();
-	Napi::Value property = info[1];
+    Napi::Object target = info[0].As<Napi::Object>();
+    Napi::Value property = info[1];
 
 #if DEBUG
-	std::string _debugproperty = property.IsString() ? (std::string)property.As<Napi::String>() : "";
-	const char* _debugPropertyName = _debugproperty.c_str();
-	(void)_debugPropertyName; //disable unused variable warning
+    std::string _debugproperty = property.IsString() ? (std::string)property.As<Napi::String>() : "";
+    const char* _debugPropertyName = _debugproperty.c_str();
+    (void)_debugPropertyName; // disable unused variable warning
 #endif
 
-	Napi::Object instance = target.Get("_instance").As<Napi::Object>();
-	if (instance.IsUndefined() || instance.IsNull()) {
-		throw Napi::Error::New(env, "Invalid object. No _instance member");
-	}
+    Napi::Object instance = target.Get("_instance").As<Napi::Object>();
+    if (instance.IsUndefined() || instance.IsNull()) {
+        throw Napi::Error::New(env, "Invalid object. No _instance member");
+    }
 
-	//skip Symbols
-	if (!property.IsString()) {
-		Napi::Value propertyValue = instance.Get(property);
-		return scope.Escape(propertyValue);
-	}
+    // skip Symbols
+    if (!property.IsString()) {
+        Napi::Value propertyValue = instance.Get(property);
+        return scope.Escape(propertyValue);
+    }
 
-	Napi::String propertyName = property.As<Napi::String>();
-	std::string propertyText = propertyName;
+    Napi::String propertyName = property.As<Napi::String>();
+    std::string propertyText = propertyName;
 
-	if (propertyText == "_instance") {
-		return scope.Escape(instance);
-	}
-	
-	//Order of execution
-	//1.check for number and call get index handlers
-	//2.check if its a native function
-	//3.get any other property name from the instance
+    if (propertyText == "_instance") {
+        return scope.Escape(instance);
+    }
 
-
-	//1.Check property is number and call index handler
-	char firstChar = *propertyText.c_str();
-
-	//myobject[""] and negative indexes return undefined in JavaScript
-	if (propertyText.length() == 0 || firstChar == '-') {
-		return scope.Escape(env.Undefined());
-	}
-
-	bool isNumber = isdigit(firstChar) || firstChar == '+';
-	if (isNumber) {
-		int32_t index = 0;
-		try {
-			index = std::stoi(propertyText);
-		}
-		catch (const std::exception & e) {
-			throw Napi::Error::New(env, "Invalid number " + propertyText);
-		}
-
-		WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
-		Napi::Value result = wrappedObject->m_indexPropertyHandlers->getter(info, instance, index);
-		return scope.Escape(result);
-	}
+    // Order of execution
+    // 1.check for number and call get index handlers
+    // 2.check if its a native function
+    // 3.get any other property name from the instance
 
 
-	//2. Check if its a native function
-	if (m_has_native_methodFunc(propertyText)) {
-		//TODO: cache this function in the wrappedObject of this instance
-		Napi::Value propertyValue = instance.Get(property);
-		Napi::Value result = bind_function(env, propertyText, propertyValue.As<Napi::Function>(), instance);
-		return scope.Escape(result);
-	}
+    // 1.Check property is number and call index handler
+    char firstChar = *propertyText.c_str();
 
-	//return all other properties from the instance
-	Napi::Value propertyValue = instance.Get(property);
-	return scope.Escape(propertyValue);
+    // myobject[""] and negative indexes return undefined in JavaScript
+    if (propertyText.length() == 0 || firstChar == '-') {
+        return scope.Escape(env.Undefined());
+    }
+
+    bool isNumber = isdigit(firstChar) || firstChar == '+';
+    if (isNumber) {
+        int32_t index = 0;
+        try {
+            index = std::stoi(propertyText);
+        }
+        catch (const std::exception& e) {
+            throw Napi::Error::New(env, "Invalid number " + propertyText);
+        }
+
+        WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
+        Napi::Value result = wrappedObject->m_indexPropertyHandlers->getter(info, instance, index);
+        return scope.Escape(result);
+    }
+
+
+    // 2. Check if its a native function
+    if (m_has_native_methodFunc(propertyText)) {
+        // TODO: cache this function in the wrappedObject of this instance
+        Napi::Value propertyValue = instance.Get(property);
+        Napi::Value result = bind_function(env, propertyText, propertyValue.As<Napi::Function>(), instance);
+        return scope.Escape(result);
+    }
+
+    // return all other properties from the instance
+    Napi::Value propertyValue = instance.Get(property);
+    return scope.Escape(propertyValue);
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::set_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::set_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object target = info[0].As<Napi::Object>();
-	Napi::Value property = info[1];
-	Napi::Value value = info[2];
+    Napi::Object target = info[0].As<Napi::Object>();
+    Napi::Value property = info[1];
+    Napi::Value value = info[2];
 
 #if DEBUG
-	std::string _debugproperty = property.IsString() ? (std::string)property.As<Napi::String>() : "";
-	const char* _debugPropertyName = _debugproperty.c_str();
-	(void)_debugPropertyName; //disable unused variable warning
+    std::string _debugproperty = property.IsString() ? (std::string)property.As<Napi::String>() : "";
+    const char* _debugPropertyName = _debugproperty.c_str();
+    (void)_debugPropertyName; // disable unused variable warning
 #endif
 
 
-	Napi::Object instance = target.Get("_instance").As<Napi::Object>();
-	if (instance.IsUndefined() || instance.IsNull()) {
-		throw Napi::Error::New(env, "Invalid object. No _instance member");
-	}
+    Napi::Object instance = target.Get("_instance").As<Napi::Object>();
+    if (instance.IsUndefined() || instance.IsNull()) {
+        throw Napi::Error::New(env, "Invalid object. No _instance member");
+    }
 
-	//skip Symbols
-	if (!property.IsString()) {
-		instance.Set(property, value);
-		return scope.Escape(value);
-	}
+    // skip Symbols
+    if (!property.IsString()) {
+        instance.Set(property, value);
+        return scope.Escape(value);
+    }
 
-	Napi::String propertyName = property.As<Napi::String>();
-	std::string propertyText = propertyName;
+    Napi::String propertyName = property.As<Napi::String>();
+    std::string propertyText = propertyName;
 
-	//Order of execution
-	//1.check for number and call set index handlers
-	//2.get any other property name from the instance
+    // Order of execution
+    // 1.check for number and call set index handlers
+    // 2.get any other property name from the instance
 
-	//do not assign empty property name. myarray[''] = 42; is valid in JS
-	if (propertyText.length() == 0) {
-		throw Napi::Error::New(env, "Invalid number ''");
-	}
+    // do not assign empty property name. myarray[''] = 42; is valid in JS
+    if (propertyText.length() == 0) {
+        throw Napi::Error::New(env, "Invalid number ''");
+    }
 
-	//1.Check property is number and call set index handler
-	char firstChar = *propertyText.c_str();
-	bool isNumber = isdigit(firstChar) || firstChar == '+' || firstChar == '-';
-	if (isNumber) {
-		try {
-			realm::js::validated_positive_index(propertyText);
-		}
-		catch (const std::out_of_range & e) {
-			throw Napi::Error::New(env, e.what());
-		}
+    // 1.Check property is number and call set index handler
+    char firstChar = *propertyText.c_str();
+    bool isNumber = isdigit(firstChar) || firstChar == '+' || firstChar == '-';
+    if (isNumber) {
+        try {
+            realm::js::validated_positive_index(propertyText);
+        }
+        catch (const std::out_of_range& e) {
+            throw Napi::Error::New(env, e.what());
+        }
 
-		int32_t index = 0;
-		try {
-			index = std::stoi(propertyText);
-		}
-		catch (const std::exception & e) {
-			throw Napi::Error::New(env, "Invalid number " + propertyText);
-		}
+        int32_t index = 0;
+        try {
+            index = std::stoi(propertyText);
+        }
+        catch (const std::exception& e) {
+            throw Napi::Error::New(env, "Invalid number " + propertyText);
+        }
 
-		WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
-		if (wrappedObject->m_indexPropertyHandlers->setter == nullptr) {
-			std::string message = std::string("Cannot assign to read only index ") + util::to_string(index);
-			throw Napi::Error::New(env, message);
-		}
+        WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
+        if (wrappedObject->m_indexPropertyHandlers->setter == nullptr) {
+            std::string message = std::string("Cannot assign to read only index ") + util::to_string(index);
+            throw Napi::Error::New(env, message);
+        }
 
-		Napi::Value result = wrappedObject->m_indexPropertyHandlers->setter(info, instance, index, value);
-		return scope.Escape(result);
-	}
+        Napi::Value result = wrappedObject->m_indexPropertyHandlers->setter(info, instance, index, value);
+        return scope.Escape(result);
+    }
 
-	//call Set on the instance for non indexed properties
-	try {
-		instance.Set(property, value);
-		return scope.Escape(Napi::Boolean::New(env, true));
-	}
-	catch (const Napi::Error & e) {
-		Napi::Boolean readOnly = e.Get("readOnly").As<Napi::Boolean>();
-		if (!readOnly.IsUndefined() && readOnly) {
-			std::string message = "Cannot assign to read only property '" + propertyText + "'";
-			throw Napi::Error::New(env, message);
-		}
+    // call Set on the instance for non indexed properties
+    try {
+        instance.Set(property, value);
+        return scope.Escape(Napi::Boolean::New(env, true));
+    }
+    catch (const Napi::Error& e) {
+        Napi::Boolean readOnly = e.Get("readOnly").As<Napi::Boolean>();
+        if (!readOnly.IsUndefined() && readOnly) {
+            std::string message = "Cannot assign to read only property '" + propertyText + "'";
+            throw Napi::Error::New(env, message);
+        }
 
-		throw e;
-	}
+        throw e;
+    }
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::own_keys_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::own_keys_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object target = info[0].As<Napi::Object>();
-	
-	Napi::Object instance = target.Get("_instance").As<Napi::Object>();
-	WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
+    Napi::Object target = info[0].As<Napi::Object>();
 
-	if (wrappedObject->m_indexPropertyHandlers != nullptr) {
-		uint32_t length = instance.Get("length").As<Napi::Number>();
-		Napi::Array array = Napi::Array::New(env, length);
-		for (uint32_t i = 0; i < length; i++) {
-			array.Set(i, Napi::Number::New(env, i).ToString());
-		}
-		return scope.Escape(array);
-	}
+    Napi::Object instance = target.Get("_instance").As<Napi::Object>();
+    WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::Unwrap(instance);
 
-	return scope.Escape(Napi::Array::New(env, 0));
+    if (wrappedObject->m_indexPropertyHandlers != nullptr) {
+        uint32_t length = instance.Get("length").As<Napi::Number>();
+        Napi::Array array = Napi::Array::New(env, length);
+        for (uint32_t i = 0; i < length; i++) {
+            array.Set(i, Napi::Number::New(env, i).ToString());
+        }
+        return scope.Escape(array);
+    }
+
+    return scope.Escape(Napi::Array::New(env, 0));
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::has_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::has_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object target = info[0].As<Napi::Object>();
-	Napi::Value propertyArg = info[1];
+    Napi::Object target = info[0].As<Napi::Object>();
+    Napi::Value propertyArg = info[1];
 
 
-	//skip symbols
-	if (!propertyArg.IsString()) {
-		bool hasProperty = target.Has(propertyArg);
-		return scope.Escape(Napi::Boolean::From(env, hasProperty));
-	}
+    // skip symbols
+    if (!propertyArg.IsString()) {
+        bool hasProperty = target.Has(propertyArg);
+        return scope.Escape(Napi::Boolean::From(env, hasProperty));
+    }
 
-	Napi::String property = propertyArg.As<Napi::String>();
-	std::string propertyText = property;
+    Napi::String property = propertyArg.As<Napi::String>();
+    std::string propertyText = property;
 
-	if (propertyText.length() == 0) {
-		return scope.Escape(Napi::Boolean::From(env, false));
-	}
+    if (propertyText.length() == 0) {
+        return scope.Escape(Napi::Boolean::From(env, false));
+    }
 
-	Napi::Object instance = target.Get("_instance").As<Napi::Object>();
-	if (instance.IsUndefined() || instance.IsNull()) {
-		bool hasProperty = target.Has(propertyArg);
-		return scope.Escape(Napi::Boolean::From(env, hasProperty));
-	}
+    Napi::Object instance = target.Get("_instance").As<Napi::Object>();
+    if (instance.IsUndefined() || instance.IsNull()) {
+        bool hasProperty = target.Has(propertyArg);
+        return scope.Escape(Napi::Boolean::From(env, hasProperty));
+    }
 
-	if (target.Has(property)) {
-		return scope.Escape(Napi::Boolean::From(env, true));
-	}
+    if (target.Has(property)) {
+        return scope.Escape(Napi::Boolean::From(env, true));
+    }
 
-	//Property should be a number from here on
-	char firstChar = *propertyText.c_str();
-	bool isNumber = isdigit(firstChar) || firstChar == '+';
+    // Property should be a number from here on
+    char firstChar = *propertyText.c_str();
+    bool isNumber = isdigit(firstChar) || firstChar == '+';
 
-	//return false for negative indexes and non numbers
-	if (!isNumber || firstChar == '-') {
-		return scope.Escape(Napi::Boolean::From(env, false));
-	}
+    // return false for negative indexes and non numbers
+    if (!isNumber || firstChar == '-') {
+        return scope.Escape(Napi::Boolean::From(env, false));
+    }
 
-	int32_t index = 0;
-	try {
-		index = std::stoi(propertyText);
-	}
-	catch (const std::exception& e) {
-		//not a number. return false;
-		return scope.Escape(Napi::Boolean::From(env, false));
-	}
-	
-	int32_t length = instance.Get("length").As<Napi::Number>();
-	bool hasIndex = index >= 0 && index < length;
-	return scope.Escape(Napi::Boolean::From(env, hasIndex));
+    int32_t index = 0;
+    try {
+        index = std::stoi(propertyText);
+    }
+    catch (const std::exception& e) {
+        // not a number. return false;
+        return scope.Escape(Napi::Boolean::From(env, false));
+    }
+
+    int32_t length = instance.Get("length").As<Napi::Number>();
+    bool hasIndex = index >= 0 && index < length;
+    return scope.Escape(Napi::Boolean::From(env, hasIndex));
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_trap(const Napi::CallbackInfo& info) {
-	//This exists only for ownKeysTrap to work properly with Object.keys(). It does not check if the property is from the named handler or it is an existing property on the instance. 
-	//This implementation can be extended to return the true property descriptor if the property is an existing one
-	
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_trap(const Napi::CallbackInfo& info)
+{
+    // This exists only for ownKeysTrap to work properly with Object.keys(). It does not check if the property is from
+    // the named handler or it is an existing property on the instance. This implementation can be extended to return
+    // the true property descriptor if the property is an existing one
 
-	//Napi::Object target = info[0].As<Napi::Object>();
-	Napi::String key = info[1].As<Napi::String>();
-	std::string text = key;
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object descriptor = Napi::Object::New(env);
-	descriptor.Set("enumerable", Napi::Boolean::New(env, true));
-	descriptor.Set("configurable", Napi::Boolean::New(env, true));
-	
-	return scope.Escape(descriptor);
+    // Napi::Object target = info[0].As<Napi::Object>();
+    Napi::String key = info[1].As<Napi::String>();
+    std::string text = key;
+
+    Napi::Object descriptor = Napi::Object::New(env);
+    descriptor.Set("enumerable", Napi::Boolean::New(env, true));
+    descriptor.Set("configurable", Napi::Boolean::New(env, true));
+
+    return scope.Escape(descriptor);
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::get_prototype_of_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::get_prototype_of_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::Object target = info[0].As<Napi::Object>();
-	Napi::Object proto = get_prototype(env, target);
-	return scope.Escape(proto);
+    Napi::Object target = info[0].As<Napi::Object>();
+    Napi::Object proto = get_prototype(env, target);
+    return scope.Escape(proto);
 }
 
-template<typename ClassType>
-Napi::Value WrappedObject<ClassType>::ProxyHandler::set_prototype_of_proxy_trap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	throw Napi::Error::New(env, "Setting the prototype on this type of object is not supported");
+template <typename ClassType>
+Napi::Value WrappedObject<ClassType>::ProxyHandler::set_prototype_of_proxy_trap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    throw Napi::Error::New(env, "Setting the prototype on this type of object is not supported");
 }
 
-static Napi::Value property_getter_callback(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	try {
-		PropertyType* propertyType = (PropertyType*)info.Data();
-		Napi::Value result = propertyType->getter(info);
-		return result;
-	}
-	catch (const Napi::Error & e) {
-		e.ThrowAsJavaScriptException();
-		return env.Undefined();
-	}
+static Napi::Value property_getter_callback(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    try {
+        PropertyType* propertyType = (PropertyType*)info.Data();
+        Napi::Value result = propertyType->getter(info);
+        return result;
+    }
+    catch (const Napi::Error& e) {
+        e.ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
 }
 
-template<typename ClassType>
-Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	auto& s_class = get_class();
-	try {
-		auto propertyName = (node::String*)info.Data();
-		return s_class.string_accessor.getter(info, info.This().As<Napi::Object>(), propertyName->ToString(env));
-	}
-	catch (const Napi::Error & e) {
-		e.ThrowAsJavaScriptException();
-		return env.Undefined();
-	}
+template <typename ClassType>
+Napi::Value ObjectWrap<ClassType>::property_getter(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    auto& s_class = get_class();
+    try {
+        auto propertyName = (node::String*)info.Data();
+        return s_class.string_accessor.getter(info, info.This().As<Napi::Object>(), propertyName->ToString(env));
+    }
+    catch (const Napi::Error& e) {
+        e.ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
 }
 
-template<typename ClassType>
-void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	auto& s_class = get_class();
-	try {
-		auto propertyName = (node::String*)info.Data();
-		auto value = info[0];
-		s_class.string_accessor.setter(info, info.This().As<Napi::Object>(), propertyName->ToString(env), value);
-	}
-	catch (const Napi::Error & e) {
-		e.ThrowAsJavaScriptException();
-	}
+template <typename ClassType>
+void ObjectWrap<ClassType>::property_setter(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    auto& s_class = get_class();
+    try {
+        auto propertyName = (node::String*)info.Data();
+        auto value = info[0];
+        s_class.string_accessor.setter(info, info.This().As<Napi::Object>(), propertyName->ToString(env), value);
+    }
+    catch (const Napi::Error& e) {
+        e.ThrowAsJavaScriptException();
+    }
 }
 
-template<typename ClassType>
-Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env) {
-	auto& s_class = get_class();
-	Napi::Function ctor = init_class(env);
-	
-	//If the class has no index accessor we can create an instance of the class itself and can skip proxy objects
-	bool has_index_accessor = (s_class.index_accessor.getter || s_class.index_accessor.setter);
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+template <typename ClassType>
+Napi::Function ObjectWrap<ClassType>::create_constructor(Napi::Env env)
+{
+    auto& s_class = get_class();
+    Napi::Function ctor = init_class(env);
 
-	if (!has_index_accessor || isRealmObjectClass) {
-		WrappedObject<ClassType>::set_factory_constructor(ctor);
-		return ctor;
-	}
+    // If the class has no index accessor we can create an instance of the class itself and can skip proxy objects
+    bool has_index_accessor = (s_class.index_accessor.getter || s_class.index_accessor.setter);
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 
-	//since NAPI ctors can't change the returned type we need to return a factory func which will be called when 'new ctor()' is called from JS. 
-	//This will create a JS Proxy and return it to the caller. The proxy is needed to support named and index handlers
-	Napi::Function factory = Napi::Function::New(env, WrappedObject<ClassType>::create_instance_with_proxy, s_class.name);
-	auto ctorPrototypeProperty = ctor.Get("prototype");
+    if (!has_index_accessor || isRealmObjectClass) {
+        WrappedObject<ClassType>::set_factory_constructor(ctor);
+        return ctor;
+    }
 
-	//the factory function should have the same prototype property as the constructor.prototype so `instanceOf` works
-	factory.Set("prototype", ctorPrototypeProperty);
-	ObjectSetPrototypeOf.Call({ factory, ctor });
+    // since NAPI ctors can't change the returned type we need to return a factory func which will be called when 'new
+    // ctor()' is called from JS. This will create a JS Proxy and return it to the caller. The proxy is needed to
+    // support named and index handlers
+    Napi::Function factory =
+        Napi::Function::New(env, WrappedObject<ClassType>::create_instance_with_proxy, s_class.name);
+    auto ctorPrototypeProperty = ctor.Get("prototype");
 
-	WrappedObject<ClassType>::set_factory_constructor(factory);
+    // the factory function should have the same prototype property as the constructor.prototype so `instanceOf` works
+    factory.Set("prototype", ctorPrototypeProperty);
+    ObjectSetPrototypeOf.Call({factory, ctor});
 
-	return factory;
+    WrappedObject<ClassType>::set_factory_constructor(factory);
+
+    return factory;
 }
 
-template<typename ClassType>
-Napi::Function ObjectWrap<ClassType>::init_class(Napi::Env env) {
-	auto& s_class = get_class();
-	//check if the constructor is already created. It means this class and it's parent are already initialized.
-	Napi::Function ctor = WrappedObject<ClassType>::get_constructor(env);
-	if (!ctor.IsNull()) {
-		return ctor;
-	}
+template <typename ClassType>
+Napi::Function ObjectWrap<ClassType>::init_class(Napi::Env env)
+{
+    auto& s_class = get_class();
+    // check if the constructor is already created. It means this class and it's parent are already initialized.
+    Napi::Function ctor = WrappedObject<ClassType>::get_constructor(env);
+    if (!ctor.IsNull()) {
+        return ctor;
+    }
 
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 
-	std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>> properties;
+    std::vector<Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>> properties;
 
-	if (!isRealmObjectClass) {
-		//setup properties and accessors on the class
-		for (auto& pair : s_class.static_properties) {
-			Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> statc_property = setup_static_property(env, pair.first, pair.second);
-			properties.push_back(statc_property);
-		}
+    if (!isRealmObjectClass) {
+        // setup properties and accessors on the class
+        for (auto& pair : s_class.static_properties) {
+            Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> statc_property =
+                setup_static_property(env, pair.first, pair.second);
+            properties.push_back(statc_property);
+        }
 
-		for (auto& pair : s_class.static_methods) {
-			Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> staticMethod = setup_static_method(env, pair.first, pair.second);
-			properties.push_back(staticMethod);
-		}
+        for (auto& pair : s_class.static_methods) {
+            Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> staticMethod =
+                setup_static_method(env, pair.first, pair.second);
+            properties.push_back(staticMethod);
+        }
 
-		for (auto& pair : s_class.methods) {
-			Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> method = setup_method(env, pair.first, pair.second);
-			properties.push_back(method);
-		}
+        for (auto& pair : s_class.methods) {
+            Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> method =
+                setup_method(env, pair.first, pair.second);
+            properties.push_back(method);
+        }
 
-		for (auto& pair : s_class.properties) {
-			Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> property = setup_property(env, pair.first, pair.second);
-			properties.push_back(property);
-		}
-	}
+        for (auto& pair : s_class.properties) {
+            Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> property =
+                setup_property(env, pair.first, pair.second);
+            properties.push_back(property);
+        }
+    }
 
-	bool has_index_accessor = (s_class.index_accessor.getter || s_class.index_accessor.setter);
-	const IndexPropertyType* index_accessor = has_index_accessor ? &s_class.index_accessor : nullptr;
+    bool has_index_accessor = (s_class.index_accessor.getter || s_class.index_accessor.setter);
+    const IndexPropertyType* index_accessor = has_index_accessor ? &s_class.index_accessor : nullptr;
 
-	ctor = WrappedObject<ClassType>::init(env, s_class.name, &ObjectWrap<ClassType>::constructor_callback, &ObjectWrap<ClassType>::has_native_method, properties, index_accessor);
+    ctor = WrappedObject<ClassType>::init(env, s_class.name, &ObjectWrap<ClassType>::constructor_callback,
+                                          &ObjectWrap<ClassType>::has_native_method, properties, index_accessor);
 
-	auto ctorPrototypeProperty = ctor.Get("prototype");
-	if (ctorPrototypeProperty.IsUndefined()) {
-		throw std::runtime_error("undefined 'prototype' on constructor");
-	}
+    auto ctorPrototypeProperty = ctor.Get("prototype");
+    if (ctorPrototypeProperty.IsUndefined()) {
+        throw std::runtime_error("undefined 'prototype' on constructor");
+    }
 
-	Napi::Function parentCtor = ObjectWrapAccessor<ParentClassType>::init_class(env);
-	if (!parentCtor.IsEmpty()) {
+    Napi::Function parentCtor = ObjectWrapAccessor<ParentClassType>::init_class(env);
+    if (!parentCtor.IsEmpty()) {
 
-		auto parentCtorPrototypeProperty = parentCtor.Get("prototype");
-		if (parentCtorPrototypeProperty.IsUndefined()) {
-			throw std::runtime_error("undefined 'prototype' on parent constructor");
-		}
+        auto parentCtorPrototypeProperty = parentCtor.Get("prototype");
+        if (parentCtorPrototypeProperty.IsUndefined()) {
+            throw std::runtime_error("undefined 'prototype' on parent constructor");
+        }
 
-		ObjectSetPrototypeOf.Call({ ctorPrototypeProperty, parentCtorPrototypeProperty });
-		ObjectSetPrototypeOf.Call({ ctor, parentCtor });
-	}
+        ObjectSetPrototypeOf.Call({ctorPrototypeProperty, parentCtorPrototypeProperty});
+        ObjectSetPrototypeOf.Call({ctor, parentCtor});
+    }
 
-	//use PropertyDescriptors instead of ClassPropertyDescriptors, since ClassPropertyDescriptors requires the JS instance members callbacks to be instance members of the WrappedObject<ClassType> class
-	if (isRealmObjectClass) {
-		std::vector<Napi::PropertyDescriptor> properties;
-		auto ctorPrototype = ctor.Get("prototype").As<Napi::Object>();
-		for (auto& pair : s_class.methods) {
-			auto descriptor = Napi::PropertyDescriptor::Function(env, ctorPrototype, Napi::String::New(env, pair.first) /*name*/, &method_callback, napi_default | realm::js::PropertyAttributes::DontEnum, (void*)pair.second /*callback*/);
-			properties.push_back(descriptor);
-		}
+    // use PropertyDescriptors instead of ClassPropertyDescriptors, since ClassPropertyDescriptors requires the JS
+    // instance members callbacks to be instance members of the WrappedObject<ClassType> class
+    if (isRealmObjectClass) {
+        std::vector<Napi::PropertyDescriptor> properties;
+        auto ctorPrototype = ctor.Get("prototype").As<Napi::Object>();
+        for (auto& pair : s_class.methods) {
+            auto descriptor = Napi::PropertyDescriptor::Function(
+                env, ctorPrototype, Napi::String::New(env, pair.first) /*name*/, &method_callback,
+                napi_default | realm::js::PropertyAttributes::DontEnum, (void*)pair.second /*callback*/);
+            properties.push_back(descriptor);
+        }
 
-		for (auto& pair : s_class.properties) {
-			napi_property_attributes napi_attributes = napi_default | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
-			auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter_callback>(Napi::String::New(env, pair.first) /*name*/, napi_attributes, (void*)&pair.second /*callback*/);
-			properties.push_back(descriptor);
-		}
-		
-		ctorPrototype.DefineProperties(properties);
-	}
+        for (auto& pair : s_class.properties) {
+            napi_property_attributes napi_attributes =
+                napi_default | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
+            auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter_callback>(
+                Napi::String::New(env, pair.first) /*name*/, napi_attributes, (void*)&pair.second /*callback*/);
+            properties.push_back(descriptor);
+        }
 
-	bool isRealmClass = std::is_same<ClassType, realm::js::RealmClass<realm::node::Types>>::value;
-	if (isRealmClass) {
-		RealmClassConstructor = Napi::Persistent(ctor);
-		RealmClassConstructor.SuppressDestruct();
-	}
+        ctorPrototype.DefineProperties(properties);
+    }
+
+    bool isRealmClass = std::is_same<ClassType, realm::js::RealmClass<realm::node::Types>>::value;
+    if (isRealmClass) {
+        RealmClassConstructor = Napi::Persistent(ctor);
+        RealmClassConstructor.SuppressDestruct();
+    }
 
 
-	return ctor;
+    return ctor;
 }
 
-template<typename ClassType>
-Napi::Object ObjectWrap<ClassType>::create_instance(Napi::Env env, Internal* internal) {
-	Napi::EscapableHandleScope scope(env);
+template <typename ClassType>
+Napi::Object ObjectWrap<ClassType>::create_instance(Napi::Env env, Internal* internal)
+{
+    Napi::EscapableHandleScope scope(env);
 
 
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
 
-	if (isRealmObjectClass && !internal) {
-		throw Napi::Error::New(env, "RealmObjectClass requires an internal realm object when creating instances");
-	}
+    if (isRealmObjectClass && !internal) {
+        throw Napi::Error::New(env, "RealmObjectClass requires an internal realm object when creating instances");
+    }
 
-	Napi::Object factory = WrappedObject<ClassType>::create_instance(env, internal);
+    Napi::Object factory = WrappedObject<ClassType>::create_instance(env, internal);
     return scope.Escape(factory).As<Napi::Object>();
 }
 
-inline static void schema_object_type_constructor(const Napi::CallbackInfo& info) {
+inline static void schema_object_type_constructor(const Napi::CallbackInfo& info) {}
+
+template <typename ClassType>
+void ObjectWrap<ClassType>::internal_finalizer(Napi::Env, typename ClassType::Internal* internal)
+{
+    if (internal) {
+        delete internal;
+        internal = nullptr;
+    }
 }
 
-template<typename ClassType>
-void ObjectWrap<ClassType>::internal_finalizer(Napi::Env, typename ClassType::Internal* internal) {
-	if (internal) {
-		delete internal;
-		internal = nullptr;
-	}
+static inline void remove_schema_object(std::unordered_map<std::string, SchemaObjectType*>* schemaObjects,
+                                        const std::string& schemaName)
+{
+    bool schemaExists = schemaObjects->count(schemaName);
+    if (!schemaExists) {
+        return;
+    }
+
+    SchemaObjectType* schemaObjectType = schemaObjects->at(schemaName);
+    schemaObjects->erase(schemaName);
+    schemaObjectType->constructor.Reset();
+    delete schemaObjectType;
 }
 
-static inline void remove_schema_object(std::unordered_map<std::string, SchemaObjectType*>* schemaObjects, const std::string& schemaName) {
-	bool schemaExists = schemaObjects->count(schemaName);
-	if (!schemaExists) {
-		return;
-	}
+template <typename ClassType>
+inline std::vector<Napi::PropertyDescriptor>
+ObjectWrap<ClassType>::create_napi_property_descriptors(Napi::Env env, const Napi::Object& constructorPrototype,
+                                                        const realm::ObjectSchema& schema, bool redefine)
+{
+    std::vector<Napi::PropertyDescriptor> properties;
 
-	SchemaObjectType* schemaObjectType = schemaObjects->at(schemaName);
-	schemaObjects->erase(schemaName);
-	schemaObjectType->constructor.Reset();
-	delete schemaObjectType;
+    for (auto& property : schema.persisted_properties) {
+        std::string propName = property.public_name.empty() ? property.name : property.public_name;
+        if (redefine || !constructorPrototype.HasOwnProperty(propName)) {
+            node::String* name = get_cached_property_name(propName);
+            auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter, property_setter>(
+                name->ToString(env), napi_enumerable, (void*)name);
+            properties.push_back(descriptor);
+        }
+    }
+
+    for (auto& property : schema.computed_properties) {
+        std::string propName = property.public_name.empty() ? property.name : property.public_name;
+        if (redefine || !constructorPrototype.HasOwnProperty(propName)) {
+            node::String* name = get_cached_property_name(propName);
+            auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter, property_setter>(
+                name->ToString(env), napi_enumerable, (void*)name);
+            properties.push_back(descriptor);
+        }
+    }
+
+    return properties;
 }
 
-template<typename ClassType>
-inline std::vector<Napi::PropertyDescriptor> ObjectWrap<ClassType>::create_napi_property_descriptors(Napi::Env env, const Napi::Object& constructorPrototype, const realm::ObjectSchema& schema, bool redefine) {
-	std::vector<Napi::PropertyDescriptor> properties;
+template <typename ClassType>
+Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Napi::Function& constructor,
+                                                              const realm::ObjectSchema& schema, Internal* internal)
+{
+    Napi::EscapableHandleScope scope(env);
+    auto& s_schemaObjectTypes = get_schemaObjectTypes();
+    auto& s_class = get_class();
 
-	for (auto& property : schema.persisted_properties) {
-		std::string propName = property.public_name.empty() ? property.name : property.public_name;
-		if (redefine || !constructorPrototype.HasOwnProperty(propName)) {
-			node::String* name = get_cached_property_name(propName);
-			auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter, property_setter>(name->ToString(env), napi_enumerable, (void*)name);
-			properties.push_back(descriptor);
-		}
-	}
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+    if (!isRealmObjectClass) {
+        throw Napi::Error::New(env, "Creating instances by schema is supported for RealmObjectClass only");
+    }
 
-	for (auto& property : schema.computed_properties) {
-		std::string propName = property.public_name.empty() ? property.name : property.public_name;
-		if (redefine || !constructorPrototype.HasOwnProperty(propName)) {
-			node::String* name = get_cached_property_name(propName);
-			auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter, property_setter>(name->ToString(env), napi_enumerable, (void*)name);
-			properties.push_back(descriptor);
-		}
-	}
+    if (isRealmObjectClass && !internal) {
+        throw Napi::Error::New(
+            env, "RealmObjectClass requires an internal realm object when creating instances by schema");
+    }
 
-	return properties;
+    Napi::Object instance;
+    auto config = internal->realm()->config();
+    std::string path = config.path;
+    auto version = internal->realm()->schema_version();
+    std::string schemaName = schema.name + ":" + std::to_string(version);
+
+    std::unordered_map<std::string, SchemaObjectType*>* schemaObjects = nullptr;
+    if (!s_schemaObjectTypes.count(path)) {
+        // std::map<std::string, std::map<std::string, SchemaObjectType*>>
+        schemaObjects = new std::unordered_map<std::string, SchemaObjectType*>();
+        s_schemaObjectTypes.emplace(path, schemaObjects);
+    }
+    else {
+        schemaObjects = s_schemaObjectTypes.at(path);
+    }
+
+    Napi::Function schemaObjectConstructor;
+    Napi::Symbol externalSymbol = ExternalSymbol;
+    // if we are creating a RealmObject from schema with no user defined constructor
+    if (constructor.IsEmpty()) {
+        // 1.Check by name if the constructor is already created for this RealmObject
+        if (!schemaObjects->count(schemaName)) {
+
+            // 2.Create the constructor
+
+            // get or create the RealmObjectClass<T> constructor
+
+            // create the RealmObject function by name
+            schemaObjectConstructor = Napi::Function::New(env, schema_object_type_constructor, schema.name);
+
+            Napi::Function realmObjectClassConstructor = ObjectWrap<ClassType>::create_constructor(env);
+            auto parentCtorPrototypeProperty = realmObjectClassConstructor.Get("prototype");
+            auto childPrototypeProperty = schemaObjectConstructor.Get("prototype").As<Napi::Object>();
+            ObjectSetPrototypeOf.Call({childPrototypeProperty, parentCtorPrototypeProperty});
+            ObjectSetPrototypeOf.Call({schemaObjectConstructor, realmObjectClassConstructor});
+
+            // get all properties from the schema
+            std::vector<Napi::PropertyDescriptor> properties =
+                create_napi_property_descriptors(env, childPrototypeProperty, schema, true /*redefine*/);
+
+            // define the properties on the prototype of the schema object constructor
+            childPrototypeProperty.DefineProperties(properties);
+
+            SchemaObjectType* schemaObjectType = new SchemaObjectType();
+            schemaObjects->emplace(schemaName, schemaObjectType);
+            schemaObjectType->constructor = Napi::Persistent(schemaObjectConstructor);
+            schemaObjectType->constructor.SuppressDestruct();
+        }
+        else {
+            // hot path. The constructor for this schema object is already cached. use it and return a new instance
+            SchemaObjectType* schemaObjectType = schemaObjects->at(schemaName);
+            schemaObjectConstructor = schemaObjectType->constructor.Value();
+        }
+
+        Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
+        instance = schemaObjectConstructor.New({});
+        instance.Set(externalSymbol, externalValue);
+    }
+    else {
+        // creating a RealmObject with user defined constructor
+
+        bool schemaExists = schemaObjects->count(schemaName);
+        SchemaObjectType* schemaObjectType;
+        if (schemaExists) {
+            schemaObjectType = schemaObjects->at(schemaName);
+            schemaObjectConstructor = schemaObjectType->constructor.Value();
+
+            // check if constructors have changed for the same schema object and name
+            if (!schemaObjectConstructor.StrictEquals(constructor)) {
+                schemaExists = false;
+                remove_schema_object(schemaObjects, schemaName);
+            }
+        }
+
+        // hot path. The constructor for this schema object is already cached. use it and return a new instance
+        if (schemaExists) {
+            schemaObjectType = schemaObjects->at(schemaName);
+            schemaObjectConstructor = schemaObjectType->constructor.Value();
+
+            instance = schemaObjectConstructor.New({});
+
+            Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
+            instance.Set(externalSymbol, externalValue);
+
+            return scope.Escape(instance).As<Napi::Object>();
+        }
+
+        schemaObjectConstructor = constructor;
+        Napi::Object constructorPrototype = constructor.Get("prototype").As<Napi::Object>();
+
+        // get all properties from the schema
+        std::vector<Napi::PropertyDescriptor> properties =
+            create_napi_property_descriptors(env, constructorPrototype, schema, false /*redefine*/);
+
+        Napi::Function realmObjectClassConstructor = ObjectWrap<ClassType>::create_constructor(env);
+        bool isInstanceOfRealmObjectClass = constructorPrototype.InstanceOf(realmObjectClassConstructor);
+
+        // Skip if the user defined constructor inherited the RealmObjectClass. All RealmObjectClass members are
+        // available already.
+        if (!isInstanceOfRealmObjectClass) {
+            // setup all RealmObjectClass<T> methods to the prototype of the object
+            for (auto& pair : s_class.methods) {
+                // don't redefine if exists
+                if (!constructorPrototype.HasOwnProperty(pair.first)) {
+                    auto descriptor = Napi::PropertyDescriptor::Function(
+                        env, constructorPrototype, Napi::String::New(env, pair.first) /*name*/, &method_callback,
+                        napi_default | realm::js::PropertyAttributes::DontEnum, (void*)pair.second /*callback*/);
+                    properties.push_back(descriptor);
+                }
+            }
+
+            for (auto& pair : s_class.properties) {
+                // don't redefine if exists
+                if (!constructorPrototype.HasOwnProperty(pair.first)) {
+                    napi_property_attributes napi_attributes =
+                        napi_default |
+                        (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
+                    auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter_callback>(
+                        Napi::String::New(env, pair.first) /*name*/, napi_attributes,
+                        (void*)&pair.second /*callback*/);
+                    properties.push_back(descriptor);
+                }
+            }
+        }
+
+        // define the properties on the prototype of the schema object constructor
+        if (properties.size() > 0) {
+            constructorPrototype.DefineProperties(properties);
+        }
+
+        instance = schemaObjectConstructor.New({});
+        if (!instance.InstanceOf(schemaObjectConstructor)) {
+            throw Napi::Error::New(env, "Realm object constructor must not return another value");
+        }
+
+        Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
+        instance.Set(externalSymbol, externalValue);
+
+        schemaObjectType = new SchemaObjectType();
+        schemaObjects->emplace(schemaName, schemaObjectType);
+        schemaObjectType->constructor = Napi::Persistent(schemaObjectConstructor);
+        schemaObjectType->constructor.SuppressDestruct();
+    }
+
+    return scope.Escape(instance).As<Napi::Object>();
 }
 
-template<typename ClassType>
-Napi::Object ObjectWrap<ClassType>::create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, Internal* internal) {
-	Napi::EscapableHandleScope scope(env);
-	auto& s_schemaObjectTypes = get_schemaObjectTypes();
-	auto& s_class = get_class();
+template <typename ClassType>
+inline void ObjectWrap<ClassType>::on_context_destroy(Napi::Env env, std::string realmPath)
+{
+    std::unordered_map<std::string, SchemaObjectType*>* schemaObjects = nullptr;
+    auto& s_schemaObjectTypes = get_schemaObjectTypes();
+    if (!s_schemaObjectTypes.count(realmPath)) {
+        return;
+    }
 
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
-	if (!isRealmObjectClass) {
-		throw Napi::Error::New(env, "Creating instances by schema is supported for RealmObjectClass only");
-	}
+    schemaObjects = s_schemaObjectTypes.at(realmPath);
+    for (auto it = schemaObjects->begin(); it != schemaObjects->end(); ++it) {
+        it->second->constructor.Reset();
+        SchemaObjectType* schemaObjecttype = it->second;
+        delete schemaObjecttype;
+    }
+    s_schemaObjectTypes.erase(realmPath);
 
-	if (isRealmObjectClass && !internal) {
-		throw Napi::Error::New(env, "RealmObjectClass requires an internal realm object when creating instances by schema");
-	}
-
-	Napi::Object instance;
-	auto config = internal->realm()->config();
-	std::string path = config.path;
-	auto version = internal->realm()->schema_version();
-	std::string schemaName = schema.name + ":" + std::to_string(version); 
-
-	std::unordered_map<std::string, SchemaObjectType*>* schemaObjects = nullptr;
-	if (!s_schemaObjectTypes.count(path)) {
-		//std::map<std::string, std::map<std::string, SchemaObjectType*>>
-		schemaObjects = new std::unordered_map<std::string, SchemaObjectType*>();
-		s_schemaObjectTypes.emplace(path, schemaObjects);
-	}
-	else {
-		schemaObjects = s_schemaObjectTypes.at(path);
-	}
-
-	Napi::Function schemaObjectConstructor;
-	Napi::Symbol externalSymbol = ExternalSymbol;
-	//if we are creating a RealmObject from schema with no user defined constructor
-	if (constructor.IsEmpty()) {
-		//1.Check by name if the constructor is already created for this RealmObject 
-		if (!schemaObjects->count(schemaName)) {
-
-			//2.Create the constructor
-
-			//get or create the RealmObjectClass<T> constructor
-
-			//create the RealmObject function by name
-			schemaObjectConstructor = Napi::Function::New(env, schema_object_type_constructor, schema.name);
-
-			Napi::Function realmObjectClassConstructor = ObjectWrap<ClassType>::create_constructor(env);
-			auto parentCtorPrototypeProperty = realmObjectClassConstructor.Get("prototype");
-			auto childPrototypeProperty = schemaObjectConstructor.Get("prototype").As<Napi::Object>();
-			ObjectSetPrototypeOf.Call({ childPrototypeProperty, parentCtorPrototypeProperty });
-			ObjectSetPrototypeOf.Call({ schemaObjectConstructor, realmObjectClassConstructor });
-
-			//get all properties from the schema 
-			std::vector<Napi::PropertyDescriptor> properties = create_napi_property_descriptors(env, childPrototypeProperty, schema, true /*redefine*/);
-
-			//define the properties on the prototype of the schema object constructor
-			childPrototypeProperty.DefineProperties(properties);
-			
-			SchemaObjectType* schemaObjectType = new SchemaObjectType();
-			schemaObjects->emplace(schemaName, schemaObjectType);
-			schemaObjectType->constructor = Napi::Persistent(schemaObjectConstructor);
-			schemaObjectType->constructor.SuppressDestruct();
-		}
-		else {
-			//hot path. The constructor for this schema object is already cached. use it and return a new instance
-			SchemaObjectType* schemaObjectType = schemaObjects->at(schemaName);
-			schemaObjectConstructor = schemaObjectType->constructor.Value();
-		}
-
-		Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
-		instance = schemaObjectConstructor.New({});
-		instance.Set(externalSymbol, externalValue);
-	}
-	else {
-		//creating a RealmObject with user defined constructor
-
-		bool schemaExists = schemaObjects->count(schemaName);
-		SchemaObjectType* schemaObjectType;
-		if (schemaExists) {
-			schemaObjectType = schemaObjects->at(schemaName);
-			schemaObjectConstructor = schemaObjectType->constructor.Value();
-			
-			//check if constructors have changed for the same schema object and name
-			if (!schemaObjectConstructor.StrictEquals(constructor)) {
-				schemaExists = false;
-				remove_schema_object(schemaObjects, schemaName);
-			}
-		}
-
-		//hot path. The constructor for this schema object is already cached. use it and return a new instance
-		if (schemaExists) {
-			schemaObjectType = schemaObjects->at(schemaName);
-			schemaObjectConstructor = schemaObjectType->constructor.Value();
-
-			instance = schemaObjectConstructor.New({});
-
-			Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
-			instance.Set(externalSymbol, externalValue);
-
-			return scope.Escape(instance).As<Napi::Object>();
-		}
-
-		schemaObjectConstructor = constructor;
-		Napi::Object constructorPrototype = constructor.Get("prototype").As<Napi::Object>();
-
-		//get all properties from the schema 
-		std::vector<Napi::PropertyDescriptor> properties = create_napi_property_descriptors(env, constructorPrototype, schema, false /*redefine*/);
-
-		Napi::Function realmObjectClassConstructor = ObjectWrap<ClassType>::create_constructor(env);
-		bool isInstanceOfRealmObjectClass = constructorPrototype.InstanceOf(realmObjectClassConstructor);
-
-		//Skip if the user defined constructor inherited the RealmObjectClass. All RealmObjectClass members are available already.
-		if (!isInstanceOfRealmObjectClass) {
-			//setup all RealmObjectClass<T> methods to the prototype of the object
-			for (auto& pair : s_class.methods) {
-				//don't redefine if exists
-				if (!constructorPrototype.HasOwnProperty(pair.first)) {
-					auto descriptor = Napi::PropertyDescriptor::Function(env, constructorPrototype, Napi::String::New(env, pair.first) /*name*/, &method_callback, napi_default | realm::js::PropertyAttributes::DontEnum, (void*)pair.second /*callback*/);
-					properties.push_back(descriptor);
-				}
-			}
-
-			for (auto& pair : s_class.properties) {
-				//don't redefine if exists
-				if (!constructorPrototype.HasOwnProperty(pair.first)) {
-					napi_property_attributes napi_attributes = napi_default | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
-					auto descriptor = Napi::PropertyDescriptor::Accessor<property_getter_callback>(Napi::String::New(env, pair.first) /*name*/, napi_attributes, (void*)&pair.second /*callback*/);
-					properties.push_back(descriptor);
-				}
-			}
-		}
-
-		//define the properties on the prototype of the schema object constructor
-		if (properties.size() > 0) {
-			constructorPrototype.DefineProperties(properties);
-		}
-
-		instance = schemaObjectConstructor.New({});
-		if (!instance.InstanceOf(schemaObjectConstructor)) {
-			throw Napi::Error::New(env, "Realm object constructor must not return another value");
-		}
-
-		Napi::External<Internal> externalValue = Napi::External<Internal>::New(env, internal, internal_finalizer);
-		instance.Set(externalSymbol, externalValue);
-
-		schemaObjectType = new SchemaObjectType();
-		schemaObjects->emplace(schemaName, schemaObjectType);
-		schemaObjectType->constructor = Napi::Persistent(schemaObjectConstructor);
-		schemaObjectType->constructor.SuppressDestruct();
-	}
-	
-	return scope.Escape(instance).As<Napi::Object>();
+    delete schemaObjects;
 }
 
-template<typename ClassType>
-inline void ObjectWrap<ClassType>::on_context_destroy(Napi::Env env, std::string realmPath) {
-	std::unordered_map<std::string, SchemaObjectType*>* schemaObjects = nullptr;
-	auto& s_schemaObjectTypes = get_schemaObjectTypes();
-	if (!s_schemaObjectTypes.count(realmPath)) {
-		return;
-	}
-	
-	schemaObjects = s_schemaObjectTypes.at(realmPath);
-	for (auto it = schemaObjects->begin(); it != schemaObjects->end(); ++it) {
-		it->second->constructor.Reset();
-		SchemaObjectType* schemaObjecttype = it->second;
-		delete schemaObjecttype;
-	}
-	s_schemaObjectTypes.erase(realmPath);
-
-	delete schemaObjects;
+template <typename ClassType>
+inline bool ObjectWrap<ClassType>::is_instance(Napi::Env env, const Napi::Object& object)
+{
+    return WrappedObject<ClassType>::is_instance(env, object);
 }
 
-template<typename ClassType>
-inline bool ObjectWrap<ClassType>::is_instance(Napi::Env env, const Napi::Object& object) {
-	return WrappedObject<ClassType>::is_instance(env, object);
+template <typename ClassType>
+typename ClassType::Internal* ObjectWrap<ClassType>::get_internal(Napi::Env env, const Napi::Object& object)
+{
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+    if (isRealmObjectClass) {
+        Napi::External<typename ClassType::Internal> external =
+            object.Get(ExternalSymbol).As<Napi::External<typename ClassType::Internal>>();
+        if (external.IsUndefined()) {
+            return nullptr;
+        }
+
+        return external.Data();
+    }
+
+    WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::try_unwrap(object);
+    return wrappedObject->get_internal();
 }
 
-template<typename ClassType>
-typename ClassType::Internal* ObjectWrap<ClassType>::get_internal(Napi::Env env, const Napi::Object& object) {
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
-	if (isRealmObjectClass) {
-		Napi::External<typename ClassType::Internal> external = object.Get(ExternalSymbol).As<Napi::External<typename ClassType::Internal>>();
-		if (external.IsUndefined()) {
-			return nullptr;
-		}
+template <typename ClassType>
+void ObjectWrap<ClassType>::set_internal(Napi::Env env, const Napi::Object& object,
+                                         typename ClassType::Internal* internal)
+{
+    bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+    if (isRealmObjectClass) {
+        Napi::Object& obj = const_cast<Napi::Object&>(object);
+        obj.Set(ExternalSymbol, Napi::External<typename ClassType::Internal>::New(env, internal));
+        return;
+    }
 
-		return external.Data();
-	}
-
-	WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::try_unwrap(object);
-	return wrappedObject->get_internal();
+    WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::try_unwrap(object);
+    wrappedObject->set_internal(internal);
 }
 
-template<typename ClassType>
-void ObjectWrap<ClassType>::set_internal(Napi::Env env, const Napi::Object& object, typename ClassType::Internal* internal) {
-	bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
-	if (isRealmObjectClass) {
-		Napi::Object& obj = const_cast<Napi::Object&>(object);
-		obj.Set(ExternalSymbol, Napi::External<typename ClassType::Internal>::New(env, internal));
-		return;
-	}
+template <typename ClassType>
+Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::EscapableHandleScope scope(env);
+    auto& s_class = get_class();
 
-	WrappedObject<ClassType>* wrappedObject = WrappedObject<ClassType>::try_unwrap(object);
-	wrappedObject->set_internal(internal);
+    if (reinterpret_cast<void*>(s_class.constructor) != nullptr) {
+        auto arguments = get_arguments(info);
+        node::Arguments args{env, arguments.size(), arguments.data()};
+        s_class.constructor(env, info.This().As<Napi::Object>(), args);
+        return scope.Escape(env.Null()); // return a value to comply with Napi::FunctionCallback
+    }
+    else {
+        bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
+        if (isRealmObjectClass) {
+            return scope.Escape(env.Null()); // return a value to comply with Napi::FunctionCallback
+        }
+
+        throw Napi::Error::New(env, "Illegal constructor");
+    }
 }
 
-template<typename ClassType>
-Napi::Value ObjectWrap<ClassType>::constructor_callback(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	Napi::EscapableHandleScope scope(env);
-	auto& s_class = get_class();
+template <typename ClassType>
+bool ObjectWrap<ClassType>::has_native_method(const std::string& name)
+{
+    auto& s_nativeMethods = get_nativeMethods();
+    if (s_nativeMethods.find(name) != s_nativeMethods.end()) {
+        return true;
+    }
 
-	if (reinterpret_cast<void*>(s_class.constructor) != nullptr) {
-		auto arguments = get_arguments(info);
-		node::Arguments args { env, arguments.size(), arguments.data() };
-		s_class.constructor(env, info.This().As<Napi::Object>(), args);
-		return scope.Escape(env.Null()); //return a value to comply with Napi::FunctionCallback
-	}
-	else {
-		bool isRealmObjectClass = std::is_same<ClassType, realm::js::RealmObjectClass<realm::node::Types>>::value;
-		if (isRealmObjectClass) {
-			return scope.Escape(env.Null()); //return a value to comply with Napi::FunctionCallback
-		}
-
-		throw Napi::Error::New(env, "Illegal constructor");
-	}
+    return ObjectWrap<ParentClassType>::has_native_method(name);
 }
 
-template<typename ClassType>
-bool ObjectWrap<ClassType>::has_native_method(const std::string& name) {
-	auto& s_nativeMethods = get_nativeMethods();
-	if (s_nativeMethods.find(name) != s_nativeMethods.end()) {
-		return true;
-	}
-
-	return ObjectWrap<ParentClassType>::has_native_method(name);
+template <typename ClassType>
+Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+ObjectWrap<ClassType>::setup_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback)
+{
+    auto& s_nativeMethods = get_nativeMethods();
+    auto methodCallback =
+        (typename WrappedObject<ClassType>::InstanceMethodCallback)(&WrappedObject<ClassType>::method_callback);
+    s_nativeMethods.insert(name);
+    return WrappedObject<ClassType>::InstanceMethod(
+        name.c_str(), methodCallback, napi_default | realm::js::PropertyAttributes::DontEnum, (void*)callback);
 }
 
-template<typename ClassType>
-Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> ObjectWrap<ClassType>::setup_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback) {
-	auto& s_nativeMethods = get_nativeMethods();
-	auto methodCallback = (typename WrappedObject<ClassType>::InstanceMethodCallback)(&WrappedObject<ClassType>::method_callback);
-	s_nativeMethods.insert(name);
-	return WrappedObject<ClassType>::InstanceMethod(name.c_str(), methodCallback, napi_default | realm::js::PropertyAttributes::DontEnum, (void*)callback);
+template <typename ClassType>
+Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+ObjectWrap<ClassType>::setup_static_method(Napi::Env env, const std::string& name,
+                                           node::Types::FunctionCallback callback)
+{
+    return Napi::ObjectWrap<WrappedObject<ClassType>>::StaticMethod(
+        name.c_str(), callback, napi_static | realm::js::PropertyAttributes::DontEnum);
 }
 
-template<typename ClassType>
-Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> ObjectWrap<ClassType>::setup_static_method(Napi::Env env, const std::string& name, node::Types::FunctionCallback callback) {
-	return Napi::ObjectWrap<WrappedObject<ClassType>>::StaticMethod(name.c_str(), callback, napi_static | realm::js::PropertyAttributes::DontEnum);
+template <typename ClassType>
+Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+ObjectWrap<ClassType>::setup_property(Napi::Env env, const std::string& name, const PropertyType& property)
+{
+    napi_property_attributes napi_attributes =
+        napi_default | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
+
+    auto getterCallback =
+        (typename WrappedObject<ClassType>::InstanceGetterCallback)(&WrappedObject<ClassType>::getter_callback);
+    auto setterCallback = (typename WrappedObject<ClassType>::InstanceSetterCallback)(
+        &WrappedObject<ClassType>::readonly_setter_callback);
+    if (property.setter) {
+        setterCallback =
+            (typename WrappedObject<ClassType>::InstanceSetterCallback)(&WrappedObject<ClassType>::setter_callback);
+    }
+
+    return WrappedObject<ClassType>::InstanceAccessor(name.c_str(), getterCallback, setterCallback, napi_attributes,
+                                                      (void*)&property);
 }
 
-template<typename ClassType>
-Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> ObjectWrap<ClassType>::setup_property(Napi::Env env, const std::string& name, const PropertyType& property) {
-	napi_property_attributes napi_attributes = napi_default | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
-	
-	auto getterCallback = (typename WrappedObject<ClassType>::InstanceGetterCallback)(&WrappedObject<ClassType>::getter_callback);
-	auto setterCallback = (typename WrappedObject<ClassType>::InstanceSetterCallback)(&WrappedObject<ClassType>::readonly_setter_callback);
-	if (property.setter) {
-		setterCallback = (typename WrappedObject<ClassType>::InstanceSetterCallback)(&WrappedObject<ClassType>::setter_callback);
-	}
+template <typename ClassType>
+Napi::ClassPropertyDescriptor<WrappedObject<ClassType>>
+ObjectWrap<ClassType>::setup_static_property(Napi::Env env, const std::string& name, const PropertyType& property)
+{
+    napi_property_attributes napi_attributes =
+        napi_static | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
 
-	return WrappedObject<ClassType>::InstanceAccessor(name.c_str(), getterCallback, setterCallback, napi_attributes, (void*)&property);
+    auto getterCallback = (typename WrappedObject<ClassType>::StaticGetterCallback)(property.getter);
+    typename WrappedObject<ClassType>::StaticSetterCallback setterCallback =
+        &WrappedObject<ClassType>::readonly_static_setter_callback;
+    if (property.setter) {
+        setterCallback = (typename WrappedObject<ClassType>::StaticSetterCallback)(property.setter);
+    }
+
+    return WrappedObject<ClassType>::StaticAccessor(name.c_str(), getterCallback, setterCallback, napi_attributes,
+                                                    nullptr);
 }
 
-template<typename ClassType>
-Napi::ClassPropertyDescriptor<WrappedObject<ClassType>> ObjectWrap<ClassType>::setup_static_property(Napi::Env env, const std::string& name, const PropertyType& property) {
-	napi_property_attributes napi_attributes = napi_static | (realm::js::PropertyAttributes::DontEnum | realm::js::PropertyAttributes::DontDelete);
-
-	auto getterCallback = (typename WrappedObject<ClassType>::StaticGetterCallback)(property.getter);
-	typename WrappedObject<ClassType>::StaticSetterCallback setterCallback = &WrappedObject<ClassType>::readonly_static_setter_callback;
-	if (property.setter) {
-		setterCallback = (typename WrappedObject<ClassType>::StaticSetterCallback)(property.setter);
-	}
-
-	return WrappedObject<ClassType>::StaticAccessor(name.c_str(), getterCallback, setterCallback, napi_attributes, nullptr);
-}
-
-} // node
+} // namespace node
 
 namespace js {
 
-template<typename ClassType>
-class ObjectWrap<node::Types, ClassType> : public node::ObjectWrap<ClassType> {};
+template <typename ClassType>
+class ObjectWrap<node::Types, ClassType> : public node::ObjectWrap<ClassType> {
+};
 
 
-#define HANDLE_WRAP_EXCEPTION           \
-catch (const Napi::Error & e) { \
-	throw;\
-}\
-catch (const node::Exception & e) {\
-	Napi::Error error = Napi::Error::New(info.Env(), e.what());\
-	copy_object(env, e.m_value, error);\
-	throw error;\
-}\
-catch (const std::exception & e) {\
-	throw Napi::Error::New(info.Env(), e.what());\
+#define HANDLE_WRAP_EXCEPTION                                                                                        \
+    catch (const Napi::Error& e)                                                                                     \
+    {                                                                                                                \
+        throw;                                                                                                       \
+    }                                                                                                                \
+    catch (const node::Exception& e)                                                                                 \
+    {                                                                                                                \
+        Napi::Error error = Napi::Error::New(info.Env(), e.what());                                                  \
+        copy_object(env, e.m_value, error);                                                                          \
+        throw error;                                                                                                 \
+    }                                                                                                                \
+    catch (const std::exception& e)                                                                                  \
+    {                                                                                                                \
+        throw Napi::Error::New(info.Env(), e.what());                                                                \
+    }
+
+
+template <node::ArgumentsMethodType F>
+Napi::Value wrap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    auto arguments = node::get_arguments(info);
+    node::Arguments args{info.Env(), arguments.size(), arguments.data()};
+    node::ReturnValue result(env);
+
+    Napi::Object instanceProxy = info.This().As<Napi::Object>().Get("_instanceProxy").As<Napi::Object>();
+    if (instanceProxy.IsUndefined()) {
+        instanceProxy = info.This().As<Napi::Object>();
+    }
+
+    try {
+        F(env, instanceProxy, args, result);
+        return result.ToValue();
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-
-template<node::ArgumentsMethodType F>
-Napi::Value wrap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	auto arguments = node::get_arguments(info);
-	node::Arguments args{ info.Env(), arguments.size(), arguments.data() };
-	node::ReturnValue result(env);
-
-	Napi::Object instanceProxy = info.This().As<Napi::Object>().Get("_instanceProxy").As<Napi::Object>();
-	if (instanceProxy.IsUndefined()) {
-		instanceProxy = info.This().As<Napi::Object>();
-	}
-
-	try {
-		F(env, instanceProxy, args, result);
-		return result.ToValue();
-	}
-	HANDLE_WRAP_EXCEPTION
+template <node::PropertyType::GetterType F>
+Napi::Value wrap(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    node::ReturnValue result(env);
+    try {
+        F(env, info.This().As<Napi::Object>(), result);
+        return result.ToValue();
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::PropertyType::GetterType F>
-Napi::Value wrap(const Napi::CallbackInfo& info) {
-	Napi::Env env = info.Env();
-	node::ReturnValue result(env);
-	try {
-		F(env, info.This().As<Napi::Object>(), result);
-		return result.ToValue();
-	}
-	HANDLE_WRAP_EXCEPTION
+template <node::PropertyType::SetterType F>
+void wrap(const Napi::CallbackInfo& info, const Napi::Value& value)
+{
+    Napi::Env env = info.Env();
+
+    try {
+        F(env, info.This().As<Napi::Object>(), value);
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::PropertyType::SetterType F>
-void wrap(const Napi::CallbackInfo& info, const Napi::Value& value) {
-	Napi::Env env = info.Env();
+template <node::IndexPropertyType::GetterType F>
+Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index)
+{
+    Napi::Env env = info.Env();
+    node::ReturnValue result(env);
 
-	try {
-		F(env, info.This().As<Napi::Object>(), value);
-	}
-	HANDLE_WRAP_EXCEPTION
+    try {
+        try {
+            F(env, instance, index, result);
+            return result.ToValue();
+        }
+        catch (const std::out_of_range& e) {
+            // Out-of-bounds index getters should just return undefined in JS.
+            result.set_undefined();
+            return result.ToValue();
+        }
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::IndexPropertyType::GetterType F>
-Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index) {
-	Napi::Env env = info.Env();
-	node::ReturnValue result(env);
+template <node::IndexPropertyType::SetterType F>
+Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index,
+                 const Napi::Value& value)
+{
+    Napi::Env env = info.Env();
 
-	try {
-		try {
-			F(env, instance, index, result);
-			return result.ToValue();
-		}
-		catch (const std::out_of_range& e) {
-			// Out-of-bounds index getters should just return undefined in JS.
-			result.set_undefined();
-			return result.ToValue();
-		}
-	}
-	HANDLE_WRAP_EXCEPTION
+    try {
+        bool success = F(env, instance, index, value);
+
+        // Indicate that the property was intercepted.
+        return Napi::Value::From(env, success);
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::IndexPropertyType::SetterType F>
-Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index, const Napi::Value& value) {
-	Napi::Env env = info.Env();
+template <node::StringPropertyType::GetterType F>
+Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property)
+{
+    Napi::Env env = info.Env();
+    node::ReturnValue result(env);
 
-	try {
-		bool success = F(env, instance, index, value);
-
-		// Indicate that the property was intercepted.
-		return Napi::Value::From(env, success);
-	}
-	HANDLE_WRAP_EXCEPTION
+    try {
+        F(env, instance, property, result);
+        return result.ToValue();
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::StringPropertyType::GetterType F>
-Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property) {
-	Napi::Env env = info.Env();
-	node::ReturnValue result(env);
-
-	try {
-		F(env, instance, property, result);
-		return result.ToValue();
-	}
-	HANDLE_WRAP_EXCEPTION
+template <node::StringPropertyType::SetterType F>
+Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property,
+                 const Napi::Value& value)
+{
+    Napi::Env env = info.Env();
+    try {
+        bool success = F(env, instance, property, value);
+        return Napi::Value::From(env, success);
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::StringPropertyType::SetterType F>
-Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property, const Napi::Value& value) {
-	Napi::Env env = info.Env();
-	try {
-		bool success = F(env, instance, property, value);
-		return Napi::Value::From(env, success);
-	}
-	HANDLE_WRAP_EXCEPTION
+template <node::StringPropertyType::EnumeratorType F>
+Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance)
+{
+    Napi::Env env = info.Env();
+
+    try {
+        auto names = F(env, instance);
+
+        int count = (int)names.size();
+        Napi::Array array = Napi::Array::New(env, count);
+        for (int i = 0; i < count; i++) {
+            array.Set(i, names[i]);
+        }
+
+        return array;
+    }
+    HANDLE_WRAP_EXCEPTION
 }
 
-template<node::StringPropertyType::EnumeratorType F>
-Napi::Value wrap(const Napi::CallbackInfo& info, const Napi::Object& instance) {
-	Napi::Env env = info.Env();
-
-	try {
-		auto names = F(env, instance);
-
-		int count = (int)names.size();
-		Napi::Array array = Napi::Array::New(env, count);
-		for (int i = 0; i < count; i++) {
-			array.Set(i, names[i]);
-		}
-
-		return array;
-	}
-	HANDLE_WRAP_EXCEPTION
-}
-
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_context.hpp
+++ b/src/node/node_context.hpp
@@ -24,9 +24,10 @@
 namespace realm {
 namespace js {
 
-template<>
-inline Napi::Env node::Context::get_global_context(Napi::Env env) {
-	return env;
+template <>
+inline Napi::Env node::Context::get_global_context(Napi::Env env)
+{
+    return env;
 }
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_dummy.cpp
+++ b/src/node/node_dummy.cpp
@@ -23,8 +23,17 @@ extern "C" void node_module_register(void* mod) {}
 
 namespace node {
 namespace Buffer {
-    bool HasInstance(v8::Local<v8::Value> val) { return false; }
-    char* Data(v8::Local<v8::Value> val) { return nullptr; }
-    size_t Length(v8::Local<v8::Value> val) { return 0; }
+bool HasInstance(v8::Local<v8::Value> val)
+{
+    return false;
 }
+char* Data(v8::Local<v8::Value> val)
+{
+    return nullptr;
 }
+size_t Length(v8::Local<v8::Value> val)
+{
+    return 0;
+}
+} // namespace Buffer
+} // namespace node

--- a/src/node/node_exception.hpp
+++ b/src/node/node_exception.hpp
@@ -24,10 +24,11 @@
 namespace realm {
 namespace js {
 
-template<>
-inline Napi::Value node::Exception::value(Napi::Env env, const std::string &message) {
-	return Napi::String::New(env, message);
+template <>
+inline Napi::Value node::Exception::value(Napi::Env env, const std::string& message)
+{
+    return Napi::String::New(env, message);
 }
-    
-} // js
-} // realm
+
+} // namespace js
+} // namespace realm

--- a/src/node/node_function.hpp
+++ b/src/node/node_function.hpp
@@ -25,28 +25,38 @@ namespace realm {
 namespace js {
 
 template <>
-inline Napi::Value node::Function::call(Napi::Env env, const Napi::Function& function, const Napi::Object& this_object, size_t argc, const Napi::Value arguments[]) {
-	auto recv = this_object.IsEmpty() ? env.Global() : this_object;
+inline Napi::Value node::Function::call(Napi::Env env, const Napi::Function& function,
+                                        const Napi::Object& this_object, size_t argc, const Napi::Value arguments[])
+{
+    auto recv = this_object.IsEmpty() ? env.Global() : this_object;
 
-	std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments), const_cast<const Napi::Value*>(arguments) + argc);
-	auto result = function.Call(recv, args);
-	return result;
+    std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments),
+                                 const_cast<const Napi::Value*>(arguments) + argc);
+    auto result = function.Call(recv, args);
+    return result;
 }
 
 template <>
-inline Napi::Value node::Function::callback(Napi::Env env, const Napi::Function& function, const Napi::Object& this_object, size_t argc, const Napi::Value arguments[]) {
-	auto recv = this_object.IsEmpty() ? env.Global() : this_object;
-	
-	std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments), const_cast<const Napi::Value*>(arguments) + argc);
-	auto result = function.MakeCallback(recv, args);
-	return result;
+inline Napi::Value node::Function::callback(Napi::Env env, const Napi::Function& function,
+                                            const Napi::Object& this_object, size_t argc,
+                                            const Napi::Value arguments[])
+{
+    auto recv = this_object.IsEmpty() ? env.Global() : this_object;
+
+    std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments),
+                                 const_cast<const Napi::Value*>(arguments) + argc);
+    auto result = function.MakeCallback(recv, args);
+    return result;
 }
 
 template <>
-inline Napi::Object node::Function::construct(Napi::Env env, const Napi::Function& function, size_t argc, const Napi::Value arguments[]) {
-	std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments), const_cast<const Napi::Value*>(arguments) + argc);
-	auto result = function.New(args);
-	return result;
+inline Napi::Object node::Function::construct(Napi::Env env, const Napi::Function& function, size_t argc,
+                                              const Napi::Value arguments[])
+{
+    std::vector<napi_value> args(const_cast<const Napi::Value*>(arguments),
+                                 const_cast<const Napi::Value*>(arguments) + argc);
+    auto result = function.New(args);
+    return result;
 }
 
 } // namespace js

--- a/src/node/node_init.cpp
+++ b/src/node/node_init.cpp
@@ -21,30 +21,32 @@
 #include "napi.h"
 
 #if !REALM_ENABLE_SYNC
-#pragma comment( lib, "ws2_32.lib")
-#pragma comment (lib, "crypt32");
+#pragma comment(lib, "ws2_32.lib")
+#pragma comment(lib, "crypt32");
 #endif
 
 #include "js_realm.hpp"
 
- namespace realm {
- namespace node {
+namespace realm {
+namespace node {
 
- static void napi_init(Napi::Env env, Napi::Object exports) {
-	node_class_init(env);
+static void napi_init(Napi::Env env, Napi::Object exports)
+{
+    node_class_init(env);
 
-	Napi::Function realm_constructor = js::RealmClass<Types>::create_constructor(env);
+    Napi::Function realm_constructor = js::RealmClass<Types>::create_constructor(env);
 
-	std::string name = realm_constructor.Get("name").As<Napi::String>();
-	exports.Set(Napi::String::New(env, name), realm_constructor);
+    std::string name = realm_constructor.Get("name").As<Napi::String>();
+    exports.Set(Napi::String::New(env, name), realm_constructor);
 }
 
-} // node
-} // realm
+} // namespace node
+} // namespace realm
 
- static Napi::Object NAPI_Init(Napi::Env env, Napi::Object exports) {
-	 realm::node::napi_init(env, exports);
-	 return exports;
- }
+static Napi::Object NAPI_Init(Napi::Env env, Napi::Object exports)
+{
+    realm::node::napi_init(env, exports);
+    return exports;
+}
 
 NODE_API_MODULE(realm, NAPI_Init)

--- a/src/node/node_object.hpp
+++ b/src/node/node_object.hpp
@@ -24,196 +24,223 @@
 namespace realm {
 namespace js {
 
-inline napi_property_attributes operator|(napi_property_attributes a, PropertyAttributes b) {
-	int flag = napi_default;
+inline napi_property_attributes operator|(napi_property_attributes a, PropertyAttributes b)
+{
+    int flag = napi_default;
 
-	if ((b & DontEnum) != DontEnum) {
-		flag |= napi_enumerable;
-	}
+    if ((b & DontEnum) != DontEnum) {
+        flag |= napi_enumerable;
+    }
 
-	if ((b & DontDelete) != DontDelete) {
-		flag |= napi_configurable;
-	}
+    if ((b & DontDelete) != DontDelete) {
+        flag |= napi_configurable;
+    }
 
-	if ((b & ReadOnly) != ReadOnly) {
-		flag |= napi_writable;
-	}
+    if ((b & ReadOnly) != ReadOnly) {
+        flag |= napi_writable;
+    }
 
-	napi_property_attributes napi_flag = static_cast<napi_property_attributes>(a | flag);
-	return napi_flag;
+    napi_property_attributes napi_flag = static_cast<napi_property_attributes>(a | flag);
+    return napi_flag;
 }
 
-template<>
-inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, StringData key) {
-	try {
-		return object.Get(key);
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+template <>
+inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, StringData key)
+{
+    try {
+        return object.Get(key);
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, const node::String &key) {
-	try {
-		return object.Get(key);
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+template <>
+inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, const node::String& key)
+{
+    try {
+        return object.Get(key);
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, uint32_t index) {
-	try {
-		return object.Get(index);
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+template <>
+inline Napi::Value node::Object::get_property(Napi::Env env, const Napi::Object& object, uint32_t index)
+{
+    try {
+        return object.Get(index);
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline void node::Object::set_property(Napi::Env env, Napi::Object& object, const node::String& key, const Napi::Value& value, PropertyAttributes attributes) {
-	try {
-		Napi::Object obj = object;
-		if (attributes) {
-			napi_property_attributes napi_attributes = napi_default | attributes;
-			std::string name = key;
-			auto propDescriptor = Napi::PropertyDescriptor::Value(name, value, napi_attributes);
-			obj.DefineProperty(propDescriptor);
-		}
-		else {
-			obj.Set(key, value);
-		}
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+template <>
+inline void node::Object::set_property(Napi::Env env, Napi::Object& object, const node::String& key,
+                                       const Napi::Value& value, PropertyAttributes attributes)
+{
+    try {
+        Napi::Object obj = object;
+        if (attributes) {
+            napi_property_attributes napi_attributes = napi_default | attributes;
+            std::string name = key;
+            auto propDescriptor = Napi::PropertyDescriptor::Value(name, value, napi_attributes);
+            obj.DefineProperty(propDescriptor);
+        }
+        else {
+            obj.Set(key, value);
+        }
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline void node::Object::set_property(Napi::Env env, Napi::Object& object, uint32_t index, const Napi::Value& value) {
-	try {
-		Napi::Object obj = object;
-		obj.Set(index, value);
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+template <>
+inline void node::Object::set_property(Napi::Env env, Napi::Object& object, uint32_t index, const Napi::Value& value)
+{
+    try {
+        Napi::Object obj = object;
+        obj.Set(index, value);
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline std::vector<node::String> node::Object::get_property_names(Napi::Env env, const Napi::Object& object) {
-	try {
-		auto propertyNames = object.GetPropertyNames();
+template <>
+inline std::vector<node::String> node::Object::get_property_names(Napi::Env env, const Napi::Object& object)
+{
+    try {
+        auto propertyNames = object.GetPropertyNames();
 
-		uint32_t count = propertyNames.Length();
-		std::vector<node::String> names;
-		names.reserve(count);
+        uint32_t count = propertyNames.Length();
+        std::vector<node::String> names;
+        names.reserve(count);
 
-		for (uint32_t i = 0; i < count; i++) {
-			names.push_back(node::Value::to_string(env, propertyNames[i]));
-		}
+        for (uint32_t i = 0; i < count; i++) {
+            names.push_back(node::Value::to_string(env, propertyNames[i]));
+        }
 
-		return names;
-	}
-	catch (const Napi::Error& e) {
-		throw node::Exception(env, e.Message());
-	}
+        return names;
+    }
+    catch (const Napi::Error& e) {
+        throw node::Exception(env, e.Message());
+    }
 }
 
-template<>
-inline Napi::Value node::Object::get_prototype(Napi::Env env, const Napi::Object& object) {
-	napi_value result;
-	napi_status status = napi_get_prototype(env, object, &result);
-	if (status != napi_ok) {
-		throw node::Exception(env, "Failed to get object's prototype");
-	}
-	return Napi::Object(env, result);
+template <>
+inline Napi::Value node::Object::get_prototype(Napi::Env env, const Napi::Object& object)
+{
+    napi_value result;
+    napi_status status = napi_get_prototype(env, object, &result);
+    if (status != napi_ok) {
+        throw node::Exception(env, "Failed to get object's prototype");
+    }
+    return Napi::Object(env, result);
 }
 
-template<>
-inline void node::Object::set_prototype(Napi::Env env, const Napi::Object& object, const Napi::Value& prototype) {
-	auto setPrototypeOfFunc = env.Global().Get("Object").As<Napi::Object>().Get("setPrototypeOf").As<Napi::Function>();
-	if (setPrototypeOfFunc.IsEmpty() || setPrototypeOfFunc.IsUndefined()) {
-		throw std::runtime_error("no 'setPrototypeOf'");
-	}
+template <>
+inline void node::Object::set_prototype(Napi::Env env, const Napi::Object& object, const Napi::Value& prototype)
+{
+    auto setPrototypeOfFunc =
+        env.Global().Get("Object").As<Napi::Object>().Get("setPrototypeOf").As<Napi::Function>();
+    if (setPrototypeOfFunc.IsEmpty() || setPrototypeOfFunc.IsUndefined()) {
+        throw std::runtime_error("no 'setPrototypeOf'");
+    }
 
-	setPrototypeOfFunc.Call({ object, prototype });
+    setPrototypeOfFunc.Call({object, prototype});
 }
 
-template<>
-inline Napi::Object node::Object::create_empty(Napi::Env env) {
-	return Napi::Object::New(env);
+template <>
+inline Napi::Object node::Object::create_empty(Napi::Env env)
+{
+    return Napi::Object::New(env);
 }
 
-template<>
-inline Napi::Object node::Object::create_array(Napi::Env env, uint32_t length, const Napi::Value values[]) {
-	Napi::Array array = Napi::Array::New(env, length);
+template <>
+inline Napi::Object node::Object::create_array(Napi::Env env, uint32_t length, const Napi::Value values[])
+{
+    Napi::Array array = Napi::Array::New(env, length);
     for (uint32_t i = 0; i < length; i++) {
         set_property(env, array, i, values[i]);
     }
     return array;
 }
 
-template<>
-inline Napi::Object node::Object::create_date(Napi::Env env, double time) {
-	Napi::Function date_constructor = env.Global().Get("Date").As<Napi::Function>();
-	Napi::Number value = Napi::Number::New(env, time);
-	return date_constructor.New({ value });
+template <>
+inline Napi::Object node::Object::create_date(Napi::Env env, double time)
+{
+    Napi::Function date_constructor = env.Global().Get("Date").As<Napi::Function>();
+    Napi::Number value = Napi::Number::New(env, time);
+    return date_constructor.New({value});
 }
 
-template<>
-template<typename ClassType>
-inline Napi::Object node::Object::create_instance(Napi::Env env, typename ClassType::Internal* internal) {
+template <>
+template <typename ClassType>
+inline Napi::Object node::Object::create_instance(Napi::Env env, typename ClassType::Internal* internal)
+{
     return node::ObjectWrap<ClassType>::create_instance(env, internal);
 }
 
-template<>
-template<typename ClassType>
-inline Napi::Object node::Object::create_instance_by_schema(Napi::Env env, Napi::Function& constructor, const realm::ObjectSchema& schema, typename ClassType::Internal* internal) {
-	return node::ObjectWrap<ClassType>::create_instance_by_schema(env, constructor, schema, internal);
+template <>
+template <typename ClassType>
+inline Napi::Object node::Object::create_instance_by_schema(Napi::Env env, Napi::Function& constructor,
+                                                            const realm::ObjectSchema& schema,
+                                                            typename ClassType::Internal* internal)
+{
+    return node::ObjectWrap<ClassType>::create_instance_by_schema(env, constructor, schema, internal);
 }
 
-template<>
-template<typename ClassType>
-inline Napi::Object node::Object::create_instance_by_schema(Napi::Env env, const realm::ObjectSchema& schema, typename ClassType::Internal* internal) {
-	return node::ObjectWrap<ClassType>::create_instance_by_schema(env, schema, internal);
+template <>
+template <typename ClassType>
+inline Napi::Object node::Object::create_instance_by_schema(Napi::Env env, const realm::ObjectSchema& schema,
+                                                            typename ClassType::Internal* internal)
+{
+    return node::ObjectWrap<ClassType>::create_instance_by_schema(env, schema, internal);
 }
 
-template<typename ClassType>
-inline void on_context_destroy(Napi::Env env, std::string realmPath) {
-	node::ObjectWrap<ClassType>::on_context_destroy(env, realmPath);
+template <typename ClassType>
+inline void on_context_destroy(Napi::Env env, std::string realmPath)
+{
+    node::ObjectWrap<ClassType>::on_context_destroy(env, realmPath);
 }
 
-template<>
-template<typename ClassType>
-inline bool node::Object::is_instance(Napi::Env env, const Napi::Object& object) {
+template <>
+template <typename ClassType>
+inline bool node::Object::is_instance(Napi::Env env, const Napi::Object& object)
+{
     return node::ObjectWrap<ClassType>::is_instance(env, object);
 }
 
-template<>
-template<typename ClassType>
-inline typename ClassType::Internal* node::Object::get_internal(Napi::Env env, const Napi::Object& object) {
-	return node::ObjectWrap<ClassType>::get_internal(env, object);
+template <>
+template <typename ClassType>
+inline typename ClassType::Internal* node::Object::get_internal(Napi::Env env, const Napi::Object& object)
+{
+    return node::ObjectWrap<ClassType>::get_internal(env, object);
 }
 
-template<>
-template<typename ClassType>
-inline void node::Object::set_internal(Napi::Env env, const Napi::Object& object, typename ClassType::Internal* internal) {
-	return node::ObjectWrap<ClassType>::set_internal(env, object, internal);
+template <>
+template <typename ClassType>
+inline void node::Object::set_internal(Napi::Env env, const Napi::Object& object,
+                                       typename ClassType::Internal* internal)
+{
+    return node::ObjectWrap<ClassType>::set_internal(env, object, internal);
 }
 
-template<>
-inline void node::Object::set_global(Napi::Env env, const node::String &key, const Napi::Value &value) {
-	Object::set_property(env, env.Global(), key, value);
+template <>
+inline void node::Object::set_global(Napi::Env env, const node::String& key, const Napi::Value& value)
+{
+    Object::set_property(env, env.Global(), key, value);
 }
 
-template<>
-inline Napi::Value node::Object::get_global(Napi::Env env, const node::String &key) {
-	return Object::get_property(env, env.Global(), key);
+template <>
+inline Napi::Value node::Object::get_global(Napi::Env env, const node::String& key)
+{
+    return Object::get_property(env, env.Global(), key);
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_protected.hpp
+++ b/src/node/node_protected.hpp
@@ -23,182 +23,225 @@
 namespace realm {
 namespace node {
 
-template<typename MemberType>
+template <typename MemberType>
 class Protected {
 protected:
-	Napi::Env m_env;
-	napi_ref m_ref;
-	bool m_isValue;
-	bool m_suppressDestruct = false;
+    Napi::Env m_env;
+    napi_ref m_ref;
+    bool m_isValue;
+    bool m_suppressDestruct = false;
+
 public:
-	Protected() : m_env(nullptr), m_ref(nullptr), m_isValue(false) {}
+    Protected()
+        : m_env(nullptr)
+        , m_ref(nullptr)
+        , m_isValue(false)
+    {
+    }
 
-	Protected(Napi::Env env, MemberType value) : m_env(env), m_isValue(false) {
-		napi_status status = napi_create_reference(env, value, 1, &m_ref);
-		if (status == napi_object_expected) {
-			m_isValue = true;
-			Napi::Object object = Napi::Object::New(m_env);
-			object.Set("value", value);
-			status = napi_create_reference(env, object, 1, &m_ref);
-		}
+    Protected(Napi::Env env, MemberType value)
+        : m_env(env)
+        , m_isValue(false)
+    {
+        napi_status status = napi_create_reference(env, value, 1, &m_ref);
+        if (status == napi_object_expected) {
+            m_isValue = true;
+            Napi::Object object = Napi::Object::New(m_env);
+            object.Set("value", value);
+            status = napi_create_reference(env, object, 1, &m_ref);
+        }
 
-		if (status != napi_ok) {
-			throw std::runtime_error(util::format("Can't create protected reference: napi_status %1", status));
-		}
-	}
+        if (status != napi_ok) {
+            throw std::runtime_error(util::format("Can't create protected reference: napi_status %1", status));
+        }
+    }
 
-	Protected(const Protected& other) : m_env(other.m_env), m_ref(other.m_ref), m_isValue(other.m_isValue) {
-		uint32_t result;
-		napi_status status = napi_reference_ref(m_env, m_ref, &result);
-		if (status != napi_ok) {
-			throw std::runtime_error(util::format("Can't increase protected reference count: napi_status %1", status));
-		}
-	}
+    Protected(const Protected& other)
+        : m_env(other.m_env)
+        , m_ref(other.m_ref)
+        , m_isValue(other.m_isValue)
+    {
+        uint32_t result;
+        napi_status status = napi_reference_ref(m_env, m_ref, &result);
+        if (status != napi_ok) {
+            throw std::runtime_error(
+                util::format("Can't increase protected reference count: napi_status %1", status));
+        }
+    }
 
-	Protected(Protected&& other) : Protected() {
-		swap(*this, other);
-	}
+    Protected(Protected&& other)
+        : Protected()
+    {
+        swap(*this, other);
+    }
 
-	friend void swap(Protected& first, Protected& second) {
-		std::swap(first.m_env, second.m_env);
-		std::swap(first.m_ref, second.m_ref);
-		std::swap(first.m_isValue, second.m_isValue);
-		std::swap(first.m_suppressDestruct, second.m_suppressDestruct);
-	}
+    friend void swap(Protected& first, Protected& second)
+    {
+        std::swap(first.m_env, second.m_env);
+        std::swap(first.m_ref, second.m_ref);
+        std::swap(first.m_isValue, second.m_isValue);
+        std::swap(first.m_suppressDestruct, second.m_suppressDestruct);
+    }
 
-	//uses the copy and swap idiom
-	Protected& operator=(Protected other) {
-		swap(*this, other);
-		return *this;
-	}
+    // uses the copy and swap idiom
+    Protected& operator=(Protected other)
+    {
+        swap(*this, other);
+        return *this;
+    }
 
-	~Protected() {
-		if (m_ref == nullptr || m_suppressDestruct) {
-			return;
-		}
+    ~Protected()
+    {
+        if (m_ref == nullptr || m_suppressDestruct) {
+            return;
+        }
 
-		try {
-			uint32_t result;
-			napi_status status = napi_reference_unref(m_env, m_ref, &result);
-			REALM_ASSERT((status == napi_ok) && "~Protected: Can't decrease protected reference count");
+        try {
+            uint32_t result;
+            napi_status status = napi_reference_unref(m_env, m_ref, &result);
+            REALM_ASSERT((status == napi_ok) && "~Protected: Can't decrease protected reference count");
 
-			if (result == 0) {
-				napi_status status = napi_delete_reference(m_env, m_ref);
-				REALM_ASSERT((status == napi_ok) && "~Protected: Can't unallocate protected reference");
-			}
+            if (result == 0) {
+                napi_status status = napi_delete_reference(m_env, m_ref);
+                REALM_ASSERT((status == napi_ok) && "~Protected: Can't unallocate protected reference");
+            }
 
-			m_ref = nullptr;
-		}
-		catch (...) {}
-	}
+            m_ref = nullptr;
+        }
+        catch (...) {
+        }
+    }
 
-	operator MemberType() const {
-		napi_value value;
-		napi_status status = napi_get_reference_value(m_env, m_ref, &value);
-		if (status != napi_ok) {
-			throw std::runtime_error(util::format("Can't get protected reference: napi_status %1", status));
-		}
+    operator MemberType() const
+    {
+        napi_value value;
+        napi_status status = napi_get_reference_value(m_env, m_ref, &value);
+        if (status != napi_ok) {
+            throw std::runtime_error(util::format("Can't get protected reference: napi_status %1", status));
+        }
 
-		if (value == nullptr) {
-			throw std::runtime_error(util::format("Can not use unallocated protected reference"));
-		}
+        if (value == nullptr) {
+            throw std::runtime_error(util::format("Can not use unallocated protected reference"));
+        }
 
-		if (m_isValue) {
-			Napi::Object object = Napi::Object(m_env, value);
-			return object.Get("value").As<MemberType>();
-		}
+        if (m_isValue) {
+            Napi::Object object = Napi::Object(m_env, value);
+            return object.Get("value").As<MemberType>();
+        }
 
-		MemberType member = MemberType(m_env, value);
-		return member;
-	}
+        MemberType member = MemberType(m_env, value);
+        return member;
+    }
 
-	explicit operator bool() const {
-		napi_value value;
-		napi_status status = napi_get_reference_value(m_env, m_ref, &value);
-		if (status != napi_ok) {
-			throw std::runtime_error(util::format("Can't get protected reference: napi_status %1", status));
-		}
+    explicit operator bool() const
+    {
+        napi_value value;
+        napi_status status = napi_get_reference_value(m_env, m_ref, &value);
+        if (status != napi_ok) {
+            throw std::runtime_error(util::format("Can't get protected reference: napi_status %1", status));
+        }
 
-		if (value == nullptr) {
-			throw std::runtime_error(util::format("Can not use unallocated protected reference"));
-		}
+        if (value == nullptr) {
+            throw std::runtime_error(util::format("Can not use unallocated protected reference"));
+        }
 
-		return value == nullptr;
-	}
+        return value == nullptr;
+    }
 
-	bool operator==(const MemberType &other) const {
-		MemberType memberType = *this;
+    bool operator==(const MemberType& other) const
+    {
+        MemberType memberType = *this;
 
-	    return memberType == other;
-	}
+        return memberType == other;
+    }
 
-	bool operator!=(const MemberType& other) const {
-		MemberType memberType = *this;
-		return memberType != other;
-	}
+    bool operator!=(const MemberType& other) const
+    {
+        MemberType memberType = *this;
+        return memberType != other;
+    }
 
-	bool operator==(const Protected<MemberType> &other) const {
-		MemberType thisValue = *this;
-		MemberType otherValue = *other;
-		return thisValue == otherValue;
-	}
+    bool operator==(const Protected<MemberType>& other) const
+    {
+        MemberType thisValue = *this;
+        MemberType otherValue = *other;
+        return thisValue == otherValue;
+    }
 
-	bool operator!=(const Protected<MemberType> &other) const {
-		MemberType thisValue = *this;
-		MemberType otherValue = *other;
-		return thisValue != otherValue;
-	}
+    bool operator!=(const Protected<MemberType>& other) const
+    {
+        MemberType thisValue = *this;
+        MemberType otherValue = *other;
+        return thisValue != otherValue;
+    }
 
-	void SuppressDestruct() {
-		m_suppressDestruct = true;
-	}
+    void SuppressDestruct()
+    {
+        m_suppressDestruct = true;
+    }
 
-	struct Comparator {
-	    bool operator()(const Protected<MemberType>& a, const Protected<MemberType>& b) const {
-			MemberType aValue = a;
-			MemberType bValue = b;
-			return aValue == bValue;
-	    }
-	};
+    struct Comparator {
+        bool operator()(const Protected<MemberType>& a, const Protected<MemberType>& b) const
+        {
+            MemberType aValue = a;
+            MemberType bValue = b;
+            return aValue == bValue;
+        }
+    };
 };
 
-} // node
+} // namespace node
 
 namespace js {
 
-template<>
+template <>
 class Protected<node::Types::GlobalContext> {
-	node::Types::GlobalContext m_ctx;
-  public:
-	Protected(node::Types::GlobalContext ctx) : m_ctx(ctx) {}
+    node::Types::GlobalContext m_ctx;
 
-	operator Napi::Env() const {
-		return m_ctx;
+public:
+    Protected(node::Types::GlobalContext ctx)
+        : m_ctx(ctx)
+    {
     }
 
-	bool operator==(const Protected<node::Types::GlobalContext>& other) const {
-		//GlobalContext is always equal since its Napi::Env
-		return true;
-	}
+    operator Napi::Env() const
+    {
+        return m_ctx;
+    }
+
+    bool operator==(const Protected<node::Types::GlobalContext>& other) const
+    {
+        // GlobalContext is always equal since its Napi::Env
+        return true;
+    }
 };
 
-template<>
+template <>
 class Protected<node::Types::Value> : public node::Protected<Napi::Value> {
-  public:
-    Protected(Napi::Env env, Napi::Value value) : node::Protected<Napi::Value>(env, value) {}
+public:
+    Protected(Napi::Env env, Napi::Value value)
+        : node::Protected<Napi::Value>(env, value)
+    {
+    }
 };
 
-template<>
+template <>
 class Protected<node::Types::Object> : public node::Protected<Napi::Object> {
-  public:
-    Protected(Napi::Env env, Napi::Object object) : node::Protected<Napi::Object>(env, object) {}
+public:
+    Protected(Napi::Env env, Napi::Object object)
+        : node::Protected<Napi::Object>(env, object)
+    {
+    }
 };
 
-template<>
+template <>
 class Protected<node::Types::Function> : public node::Protected<Napi::Function> {
-  public:
-    Protected(Napi::Env env, Napi::Function function) : node::Protected<Napi::Function>(env, function) {}
+public:
+    Protected(Napi::Env env, Napi::Function function)
+        : node::Protected<Napi::Function>(env, function)
+    {
+    }
 };
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_return_value.hpp
+++ b/src/node/node_return_value.hpp
@@ -24,80 +24,100 @@
 namespace realm {
 namespace js {
 
-template<>
+template <>
 class ReturnValue<node::Types> {
-	Napi::Env m_env;
-	Napi::Value m_value;
+    Napi::Env m_env;
+    Napi::Value m_value;
 
-  public:
-	ReturnValue(Napi::Env env) : m_env(env), m_value(Napi::Value(env, env.Undefined())) {}
-	ReturnValue(Napi::Env env, Napi::Value value) : m_env(env), m_value(value) {}
+public:
+    ReturnValue(Napi::Env env)
+        : m_env(env)
+        , m_value(Napi::Value(env, env.Undefined()))
+    {
+    }
+    ReturnValue(Napi::Env env, Napi::Value value)
+        : m_env(env)
+        , m_value(value)
+    {
+    }
 
-	Napi::Value ToValue() {
-		//guard check. env.Empty() values cause node to fail in obscure places, so return undefined instead
-		if (m_value.IsEmpty()) {
-			return Napi::Value(m_env, m_env.Undefined());
-		}
+    Napi::Value ToValue()
+    {
+        // guard check. env.Empty() values cause node to fail in obscure places, so return undefined instead
+        if (m_value.IsEmpty()) {
+            return Napi::Value(m_env, m_env.Undefined());
+        }
 
-		return m_value;
-	}
+        return m_value;
+    }
 
-    void set(const Napi::Value &value) {
+    void set(const Napi::Value& value)
+    {
         m_value = Napi::Value(m_env, value);
     }
 
-    void set(const std::string &string) {
-		m_value = Napi::Value::From(m_env, string);
+    void set(const std::string& string)
+    {
+        m_value = Napi::Value::From(m_env, string);
     }
 
-    void set(const char *str) {
+    void set(const char* str)
+    {
         if (!str) {
-			m_value = Napi::Value(m_env, m_env.Null());
+            m_value = Napi::Value(m_env, m_env.Null());
         }
         else {
-			m_value = Napi::Value::From(m_env, str);
+            m_value = Napi::Value::From(m_env, str);
         }
     }
 
-    void set(bool boolean) {
-		m_value = Napi::Value::From(m_env, boolean);
+    void set(bool boolean)
+    {
+        m_value = Napi::Value::From(m_env, boolean);
     }
 
-	void set(double number) {
-		m_value = Napi::Value::From(m_env, number);
+    void set(double number)
+    {
+        m_value = Napi::Value::From(m_env, number);
     }
 
-	void set(int32_t number) {
-		m_value = Napi::Value::From(m_env, number);
+    void set(int32_t number)
+    {
+        m_value = Napi::Value::From(m_env, number);
     }
 
-	void set(uint32_t number) {
-		m_value = Napi::Value::From(m_env, number);
+    void set(uint32_t number)
+    {
+        m_value = Napi::Value::From(m_env, number);
     }
 
-    void set(realm::Mixed mixed) {
-		m_value = Value<node::Types>::from_mixed(m_env, nullptr, mixed);
+    void set(realm::Mixed mixed)
+    {
+        m_value = Value<node::Types>::from_mixed(m_env, nullptr, mixed);
     }
 
-    void set_null() {
-		m_value = Napi::Value(m_env, m_env.Null());
+    void set_null()
+    {
+        m_value = Napi::Value(m_env, m_env.Null());
     }
 
 
-    void set_undefined() {
-		m_value = Napi::Value(m_env, m_env.Undefined());
+    void set_undefined()
+    {
+        m_value = Napi::Value(m_env, m_env.Undefined());
     }
 
-    template<typename T>
-    void set(util::Optional<T> value) {
+    template <typename T>
+    void set(util::Optional<T> value)
+    {
         if (value) {
             set(*value);
         }
         else {
-			set_undefined();
+            set_undefined();
         }
     }
 };
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_string.hpp
+++ b/src/node/node_string.hpp
@@ -25,42 +25,57 @@
 namespace realm {
 namespace js {
 
-template<>
+template <>
 class String<node::Types> {
     using StringType = String<node::Types>;
 
     std::string m_str;
 
-  public:
-    static bson::Bson to_bson(StringType stringified_ejson) {
+public:
+    static bson::Bson to_bson(StringType stringified_ejson)
+    {
         return bson::parse(std::string(stringified_ejson));
     }
 
-    static std::string from_bson(const bson::Bson& bson) {
+    static std::string from_bson(const bson::Bson& bson)
+    {
         return bson.to_string();
     }
 
-    String(const char* s) : m_str(s) {}
-    String(const std::string& s) : m_str(s) {}
+    String(const char* s)
+        : m_str(s)
+    {
+    }
+    String(const std::string& s)
+        : m_str(s)
+    {
+    }
     String(const Napi::String& s);
-    String(Napi::String&& s) : String(s) {}
+    String(Napi::String&& s)
+        : String(s)
+    {
+    }
 
-    operator std::string() const& {
+    operator std::string() const&
+    {
         return m_str;
     }
 
-    operator std::string() && {
+    operator std::string() &&
+    {
         return std::move(m_str);
     }
 
-    Napi::String ToString(Napi::Env env) {
-		return Napi::String::New(env, m_str);
+    Napi::String ToString(Napi::Env env)
+    {
+        return Napi::String::New(env, m_str);
     }
 };
 
-inline String<node::Types>::String(const Napi::String& s) {
-	m_str = s.Utf8Value();
+inline String<node::Types>::String(const Napi::String& s)
+{
+    m_str = s.Utf8Value();
 }
 
-} // js
-} // realm
+} // namespace js
+} // namespace realm

--- a/src/node/node_types.hpp
+++ b/src/node/node_types.hpp
@@ -35,37 +35,44 @@ namespace node {
 extern Napi::FunctionReference RealmClassConstructor;
 
 struct Types {
-	using Context = Napi::Env;
-	using GlobalContext = Napi::Env;
-	using Value = Napi::Value;
-	using Object = Napi::Object;
-	using String = Napi::String;
-	using Function = Napi::Function;
+    using Context = Napi::Env;
+    using GlobalContext = Napi::Env;
+    using Value = Napi::Value;
+    using Object = Napi::Object;
+    using String = Napi::String;
+    using Function = Napi::Function;
 
-	typedef Napi::Value(*NapiFunctionCallback)(const Napi::CallbackInfo& info);
+    typedef Napi::Value (*NapiFunctionCallback)(const Napi::CallbackInfo& info);
 
-	typedef Napi::Value(*NapiIndexGetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index);
-	typedef Napi::Value(*NapiIndexSetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance, uint32_t index, const Napi::Value& value);
-	typedef Napi::Value(*NapiPropertyGetterCallback)(const Napi::CallbackInfo& info);
-	typedef void(*NapiPropertySetterCallback)(const Napi::CallbackInfo& info, const Napi::Value& value);
+    typedef Napi::Value (*NapiIndexGetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance,
+                                                   uint32_t index);
+    typedef Napi::Value (*NapiIndexSetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance,
+                                                   uint32_t index, const Napi::Value& value);
+    typedef Napi::Value (*NapiPropertyGetterCallback)(const Napi::CallbackInfo& info);
+    typedef void (*NapiPropertySetterCallback)(const Napi::CallbackInfo& info, const Napi::Value& value);
 
-	typedef Napi::Value(*NapiStringPropertyGetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property);
-	typedef Napi::Value(*NapiStringPropertySetterCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance, const Napi::String& property, const Napi::Value& value);
-	typedef Napi::Value(*NapiStringPropertyEnumeratorCallback)(const Napi::CallbackInfo& info, const Napi::Object& instance);
+    typedef Napi::Value (*NapiStringPropertyGetterCallback)(const Napi::CallbackInfo& info,
+                                                            const Napi::Object& instance,
+                                                            const Napi::String& property);
+    typedef Napi::Value (*NapiStringPropertySetterCallback)(const Napi::CallbackInfo& info,
+                                                            const Napi::Object& instance,
+                                                            const Napi::String& property, const Napi::Value& value);
+    typedef Napi::Value (*NapiStringPropertyEnumeratorCallback)(const Napi::CallbackInfo& info,
+                                                                const Napi::Object& instance);
 
-	using ConstructorCallback = NapiFunctionCallback;
-	using FunctionCallback = NapiFunctionCallback;
-	using PropertyGetterCallback = NapiPropertyGetterCallback;
-	using PropertySetterCallback = NapiPropertySetterCallback;
-	using IndexPropertyGetterCallback = NapiIndexGetterCallback;
-	using IndexPropertySetterCallback = NapiIndexSetterCallback;
+    using ConstructorCallback = NapiFunctionCallback;
+    using FunctionCallback = NapiFunctionCallback;
+    using PropertyGetterCallback = NapiPropertyGetterCallback;
+    using PropertySetterCallback = NapiPropertySetterCallback;
+    using IndexPropertyGetterCallback = NapiIndexGetterCallback;
+    using IndexPropertySetterCallback = NapiIndexSetterCallback;
 
-	using StringPropertyGetterCallback = NapiStringPropertyGetterCallback;
-	using StringPropertySetterCallback = NapiStringPropertySetterCallback;
-	using StringPropertyEnumeratorCallback = NapiStringPropertyEnumeratorCallback;
+    using StringPropertyGetterCallback = NapiStringPropertyGetterCallback;
+    using StringPropertySetterCallback = NapiStringPropertySetterCallback;
+    using StringPropertyEnumeratorCallback = NapiStringPropertyEnumeratorCallback;
 };
 
-template<typename ClassType>
+template <typename ClassType>
 class ObjectWrap;
 
 using String = js::String<Types>;
@@ -76,5 +83,5 @@ using Object = js::Object<Types>;
 using Exception = js::Exception<Types>;
 using ReturnValue = js::ReturnValue<Types>;
 
-} // node
-} // realm
+} // namespace node
+} // namespace realm

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -25,219 +25,265 @@
 namespace realm {
 namespace js {
 
-template<>
-inline const char* node::Value::typeof(Napi::Env env, const Napi::Value& value) {
-	if (value.IsNull()) { return "null"; }
-	if (value.IsNumber()) { return "number"; }
-	if (value.IsString()) { return "string"; }
-	if (value.IsBoolean()) { return "boolean"; }
-	if (value.IsUndefined()) { return "undefined"; }
-	if (value.IsObject()) { return "object"; }
-	return "unknown";
-}
-
-template<>
-inline bool node::Value::is_array(Napi::Env env, const Napi::Value& value) {
-	return value.IsArray();
-}
-
-template<>
-inline bool node::Value::is_array_buffer(Napi::Env env, const Napi::Value& value) {
-	return value.IsArrayBuffer();
-}
-
-template<>
-inline bool node::Value::is_array_buffer_view(Napi::Env env, const Napi::Value& value) {
-	return value.IsTypedArray() || value.IsDataView();
-}
-
-template<>
-inline bool node::Value::is_date(Napi::Env env, const Napi::Value& value) {
-	if (value.IsEmpty()) {
-		return false;
-	}
-
-//if rebuilding the binary on Node.js with NAPI 4. On CI we should always be building with Node.js NAPI 5
-#if NAPI_VERSION >= 5
-	uint32_t version;
-	napi_status status = napi_get_version(env, &version);
-	NAPI_THROW_IF_FAILED(env, status, false);
-	if (version >= 5) {
-		bool isDate;
-		status = napi_is_date(env, value, &isDate);
-		NAPI_THROW_IF_FAILED(env, status, false);
-		return isDate;
-	}
-#endif
-
-	return value.IsObject() && value.As<Napi::Object>().InstanceOf(env.Global().Get("Date").As<Napi::Function>());
-}
-
-template<>
-inline bool node::Value::is_boolean(Napi::Env env, const Napi::Value& value) {
-    return value.IsBoolean();
-}
-
-template<>
-inline bool node::Value::is_constructor(Napi::Env env, const Napi::Value& value) {
-	return value.IsFunction();
-}
-
-
-template<>
-inline bool node::Value::is_error(Napi::Env env, const Napi::Value& value) {
-	return value.IsObject() && value.As<Napi::Object>().InstanceOf(env.Global().Get("Error").As<Napi::Function>());
-}
-
-template<>
-inline bool node::Value::is_function(Napi::Env env, const Napi::Value& value) {
-	return value.IsFunction();
-}
-
-template<>
-inline bool node::Value::is_null(Napi::Env env, const Napi::Value& value) {
-	return value.IsNull();
-}
-
-template<>
-inline bool node::Value::is_number(Napi::Env env, const Napi::Value& value) {
-	return value.IsNumber();
-}
-
-inline bool is_bson_type(Napi::Env env, const Napi::Value& value, std::string type) {
-	if (value.IsNull() || value.IsUndefined() || !value.IsObject()) {
-		return false;
-	}
-
-	Napi::Object object = value.As<Napi::Object>();
-	Napi::Value bsonType = object.Get("_bsontype");
-	if (bsonType.IsUndefined()) {
-		return false;
-	}
-
-	return bsonType.StrictEquals(Napi::String::New(env, type));
-}
-
-template<>
-inline bool node::Value::is_decimal128(Napi::Env env, const Napi::Value& value) {
-	return is_bson_type(env, value, "Decimal128");
-}
-
-template<>
-inline bool node::Value::is_object_id(Napi::Env env, const Napi::Value& value) {
-	return is_bson_type(env, value, "ObjectID");
+template <>
+inline const char* node::Value::typeof(Napi::Env env, const Napi::Value& value)
+{
+    if (value.IsNull()) {
+        return "null";
+    }
+    if (value.IsNumber()) {
+        return "number";
+    }
+    if (value.IsString()) {
+        return "string";
+    }
+    if (value.IsBoolean()) {
+        return "boolean";
+    }
+    if (value.IsUndefined()) {
+        return "undefined";
+    }
+    if (value.IsObject()) {
+        return "object";
+    }
+    return "unknown";
 }
 
 template <>
-inline bool node::Value::is_uuid(Napi::Env env, const Napi::Value& value) {
+inline bool node::Value::is_array(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsArray();
+}
+
+template <>
+inline bool node::Value::is_array_buffer(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsArrayBuffer();
+}
+
+template <>
+inline bool node::Value::is_array_buffer_view(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsTypedArray() || value.IsDataView();
+}
+
+template <>
+inline bool node::Value::is_date(Napi::Env env, const Napi::Value& value)
+{
+    if (value.IsEmpty()) {
+        return false;
+    }
+
+// if rebuilding the binary on Node.js with NAPI 4. On CI we should always be building with Node.js NAPI 5
+#if NAPI_VERSION >= 5
+    uint32_t version;
+    napi_status status = napi_get_version(env, &version);
+    NAPI_THROW_IF_FAILED(env, status, false);
+    if (version >= 5) {
+        bool isDate;
+        status = napi_is_date(env, value, &isDate);
+        NAPI_THROW_IF_FAILED(env, status, false);
+        return isDate;
+    }
+#endif
+
+    return value.IsObject() && value.As<Napi::Object>().InstanceOf(env.Global().Get("Date").As<Napi::Function>());
+}
+
+template <>
+inline bool node::Value::is_boolean(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsBoolean();
+}
+
+template <>
+inline bool node::Value::is_constructor(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsFunction();
+}
+
+
+template <>
+inline bool node::Value::is_error(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsObject() && value.As<Napi::Object>().InstanceOf(env.Global().Get("Error").As<Napi::Function>());
+}
+
+template <>
+inline bool node::Value::is_function(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsFunction();
+}
+
+template <>
+inline bool node::Value::is_null(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsNull();
+}
+
+template <>
+inline bool node::Value::is_number(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsNumber();
+}
+
+inline bool is_bson_type(Napi::Env env, const Napi::Value& value, std::string type)
+{
+    if (value.IsNull() || value.IsUndefined() || !value.IsObject()) {
+        return false;
+    }
+
+    Napi::Object object = value.As<Napi::Object>();
+    Napi::Value bsonType = object.Get("_bsontype");
+    if (bsonType.IsUndefined()) {
+        return false;
+    }
+
+    return bsonType.StrictEquals(Napi::String::New(env, type));
+}
+
+template <>
+inline bool node::Value::is_decimal128(Napi::Env env, const Napi::Value& value)
+{
+    return is_bson_type(env, value, "Decimal128");
+}
+
+template <>
+inline bool node::Value::is_object_id(Napi::Env env, const Napi::Value& value)
+{
+    return is_bson_type(env, value, "ObjectID");
+}
+
+template <>
+inline bool node::Value::is_uuid(Napi::Env env, const Napi::Value& value)
+{
     return is_bson_type(env, value, "UUID");
 }
 
-template<>
-inline bool node::Value::is_object(Napi::Env env, const Napi::Value& value) {
-	return value.IsObject();
+template <>
+inline bool node::Value::is_object(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsObject();
 }
 
-template<>
-inline bool node::Value::is_string(Napi::Env env, const Napi::Value& value) {
-	return value.IsString();
+template <>
+inline bool node::Value::is_string(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsString();
 }
 
-template<>
-inline bool node::Value::is_undefined(Napi::Env env, const Napi::Value& value) {
-	return value.IsUndefined();
+template <>
+inline bool node::Value::is_undefined(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsUndefined();
 }
 
-template<>
-inline bool node::Value::is_binary(Napi::Env env, const Napi::Value& value) {
-	return Value::is_array_buffer(env, value) || Value::is_array_buffer_view(env, value);
+template <>
+inline bool node::Value::is_binary(Napi::Env env, const Napi::Value& value)
+{
+    return Value::is_array_buffer(env, value) || Value::is_array_buffer_view(env, value);
 }
 
-template<>
-inline bool node::Value::is_valid(const Napi::Value& value) {
-	return !value.IsEmpty();
+template <>
+inline bool node::Value::is_valid(const Napi::Value& value)
+{
+    return !value.IsEmpty();
 }
 
-template<>
-inline Napi::Value node::Value::from_boolean(Napi::Env env, bool boolean) {
-	return Napi::Boolean::New(env, boolean);
+template <>
+inline Napi::Value node::Value::from_boolean(Napi::Env env, bool boolean)
+{
+    return Napi::Boolean::New(env, boolean);
 }
 
 
-template<>
-inline Napi::Value node::Value::from_null(Napi::Env env) {
-	return Napi::Value(env, env.Null());
+template <>
+inline Napi::Value node::Value::from_null(Napi::Env env)
+{
+    return Napi::Value(env, env.Null());
 }
 
-template<>
-inline Napi::Value node::Value::from_number(Napi::Env env, double number) {
-	return Napi::Number::New(env, number);
+template <>
+inline Napi::Value node::Value::from_number(Napi::Env env, double number)
+{
+    return Napi::Number::New(env, number);
 }
 
-template<>
-inline Napi::Value node::Value::from_nonnull_string(Napi::Env env, const node::String& string) {
-	return Napi::String::New(env, string);
+template <>
+inline Napi::Value node::Value::from_nonnull_string(Napi::Env env, const node::String& string)
+{
+    return Napi::String::New(env, string);
 }
 
-template<>
-inline Napi::Value node::Value::from_nonnull_binary(Napi::Env env, BinaryData data) {
-	Napi::EscapableHandleScope scope(env);
+template <>
+inline Napi::Value node::Value::from_nonnull_binary(Napi::Env env, BinaryData data)
+{
+    Napi::EscapableHandleScope scope(env);
 
-	Napi::ArrayBuffer buffer = Napi::ArrayBuffer::New(env, data.size());
+    Napi::ArrayBuffer buffer = Napi::ArrayBuffer::New(env, data.size());
 
-	if (data.size()) {
-		memcpy(buffer.Data(), data.data(), data.size());
-	}
+    if (data.size()) {
+        memcpy(buffer.Data(), data.data(), data.size());
+    }
 
-	return scope.Escape(buffer);
+    return scope.Escape(buffer);
 }
 
-template<>
-inline Napi::Value node::Value::from_undefined(Napi::Env env) {
-	return Napi::Value(env, env.Undefined());
+template <>
+inline Napi::Value node::Value::from_undefined(Napi::Env env)
+{
+    return Napi::Value(env, env.Undefined());
 }
 
-template<>
-inline bool node::Value::to_boolean(Napi::Env env, const Napi::Value& value) {
-	return value.ToBoolean();
+template <>
+inline bool node::Value::to_boolean(Napi::Env env, const Napi::Value& value)
+{
+    return value.ToBoolean();
 }
 
-template<>
-inline node::String node::Value::to_string(Napi::Env env, const Napi::Value& value) {
-	return value.ToString();
+template <>
+inline node::String node::Value::to_string(Napi::Env env, const Napi::Value& value)
+{
+    return value.ToString();
 }
 
-template<>
-inline double node::Value::to_number(Napi::Env env, const Napi::Value& value) {
-	double number = value.ToNumber();
-	if (std::isnan(number)) {
-		throw std::invalid_argument(util::format("Value '%1' not convertible to a number.", (std::string)to_string(env, value)));
-	}
+template <>
+inline double node::Value::to_number(Napi::Env env, const Napi::Value& value)
+{
+    double number = value.ToNumber();
+    if (std::isnan(number)) {
+        throw std::invalid_argument(
+            util::format("Value '%1' not convertible to a number.", (std::string)to_string(env, value)));
+    }
 
-	return number;
+    return number;
 }
 
-template<>
-inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value& value) {
+template <>
+inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value& value)
+{
 
-    NodeBinary *node_binary = nullptr;
-    
+    NodeBinary* node_binary = nullptr;
 
-    if(value.IsDataView()) {
+
+    if (value.IsDataView()) {
         node_binary = new NodeBinaryManager<Napi::DataView, Napi::Value>{value};
-    }else if(value.IsBuffer()) {
+    }
+    else if (value.IsBuffer()) {
         node_binary = new NodeBinaryManager<Napi::Buffer<char>, Napi::Value>{value};
-    }else if(value.IsTypedArray()) {
+    }
+    else if (value.IsTypedArray()) {
         node_binary = new NodeBinaryManager<Napi::TypedArray, Napi::Value>{value};
-    }else if(value.IsArrayBuffer()) {
+    }
+    else if (value.IsArrayBuffer()) {
         node_binary = new NodeBinaryManager<Napi::ArrayBuffer, Napi::Value>{value};
     }
 
-    if(node_binary == nullptr) {
+    if (node_binary == nullptr) {
         throw std::runtime_error("Can only convert Buffer, ArrayBuffer, and ArrayBufferView objects to binary");
     }
 
-    if(node_binary->is_empty()) {
+    if (node_binary->is_empty()) {
         char placeholder;
         return OwnedBinaryData(&placeholder, 0);
     }
@@ -246,115 +292,127 @@ inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value& 
 }
 
 
-template<>
-inline Napi::Object node::Value::to_object(Napi::Env env, const Napi::Value& value) {
-	return value.ToObject();
-}
-
-template<>
-inline Napi::Object node::Value::to_array(Napi::Env env, const Napi::Value& value) {
-	return to_object(env, value);
-}
-
-template<>
-inline Napi::Function node::Value::to_function(Napi::Env env, const Napi::Value& value) {
-	return value.IsFunction() ? value.As<Napi::Function>() : Napi::Function();
-}
-
-template<>
-inline Napi::Function node::Value::to_constructor(Napi::Env env, const Napi::Value& value) {
-	return to_function(env, value);
-}
-
-template<>
-inline Napi::Object node::Value::to_date(Napi::Env env, const Napi::Value& value) {
-	if (value.IsString()) {
-		Napi::Function date_constructor = to_constructor(env, env.Global().Get("Date"));
-		std::array<Napi::Value, 1 > args{ {value} };
-		return node::Function::construct(env, date_constructor, args.size(), args.data());
-	}
-
-	return to_object(env, value);
-}
-
-template<>
-inline Napi::Value node::Value::from_decimal128(Napi::Env env, const Decimal128& number) {
-	Napi::EscapableHandleScope scope(env);
-
-	if (number.is_null()) {
-		return scope.Escape(Napi::Value(env, env.Null()));
-	}
-
-	Napi::Function realm_constructor = node::RealmClassConstructor.Value();
-	Napi::Object decimal_constructor = realm_constructor.Get("_Decimal128").As<Napi::Object>();
-	Napi::Function fromStringFunc = decimal_constructor.Get("fromString").As<Napi::Function>();
-	Napi::String numberAsString = Napi::String::New(env, number.to_string());
-	Napi::Value result = fromStringFunc.Call({ numberAsString });
-
-	return scope.Escape(result);
-}
-
-template<>
-inline Decimal128 node::Value::to_decimal128(Napi::Env env, const Napi::Value& value) {
-	Napi::HandleScope scope(env);
-
-	Napi::Object decimal128 = value.As<Napi::Object>();
-	Napi::Function toStringFunc = decimal128.Get("toString").As<Napi::Function>();
-	node::String string = toStringFunc.Call(value, {}).As<Napi::String>();
-	std::string decimal128AsString = string;
-	Decimal128 result(decimal128AsString);
-	return result;
-}
-
-template<>
-inline Napi::Value node::Value::from_object_id(Napi::Env env, const ObjectId& objectId) {
-	Napi::EscapableHandleScope scope(env);
-
-	Napi::Function realm_constructor = node::RealmClassConstructor.Value();
-	Napi::Function object_id_constructor = realm_constructor.Get("_ObjectId").As<Napi::Function>();
-	napi_value args[] = { Napi::String::New(env, objectId.to_string()) };
-	Napi::Value result = object_id_constructor.New(1, args);
-	return scope.Escape(result);
-}
-
-template<>
-inline ObjectId node::Value::to_object_id(Napi::Env env, const Napi::Value& value) {
-	Napi::HandleScope scope(env);
-
-	Napi::Object objectId = value.As<Napi::Object>();
-	Napi::Function toHexStringFunc = objectId.Get("toHexString").As<Napi::Function>();
-	node::String string = toHexStringFunc.Call(value, {}).As<Napi::String>();
-	std::string objectIdAsString = string;
-	ObjectId result(objectIdAsString.c_str());
-	return result;
-}
-
-template<>
-Napi::Value node::Value::from_uuid(Napi::Env env, const UUID& uuid) {
-	Napi::EscapableHandleScope scope(env);
-
-	Napi::Function realm_constructor = node::RealmClassConstructor.Value();
-	Napi::Function uuid_constructor = realm_constructor.Get("_UUID").As<Napi::Function>();
-
-	napi_value args[] = { Napi::Buffer<std::uint8_t>::Copy(env, uuid.to_bytes().data(), UUID::num_bytes) };
-	Napi::Value result = uuid_constructor.New(1, args);
-
-	return scope.Escape(result);
+template <>
+inline Napi::Object node::Value::to_object(Napi::Env env, const Napi::Value& value)
+{
+    return value.ToObject();
 }
 
 template <>
-inline UUID node::Value::to_uuid(Napi::Env env, const Napi::Value& value) {
-	Napi::HandleScope scope(env);
-
-	Napi::Object uuid = value.As<Napi::Object>();
-	// TODO: Temp implementation of JS UUID has a buffer on the "id" key. This is corresponding to the official ObjectId implementation - BUT could change.
-	auto buffer = uuid.Get("id").As<Napi::Buffer<std::uint8_t>>();
-	UUID::UUIDBytes bytes;
-	memcpy(&bytes, buffer.Data(), UUID::num_bytes);
-
-	UUID result(bytes);
-	return result;
+inline Napi::Object node::Value::to_array(Napi::Env env, const Napi::Value& value)
+{
+    return to_object(env, value);
 }
 
-} // js
-} // realm
+template <>
+inline Napi::Function node::Value::to_function(Napi::Env env, const Napi::Value& value)
+{
+    return value.IsFunction() ? value.As<Napi::Function>() : Napi::Function();
+}
+
+template <>
+inline Napi::Function node::Value::to_constructor(Napi::Env env, const Napi::Value& value)
+{
+    return to_function(env, value);
+}
+
+template <>
+inline Napi::Object node::Value::to_date(Napi::Env env, const Napi::Value& value)
+{
+    if (value.IsString()) {
+        Napi::Function date_constructor = to_constructor(env, env.Global().Get("Date"));
+        std::array<Napi::Value, 1> args{{value}};
+        return node::Function::construct(env, date_constructor, args.size(), args.data());
+    }
+
+    return to_object(env, value);
+}
+
+template <>
+inline Napi::Value node::Value::from_decimal128(Napi::Env env, const Decimal128& number)
+{
+    Napi::EscapableHandleScope scope(env);
+
+    if (number.is_null()) {
+        return scope.Escape(Napi::Value(env, env.Null()));
+    }
+
+    Napi::Function realm_constructor = node::RealmClassConstructor.Value();
+    Napi::Object decimal_constructor = realm_constructor.Get("_Decimal128").As<Napi::Object>();
+    Napi::Function fromStringFunc = decimal_constructor.Get("fromString").As<Napi::Function>();
+    Napi::String numberAsString = Napi::String::New(env, number.to_string());
+    Napi::Value result = fromStringFunc.Call({numberAsString});
+
+    return scope.Escape(result);
+}
+
+template <>
+inline Decimal128 node::Value::to_decimal128(Napi::Env env, const Napi::Value& value)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Object decimal128 = value.As<Napi::Object>();
+    Napi::Function toStringFunc = decimal128.Get("toString").As<Napi::Function>();
+    node::String string = toStringFunc.Call(value, {}).As<Napi::String>();
+    std::string decimal128AsString = string;
+    Decimal128 result(decimal128AsString);
+    return result;
+}
+
+template <>
+inline Napi::Value node::Value::from_object_id(Napi::Env env, const ObjectId& objectId)
+{
+    Napi::EscapableHandleScope scope(env);
+
+    Napi::Function realm_constructor = node::RealmClassConstructor.Value();
+    Napi::Function object_id_constructor = realm_constructor.Get("_ObjectId").As<Napi::Function>();
+    napi_value args[] = {Napi::String::New(env, objectId.to_string())};
+    Napi::Value result = object_id_constructor.New(1, args);
+    return scope.Escape(result);
+}
+
+template <>
+inline ObjectId node::Value::to_object_id(Napi::Env env, const Napi::Value& value)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Object objectId = value.As<Napi::Object>();
+    Napi::Function toHexStringFunc = objectId.Get("toHexString").As<Napi::Function>();
+    node::String string = toHexStringFunc.Call(value, {}).As<Napi::String>();
+    std::string objectIdAsString = string;
+    ObjectId result(objectIdAsString.c_str());
+    return result;
+}
+
+template <>
+Napi::Value node::Value::from_uuid(Napi::Env env, const UUID& uuid)
+{
+    Napi::EscapableHandleScope scope(env);
+
+    Napi::Function realm_constructor = node::RealmClassConstructor.Value();
+    Napi::Function uuid_constructor = realm_constructor.Get("_UUID").As<Napi::Function>();
+
+    napi_value args[] = {Napi::Buffer<std::uint8_t>::Copy(env, uuid.to_bytes().data(), UUID::num_bytes)};
+    Napi::Value result = uuid_constructor.New(1, args);
+
+    return scope.Escape(result);
+}
+
+template <>
+inline UUID node::Value::to_uuid(Napi::Env env, const Napi::Value& value)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Object uuid = value.As<Napi::Object>();
+    // TODO: Temp implementation of JS UUID has a buffer on the "id" key. This is corresponding to the official
+    // ObjectId implementation - BUT could change.
+    auto buffer = uuid.Get("id").As<Napi::Buffer<std::uint8_t>>();
+    UUID::UUIDBytes bytes;
+    memcpy(&bytes, buffer.Data(), UUID::num_bytes);
+
+    UUID result(bytes);
+    return result;
+}
+
+} // namespace js
+} // namespace realm

--- a/src/node/platform.cpp
+++ b/src/node/platform.cpp
@@ -29,15 +29,17 @@ namespace realm {
 class UVException : public std::runtime_error {
 public:
     UVException(uv_errno_t error)
-    : std::runtime_error(uv_strerror(error))
-    , m_error(error)
-    { }
+        : std::runtime_error(uv_strerror(error))
+        , m_error(error)
+    {
+    }
 
     const uv_errno_t m_error;
 };
 
 struct FileSystemRequest : uv_fs_t {
-    ~FileSystemRequest() {
+    ~FileSystemRequest()
+    {
         uv_fs_req_cleanup(this);
     }
 };
@@ -46,10 +48,10 @@ struct FileSystemRequest : uv_fs_t {
 std::string default_realm_file_directory()
 {
 #ifdef _WIN32
-  /* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
-  char buf[MAX_PATH * 4];
+    /* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
+    char buf[MAX_PATH * 4];
 #else
-  char buf[PATH_MAX];
+    char buf[PATH_MAX];
 #endif
 
     size_t cwd_len = sizeof(buf);
@@ -61,7 +63,7 @@ std::string default_realm_file_directory()
     return std::string(buf, cwd_len);
 }
 
-void ensure_directory_exists_for_file(const std::string &file_path)
+void ensure_directory_exists_for_file(const std::string& file_path)
 {
     size_t pos = 0;
 
@@ -85,11 +87,12 @@ void copy_bundled_realm_files()
     throw std::runtime_error("Realm for Node does not support this method.");
 }
 
-inline bool ends_with(const std::string& str, const std::string& suffix) {
+inline bool ends_with(const std::string& str, const std::string& suffix)
+{
     return str.size() > suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-void remove_realm_files_from_directory(const std::string &dir_path)
+void remove_realm_files_from_directory(const std::string& dir_path)
 {
     FileSystemRequest scandir_req;
     if (uv_fs_scandir(uv_default_loop(), &scandir_req, dir_path.c_str(), 0, nullptr) < 0) {
@@ -122,16 +125,17 @@ void remove_realm_files_from_directory(const std::string &dir_path)
                     throw UVException(static_cast<uv_errno_t>(management_rmdir_req.result));
                 }
             }
-        } else {
+        }
+        else {
             static std::string realm_extension(".realm");
             static std::string realm_note_extension(".realm.note");
             static std::string realm_lock_extension(".realm.lock");
             static std::string realm_log_extension(".realm.log");
             static std::string realm_log_a_extension(".realm.log_a"); // legacy
             static std::string realm_log_b_extension(".realm.log_b"); // legacy
-            if (ends_with(path, realm_extension) || ends_with(path, realm_note_extension)
-                || ends_with(path, realm_lock_extension) || ends_with(path, realm_log_extension)
-                || ends_with(path, realm_log_a_extension) || ends_with(path, realm_log_b_extension)) {
+            if (ends_with(path, realm_extension) || ends_with(path, realm_note_extension) ||
+                ends_with(path, realm_lock_extension) || ends_with(path, realm_log_extension) ||
+                ends_with(path, realm_log_a_extension) || ends_with(path, realm_log_b_extension)) {
                 FileSystemRequest delete_req;
                 if (uv_fs_unlink(uv_default_loop(), &delete_req, path.c_str(), nullptr) != 0) {
                     throw UVException(static_cast<uv_errno_t>(delete_req.result));
@@ -141,14 +145,15 @@ void remove_realm_files_from_directory(const std::string &dir_path)
     }
 }
 
-void remove_directory(const std::string &path)
+void remove_directory(const std::string& path)
 {
     FileSystemRequest exists_req;
     if (uv_fs_stat(uv_default_loop(), &exists_req, path.c_str(), nullptr) != 0) {
         if (exists_req.result == UV_ENOENT) {
             // path doesn't exist, ignore
             return;
-        } else {
+        }
+        else {
             throw UVException(static_cast<uv_errno_t>(exists_req.result));
         }
     }
@@ -174,14 +179,15 @@ void remove_directory(const std::string &path)
 }
 
 
-void remove_file(const std::string &path)
+void remove_file(const std::string& path)
 {
     FileSystemRequest exists_req;
     if (uv_fs_stat(uv_default_loop(), &exists_req, path.c_str(), nullptr) != 0) {
         if (exists_req.result == UV_ENOENT) {
             // path doesn't exist, ignore
             return;
-        } else {
+        }
+        else {
             throw UVException(static_cast<uv_errno_t>(exists_req.result));
         }
     }
@@ -202,4 +208,4 @@ void print(const char* fmt, ...)
     va_end(vl);
 }
 
-} // realm
+} // namespace realm

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -33,21 +33,21 @@ void set_default_realm_file_directory(std::string dir);
 std::string default_realm_file_directory();
 
 // create the directories for the given filename
-void ensure_directory_exists_for_file(const std::string &file);
+void ensure_directory_exists_for_file(const std::string& file);
 
 // copy all realm files from resources directory to default realm dir
 void copy_bundled_realm_files();
 
 // remove all realm files in the given directory
-void remove_realm_files_from_directory(const std::string &directory);
+void remove_realm_files_from_directory(const std::string& directory);
 
 // remove file at the given path
-void remove_file(const std::string &path);
+void remove_file(const std::string& path);
 
 // remove directory at the given path
-void remove_directory(const std::string &path);
+void remove_directory(const std::string& path);
 
 // print something
 void print(const char* fmt, ...);
 
-}
+} // namespace realm

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -11,81 +11,101 @@ using namespace std;
 using namespace realm;
 
 
-struct MockedCollection: public IOCollection{
+struct MockedCollection : public IOCollection {
     double N = 1000;
-    MockedCollection(double start): N{start} {}
-    realm::Mixed get(std::string) override{
+    MockedCollection(double start)
+        : N{start}
+    {
+    }
+    realm::Mixed get(std::string) override
+    {
         return realm::Mixed(N);
     }
 
-    void set(std::string key, realm::Mixed val) override{
+    void set(std::string key, realm::Mixed val) override
+    {
         N = val.get_double();
     }
 
-    void remove(std::string key) override {
+    void remove(std::string key) override
+    {
         N = 0;
     }
 
-    bool contains(std::string key) override {
+    bool contains(std::string key) override
+    {
         return true;
     }
 };
 
 struct MockedGetterSetter {
-    IOCollection *collection{nullptr};
+    IOCollection* collection{nullptr};
 
-    MockedGetterSetter(IOCollection *_collection): collection{_collection}{}
+    MockedGetterSetter(IOCollection* _collection)
+        : collection{_collection}
+    {
+    }
 
-    void set(accessor::Arguments args) {
+    void set(accessor::Arguments args)
+    {
         double N = JSValueToNumber(args.context, args.value, nullptr);
         collection->set("N", realm::Mixed(N));
 
-        if(N == -1){
+        if (N == -1) {
             args.throw_error("Error: No Negative Number Please.");
         }
     }
 
-    JSValueRef get(accessor::Arguments args) {
+    JSValueRef get(accessor::Arguments args)
+    {
         return JSValueMakeNumber(args.context, collection->get(args.property_name).get_double());
     }
 
-    ~MockedGetterSetter(){}
+    ~MockedGetterSetter() {}
 };
 
 struct TNull : public ObjectObserver {
-    IOCollection* get_collection() { return nullptr; }
+    IOCollection* get_collection()
+    {
+        return nullptr;
+    }
 };
 
 struct T1 : public ObjectObserver {
     int call_count = 0;
-    void subscribe(std::unique_ptr<Subscriber>) { call_count++; }
+    void subscribe(std::unique_ptr<Subscriber>)
+    {
+        call_count++;
+    }
 
-    void remove_subscription(std::unique_ptr<Subscriber>) {
+    void remove_subscription(std::unique_ptr<Subscriber>)
+    {
         call_count++;
         // Making Sure that unsubscribe_all & subscribe has been successfully
         // invoked.
         REQUIRE(call_count == 3);
     }
-    void unsubscribe_all() { call_count++; }
+    void unsubscribe_all()
+    {
+        call_count++;
+    }
 
-    static void test_for_null_data_method(method::Arguments arguments) {
-        SECTION(
-            "This callback should have null values for observer and "
-            "collection.") {
+    static void test_for_null_data_method(method::Arguments arguments)
+    {
+        SECTION("This callback should have null values for observer and "
+                "collection.") {
             REQUIRE(true == JSValueIsBoolean(arguments.context, arguments.get(0)));
             REQUIRE(arguments.collection == nullptr);
             REQUIRE(arguments.observer == nullptr);
         }
     }
 
-    static void removeTest(method::Arguments args){
+    static void removeTest(method::Arguments args) {}
 
-    }
-
-    static void methods(method::Arguments args) {
-        SECTION(
-            "This callback should have non-null values for observer and "
-            "collection.") {
+    static void methods(method::Arguments args)
+    {
+        SECTION("This callback should have non-null values for observer and "
+                "collection.") {
 
             auto context = args.context;
 
@@ -112,17 +132,14 @@ struct T1 : public ObjectObserver {
 };
 
 TEST_CASE("Testing Logger#get_level") {
-    REQUIRE(realm::common::logger::Logger::get_level("all") ==
-            realm::common::logger::LoggerLevel::all);
-    REQUIRE(realm::common::logger::Logger::get_level("debug") ==
-            realm::common::logger::LoggerLevel::debug);
-    REQUIRE_THROWS_WITH(realm::common::logger::Logger::get_level("coffeebabe"),
-                        "Bad log level");
+    REQUIRE(realm::common::logger::Logger::get_level("all") == realm::common::logger::LoggerLevel::all);
+    REQUIRE(realm::common::logger::Logger::get_level("debug") == realm::common::logger::LoggerLevel::debug);
+    REQUIRE_THROWS_WITH(realm::common::logger::Logger::get_level("coffeebabe"), "Bad log level");
 }
 
-JSValueRef Test(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-                size_t argumentCount, const JSValueRef arguments[],
-                JSValueRef* exception) {
+JSValueRef Test(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                const JSValueRef arguments[], JSValueRef* exception)
+{
     SECTION("The Object should contain accessor *X* and method *doSomething*") {
         REQUIRE(JSValueIsBoolean(ctx, arguments[0]) == true);
         bool val = JSValueToBoolean(ctx, arguments[0]);
@@ -138,16 +155,15 @@ JSValueRef Test(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
 
     test_accessor(dictionary, 'X', 666)  // Will look for the field X and 666.
  */
-JSValueRef TestingGetterSetter(JSContextRef ctx, JSObjectRef function,
-                        JSObjectRef thisObject, size_t argumentCount,
-                        const JSValueRef arguments[], JSValueRef* exception) {
+JSValueRef TestingGetterSetter(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                               const JSValueRef arguments[], JSValueRef* exception)
+{
     SECTION("Testing accessors I/O for input X") {
         auto accessor_name = JSC_VM::s("X");
         REQUIRE(true == JSValueIsObject(ctx, arguments[0]));
 
         auto obj = (JSObjectRef)arguments[0];
-        REQUIRE(true ==
-                JSObjectHasProperty(ctx, obj, (JSStringRef)arguments[1]));
+        REQUIRE(true == JSObjectHasProperty(ctx, obj, (JSStringRef)arguments[1]));
 
         JSValueRef v = JSObjectGetProperty(ctx, obj, accessor_name, NULL);
         REQUIRE(true == JSValueIsNumber(ctx, v));
@@ -159,7 +175,8 @@ JSValueRef TestingGetterSetter(JSContextRef ctx, JSObjectRef function,
     return JSValueMakeUndefined(ctx);
 }
 
-void TestingEnumeration(std::string& str_param) {
+void TestingEnumeration(std::string& str_param)
+{
     const char* payload = "{\"X\":666,\"A\":666,\"B\":666,\"C\":666}";
     const char* _str = str_param.c_str();
 
@@ -171,7 +188,8 @@ void TestingEnumeration(std::string& str_param) {
         REQUIRE(e1 == e2);
     }
 }
-void TestingExceptionMessage(std::string& str_param) {
+void TestingExceptionMessage(std::string& str_param)
+{
     const char* payload = "Error: No Negative Number Please.";
     const char* _str = str_param.c_str();
 
@@ -224,7 +242,6 @@ TEST_CASE("Testing Object creation on JavascriptCore.") {
     });
 
     JSObjectRef null_dict_js_object = null_dict->create();
-
 
 
     // Adds object to the JS global scope. This way we can call the functions

--- a/src/test/test_bed.hpp
+++ b/src/test/test_bed.hpp
@@ -31,54 +31,59 @@ struct JSC_VM {
     JSObjectRef globalObject;
     vector<JSStringRef> strings;
 
-    JSC_VM() {
+    JSC_VM()
+    {
         group = JSContextGroupCreate();
         globalContext = JSGlobalContextCreateInGroup(group, nullptr);
         globalObject = JSContextGetGlobalObject(globalContext);
     }
 
-    void set_obj_prop(std::string name, JSObjectRef fn) {
+    void set_obj_prop(std::string name, JSObjectRef fn)
+    {
         JSStringRef _name = str(name);
-        JSObjectSetProperty(globalContext, globalObject, _name, fn,
-                            kJSPropertyAttributeNone, nullptr);
+        JSObjectSetProperty(globalContext, globalObject, _name, fn, kJSPropertyAttributeNone, nullptr);
     }
 
-    JSStringRef str(std::string str) {
+    JSStringRef str(std::string str)
+    {
         auto _str = JSStringCreateWithUTF8CString(str.c_str());
         strings.push_back(_str);
         return _str;
     }
 
-    void load_into_vm(std::string file_name) {
+    void load_into_vm(std::string file_name)
+    {
         std::ifstream t(file_name);
         std::stringstream buffer;
         buffer << t.rdbuf();
 
         vm(buffer.str());
     }
-    void vm(std::string&& script) {
-        SECTION("Virtual machine should end in a clean state.")
-        {
+    void vm(std::string&& script)
+    {
+        SECTION("Virtual machine should end in a clean state.") {
             auto _script = str(script);
             auto ret = JSEvaluateScript(globalContext, _script, nullptr, nullptr, 1, nullptr);
             REQUIRE(ret != NULL);
         }
     }
 
-    static JSStringRef s(std::string str) {
+    static JSStringRef s(std::string str)
+    {
         return JSStringCreateWithUTF8CString(str.c_str());
     }
 
 
-    JSObjectRef make_gbl_fn(std::string&& fn_name, JSObjectCallAsFunctionCallback fn) {
+    JSObjectRef make_gbl_fn(std::string&& fn_name, JSObjectCallAsFunctionCallback fn)
+    {
         JSStringRef _fn_name = str(fn_name);
-        JSObjectRef _fn =
-            JSObjectMakeFunctionWithCallback(globalContext, _fn_name, fn);
+        JSObjectRef _fn = JSObjectMakeFunctionWithCallback(globalContext, _fn_name, fn);
         set_obj_prop(fn_name, _fn);
         return _fn;
     }
 
-    ~JSC_VM() {
+    ~JSC_VM()
+    {
         for (auto str : strings) {
             JSStringRelease(str);
         }
@@ -87,9 +92,10 @@ struct JSC_VM {
     }
 };
 
-struct TestTools{
+struct TestTools {
 
-    static std::string __to_string(JSContextRef context, JSValueRef value) {
+    static std::string __to_string(JSContextRef context, JSValueRef value)
+    {
         std::string str;
         JSStringRef valueAsString = JSValueToStringCopy(context, value, NULL);
         size_t sizeUTF8 = JSStringGetMaximumUTF8CStringSize(valueAsString);
@@ -99,13 +105,14 @@ struct TestTools{
         return str;
     }
 
-    static void Load(JSC_VM& vm){
+    static void Load(JSC_VM& vm)
+    {
         vm.make_gbl_fn("print", &TestTools::Print);
     }
 
-    static JSValueRef Print(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-                     size_t argumentCount, const JSValueRef arguments[],
-                     JSValueRef* exception) {
+    static JSValueRef Print(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                            const JSValueRef arguments[], JSValueRef* exception)
+    {
 
         std::string str = __to_string(ctx, arguments[0]);
         printf("printing: %s \n", str.c_str());
@@ -114,29 +121,29 @@ struct TestTools{
 
     template <void callback(std::string&)>
     static JSValueRef SimpleJSStringFunction(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-                            size_t argumentCount, const JSValueRef arguments[],
-                            JSValueRef* exception) {
+                                             size_t argumentCount, const JSValueRef arguments[],
+                                             JSValueRef* exception)
+    {
 
         std::string str = __to_string(ctx, arguments[0]);
         callback(str);
         return JSValueMakeUndefined(ctx);
     }
-
 };
 
 
 struct AccessorsTest {
-    IOCollection *N;
+    IOCollection* N;
 
     template <typename ContextType>
-    auto get(ContextType context, std::string key_name) {
+    auto get(ContextType context, std::string key_name)
+    {
         return N->get(context, key_name);
     }
 
     template <typename ContextType, typename ValueType>
-    auto set(ContextType context, std::string key_name, ValueType value) {
-       N->set(context, key_name, value);
+    auto set(ContextType context, std::string key_name, ValueType value)
+    {
+        N->set(context, key_name, value);
     }
 };
-
-


### PR DESCRIPTION
## What, How & Why?

Add consistent formatting to our C++ files using the same `.clang-format` as core

Applied to existing files using ```for i in `find src -name "*.?pp" | grep -v catch`;  do echo $i; clang-format --style=file $i -i; done``` from the root directory

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
