### PR TITLE
Update linting.md to clarify disabling any other formatting extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,19 @@
       "mode": "auto"
     }
   ],
+  "eslint.format.enable": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
   "gitlens.advanced.blame.customArguments": [
     "--ignore-revs-file",
     ".gitignore-revs"
-  ],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  ]
 }

--- a/contrib/linting.md
+++ b/contrib/linting.md
@@ -12,6 +12,7 @@ To help yourself keep your code passing linters at all times, it's highly recomm
 ### Visual Studio Code
 
 - Install and enable the ["eslint" extension for VS Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+- Disable any other code formatting extensions (such as Prettier / [`esbenp.prettier-vscode`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)) for the workspace, as they might interfere with the format enforced by eslint.
 - Make sure you've enabled "format on save" on your workspace.
 
 Both the eslint plugin and formatting on save can be enabled via the UI or you can <kbd>Cmd</kbd> + <kbd>P</kbd>, type *"> Preferences Open Workspace Settings (JSON)"* and paste in the following in the `settings` object:

--- a/contrib/linting.md
+++ b/contrib/linting.md
@@ -19,6 +19,7 @@ Both the eslint plugin and formatting on save can be enabled via the UI or you c
 
 ```json
 "eslint.format.enable": true,
+"eslint.validate": ["typescript", "typescriptreact", "javascript"],
 "editor.formatOnSave": true
 ```
 

--- a/contrib/linting.md
+++ b/contrib/linting.md
@@ -15,11 +15,9 @@ To help yourself keep your code passing linters at all times, it's highly recomm
 - Disable any other code formatting extensions (such as Prettier / [`esbenp.prettier-vscode`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)) for the workspace, as they might interfere with the format enforced by eslint.
 - Make sure you've enabled "format on save" on your workspace.
 
-Both the eslint plugin and formatting on save can be enabled via the UI or you can <kbd>Cmd</kbd> + <kbd>P</kbd>, type *"> Preferences Open Workspace Settings (JSON)"* and paste in the following in the `settings` object:
+The eslint formatting on save can be enabled via the UI or you can <kbd>Cmd</kbd> + <kbd>P</kbd>, type *"> Preferences Open Workspace Settings (JSON)"* and paste in the following in the `settings` object:
 
 ```json
-"eslint.format.enable": true,
-"eslint.validate": ["typescript", "typescriptreact", "javascript"],
 "editor.formatOnSave": true
 ```
 


### PR DESCRIPTION
## What, How & Why?

This is an attempt to clarify the need to disable other formatting extensions when developing on the project.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
