### PR TITLE
Exclude react-native/android/build from NPM package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Add `.clang-format` file for formatting C++ code, formatted all existing code and added a lint check for C++.
 * Updated Docker URL to new canonical URL of `ghcr.io`
+* Excluding the `react-native/android/build` directory from the NPM package.
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/react-native/android/.npmignore
+++ b/react-native/android/.npmignore
@@ -1,0 +1,2 @@
+.gradle/
+build/


### PR DESCRIPTION
## What, How & Why?

Since we're now including the `react-native` directory in the list of `files` to include in our package, the root `.gitignore` file no longer excludes the `react-native/android/build` directory from our .tar.gz as published to NPM.

We can do this because our final .so files are stored in `react-native/android/src/main/jniLibs/*`.

This is a less agressive variant of https://github.com/realm/realm-js/pull/4061.

### As is

```
npm notice package size:  146.5 MB
npm notice unpacked size: 418.6 MB
```

### To be

```     
npm notice package size:  97.5 MB
npm notice unpacked size: 291.8 MB
```

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
