### PR TITLE
Updated RN peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "url-parse": "^1.4.4"
   },
   "peerDependencies": {
-    "react-native": ">=0.60"
+    "react-native": ">=0.66.0"
   },
   "peerDependenciesMeta": {
     "react-native": {


### PR DESCRIPTION
## What, How & Why?

This updates the peer dependency version on React Native to 0.66.0, as it ships the "libjsi.so" that we're depending on.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
