### PR TITLE
Fix classes not extending `Realm.Object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Catching missing libjsi.so when loading the librealm.so and rethrowing a more meaningful error, instructing users to upgrade their version of React Native.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed support of user defined classes that doesn't extend `Realm.Object`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Catching missing libjsi.so when loading the librealm.so and rethrowing a more meaningful error, instructing users to upgrade their version of React Native.
 
 ### Fixed
-* Fixed support of user defined classes that doesn't extend `Realm.Object`.
+* Fixed support of user defined classes that don't extend `Realm.Object`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -128,7 +128,7 @@ inline void copyProperty(JsiEnv env, const fbjsi::Object& from, const fbjsi::Obj
 {
     auto prop = ObjectGetOwnPropertyDescriptor(env, from, name);
     REALM_ASSERT_RELEASE(prop);
-    defineProperty(env, to, "name", *prop);
+    defineProperty(env, to, name, *prop);
 }
 
 inline constexpr const char g_internal_field[] = "__Realm_internal";
@@ -439,9 +439,10 @@ public:
                 return nullptr;
             throw fbjsi::JSError(env, "no internal field");
         }
-        if (!JsiObj(object)->instanceOf(env, *s_ctor)) {
-            throw fbjsi::JSError(env, "calling method on wrong type of object");
-        }
+        // The following check is disabled to support user defined classes that doesn't extend Realm.Object
+        // if (!JsiObj(object)->instanceOf(env, *s_ctor)) {
+        //     throw fbjsi::JSError(env, "calling method on wrong type of object");
+        // }
         return unwrapUnique<Internal>(env, std::move(internal));
     }
     static void set_internal(JsiEnv env, const JsiObj& object, Internal* data)


### PR DESCRIPTION
## What, How & Why?

This provides a fix for the failing tests:

```
ERROR - testRealmObjectCreationByConstructor
ERROR property is not writable

ERROR - testRealmCreateWithConstructor
ERROR property is not writable

ERROR - testRealmCreateWithChangingConstructor
ERROR property is not writable
```

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
