### PR TITLE
Fixed throwing "Illegal constructor"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * Fixed support of user defined classes that don't extend `Realm.Object`.
+* Fixed throwing "Illegal constructor" when `new` constructing anything other than `Realm` and `Realm.Object`.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -248,11 +248,9 @@ public:
                          .call(env, "nativeFunc",
                                util::format(R"(
                       return function %1(...args) {
-                          // "use strict"; 
-                          if (!nativeFunc && false) // XXX only disable check for Realm.Object
-                              throw TypeError("%1() cannot be constructed directly from javascript");
-                          if (!new.target && false) { // XXX find another way to detect this correctly
-                              throw TypeError("%1() must be called as a constructor");
+                          // Allow explicit construction only for `Realm` and `Realm.Object`
+                          if (new.target && "%1" !== "Object" && "%1" !== "Realm") {
+                              throw TypeError("Illegal constructor");
                           }
                           if (nativeFunc)
                               nativeFunc(this, ...args);


### PR DESCRIPTION
## What, How & Why?

This closes two more of the failing unit tests.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
