### PR TITLE
Fixes for type conversions and minor cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "npm": ">=7"
       },
       "peerDependencies": {
-        "react-native": ">=0.60"
+        "react-native": ">=0.66.0"
       },
       "peerDependenciesMeta": {
         "react-native": {
@@ -3104,6 +3104,27 @@
       },
       "engines": {
         "node": ">=0.1.95"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -6953,6 +6974,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -7376,6 +7421,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -7627,6 +7681,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -9471,6 +9531,12 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-fetch": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
@@ -9757,6 +9823,15 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -14987,6 +15062,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/make-fetch-happen": {
       "version": "8.0.14",
@@ -21819,6 +21900,59 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -21898,9 +22032,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -22719,6 +22853,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     }
   },
@@ -24917,6 +25060,21 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
     "@es-joy/jsdoccomment": {
@@ -27934,6 +28092,30 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -28228,6 +28410,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -28422,6 +28610,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -29897,6 +30091,12 @@
         "object-assign": "^4.1.1"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-fetch": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
@@ -30121,6 +30321,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -34221,6 +34427,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "make-fetch-happen": {
       "version": "8.0.14",
@@ -39712,9 +39924,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typical": {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -342,7 +342,10 @@ public:
     static void get_schema_name_from_object(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void update_schema(ContextType, ObjectType, Arguments&, ReturnValue&);
 
+    // NOTE:  __to_object and __to_boolean are shims that allow type conversion tests
+    // on unit tests / CI.  They probably shouldn't be available in production
     static void __to_object(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void __to_boolean(ContextType, ObjectType, Arguments &, ReturnValue &);
 
 #if REALM_ENABLE_SYNC
     static void async_open_realm(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -419,7 +422,11 @@ public:
         {"deleteModel", wrap<delete_model>},
         {"_updateSchema", wrap<update_schema>},
         {"_schemaName", wrap<get_schema_name_from_object>},
+
+        // NOTE:  __to_object and __to_boolean are shims that allow type conversion tests
+        // on unit tests / CI.  They probably shouldn't be available in production
         {"__to_object", wrap<__to_object>},
+        {"__to_boolean", wrap<__to_boolean>},
     };
 
     PropertyMap<T> const properties = {
@@ -1441,6 +1448,16 @@ void RealmClass<T>::__to_object(ContextType ctx, ObjectType this_object, Argumen
     ObjectType newobj = Value::to_object(ctx, args[0]);
 
     return_value.set(newobj);
+}
+
+template <typename T>
+void RealmClass<T>::__to_boolean(ContextType ctx, ObjectType this_object, Arguments& args,
+                                     ReturnValue& return_value)
+{
+    args.validate_count(1);
+    bool is_bool = Value::to_boolean(ctx, args[0]);
+
+    return_value.set(is_bool);
 }
 
 /**

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -344,8 +344,8 @@ public:
 
     // NOTE:  __to_object and __to_boolean are shims that allow type conversion tests
     // on unit tests / CI.  They probably shouldn't be available in production
-    static void __to_object(ContextType, ObjectType, Arguments &, ReturnValue &);
-    static void __to_boolean(ContextType, ObjectType, Arguments &, ReturnValue &);
+    static void __to_object(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void __to_boolean(ContextType, ObjectType, Arguments&, ReturnValue&);
 
 #if REALM_ENABLE_SYNC
     static void async_open_realm(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -1441,8 +1441,7 @@ void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this
 }
 
 template <typename T>
-void RealmClass<T>::__to_object(ContextType ctx, ObjectType this_object, Arguments& args,
-                                     ReturnValue& return_value)
+void RealmClass<T>::__to_object(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
 {
     args.validate_count(1);
     ObjectType newobj = Value::to_object(ctx, args[0]);
@@ -1451,8 +1450,7 @@ void RealmClass<T>::__to_object(ContextType ctx, ObjectType this_object, Argumen
 }
 
 template <typename T>
-void RealmClass<T>::__to_boolean(ContextType ctx, ObjectType this_object, Arguments& args,
-                                     ReturnValue& return_value)
+void RealmClass<T>::__to_boolean(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
 {
     args.validate_count(1);
     bool is_bool = Value::to_boolean(ctx, args[0]);

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -342,6 +342,8 @@ public:
     static void get_schema_name_from_object(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void update_schema(ContextType, ObjectType, Arguments&, ReturnValue&);
 
+    static void __to_object(ContextType, ObjectType, Arguments &, ReturnValue &);
+
 #if REALM_ENABLE_SYNC
     static void async_open_realm(ContextType, ObjectType, Arguments&, ReturnValue&);
 #endif
@@ -417,6 +419,7 @@ public:
         {"deleteModel", wrap<delete_model>},
         {"_updateSchema", wrap<update_schema>},
         {"_schemaName", wrap<get_schema_name_from_object>},
+        {"__to_object", wrap<__to_object>},
     };
 
     PropertyMap<T> const properties = {
@@ -1428,6 +1431,16 @@ void RealmClass<T>::get_schema_name_from_object(ContextType ctx, ObjectType this
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
     auto& object_schema = validated_object_schema_for_value(ctx, realm, args[0]);
     return_value.set(object_schema.name);
+}
+
+template <typename T>
+void RealmClass<T>::__to_object(ContextType ctx, ObjectType this_object, Arguments& args,
+                                     ReturnValue& return_value)
+{
+    args.validate_count(1);
+    ObjectType newobj = Value::to_object(ctx, args[0]);
+
+    return_value.set(newobj);
 }
 
 /**

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -226,11 +226,30 @@ public:
     // Also, may need to suppress destruction.
     inline static std::optional<JsiFunc> s_ctor;
 
-    // TODO / FF:  Pass property name along in exception
-    static fbjsi::Value readonly_setter_callback(fbjsi::Runtime& env, const fbjsi::Value& thisVal,
+    /**
+     * @brief callback for invalid access to index setters
+     * Throws an error when a users attemps to write to an index on a type that 
+     * doesn't support it.
+     * 
+     * @return nothing; always throws
+     */
+    static fbjsi::Value readonly_index_setter_callback(fbjsi::Runtime& env, const fbjsi::Value& thisVal,
                                                  const fbjsi::Value* args, size_t count)
     {
-        throw fbjsi::JSError(env, "Cannot assign to read only property");
+        throw fbjsi::JSError(env, "Cannot assign to index");
+    }
+
+    /**
+     * @brief callback for invalid access to property setters
+     * Trows an error when a user attempts to write to a read-only property
+     * 
+     * @param propname name of the property the user is trying to write to
+     * @return nothin; always throws
+     */
+    static fbjsi::Value readonly_setter_callback(fbjsi::Runtime& env, const fbjsi::Value& thisVal,
+                                                 const fbjsi::Value* args, size_t count, std::string const &propname)
+    {
+        throw fbjsi::JSError(env, util::format("Cannot assign to read only property '%1'", propname));
     }
 
     static JsiFunc create_constructor(JsiEnv env)
@@ -291,7 +310,8 @@ public:
                 desc.setProperty(env, "set", funcVal(env, "set_" + name, 1, prop.setter));
             }
             else {
-                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0, ObjectWrap::readonly_setter_callback));
+                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0, 
+                std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
             }
             defineProperty(env, *s_ctor, name, desc);
         }
@@ -314,7 +334,8 @@ public:
                 desc.setProperty(env, "set", funcVal(env, "set_" + name, 1, prop.setter));
             }
             else {
-                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0, ObjectWrap::readonly_setter_callback));
+                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0,
+                std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
             }
             defineProperty(env, proto, name, desc);
         }
@@ -403,7 +424,8 @@ public:
                     .asObject(env)
                     .asFunction(env)
                     .call(env, funcVal(env, "getter", 0, getter),
-                          funcVal(env, "setter", 1, setter ? setter : ObjectWrap::readonly_setter_callback))
+                          funcVal(env, "setter", 1, setter ? setter : 
+                          ObjectWrap::readonly_index_setter_callback))
                     .asObject(env)
                     .asFunction(env));
             defineProperty(env, *s_ctor, "_proxyWrapper", desc);

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -222,7 +222,7 @@ public:
     using Internal = typename T::Internal;
     using ParentClassType = typename T::Parent;
 
-    // XXX if this is static, it won't support multiple runtimes.
+    // NOTE:  if this is static, it won't support multiple runtimes.
     // Also, may need to suppress destruction.
     inline static std::optional<JsiFunc> s_ctor;
 
@@ -664,7 +664,7 @@ private:
 
     inline static auto& get_schemaObjectTypes()
     {
-        // XXX this being static prevents using multiple runtimes.
+        // NOTE:  this being static prevents using multiple runtimes.
         static std::unordered_map<std::string, std::unordered_map<std::string, fbjsi::Function>> s_schemaObjectTypes;
         return s_schemaObjectTypes;
     }

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -228,13 +228,13 @@ public:
 
     /**
      * @brief callback for invalid access to index setters
-     * Throws an error when a users attemps to write to an index on a type that 
+     * Throws an error when a users attemps to write to an index on a type that
      * doesn't support it.
-     * 
+     *
      * @return nothing; always throws
      */
     static fbjsi::Value readonly_index_setter_callback(fbjsi::Runtime& env, const fbjsi::Value& thisVal,
-                                                 const fbjsi::Value* args, size_t count)
+                                                       const fbjsi::Value* args, size_t count)
     {
         throw fbjsi::JSError(env, "Cannot assign to index");
     }
@@ -242,12 +242,12 @@ public:
     /**
      * @brief callback for invalid access to property setters
      * Trows an error when a user attempts to write to a read-only property
-     * 
+     *
      * @param propname name of the property the user is trying to write to
      * @return nothin; always throws
      */
     static fbjsi::Value readonly_setter_callback(fbjsi::Runtime& env, const fbjsi::Value& thisVal,
-                                                 const fbjsi::Value* args, size_t count, std::string const &propname)
+                                                 const fbjsi::Value* args, size_t count, std::string const& propname)
     {
         throw fbjsi::JSError(env, util::format("Cannot assign to read only property '%1'", propname));
     }
@@ -310,8 +310,11 @@ public:
                 desc.setProperty(env, "set", funcVal(env, "set_" + name, 1, prop.setter));
             }
             else {
-                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0, 
-                std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
+                desc.setProperty(
+                    env, "set",
+                    funcVal(env, "set_" + name, 0,
+                            std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1,
+                                      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
             }
             defineProperty(env, *s_ctor, name, desc);
         }
@@ -334,8 +337,11 @@ public:
                 desc.setProperty(env, "set", funcVal(env, "set_" + name, 1, prop.setter));
             }
             else {
-                desc.setProperty(env, "set", funcVal(env, "set_" + name, 0,
-                std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
+                desc.setProperty(
+                    env, "set",
+                    funcVal(env, "set_" + name, 0,
+                            std::bind(ObjectWrap::readonly_setter_callback, std::placeholders::_1,
+                                      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, name)));
             }
             defineProperty(env, proto, name, desc);
         }
@@ -424,8 +430,7 @@ public:
                     .asObject(env)
                     .asFunction(env)
                     .call(env, funcVal(env, "getter", 0, getter),
-                          funcVal(env, "setter", 1, setter ? setter : 
-                          ObjectWrap::readonly_index_setter_callback))
+                          funcVal(env, "setter", 1, setter ? setter : ObjectWrap::readonly_index_setter_callback))
                     .asObject(env)
                     .asFunction(env));
             defineProperty(env, *s_ctor, "_proxyWrapper", desc);

--- a/src/jsi/jsi_value.hpp
+++ b/src/jsi/jsi_value.hpp
@@ -250,12 +250,12 @@ inline bool realmjsi::Value::to_boolean(JsiEnv env, const JsiVal& value)
 
     if (value->isString()) {
         // only the empty string is false
-        return value->toString(env).utf8(env) == "";
+        return value->toString(env).utf8(env) != "";
     }
 
     if (value->isNumber()) {
-        double const dblval = value->getNumber();
-        if (dblval == std::nan("")) {
+        double const dblval = value->asNumber();
+        if (std::isnan(dblval)) {
             return false;
         }
 
@@ -263,10 +263,10 @@ inline bool realmjsi::Value::to_boolean(JsiEnv env, const JsiVal& value)
         fbjsi::String const jsistringval = value->toString(env);
         std::string const stringval = jsistringval.utf8(env);
 
-        return (stringval == "0" || stringval == "-0");
+        return (stringval != "0" && stringval != "-0");
     }
 
-    throw fbjsi::JSError(env, util::format("cannot convert type %1 to boolean", Value::typeof(env, value)));
+    throw fbjsi::JSError(env, util::format("TypeError:  cannot convert type %1 to boolean", Value::typeof(env, value)));
 }
 
 template <>
@@ -341,7 +341,7 @@ inline JsiObj realmjsi::Value::to_object(JsiEnv env, JsiVal const &value)
 
     // trivial non-conversions
     if (value->isNull() || value->isUndefined()) {
-        throw fbjsi::JSError(env, util::format("TypeError:  cannot convert %1 to object", realmjsi::Value::typeof(env, value))); // throw TypeError
+        throw fbjsi::JSError(env, util::format("TypeError:  cannot convert '%1' to object", realmjsi::Value::typeof(env, value))); // throw TypeError
     }
 
     // use JavaScript's `Object()` to wrap types in their corresponding object types

--- a/src/jsi/jsi_value.hpp
+++ b/src/jsi/jsi_value.hpp
@@ -264,7 +264,8 @@ inline bool realmjsi::Value::to_boolean(JsiEnv env, const JsiVal& value)
         return (stringval != "0" && stringval != "-0");
     }
 
-    throw fbjsi::JSError(env, util::format("TypeError:  cannot convert type %1 to boolean", Value::typeof(env, value)));
+    throw fbjsi::JSError(env,
+                         util::format("TypeError:  cannot convert type %1 to boolean", Value::typeof(env, value)));
 }
 
 template <>
@@ -322,16 +323,16 @@ inline OwnedBinaryData realmjsi::Value::to_binary(JsiEnv env, const JsiVal& valu
 
 /**
  * @brief convert a JSI value to an object
- * Will try to convert a given value to a JavaScript object according to 
+ * Will try to convert a given value to a JavaScript object according to
  * https://tc39.es/ecma262/#sec-toobject.  Most primitive types will be wrapped
  * in their corresponding object types (e.g., string -> String).
- * 
+ *
  * @param env JSI runtime environment
  * @param value JSI value that will be converted to object
- * @return JsiObj 
+ * @return JsiObj
  */
 template <>
-inline JsiObj realmjsi::Value::to_object(JsiEnv env, JsiVal const &value)
+inline JsiObj realmjsi::Value::to_object(JsiEnv env, JsiVal const& value)
 {
     if (value->isObject()) {
         return env(value->asObject(env));
@@ -339,14 +340,16 @@ inline JsiObj realmjsi::Value::to_object(JsiEnv env, JsiVal const &value)
 
     // trivial non-conversions
     if (value->isNull() || value->isUndefined()) {
-        throw fbjsi::JSError(env, util::format("TypeError:  cannot convert '%1' to object", realmjsi::Value::typeof(env, value))); // throw TypeError
+        throw fbjsi::JSError(env, util::format("TypeError:  cannot convert '%1' to object",
+                                               realmjsi::Value::typeof(env, value))); // throw TypeError
     }
 
     // use JavaScript's `Object()` to wrap types in their corresponding object types
     auto objectCtor = env->global().getPropertyAsFunction(env, "Object");
     fbjsi::Value wrappedValue = objectCtor.callAsConstructor(env, value);
     if (!wrappedValue.isObject()) {
-        throw fbjsi::JSError(env, util::format("TypeError:  cannot wrap %1 in Object", realmjsi::Value::typeof(env, value)));
+        throw fbjsi::JSError(
+            env, util::format("TypeError:  cannot wrap %1 in Object", realmjsi::Value::typeof(env, value)));
     }
     return env(wrappedValue.asObject(env));
 }

--- a/src/jsi/jsi_value.hpp
+++ b/src/jsi/jsi_value.hpp
@@ -20,9 +20,7 @@
 
 #include "jsi_string.hpp"
 #include "jsi_types.hpp"
-#include "realm/object-store/sync/generic_network_transport.hpp"
 #include "realm/util/to_string.hpp"
-//#include "node_buffer.hpp"
 
 namespace realm {
 namespace js {

--- a/src/jsi/jsi_value.hpp
+++ b/src/jsi/jsi_value.hpp
@@ -257,10 +257,7 @@ inline bool realmjsi::Value::to_boolean(JsiEnv env, const JsiVal& value)
             return false;
         }
 
-        // TODO:  add tests for these -- specifcally the case of numerals 0 and -0
-        fbjsi::String const jsistringval = value->toString(env);
-        std::string const stringval = jsistringval.utf8(env);
-
+        std::string const stringval = value->toString(env).utf8(env);
         return (stringval != "0" && stringval != "-0");
     }
 

--- a/tests/js/asserts.js
+++ b/tests/js/asserts.js
@@ -177,25 +177,6 @@ module.exports = {
       func();
     } catch (e) {
       caught = true;
-      if (!e.message.includes(expectedMessage)) {
-        throw new TestFailureError(
-          `Expected exception "${expectedMessage}" not thrown - instead caught: "${e}"`,
-          depth,
-        );
-      }
-    }
-
-    if (!caught) {
-      throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown`, depth);
-    }
-  },
-
-  assertThrowsNameOrContaining: function (func, expectedMessage, depth) {
-    let caught = false;
-    try {
-      func();
-    } catch (e) {
-      caught = true;
       if (!e.message.includes(expectedMessage) && !e.name.includes(expectedMessage)) {
         throw new TestFailureError(
           `Expected exception "${expectedMessage}" not thrown - instead caught: "${e}"`,

--- a/tests/js/asserts.js
+++ b/tests/js/asserts.js
@@ -189,6 +189,26 @@ module.exports = {
       throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown`, depth);
     }
   },
+
+  assertThrowsNameOrContaining: function (func, expectedMessage, depth) {
+    let caught = false;
+    try {
+      func();
+    } catch (e) {
+      caught = true;
+      if (!e.message.includes(expectedMessage) && !e.name.includes(expectedMessage)) {
+        throw new TestFailureError(
+          `Expected exception "${expectedMessage}" not thrown - instead caught: "${e}"`,
+          depth,
+        );
+      }
+    }
+
+    if (!caught) {
+      throw new TestFailureError(`Expected exception "${expectedMessage}" not thrown`, depth);
+    }
+  },
+
   assertThrowsAsyncContaining: async function (func, expectedMessage, depth) {
     let caught = false;
     try {

--- a/tests/js/list-tests.js
+++ b/tests/js/list-tests.js
@@ -142,9 +142,7 @@ module.exports = {
       obj.arrayCol = [{ doubleCol: 1 }, { doubleCol: 2 }];
       TestCase.assertEqual(array.length, 2);
 
-      // TODO / FF: switch tests when property name can be passed along again
-      //      TestCase.assertThrowsContaining(() => (array.length = 0), "Cannot assign to read only property 'length'");
-      TestCase.assertThrowsContaining(() => (array.length = 0), "Cannot assign to read only property");
+      TestCase.assertThrowsContaining(() => (array.length = 0), "Cannot assign to read only property 'length'");
     });
 
     TestCase.assertEqual(array.length, 2);

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -470,6 +470,13 @@ module.exports = {
     TestCase.assertTrue(realm.__to_boolean(false) == false, "__to_boolean(false) should return false");
     TestCase.assertTrue(realm.__to_boolean(NaN) == false, "__to_boolean(NaN) should return false");
     TestCase.assertTrue(realm.__to_boolean(undefined) == false, "__to_boolean(undefined) should return false");
+
+    TestCase.assertTrue(realm.__to_boolean("false") == true, '__to_boolean("false") should return true');
+    TestCase.assertTrue(realm.__to_boolean(1) == true, "__to_boolean(1) should return true");
+    TestCase.assertTrue(realm.__to_boolean(-1) == true, "__to_boolean(-1) should return true");
+    TestCase.assertTrue(realm.__to_boolean([]) == true, "__to_boolean([]) should return true");
+    TestCase.assertTrue(realm.__to_boolean(Object()) == true, "__to_boolean(Object()) should return true");
+
     realm.close();
   },
 

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -438,19 +438,38 @@ module.exports = {
 
   testObjectConversion: function () {
     const realm = new Realm({ schema: [schemas.TestObject] });
-    TestCase.assertTrue(realm.__to_object("This is a string") instanceof Object, "__to_object should return Object");
-    TestCase.assertTrue(realm.__to_object(12345) instanceof Object, "__to_object should return Object");
-    TestCase.assertTrue(realm.__to_object(false) instanceof Object, "__to_object should return Object");
-    TestCase.assertTrue(realm.__to_object(new Date()) instanceof Object, "__to_object should return Object");
+    TestCase.assertTrue(
+      realm.__to_object("This is a string") instanceof Object,
+      "__to_object(string) should return Object",
+    );
+    TestCase.assertTrue(realm.__to_object(12345) instanceof Object, "__to_object(int) should return Object");
+    TestCase.assertTrue(realm.__to_object(false) instanceof Object, "__to_object(bool) should return Object");
+    TestCase.assertTrue(realm.__to_object(new Date()) instanceof Object, "__to_object(Date) should return Object");
 
-    TestCase.assertThrowsContaining(() => {
+    TestCase.assertThrowsNameOrContaining(() => {
       realm.__to_object(null);
     }, "TypeError");
 
-    TestCase.assertThrowsContaining(() => {
+    TestCase.assertThrowsNameOrContaining(() => {
       realm.__to_object(undefined);
     }, "TypeError");
 
+    realm.close();
+  },
+
+  // tests conversion of various types to boolean as specified in
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+  // it resides here for lack of a better place, and because the direct type conversion
+  // operations have been made available through the Realm object
+  testBooleanConversion: function () {
+    const realm = new Realm({ schema: [schemas.TestObject] });
+    TestCase.assertTrue(realm.__to_boolean("") == false, '__to_boolean("") should return false');
+    TestCase.assertTrue(realm.__to_boolean(0) == false, "__to_boolean(0) should return false");
+    TestCase.assertTrue(realm.__to_boolean(-0) == false, "__to_boolean(-0) should return false");
+    TestCase.assertTrue(realm.__to_boolean(null) == false, "__to_boolean(null) should return false");
+    TestCase.assertTrue(realm.__to_boolean(false) == false, "__to_boolean(false) should return false");
+    TestCase.assertTrue(realm.__to_boolean(NaN) == false, "__to_boolean(NaN) should return false");
+    TestCase.assertTrue(realm.__to_boolean(undefined) == false, "__to_boolean(undefined) should return false");
     realm.close();
   },
 

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -439,7 +439,8 @@ module.exports = {
   testObjectConversion: function () {
     const realm = new Realm({ schema: [schemas.TestObject] });
     TestCase.assertInstanceOf(
-      realm.__to_object("This is a string"), String,
+      realm.__to_object("This is a string"),
+      String,
       "__to_object(string) should return String Object",
     );
     TestCase.assertTrue(
@@ -447,9 +448,15 @@ module.exports = {
       '__to_object(string("Foo")) should return String("Foo") Object',
     );
     TestCase.assertInstanceOf(realm.__to_object(12345), Number, "__to_object(int) should return Number Object");
-    TestCase.assertTrue(realm.__to_object(12345) == Number(12345), "__to_object(int(12345)) should return Number(12345) Object");
+    TestCase.assertTrue(
+      realm.__to_object(12345) == Number(12345),
+      "__to_object(int(12345)) should return Number(12345) Object",
+    );
     TestCase.assertInstanceOf(realm.__to_object(false), Boolean, "__to_object(bool) should return Boolean Object");
-    TestCase.assertTrue(realm.__to_object(false) == Boolean(false), "__to_object(bool(false)) should return Boolean(false) Object");
+    TestCase.assertTrue(
+      realm.__to_object(false) == Boolean(false),
+      "__to_object(bool(false)) should return Boolean(false) Object",
+    );
     TestCase.assertInstanceOf(realm.__to_object(new Date()), Date, "__to_object(Date) should return Date Object");
 
     TestCase.assertThrowsContaining(() => {

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -436,6 +436,24 @@ module.exports = {
     });
   },
 
+  testObjectConversion: function () {
+    const realm = new Realm({ schema: [schemas.TestObject] });
+    TestCase.assertTrue(realm.__to_object("This is a string") instanceof Object, "__to_object should return Object");
+    TestCase.assertTrue(realm.__to_object(12345) instanceof Object, "__to_object should return Object");
+    TestCase.assertTrue(realm.__to_object(false) instanceof Object, "__to_object should return Object");
+    TestCase.assertTrue(realm.__to_object(new Date()) instanceof Object, "__to_object should return Object");
+
+    TestCase.assertThrowsContaining(() => {
+      realm.__to_object(null);
+    }, "TypeError");
+
+    TestCase.assertThrowsContaining(() => {
+      realm.__to_object(undefined);
+    }, "TypeError");
+
+    realm.close();
+  },
+
   testObjectSchema: function () {
     const realm = new Realm({ schema: [schemas.TestObject] });
     var obj;

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -438,19 +438,25 @@ module.exports = {
 
   testObjectConversion: function () {
     const realm = new Realm({ schema: [schemas.TestObject] });
-    TestCase.assertTrue(
-      realm.__to_object("This is a string") instanceof Object,
-      "__to_object(string) should return Object",
+    TestCase.assertInstanceOf(
+      realm.__to_object("This is a string"), String,
+      "__to_object(string) should return String Object",
     );
-    TestCase.assertTrue(realm.__to_object(12345) instanceof Object, "__to_object(int) should return Object");
-    TestCase.assertTrue(realm.__to_object(false) instanceof Object, "__to_object(bool) should return Object");
-    TestCase.assertTrue(realm.__to_object(new Date()) instanceof Object, "__to_object(Date) should return Object");
+    TestCase.assertTrue(
+      realm.__to_object("Foo") == String("Foo"),
+      '__to_object(string("Foo")) should return String("Foo") Object',
+    );
+    TestCase.assertInstanceOf(realm.__to_object(12345), Number, "__to_object(int) should return Number Object");
+    TestCase.assertTrue(realm.__to_object(12345) == Number(12345), "__to_object(int(12345)) should return Number(12345) Object");
+    TestCase.assertInstanceOf(realm.__to_object(false), Boolean, "__to_object(bool) should return Boolean Object");
+    TestCase.assertTrue(realm.__to_object(false) == Boolean(false), "__to_object(bool(false)) should return Boolean(false) Object");
+    TestCase.assertInstanceOf(realm.__to_object(new Date()), Date, "__to_object(Date) should return Date Object");
 
-    TestCase.assertThrowsNameOrContaining(() => {
+    TestCase.assertThrowsContaining(() => {
       realm.__to_object(null);
     }, "TypeError");
 
-    TestCase.assertThrowsNameOrContaining(() => {
+    TestCase.assertThrowsContaining(() => {
       realm.__to_object(undefined);
     }, "TypeError");
 
@@ -463,19 +469,19 @@ module.exports = {
   // operations have been made available through the Realm object
   testBooleanConversion: function () {
     const realm = new Realm({ schema: [schemas.TestObject] });
-    TestCase.assertTrue(realm.__to_boolean("") == false, '__to_boolean("") should return false');
-    TestCase.assertTrue(realm.__to_boolean(0) == false, "__to_boolean(0) should return false");
-    TestCase.assertTrue(realm.__to_boolean(-0) == false, "__to_boolean(-0) should return false");
-    TestCase.assertTrue(realm.__to_boolean(null) == false, "__to_boolean(null) should return false");
-    TestCase.assertTrue(realm.__to_boolean(false) == false, "__to_boolean(false) should return false");
-    TestCase.assertTrue(realm.__to_boolean(NaN) == false, "__to_boolean(NaN) should return false");
-    TestCase.assertTrue(realm.__to_boolean(undefined) == false, "__to_boolean(undefined) should return false");
+    TestCase.assertEqual(realm.__to_boolean(""), false, '__to_boolean("") should return false');
+    TestCase.assertEqual(realm.__to_boolean(0), false, "__to_boolean(0) should return false");
+    TestCase.assertEqual(realm.__to_boolean(-0), false, "__to_boolean(-0) should return false");
+    TestCase.assertEqual(realm.__to_boolean(null), false, "__to_boolean(null) should return false");
+    TestCase.assertEqual(realm.__to_boolean(false), false, "__to_boolean(false) should return false");
+    TestCase.assertEqual(realm.__to_boolean(NaN), false, "__to_boolean(NaN) should return false");
+    TestCase.assertEqual(realm.__to_boolean(undefined), false, "__to_boolean(undefined) should return false");
 
-    TestCase.assertTrue(realm.__to_boolean("false") == true, '__to_boolean("false") should return true');
-    TestCase.assertTrue(realm.__to_boolean(1) == true, "__to_boolean(1) should return true");
-    TestCase.assertTrue(realm.__to_boolean(-1) == true, "__to_boolean(-1) should return true");
-    TestCase.assertTrue(realm.__to_boolean([]) == true, "__to_boolean([]) should return true");
-    TestCase.assertTrue(realm.__to_boolean(Object()) == true, "__to_boolean(Object()) should return true");
+    TestCase.assertEqual(realm.__to_boolean("false"), true, '__to_boolean("false") should return true');
+    TestCase.assertEqual(realm.__to_boolean(1), true, "__to_boolean(1) should return true");
+    TestCase.assertEqual(realm.__to_boolean(-1), true, "__to_boolean(-1) should return true");
+    TestCase.assertEqual(realm.__to_boolean([]), true, "__to_boolean([]) should return true");
+    TestCase.assertEqual(realm.__to_boolean(Object()), true, "__to_boolean(Object()) should return true");
 
     realm.close();
   },


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

Notable changes:
* Fixed and tested type conversions for `to_object` and `to_boolean`
* Added callbacks for read-only properties that will report access violations


This closes RJS-1330

## ☑️ ToDos
<!-- Add your own todos here -->
~* [ ] 📝 Changelog entry~
~* [ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
~* [ ] 📱 Check the React Native/other sample apps work if necessary~
~* [ ] 📝 Public documentation PR created or is not necessary~
~* [ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
