### PR TITLE
Pass arguments correctly to callResetPasswordFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * If the option `user` in a sync configuration was not a `Realm.User` object could lead to a crash. ([#1348](https://github.com/realm/realm-js/issues/1348), since v10.0.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding. (since v10.3.0-rc.1)
 * Queries of the form `link.collection.@sum = 0` where `link` is `null` matched when `collection` was a List or Set, but not a Dictionary ([realm/realm-core#5080](https://github.com/realm/realm-core/pull/5080), since v10.5.0)
+* Fixed a bug in `Realm.App.emailPasswordAuth.callResetPasswordFunction()` which could lead to the error `Error: Error: resetDetails must be of type 'object', got (user@example.com)`. ([#4143](https://github.com/realm/realm-js/issues/4143), since v10.10.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/email-password-auth-methods.js
+++ b/lib/email-password-auth-methods.js
@@ -73,7 +73,7 @@ const instanceMethods = {
     );
 
     const stringifiedArgs = EJSON.stringify(restArgs, { relaxed: false });
-    return promisify((cb) => this._callResetPasswordFunction(argsObject.email, stringifiedArgs, cb));
+    return promisify((cb) => this._callResetPasswordFunction(argsObject, stringifiedArgs, cb));
   },
 };
 

--- a/src/js_email_password_auth.hpp
+++ b/src/js_email_password_auth.hpp
@@ -194,8 +194,8 @@ void EmailPasswordAuthClass<T>::call_reset_password_function(ContextType ctx, Ob
     auto details = Value::validated_to_object(ctx, args[0], "resetDetails");
     auto email = Object::validated_get_string(ctx, details, "email", "email");
     auto password = Object::validated_get_string(ctx, details, "password", "password");
-    auto stringified_ejson_args = Value::validated_to_string(ctx, args[2], "args");
-    auto callback = Value::validated_to_function(ctx, args[3], "callback");
+    auto stringified_ejson_args = Value::validated_to_string(ctx, args[1], "args");
+    auto callback = Value::validated_to_function(ctx, args[2], "callback");
 
     auto bson_args = String::to_bson(stringified_ejson_args);
 

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -272,6 +272,24 @@ module.exports = {
     TestCase.assertEqual(err.message, "already confirmed", "User should already be confirmed.");
   },
 
+  async testResetPassword() {
+    let app = new Realm.App(appConfig);
+
+    const validEmail = randomVerifiableEmail();
+    const validPassword = "password123456";
+    await app.emailPasswordAuth.registerUser({ email: validEmail, password: validPassword });
+
+    const newPassword = "password654321";
+    await app.emailPasswordAuth.callResetPasswordFunction({ email: validEmail, password: newPassword });
+
+    // see if we can log in
+    let creds = Realm.Credentials.emailPassword(validEmail, newPassword);
+    let user = await app.logIn(creds);
+    TestCase.assertTrue(user instanceof Realm.User);
+
+    await user.logOut();
+  },
+
   async testFunctions() {
     let app = new Realm.App(appConfig);
     let credentials = Realm.Credentials.anonymous();

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -279,7 +279,7 @@ module.exports = {
     const validPassword = "password123456";
     await app.emailPasswordAuth.registerUser({ email: validEmail, password: validPassword });
 
-    const newPassword = "password654321";
+    const newPassword = "realm_tests_do_reset654321";
     await app.emailPasswordAuth.callResetPasswordFunction({ email: validEmail, password: newPassword });
 
     // see if we can log in


### PR DESCRIPTION
## What, How & Why?

This closes #4143 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~
* [ ] Add `resetFunction` to the test set up (see https://docs.mongodb.com/realm/authentication/email-password/#run-a-password-reset-function)

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
