### PR TITLE
Tests failing for Node > 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * If the option `user` in a sync configuration was not a `Realm.User` object could lead to a crash. ([#1348](https://github.com/realm/realm-js/issues/1348), since v10.0.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding. (since v10.3.0-rc.1)
 * Queries of the form `link.collection.@sum = 0` where `link` is `null` matched when `collection` was a List or Set, but not a Dictionary ([realm/realm-core#5080](https://github.com/realm/realm-core/pull/5080), since v10.5.0)
+* Fix Realm for versions of Node greater than 14.
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "fs-extra": "^4.0.3",
         "https-proxy-agent": "^2.2.4",
         "ini": "^1.3.7",
-        "node-addon-api": "^3.1.0",
+        "node-addon-api": "4.2.0",
         "node-fetch": "^2.6.1",
         "node-machine-id": "^1.1.10",
         "prebuild-install": "^6.1.1",
@@ -9782,9 +9782,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node_modules/node-emoji": {
       "version": "1.10.0",
@@ -21500,9 +21500,9 @@
       }
     },
     "node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node-emoji": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "fs-extra": "^4.0.3",
     "https-proxy-agent": "^2.2.4",
     "ini": "^1.3.7",
-    "node-addon-api": "^3.1.0",
+    "node-addon-api": "4.2.0",
     "node-fetch": "^2.6.1",
     "node-machine-id": "^1.1.10",
     "prebuild-install": "^6.1.1",

--- a/src/node/node_protected.hpp
+++ b/src/node/node_protected.hpp
@@ -44,7 +44,7 @@ public:
         , m_isValue(false)
     {
         napi_status status = napi_create_reference(env, value, 1, &m_ref);
-        if (status == napi_object_expected) {
+        if (status == napi_object_expected || status == napi_invalid_arg) {
             m_isValue = true;
             Napi::Object object = Napi::Object::New(m_env);
             object.Set("value", value);


### PR DESCRIPTION
`napi_create_reference` returns `napi_invalid_arg` instead of `napi_object_expected`.
Extended logic for this case.

Also updated `node-addon-api` to `4.2.0`

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
