### PR TITLE
fix: #3817 Changed undefined to empty array

### DIFF
--- a/lib/browser/rpc.js
+++ b/lib/browser/rpc.js
@@ -117,7 +117,7 @@ export function setVersions(versions) {
 }
 
 export function _anonymousRPC() {
-  const result = sendRequest("_anonymous", { arguments: undefined });
+  const result = sendRequest("_anonymous", { arguments: [] });
   return deserialize(undefined, result);
 }
 


### PR DESCRIPTION
This change is made, because gettong error while trying to anonymously login https://github.com/realm/realm-js/issues/3817

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
