### PR TITLE
Fixed `MongoDBCollection#watch` on React Native

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "./header.eslintrc"
   ],
   "env": {
-    "es2017": true
+    "es2020": true
   },
   "parserOptions": {
     "ecmaVersion": 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Queries of the form `link.collection.@sum = 0` where `link` is `null` matched when `collection` was a List or Set, but not a Dictionary ([realm/realm-core#5080](https://github.com/realm/realm-core/pull/5080), since v10.5.0)
 * Type methods defined in `collection-methods.js` no longer throw `Realm not defined` errors in some environments ([#4029](https://github.com/realm/realm-js/issues/4029), [#3991](https://github.com/realm/realm-js/issues/3991), since v10.5.0)
 * Fixed a bug in `Realm.App.emailPasswordAuth.callResetPasswordFunction()` which could lead to the error `Error: Error: resetDetails must be of type 'object', got (user@example.com)`. ([#4143](https://github.com/realm/realm-js/issues/4143), since v10.10.0)
+* Fixed `MongoDBCollection#watch` on React Native (https://github.com/realm/realm-js/issues/3494, since v10.0.0). To use this, you must install:
+  1. Polyfills for `fetch`, `ReadableStream` and `TextDecoder`: https://www.npmjs.com/package/react-native-polyfill-globals
+  2. Babel plugin enabling async generator syntax: https://npmjs.com/package/@babel/plugin-proposal-async-generator-functions
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -1319,6 +1319,11 @@ class MongoDBCollection {
    * By default, yields all change events for this collection. You may specify at most one of
    * the `filter` or `ids` options.
    *
+   * Important Note: To use this on React Native, you must install:
+   *
+   * 1. Polyfills for `fetch`, `ReadableStream` and `TextDecoder`: {@link https://www.npmjs.com/package/react-native-polyfill-globals}
+   * 2. Babel plugin enabling async generator syntax: {@link https://npmjs.com/package/@babel/plugin-proposal-async-generator-functions}
+   *
    * @param {object} [options={}]
    * @param {object} [options.filter] A filter for which change events you are interested in.
    * @param {any[]} [options.ids] A list of ids that you are interested in watching

--- a/integration-tests/tests/package-lock.json
+++ b/integration-tests/tests/package-lock.json
@@ -17,9 +17,7 @@
 				"concurrently": "^6.0.2",
 				"fs-extra": "^7.0.1",
 				"mocha": "^9.1.3",
-				"node-fetch": "^2.6.1",
-				"ts-node": "^10.4.0",
-				"typescript": "^4.2.4"
+				"node-fetch": "^2.6.1"
 			},
 			"peerDependencies": {
 				"bson": "^4.2.3",
@@ -2056,27 +2054,6 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"peer": true
 		},
-		"node_modules/@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-			"integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-			"integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-			"dev": true,
-			"dependencies": {
-				"@cspotcode/source-map-consumer": "0.8.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
@@ -2522,30 +2499,6 @@
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"peer": true
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true
-		},
 		"node_modules/@types/chai": {
 			"version": "4.2.16",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.16.tgz",
@@ -2661,27 +2614,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -2873,12 +2805,6 @@
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
 		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
@@ -4078,12 +4004,6 @@
 				"loose-envify": "^1.3.1",
 				"object-assign": "^4.1.1"
 			}
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
 		},
 		"node_modules/cross-fetch": {
 			"version": "3.1.4",
@@ -6424,12 +6344,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
 		},
 		"node_modules/makeerror": {
 			"version": "1.0.11",
@@ -10086,56 +10000,6 @@
 				"tree-kill": "cli.js"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-			"integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-			"dev": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "0.7.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -10182,19 +10046,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"peer": true
-		},
-		"node_modules/typescript": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-			"integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
 		},
 		"node_modules/typical": {
 			"version": "4.0.0",
@@ -10754,15 +10605,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -12192,21 +12034,6 @@
 				}
 			}
 		},
-		"@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-			"integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-			"dev": true
-		},
-		"@cspotcode/source-map-support": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-			"integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-			"dev": true,
-			"requires": {
-				"@cspotcode/source-map-consumer": "0.8.0"
-			}
-		},
 		"@hapi/hoek": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
@@ -12601,30 +12428,6 @@
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"peer": true
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true
-		},
 		"@types/chai": {
 			"version": "4.2.16",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.16.tgz",
@@ -12735,18 +12538,6 @@
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
 			}
-		},
-		"acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-			"dev": true
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true
 		},
 		"agent-base": {
 			"version": "4.3.0",
@@ -12899,12 +12690,6 @@
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -13864,12 +13649,6 @@
 				"loose-envify": "^1.3.1",
 				"object-assign": "^4.1.1"
 			}
-		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
 		},
 		"cross-fetch": {
 			"version": "3.1.4",
@@ -15733,12 +15512,6 @@
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
 			}
-		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
 		},
 		"makeerror": {
 			"version": "1.0.11",
@@ -18741,34 +18514,6 @@
 			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
 			"dev": true
 		},
-		"ts-node": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-			"integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-			"dev": true,
-			"requires": {
-				"@cspotcode/source-map-support": "0.7.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"yn": "3.1.1"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-					"dev": true
-				}
-			}
-		},
 		"tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -18806,12 +18551,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"peer": true
-		},
-		"typescript": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-			"integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
-			"dev": true
 		},
 		"typical": {
 			"version": "4.0.0",
@@ -19251,12 +18990,6 @@
 					"dev": true
 				}
 			}
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "chai": "^4.2.0",
-    "realm-network-transport": "^0.7.0"
+    "realm-network-transport": "^0.7.1"
   },
   "files": [
     "/src"

--- a/lib/mongo-client.js
+++ b/lib/mongo-client.js
@@ -19,7 +19,24 @@
 const { EJSON } = require("bson");
 const { DefaultNetworkTransport } = require("realm-network-transport");
 
-const { cleanArguments } = require("./utils");
+const { cleanArguments, getEnvironment } = require("./utils");
+
+/**
+ * Iterates the global to ensure all globals needed for watching are available.
+ */
+function ensureWatchDependencies() {
+  const environment = getEnvironment();
+  if (environment === "reactnative") {
+    const EXPECTED_GLOBALS = ["fetch", "ReadableStream", "TextDecoder"];
+    for (const name of EXPECTED_GLOBALS) {
+      if (!(name in globalThis)) {
+        throw new Error(
+          `Realm expects the ${name} global: Please use https://www.npmjs.com/package/react-native-polyfill-globals`,
+        );
+      }
+    }
+  }
+}
 
 /**
  * A remote collection of documents.
@@ -181,6 +198,8 @@ class MongoDBCollection {
   }
 
   async *watch({ ids = undefined, filter = undefined } = {}) {
+    ensureWatchDependencies();
+
     const args = cleanArguments({
       database: this.databaseName,
       collection: this.collectionName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "prebuild-install": "^6.1.1",
         "progress": "^2.0.3",
         "prop-types": "^15.6.2",
-        "realm-network-transport": "^0.7.0",
+        "realm-network-transport": "^0.7.1",
         "request": "^2.88.0",
         "stream-counter": "^1.0.0",
         "sync-request": "^3.0.1",
@@ -11803,9 +11803,9 @@
       }
     },
     "node_modules/realm-network-transport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.0.tgz",
-      "integrity": "sha512-w81+N+YrFBkWZWFlspDPrpot50xCkfr+AB+NCQjsTI6OfVF0igqhLfl3frwrSS61fQiL5XrZrFYFV6BWU0F+iA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.1.tgz",
+      "integrity": "sha512-ZKGJVk6hzVeLE/cme9H4MyVnfpPlCTMheQdnMHWkLMhvNUqgyPFkgSCB+B5IsnGns2l5g2rmKeTNPoUFHi+Khw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"
@@ -23096,9 +23096,9 @@
       }
     },
     "realm-network-transport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.0.tgz",
-      "integrity": "sha512-w81+N+YrFBkWZWFlspDPrpot50xCkfr+AB+NCQjsTI6OfVF0igqhLfl3frwrSS61fQiL5XrZrFYFV6BWU0F+iA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.1.tgz",
+      "integrity": "sha512-ZKGJVk6hzVeLE/cme9H4MyVnfpPlCTMheQdnMHWkLMhvNUqgyPFkgSCB+B5IsnGns2l5g2rmKeTNPoUFHi+Khw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prebuild-install": "^6.1.1",
     "progress": "^2.0.3",
     "prop-types": "^15.6.2",
-    "realm-network-transport": "^0.7.0",
+    "realm-network-transport": "^0.7.1",
     "request": "^2.88.0",
     "stream-counter": "^1.0.0",
     "sync-request": "^3.0.1",

--- a/packages/realm-network-transport/package-lock.json
+++ b/packages/realm-network-transport/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "realm-network-transport",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "realm-network-transport",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"abort-controller": "^3.0.0",

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.es.js",
   "types": "./dist/bundle.d.ts",
+  "react-native": "./dist/bundle.react-native.es.js",
   "browser": {
     "./dist/bundle.cjs.js": "./dist/bundle.dom.cjs.js",
     "./dist/bundle.es.js": "./dist/bundle.dom.es.js",

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-network-transport",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Implements cross-platform fetching used by Realm JS",
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.es.js",

--- a/packages/realm-network-transport/rollup.config.js
+++ b/packages/realm-network-transport/rollup.config.js
@@ -64,6 +64,21 @@ export default [
     ],
   },
   {
+    input: "src/react-native/index.ts",
+    output: [
+      {
+        file: pkg["react-native"],
+        format: "es",
+      },
+    ],
+    plugins: [
+      typescript({
+        tsconfig: "src/react-native/tsconfig.json",
+      }),
+      nodeResolve(),
+    ],
+  },
+  {
     input: "types/generated/index.d.ts",
     output: {
       file: pkg.types,

--- a/packages/realm-network-transport/src/DefaultNetworkTransport.ts
+++ b/packages/realm-network-transport/src/DefaultNetworkTransport.ts
@@ -29,6 +29,7 @@ import type {
 export class DefaultNetworkTransport implements NetworkTransport {
   public static fetch: Fetch;
   public static AbortController: AbortController;
+  public static extraFetchOptions: Record<string, unknown> | undefined;
 
   public static DEFAULT_HEADERS = {
     "Content-Type": "application/json",
@@ -69,6 +70,7 @@ export class DefaultNetworkTransport implements NetworkTransport {
     try {
       // We'll await the response to catch throw our own error
       return await DefaultNetworkTransport.fetch(url, {
+        ...DefaultNetworkTransport.extraFetchOptions,
         signal, // Used to signal timeouts
         ...rest,
       });

--- a/packages/realm-network-transport/src/dom/tsconfig.json
+++ b/packages/realm-network-transport/src/dom/tsconfig.json
@@ -8,6 +8,7 @@
 	},
 	"exclude": [
 		"../node/*",
+		"../react-native/*",
 		"../**/*.test.ts"
 	]
 }

--- a/packages/realm-network-transport/src/react-native/index.ts
+++ b/packages/realm-network-transport/src/react-native/index.ts
@@ -1,0 +1,25 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+export * from "../index";
+
+import { DefaultNetworkTransport } from "../DefaultNetworkTransport";
+import { AbortController, Fetch } from "../types";
+
+DefaultNetworkTransport.fetch = globalThis.fetch.bind(globalThis) as Fetch;
+DefaultNetworkTransport.AbortController = globalThis.AbortController as AbortController;

--- a/packages/realm-network-transport/src/react-native/index.ts
+++ b/packages/realm-network-transport/src/react-native/index.ts
@@ -23,3 +23,8 @@ import { AbortController, Fetch } from "../types";
 
 DefaultNetworkTransport.fetch = globalThis.fetch.bind(globalThis) as Fetch;
 DefaultNetworkTransport.AbortController = globalThis.AbortController as AbortController;
+// Setting this non-standard option to enable text streaming
+// See https://github.com/react-native-community/fetch#enable-text-streaming
+DefaultNetworkTransport.extraFetchOptions = {
+  reactNative: { textStreaming: true },
+};

--- a/packages/realm-network-transport/src/react-native/tsconfig.json
+++ b/packages/realm-network-transport/src/react-native/tsconfig.json
@@ -1,17 +1,14 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"types": [
-			"node-fetch",
-			"abort-controller"
-		],
 		"lib": [
-			"ES2015"
+			"ES2015",
+			"DOM"
 		]
 	},
 	"exclude": [
+		"../node/*",
 		"../dom/*",
-		"../react-native/*",
 		"../**/*.test.ts"
 	]
 }

--- a/packages/realm-network-transport/tsconfig.types.json
+++ b/packages/realm-network-transport/tsconfig.types.json
@@ -7,6 +7,7 @@
 	"exclude": [
 		"src/node/index.ts",
 		"src/dom/index.ts",
+		"src/react-native/index.ts",
 		"src/**/*.test.ts"
 	]
 }

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -69,7 +69,7 @@
     "fs-extra": "^10.0.0",
     "mocha": "^5.2.0",
     "node-fetch": "^2.6.0",
-    "realm-network-transport": "^0.7.0",
+    "realm-network-transport": "^0.7.1",
     "rollup": "^2.6.1",
     "rollup-plugin-dts": "^1.4.0",
     "rollup-plugin-node-builtins": "^2.1.2"

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -510,6 +510,11 @@ declare namespace Realm {
          * By default, yields all change events for this collection. You may specify at most one of
          * the `filter` or `ids` options.
          *
+         * Important Note: To use this on React Native, you must install:
+         *
+         * 1. Polyfills for `fetch`, `ReadableStream` and `TextDecoder`: https://www.npmjs.com/package/react-native-polyfill-globals
+         * 2. Babel plugin enabling async generator syntax: https://npmjs.com/package/@babel/plugin-proposal-async-generator-functions
+         *
          * @param options.filter A filter for which change events you are interested in.
          * @param options.ids A list of ids that you are interested in watching.
          * @see https://docs.mongodb.com/manual/reference/change-events/


### PR DESCRIPTION
## What, How & Why?

This closes #3494 by adding documentation on installing polyfills and a babel plugin, plus calling the React Native fetch polyfill with the right option.

### If the user forgets to add the polyfill and calls `watch()`

<img width="400" src="https://user-images.githubusercontent.com/1243959/146410848-d6588a2c-02e6-4f0b-99ba-d952d60f0962.png">

### TypeScript documentation as seen in VC Code

<img src="https://user-images.githubusercontent.com/1243959/146410832-c5d3a505-0c18-47a5-9038-06cca77e7ab5.png">

### The JSDoc documentation

<img src="https://user-images.githubusercontent.com/1243959/146410841-7f0f6144-740f-4a00-a090-2600a532008f.png">

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually locally)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
