### PR TITLE
Realm App Importer: Environment variables & API keys

### DIFF
--- a/packages/realm-app-importer/README.md
+++ b/packages/realm-app-importer/README.md
@@ -71,6 +71,14 @@ When using the `import` command, a consuming integration test can to get a hold 
 2. the `--app-id-path` runtime option saves the app id to a file, which can be read by the test harness.
 3. the `--app-id-port` runtime option starts up a web-server on the specified port and serves the app id as a text response.
 
+### Environment variables
+
+Many of the runtime option's default values are configurable using environment variables:
+
+- `--base-url` via `REALM_BASE_URL`
+- `--username` via `REALM_USERNAME`
+- `--password` via `REALM_PASSWORD`
+
 ## Exporting an app
 
 Ensure you have the official Stitch CLI installed in your project as a dev-dependency,

--- a/packages/realm-app-importer/README.md
+++ b/packages/realm-app-importer/README.md
@@ -47,12 +47,16 @@ Positionals:
 Options:
   --version              Show version number                           [boolean]
   --help                 Show help                                     [boolean]
-  --base-url             Base url of the stitch server to import the app into
-                                     [string] [default: "http://localhost:9090"]
-  --username             Username of an administrative user
+  --base-url             Base url of the MongoDB Realm server to import the app
+                         into        [string] [default: "http://localhost:9090"]
+  --username             Username of an adminstrative user
                                     [string] [default: "unique_user@domain.com"]
-  --password             Password of an administrative user
+  --password             Password of an adminstrative user
                                                   [string] [default: "password"]
+  --public-api-key       Public part of API key with adminstrative privileges
+                                                                        [string]
+  --private-api-key      Private part of API key with adminstrative privileges
+                                                                        [string]
   --config               Path for the realm-cli configuration to temporarily
                          store credentials    [string] [default: "realm-config"]
   --apps-directory-path  Path to temporarily copy the app while importing it
@@ -78,6 +82,8 @@ Many of the runtime option's default values are configurable using environment v
 - `--base-url` via `REALM_BASE_URL`
 - `--username` via `REALM_USERNAME`
 - `--password` via `REALM_PASSWORD`
+- `--publicKey` via `REALM_PUBLIC_KEY`
+- `--privateKey` via `REALM_PRIVATE_KEY`
 
 ## Exporting an app
 

--- a/packages/realm-app-importer/src/cli.ts
+++ b/packages/realm-app-importer/src/cli.ts
@@ -22,7 +22,7 @@ import fs from "fs";
 import http from "http";
 import chalk from "chalk";
 
-import { AppImporter } from "./AppImporter";
+import { AppImporter, Credentials } from "./AppImporter";
 import { AppImportServer } from "./AppImportServer";
 
 /* eslint-disable no-console */
@@ -92,6 +92,36 @@ function resolveAppTemplates(paths: string[]): Record<string, string> {
   );
 }
 
+const DEFAULTS = {
+  baseUrl: process.env.REALM_BASE_URL || "http://localhost:9090",
+  username: process.env.REALM_USERNAME || "unique_user@domain.com",
+  password: process.env.REALM_PASSWORD || "password",
+  publicKey: process.env.REALM_PUBLIC_KEY,
+  privateKey: process.env.REALM_PRIVATE_KEY,
+};
+
+type CredentialsOptions = {
+  username: string;
+  password: string;
+  publicKey: string | undefined;
+  privateKey: string | undefined;
+};
+
+/*
+ * Get the credentials from the runtime parameters
+ */
+function getCredentials({ username, password, publicKey, privateKey }: CredentialsOptions): Credentials {
+  if (typeof publicKey === "string" && typeof privateKey === "string") {
+    if (username !== DEFAULTS.username || password !== DEFAULTS.password) {
+      throw new Error("Provide either --username and --password or --api-key, not all three");
+    } else {
+      return { kind: "api-key", publicKey, privateKey };
+    }
+  } else {
+    return { kind: "username-password", username, password };
+  }
+}
+
 yargs
   .command(
     ["import <template-path>", "$0"],
@@ -106,18 +136,28 @@ yargs
         })
         .option("base-url", {
           type: "string",
-          default: process.env.REALM_BASE_URL || "http://localhost:9090",
+          default: DEFAULTS.baseUrl,
           description: "Base url of the MongoDB Realm server to import the app into",
         })
         .option("username", {
           type: "string",
-          default: process.env.REALM_USERNAME || "unique_user@domain.com",
+          default: DEFAULTS.username,
           description: "Username of an adminstrative user",
         })
         .option("password", {
           type: "string",
-          default: process.env.REALM_PASSWORD || "password",
+          default: DEFAULTS.password,
           description: "Password of an adminstrative user",
+        })
+        .option("public-api-key", {
+          type: "string",
+          default: DEFAULTS.publicKey,
+          description: "Public part of API key with adminstrative privileges",
+        })
+        .option("private-api-key", {
+          type: "string",
+          default: DEFAULTS.privateKey,
+          description: "Private part of API key with adminstrative privileges",
         })
         .option("config", {
           type: "string",
@@ -150,16 +190,18 @@ yargs
       "base-url": baseUrl,
       username,
       password,
+      "public-api-key": publicKey,
+      "private-api-key": privateKey,
       config: realmConfigPath,
       "apps-directory-path": appsDirectoryPath,
       "app-id-path": appIdPath,
       "app-id-port": appIdPort,
       "clean-up": cleanUp,
     }) => {
+      const credentials = getCredentials({ username, password, publicKey, privateKey });
       const importer = new AppImporter({
         baseUrl,
-        username,
-        password,
+        credentials,
         realmConfigPath,
         appsDirectoryPath,
         cleanUp,
@@ -243,6 +285,8 @@ yargs
       "base-url": baseUrl,
       username,
       password,
+      "public-api-key": publicKey,
+      "private-api-key": privateKey,
       config: realmConfigPath,
       "apps-directory-path": appsDirectoryPath,
       "clean-up": cleanUp,
@@ -250,11 +294,10 @@ yargs
       port,
     }) => {
       const appTemplates = resolveAppTemplates(templatePaths);
-
+      const credentials = getCredentials({ username, password, publicKey, privateKey });
       const importer = new AppImporter({
         baseUrl,
-        username,
-        password,
+        credentials,
         realmConfigPath,
         appsDirectoryPath,
         cleanUp,

--- a/packages/realm-app-importer/src/cli.ts
+++ b/packages/realm-app-importer/src/cli.ts
@@ -106,17 +106,17 @@ yargs
         })
         .option("base-url", {
           type: "string",
-          default: "http://localhost:9090",
+          default: process.env.REALM_BASE_URL || "http://localhost:9090",
           description: "Base url of the MongoDB Realm server to import the app into",
         })
         .option("username", {
           type: "string",
-          default: "unique_user@domain.com",
+          default: process.env.REALM_USERNAME || "unique_user@domain.com",
           description: "Username of an adminstrative user",
         })
         .option("password", {
           type: "string",
-          default: "password",
+          default: process.env.REALM_PASSWORD || "password",
           description: "Password of an adminstrative user",
         })
         .option("config", {

--- a/packages/realm-app-importer/tsconfig.build.json
+++ b/packages/realm-app-importer/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "es2018",
 		"noEmit": false,
 		"declaration": true,
 		"outDir": "./dist"


### PR DESCRIPTION
## What, How & Why?

This close #4154 by adding to the Realm App Importer:
- Possibility to authenticate using API keys
- Specify base URL, username, password, public and private keys via environment variables.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (locally & manually)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
