### PR TITLE
Add cocoapods version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -96,3 +96,10 @@ body:
         Which debugger for React Native: ..
     validations:
       required: false
+  - type: input
+    id: cocoapods
+    attributes:
+      label: Cocoapods version
+      description: Cocoapods version (for iOS)
+    validations:
+      required: false


### PR DESCRIPTION
## What, How & Why?

#4171 was caused by an outdated Cocoapods version. Adding this to the issue template so hopefully we can catch such issues more easily in future

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
