### PR TITLE
Enable strictNullChecks for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
 * Removed `.dir-locals.el`. Please configure Emacs to use `clang-format` e.g. https://github.com/SavchenkoValeriy/emacs-clang-format-plus.
+* Enabled `strictNullChecks` for integration tests
 
 10.11.0 Release notes (2021-12-21)
 =============================================================

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -54,19 +54,16 @@ export function openRealmHook(config: LocalConfiguration | SyncedConfiguration =
   };
 }
 
-export function closeRealm(this: RealmContext): void {
+export function closeRealm(this: Partial<RealmContext> & Mocha.Context): void {
   if (this.realm) {
     this.realm.close();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Ignore error as we ensure the realm is reopened
     delete this.realm;
   } else {
     throw new Error("Expected a 'realm' in the context");
   }
+
   if (this.config) {
     Realm.deleteFile(this.config);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Ignore error as we ensure the config is recreated
     delete this.config;
   } else {
     throw new Error("Expected a 'config' in the context");

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -46,6 +46,9 @@ export function openRealmHook(config: LocalConfiguration | SyncedConfiguration =
       } as Realm.Configuration;
       this.realm = new Realm(this.config);
       // Upload the schema, ensuring a valid connection
+      if (!this.realm.syncSession) {
+        throw new Error("No syncSession found on realm");
+      }
       await this.realm.syncSession.uploadAllLocalChanges();
     }
   };
@@ -54,12 +57,16 @@ export function openRealmHook(config: LocalConfiguration | SyncedConfiguration =
 export function closeRealm(this: RealmContext): void {
   if (this.realm) {
     this.realm.close();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Ignore error as we ensure the realm is reopened
     delete this.realm;
   } else {
     throw new Error("Expected a 'realm' in the context");
   }
   if (this.config) {
     Realm.deleteFile(this.config);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Ignore error as we ensure the config is recreated
     delete this.config;
   } else {
     throw new Error("Expected a 'config' in the context");

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -73,6 +73,8 @@ describe("realm._updateSchema", () => {
     const updatedSchema = [...realm.schema];
     // Locate the Dog schema
     const dogSchema = updatedSchema.find((s) => s.name === "Dog");
+    if (!dogSchema) throw new Error("Schema not found");
+
     // Add a fields property
     dogSchema.properties.friends = "Dog[]";
     // Update the schema

--- a/integration-tests/tests/src/tests/iterators.ts
+++ b/integration-tests/tests/src/tests/iterators.ts
@@ -168,13 +168,19 @@ describe("Iterating", () => {
 
   describe("linkingObjects collections", () => {
     itCanIterate(() => {
-      return realm.objectForPrimaryKey<IPerson>("Person", "Alice").dogs;
+      const result = realm.objectForPrimaryKey<IPerson>("Person", "Alice");
+      if (!result) throw new Error("Object not found");
+
+      return result.dogs;
     }, ["Max", "Rex"]);
   });
 
   describe("lists", () => {
     itCanIterate(() => {
-      return realm.objectForPrimaryKey<IPerson>("Person", "Bob").friends;
+      const result = realm.objectForPrimaryKey<IPerson>("Person", "Bob");
+      if (!result) throw new Error("Object not found");
+
+      return result.friends;
     }, ["Charlie"]);
   });
 });

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -33,7 +33,7 @@ describe("Realm objects", () => {
   describe("Interface & object literal", () => {
     it("can be created", () => {
       const realm = new Realm({ schema: [PersonSchema] });
-      let john: IPerson;
+      let john!: IPerson;
 
       realm.write(() => {
         john = realm.create<IPerson>(PersonSchema.name, {
@@ -51,7 +51,7 @@ describe("Realm objects", () => {
 
     it("can have it's properties read", () => {
       const realm = new Realm({ schema: [PersonSchema] });
-      let john: IPerson;
+      let john!: IPerson;
 
       realm.write(() => {
         john = realm.create<IPerson>(PersonSchema.name, {
@@ -77,6 +77,7 @@ describe("Realm objects", () => {
       });
 
       const john = realm.objectForPrimaryKey<IPersonWithId>(PersonSchemaWithId.name, _id);
+      if (!john) throw new Error("Object not found");
 
       expect(john).instanceOf(Realm.Object);
       expect(john._id.equals(_id)).equals(true);
@@ -86,7 +87,7 @@ describe("Realm objects", () => {
 
     it("can be updated", () => {
       const realm = new Realm({ schema: [PersonSchemaWithId] });
-      let john: IPersonWithId;
+      let john!: IPersonWithId;
       const _id = new Realm.BSON.ObjectId();
 
       realm.write(() => {
@@ -160,7 +161,7 @@ describe("Realm objects", () => {
   describe("Class Model", () => {
     it("can be created", () => {
       const realm = new Realm({ schema: [Person] });
-      let john: Person;
+      let john!: Person;
 
       realm.write(() => {
         john = realm.create(Person, {
@@ -202,6 +203,7 @@ describe("Realm objects", () => {
       });
 
       const john = realm.objectForPrimaryKey(PersonWithId, _id);
+      if (!john) throw new Error("Object not found");
 
       expect(john).instanceOf(PersonWithId);
       expect(john._id.equals(_id)).equals(true);
@@ -211,7 +213,7 @@ describe("Realm objects", () => {
 
     it("can be updated", () => {
       const realm = new Realm({ schema: [PersonWithId] });
-      let john: PersonWithId;
+      let john!: PersonWithId;
       const _id = new Realm.BSON.ObjectId();
 
       realm.write(() => {

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -33,10 +33,9 @@ describe("Realm objects", () => {
   describe("Interface & object literal", () => {
     it("can be created", () => {
       const realm = new Realm({ schema: [PersonSchema] });
-      let john!: IPerson;
 
-      realm.write(() => {
-        john = realm.create<IPerson>(PersonSchema.name, {
+      const john = realm.write(() => {
+        return realm.create<IPerson>(PersonSchema.name, {
           name: "John Doe",
           age: 42,
         });
@@ -51,10 +50,9 @@ describe("Realm objects", () => {
 
     it("can have it's properties read", () => {
       const realm = new Realm({ schema: [PersonSchema] });
-      let john!: IPerson;
 
-      realm.write(() => {
-        john = realm.create<IPerson>(PersonSchema.name, {
+      const john = realm.write(() => {
+        return realm.create<IPerson>(PersonSchema.name, {
           name: "John Doe",
           age: 42,
         });
@@ -87,11 +85,10 @@ describe("Realm objects", () => {
 
     it("can be updated", () => {
       const realm = new Realm({ schema: [PersonSchemaWithId] });
-      let john!: IPersonWithId;
       const _id = new Realm.BSON.ObjectId();
 
-      realm.write(() => {
-        john = realm.create<IPersonWithId>(PersonSchemaWithId.name, {
+      const john = realm.write(() => {
+        return realm.create<IPersonWithId>(PersonSchemaWithId.name, {
           _id,
           name: "John Doe",
           age: 42,
@@ -161,10 +158,9 @@ describe("Realm objects", () => {
   describe("Class Model", () => {
     it("can be created", () => {
       const realm = new Realm({ schema: [Person] });
-      let john!: Person;
 
-      realm.write(() => {
-        john = realm.create(Person, {
+      const john = realm.write(() => {
+        return realm.create(Person, {
           name: "John Doe",
           age: 42,
         });
@@ -213,11 +209,10 @@ describe("Realm objects", () => {
 
     it("can be updated", () => {
       const realm = new Realm({ schema: [PersonWithId] });
-      let john!: PersonWithId;
       const _id = new Realm.BSON.ObjectId();
 
-      realm.write(() => {
-        john = realm.create(PersonWithId, {
+      const john = realm.write(() => {
+        return realm.create(PersonWithId, {
           _id,
           name: "John Doe",
           age: 42,

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -484,7 +484,8 @@ describe("JSON serialization", () => {
       afterEach(() => {
         if (realm) {
           realm.write(() => {
-            realm.deleteAll();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            realm!.deleteAll();
           });
           realm.close();
           realm = null;

--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -91,6 +91,8 @@ function describeRoundtrip(typeName: string, value: Value, testValue: ValueTeste
 
     it("reads", function (this: RealmContext) {
       const obj = this.realm.objectForPrimaryKey<MixedClass>("MixedClass", this._id);
+      if (!obj) throw new Error("Object not found");
+
       expect(typeof obj).equals("object");
       // Test the single value
       performTest(obj.value, this.value);

--- a/integration-tests/tests/src/tests/sync/upload-delete-download.ts
+++ b/integration-tests/tests/src/tests/sync/upload-delete-download.ts
@@ -21,6 +21,13 @@ export function itUploadsDeletesAndDownloads(): void {
     if (!this.realm) {
       throw new Error("Expected a 'realm' on the mocha context");
     }
+    if (!this.config) {
+      throw new Error("Expected a 'config' on the mocha context");
+    }
+    if (!this.realm.syncSession) {
+      throw new Error("Expected a 'syncSession' on the realm");
+    }
+
     // Ensure everything has been uploaded
     await this.realm.syncSession.uploadAllLocalChanges();
     // Close, delete and download the Realm from the server
@@ -29,6 +36,9 @@ export function itUploadsDeletesAndDownloads(): void {
     Realm.deleteFile(this.config);
     // Re-open the Realm with the old configuration
     this.realm = new Realm(this.config);
+    if (!this.realm.syncSession) {
+      throw new Error("Expected a 'syncSession' on the realm");
+    }
     await this.realm.syncSession.downloadAllServerChanges();
   });
 }

--- a/integration-tests/tests/src/utils/benchmark.ts
+++ b/integration-tests/tests/src/utils/benchmark.ts
@@ -35,7 +35,8 @@ export function itPerforms(title: string, fn: () => void, options?: Partial<Benc
       maximumFractionDigits: 0,
     });
     const sd = Number(result.sd.toFixed(2));
-    this.test.title += ` (${ops} ops/sec, ±${sd}%)`;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.test!.title += ` (${ops} ops/sec, ±${sd}%)`;
     this.result = result;
   });
 }

--- a/integration-tests/tests/tsconfig.json
+++ b/integration-tests/tests/tsconfig.json
@@ -17,7 +17,8 @@
 			"mocha",
 			"chai"
 		],
-		"noImplicitAny": true
+		"noImplicitAny": true,
+		"strictNullChecks": true
 	},
 	"include": [
 		"src/typings.d.ts",


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This change is required for flexible sync. Ideally we'd enable `strict: true` but this throws a lot more errors so just doing `strictNullChecks` for now.

I've tried to do runtime assertions where I thought it might make sense (e.g. there's a chance the thing might not exist, if something is badly broken, so throw) and otherwise use non-null assertions, but happy to change if people think we should take a different approach.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
