### PR TITLE
Prevent dangling objects on JSCRuntime destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* None.
+* Fixed "JSCRuntime destroyed with a dangling API object" assertion when reloading an app in debug mode while running with Hermes engine disabled. ([#4115](https://github.com/realm/realm-js/issues/4115), since 10.20.0-alpha.0)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/integration-tests/tests/.mocharc.json
+++ b/integration-tests/tests/.mocharc.json
@@ -6,5 +6,8 @@
   "require": [
     "ts-node/register/transpile-only",
     "src/node/inject-globals.ts"
+  ],
+  "node-option": [
+    "expose_gc"
   ]
 }

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -35,6 +35,13 @@ import { testSkipIf, suiteSkipIf } from "./utils/skip-if";
 global.describe.skipIf = suiteSkipIf;
 global.it.skipIf = testSkipIf;
 
+afterEach(() => {
+  // Trigger garbage collection after every test, if exposed by the environment.
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+});
+
 // Using `require` instead of `import` here to ensure the Mocha globals (including `skipIf`) are set
 
 describe("Test Harness", () => {

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -37,6 +37,10 @@ interface Global extends NodeJS.Global {
   path: path;
   environment: Environment;
   require: Require;
+  /**
+   * The environment might expose a method to suggest a garbage collection.
+   */
+  gc?: () => void;
 }
 
 declare const global: Global;

--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -22,6 +22,7 @@
 #import <realm-js-ios/jsi_init.h>
 
 #import <React/RCTBridge+Private.h>
+#import <React/RCTInvalidating.h>
 #import <jsi/jsi.h>
 
 #import <objc/runtime.h>
@@ -35,7 +36,7 @@
 - (void *)runtime;
 @end
 
-@interface RealmReact () <RCTBridgeModule>
+@interface RealmReact () <RCTBridgeModule, RCTInvalidating>
 @end
 
 @implementation RealmReact {
@@ -103,10 +104,6 @@ RCT_REMAP_METHOD(emit, emitEvent:(NSString *)eventName withObject:(id)object) {
 
 - (void)setBridge:(RCTBridge *)bridge {
     _bridge = bridge;
-
-    static __weak RealmReact *s_currentModule = nil;
-    [s_currentModule invalidate];
-    s_currentModule = self;
 
     if (objc_lookUpClass("RCTWebSocketExecutor") && [bridge executorClass] == objc_lookUpClass("RCTWebSocketExecutor")) {
         // Skip native initialization when in legacy Chrome debugging mode

--- a/src/js_list.hpp
+++ b/src/js_list.hpp
@@ -24,6 +24,7 @@
 #include "js_results.hpp"
 #include "js_types.hpp"
 #include "js_util.hpp"
+#include "js_notifications.hpp"
 
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/list.hpp>
@@ -42,7 +43,7 @@ public:
     {
     }
 
-    std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
+    notifications::NotificationHandle<T> m_notification_handle;
 };
 
 template <typename T>
@@ -56,6 +57,7 @@ struct ListClass : ClassDefinition<T, realm::js::List<T>, CollectionClass<T>> {
     using Value = js::Value<T>;
     using ReturnValue = js::ReturnValue<T>;
     using Arguments = js::Arguments<T>;
+    using NotificationBucket = notifications::NotificationBucket<T>;
 
     static ObjectType create_instance(ContextType, realm::List);
 
@@ -329,7 +331,7 @@ void ListClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object,
 {
     args.validate_maximum(0);
     auto list = get_internal<T, ListClass<T>>(ctx, this_object);
-    list->m_notification_tokens.clear();
+    NotificationBucket::erase(list->m_notification_handle);
 }
 
 template <typename T>

--- a/src/js_notifications.hpp
+++ b/src/js_notifications.hpp
@@ -1,0 +1,149 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <realm/object-store/collection_notifications.hpp>
+
+#include "js_types.hpp"
+
+namespace realm::js::notifications {
+
+using IdType = unsigned long long;
+
+template <typename T>
+class NotificationHandle;
+
+/**
+ * @brief A class with static members use to manage ownership of `NotificationToken`s returned by the object store
+ * notification APIs.
+ * This abstraction is needed to enable graceful JS runtime destruction by preventing circular references from objects
+ * owning a `NotificationToken` owning a lamda that captures `Protected` values of the object itself.
+ *
+ * @note This expose a simple `clear` method, which should be called just before the JS runtime is torn down.
+ *
+ * @tparam T The JS runtime types.
+ */
+template <typename T>
+class NotificationBucket {
+    using ProtectedFunction = Protected<typename T::Function>;
+    using NotificationHandle = NotificationHandle<T>;
+
+    static inline std::map<IdType, std::vector<std::pair<ProtectedFunction, NotificationToken>>> s_tokens;
+
+public:
+    static void emplace(NotificationHandle& handle, ProtectedFunction&& callback, NotificationToken&& token)
+    {
+        if (handle) {
+            s_tokens[handle].emplace_back(std::move(callback), std::move(token));
+        }
+        else {
+            throw std::runtime_error("Cannot emplace notifications using an unset handle");
+        }
+    }
+
+    static void clear()
+    {
+        s_tokens.clear();
+    }
+
+    static void erase(NotificationHandle& handle)
+    {
+        if (handle) {
+            s_tokens.erase(handle);
+        }
+    }
+
+    static void erase(NotificationHandle& handle, ProtectedFunction&& callback)
+    {
+        if (handle) {
+            auto& tokens = s_tokens[handle];
+            auto compare = [&callback](auto&& token) {
+                return typename ProtectedFunction::Comparator()(token.first, callback);
+            };
+            tokens.erase(std::remove_if(tokens.begin(), tokens.end(), compare), tokens.end());
+        }
+        else {
+            throw std::runtime_error("Cannot erase notifications using an unset handle");
+        }
+    }
+};
+
+/**
+ * @brief An object owned by objects which will delegate ownership of `NotificationToken`s to the
+ * `NotificationBucket`.
+ *
+ * @tparam T The JS runtime types.
+ */
+template <typename T>
+class NotificationHandle {
+    using NotificationBucket = NotificationBucket<T>;
+
+    static inline IdType s_next_id = 0;
+    std::optional<IdType> m_id;
+
+public:
+    /**
+     * @brief Construct a new Notification Handle object to be owned by an object and passed to the
+     * `NotificationBucket` when managing `NotificationToken`s returned by the object store notification APIs.
+     */
+    NotificationHandle()
+    {
+        m_id = s_next_id;
+        if (s_next_id == std::numeric_limits<IdType>::max()) {
+            throw std::overflow_error("No more NotificationHandle ids");
+        }
+        s_next_id += 1;
+    };
+
+    /**
+     * @brief Destroy the Notification Handle object and erases any outstanding listeners from the
+     * `NotificationBucket`.
+     */
+    ~NotificationHandle()
+    {
+        NotificationBucket::erase(*this);
+    }
+
+    operator IdType() const
+    {
+        return *m_id;
+    };
+
+    operator bool() const
+    {
+        return m_id.has_value();
+    };
+
+    /**
+     * @brief Move constructs a new Notification Handle by resetting the `id` on the object being moved from.
+     * This ensures that the abandoned object won't erase tokens from the `NotificationBucket` when destructed.
+     *
+     * @param other The object being moved from.
+     */
+    NotificationHandle(NotificationHandle&& other)
+    {
+        m_id = std::move(other.m_id);
+        other.m_id.reset();
+    }
+};
+
+} // namespace realm::js::notifications

--- a/src/js_notifications.hpp
+++ b/src/js_notifications.hpp
@@ -45,12 +45,11 @@ class NotificationHandle;
 template <typename T>
 class NotificationBucket {
     using ProtectedFunction = Protected<typename T::Function>;
-    using NotificationHandle = NotificationHandle<T>;
 
     static inline std::map<IdType, std::vector<std::pair<ProtectedFunction, NotificationToken>>> s_tokens;
 
 public:
-    static void emplace(NotificationHandle& handle, ProtectedFunction&& callback, NotificationToken&& token)
+    static void emplace(NotificationHandle<T>& handle, ProtectedFunction&& callback, NotificationToken&& token)
     {
         if (handle) {
             s_tokens[handle].emplace_back(std::move(callback), std::move(token));
@@ -65,14 +64,14 @@ public:
         s_tokens.clear();
     }
 
-    static void erase(NotificationHandle& handle)
+    static void erase(NotificationHandle<T>& handle)
     {
         if (handle) {
             s_tokens.erase(handle);
         }
     }
 
-    static void erase(NotificationHandle& handle, ProtectedFunction&& callback)
+    static void erase(NotificationHandle<T>& handle, ProtectedFunction&& callback)
     {
         if (handle) {
             auto& tokens = s_tokens[handle];
@@ -95,8 +94,6 @@ public:
  */
 template <typename T>
 class NotificationHandle {
-    using NotificationBucket = NotificationBucket<T>;
-
     static inline IdType s_next_id = 0;
     std::optional<IdType> m_id;
 
@@ -120,7 +117,7 @@ public:
      */
     ~NotificationHandle()
     {
-        NotificationBucket::erase(*this);
+        NotificationBucket<T>::erase(*this);
     }
 
     operator IdType() const

--- a/src/js_set.hpp
+++ b/src/js_set.hpp
@@ -24,6 +24,7 @@
 #include "js_results.hpp"
 #include "js_types.hpp"
 #include "js_util.hpp"
+#include "js_notifications.hpp"
 
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/set.hpp>
@@ -118,7 +119,7 @@ public:
     }
     void derive_property_type(StringData const& object_name, Property& prop) const;
 
-    std::vector<std::pair<Protected<typename T::Function>, NotificationToken>> m_notification_tokens;
+    notifications::NotificationHandle<T> m_notification_handle;
 };
 
 
@@ -139,6 +140,7 @@ struct SetClass : ClassDefinition<T, realm::js::Set<T>, CollectionClass<T>> {
     using Value = js::Value<T>;
     using ReturnValue = js::ReturnValue<T>;
     using Arguments = js::Arguments<T>;
+    using NotificationBucket = notifications::NotificationBucket<T>;
 
     static ObjectType create_instance(ContextType, realm::object_store::Set);
 
@@ -540,7 +542,7 @@ void SetClass<T>::remove_all_listeners(ContextType ctx, ObjectType this_object, 
 {
     args.validate_maximum(0);
     auto set = get_internal<T, SetClass<T>>(ctx, this_object);
-    set->m_notification_tokens.clear();
+    NotificationBucket::erase(set->m_notification_handle);
 }
 
 } // namespace js

--- a/src/jsi/jsi_init.cpp
+++ b/src/jsi/jsi_init.cpp
@@ -25,7 +25,7 @@
 #endif
 
 #include "js_realm.hpp"
-#include "js_realm_object.hpp"
+#include "js_notifications.hpp"
 
 #include <realm/object-store/impl/realm_coordinator.hpp>
 #include <realm/object-store/sync/app.hpp>
@@ -48,7 +48,7 @@ extern "C" void realm_jsi_invalidate_caches()
     // Clear the Object Store App cache, to prevent instances from using a context that was released
     realm::app::App::clear_cached_apps();
     // Clear Realm Object notifications
-    NotificationBucket<realm::js::realmjsi::Types>::clear();
+    notifications::NotificationBucket<realm::js::realmjsi::Types>::clear();
     // Ensure all registered invalidators get notified that the runtime is going away.
     realm::js::Context<realm::js::realmjsi::Types>::invalidate();
 }

--- a/src/jsi/jsi_init.cpp
+++ b/src/jsi/jsi_init.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "js_realm.hpp"
+#include "js_realm_object.hpp"
 
 #include <realm/object-store/impl/realm_coordinator.hpp>
 #include <realm/object-store/sync/app.hpp>
@@ -46,17 +47,10 @@ extern "C" void realm_jsi_invalidate_caches()
     realm::_impl::RealmCoordinator::clear_all_caches();
     // Clear the Object Store App cache, to prevent instances from using a context that was released
     realm::app::App::clear_cached_apps();
+    // Clear Realm Object notifications
+    NotificationBucket<realm::js::realmjsi::Types>::clear();
     // Ensure all registered invalidators get notified that the runtime is going away.
     realm::js::Context<realm::js::realmjsi::Types>::invalidate();
-}
-extern "C" void realm_hermes_invalidate_caches()
-{
-    // Close all cached Realms
-    realm::_impl::RealmCoordinator::clear_all_caches();
-    // Clear the Object Store App cache, to prevent instances from using a context that was released
-    realm::app::App::clear_cached_apps();
-    // Ensure all registered invalidators get notified that the runtime is going away.
-    realm::js::Context<realmjsi::Types>::invalidate();
 }
 } // namespace realm::js::jsi
 

--- a/tests/ReactTestApp/App.ios.js
+++ b/tests/ReactTestApp/App.ios.js
@@ -25,6 +25,9 @@ export default class ReactTests extends React.Component {
   render() {
     return (
       <View style={styles.container}>
+        <Text>
+          Engine: {global.HermesInternal ? 'Hermes' : 'JavaScriptCore'}
+        </Text>
         <TouchableHighlight style={styles.button} onPress={tests.runTests}>
           <Text>Tap to Run Tests</Text>
         </TouchableHighlight>

--- a/tests/ReactTestApp/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/tests/ReactTestApp/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -187,7 +187,6 @@
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				69BA58D14816F1A4FB16B8E0 /* [CP] Embed Pods Frameworks */,
 				71F0535264570F68F735298F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -210,7 +209,6 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				46A08488E40FB4CF2452D78E /* [CP] Embed Pods Frameworks */,
 				FA59CEA3BD6F24C57F3EE3BC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -313,40 +311,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		46A08488E40FB4CF2452D78E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp/Pods-ReactTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp/Pods-ReactTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp/Pods-ReactTestApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		69BA58D14816F1A4FB16B8E0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp-ReactTestAppTests/Pods-ReactTestApp-ReactTestAppTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp-ReactTestAppTests/Pods-ReactTestApp-ReactTestAppTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactTestApp-ReactTestAppTests/Pods-ReactTestApp-ReactTestAppTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		71F0535264570F68F735298F /* [CP] Copy Pods Resources */ = {
@@ -570,7 +534,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "$(SRCROOT)/../../../scripts/ccache-clang.sh";
-				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -601,9 +564,10 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				EXPANDED_CODE_SIGN_IDENTITY = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -642,7 +606,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "$(SRCROOT)/../../../scripts/ccache-clang.sh";
-				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -673,9 +636,10 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				EXPANDED_CODE_SIGN_IDENTITY = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
## What, How & Why?

This closes #4115 by introducing a separate static data structure (the `NotificationBucket` class) that owns `NotificationToken`s returned by object store APIs. This data structure can be cleaned as the JS runtime gets torn down to ensure no objects are left protected as the JS runtime gets destructed.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually verified the assertion in JSCRuntime.cpp no longer happens)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
