### PR TITLE
Test and document `writeCopyTo` behavior on synced realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Support arithmetic operations (+, -, *, /) in queries. Operands can be properties and/or constants of numeric types (`int`, `float`, `double` or `Decimal128`). You can now say something like `(age + 5) * 2 > child.age`.
-* `Realm.writeCopyTo()` now supports creating snapshots of synced realms, thus allowing apps to be shipped with partially-populated synced databases
+* `Realm.writeCopyTo()` now supports creating snapshots of synced Realms, thus allowing apps to be shipped with partially-populated synced databases. ([#3782](https://github.com/realm/realm-js/issues/3782)
 
 ### Fixed
 * Opening a Realm with a schema that has an orphaned embedded object type performed an extra empty write transaction. ([realm/realm-core#5115](https://github.com/realm/realm-core/pull/5115), since v10.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Support arithmetic operations (+, -, *, /) in queries. Operands can be properties and/or constants of numeric types (`int`, `float`, `double` or `Decimal128`). You can now say something like `(age + 5) * 2 > child.age`.
+* `Realm.writeCopyTo()` now supports creating snapshots of synced realms
 
 ### Fixed
 * Opening a Realm with a schema that has an orphaned embedded object type performed an extra empty write transaction. ([realm/realm-core#5115](https://github.com/realm/realm-core/pull/5115), since v10.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Support arithmetic operations (+, -, *, /) in queries. Operands can be properties and/or constants of numeric types (`int`, `float`, `double` or `Decimal128`). You can now say something like `(age + 5) * 2 > child.age`.
-* `Realm.writeCopyTo()` now supports creating snapshots of synced realms
+* `Realm.writeCopyTo()` now supports creating snapshots of synced realms, thus allowing apps to be shipped with partially-populated synced databases
 
 ### Fixed
 * Opening a Realm with a schema that has an orphaned embedded object type performed an extra empty write transaction. ([realm/realm-core#5115](https://github.com/realm/realm-core/pull/5115), since v10.5.0)

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -301,10 +301,12 @@ class Realm {
    * Writes a compacted copy of the Realm to the given path.
    *
    * The destination file cannot already exist.
+   * When invoked on a synced realm, a copy of the realm is created that any user can open and
+   * resume synchronization with the server.
    *
    * Note that if this method is called from within a write transaction, the current data is written,
    * not the data from the point when the previous write transaction was committed.
-   * @param {string} path path to save the Realm to
+   * @param {string} path path to save the Realm to.
    * @param {ArrayBuffer|ArrayBufferView} [encryptionKey] - Optional 64-byte encryption key to encrypt the new file with.
    */
   writeCopyTo(path, encryptionKey) {}

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1365,7 +1365,7 @@ module.exports = {
     encryptedRealmCopy.close();
 
     /*
-      Test2:  check that we cannot open an encrypted realm copy with an
+      Test 2:  check that we cannot open an encrypted realm copy with an
         invalid encryption key
     */
     encryptionKey[0] = 0;
@@ -1380,11 +1380,32 @@ module.exports = {
       schema: [schemas.PersonForSync, schemas.DogForSync],
     };
 
+    encryptedRealmCopy = undefined;
     TestCase.assertThrows(() => {
       encryptedRealmCopy = new Realm(encryptedCopyConfig);
     }, "Opening realm with wrong encryption key should fail");
+    TestCase.assertUndefined(encryptedRealmCopy);
 
-    encryptedRealmCopy.close();
+    /*
+      Test 3:  check that we cannot open an encrypted realm copy without
+        using an encryption key
+    */
+    encryptedCopyConfig = {
+      sync: {
+        user: user2,
+        partitionValue: partition,
+        _sessionStopPolicy: "immediately", // Make it safe to delete files after realm.close()
+      },
+      path: encryptedCopyName,
+      schema: [schemas.PersonForSync, schemas.DogForSync],
+    };
+
+    encryptedRealmCopy = undefined;
+    TestCase.assertThrows(() => {
+      encryptedRealmCopy = new Realm(encryptedCopyConfig);
+    }, "Opening realm without encryption key should fail");
+    TestCase.assertUndefined(encryptedRealmCopy);
+
     realm1.close();
   },
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -832,7 +832,10 @@ declare class Realm {
     compact(): boolean;
 
     /**
-     * Write a copy to destination path
+     * Write a copy of a realm at the destination path.  Any user will be able to open and use
+     * the new copy.  Copying a synced realm will create a snapshot of the realm that can be
+     * opened to resume syncing from the server.  Synced realms must be fully synchronized with
+     * the server before calling `writeCopyTo`.
      * @param path destination path
      * @param encryptionKey encryption key to use
      * @returns void


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
Test and document that `Realm.writeCopyTo()` now supports creating copies of synced realms that may later be opened by another user to resume synchronization.

This closes #3782

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
