### PR TITLE
Fix for #4150: crash when closing Electron app with custom sync error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * Opening a Realm with a schema that has an orphaned embedded object type performed an extra empty write transaction. ([realm/realm-core#5115](https://github.com/realm/realm-core/pull/5115), since v10.5.0)
 * Schema validation was missing for embedded objects in sets, resulting in an unhelpful error being thrown if the user attempted to define one. ([realm/realm-core#5115](https://github.com/realm/realm-core/pull/5115))
+* Fixed a crash when closing an Electron app with a custom sync error handler ([#4150](https://github.com/realm/realm-js/issues/4150)
 
 ### Compatibility
 * Removed `deprecated-react-native-listview` from root package.json

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -242,6 +242,11 @@ public:
         : m_ctx(Context<T>::get_global_context(ctx))
         , m_func(ctx, error_func)
     {
+#if defined(REALM_PLATFORM_NODE)
+        // Suppressing destruct prevents a crash when closing an Electron app with a
+        // custom sync error handler: https://github.com/realm/realm-js/issues/4150
+        m_func.SuppressDestruct();
+#endif
     }
 
     typename T::Function func() const
@@ -289,7 +294,7 @@ public:
 
 private:
     const Protected<typename T::GlobalContext> m_ctx;
-    const Protected<typename T::Function> m_func;
+    Protected<typename T::Function> m_func;
 };
 
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #4150

This follows the pattern from https://github.com/realm/realm-js/commit/d4d6eab528b8a84395dee46239cfc0c6631cf400 to prevent destruction of the functor


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
