### PR TITLE
Remove code which was causing proxy crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed a crash when using `Proxy` with a `Realm.Results` object ([#4257]https://github.com/realm/realm-js/pull/4257)
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -934,8 +934,8 @@ Napi::Value WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_
     Napi::EscapableHandleScope scope(env);
 
     // Napi::Object target = info[0].As<Napi::Object>();
-    Napi::String key = info[1].As<Napi::String>();
-    std::string text = key;
+    // Napi::String key = info[1].As<Napi::String>();
+    // std::string text = key;
 
     Napi::Object descriptor = Napi::Object::New(env);
     descriptor.Set("enumerable", Napi::Boolean::New(env, true));

--- a/src/node/node_class.hpp
+++ b/src/node/node_class.hpp
@@ -933,10 +933,6 @@ Napi::Value WrappedObject<ClassType>::ProxyHandler::get_own_property_descriptor_
     Napi::Env env = info.Env();
     Napi::EscapableHandleScope scope(env);
 
-    // Napi::Object target = info[0].As<Napi::Object>();
-    // Napi::String key = info[1].As<Napi::String>();
-    // std::string text = key;
-
     Napi::Object descriptor = Napi::Object::New(env);
     descriptor.Set("enumerable", Napi::Boolean::New(env, true));
     descriptor.Set("configurable", Napi::Boolean::New(env, true));


### PR DESCRIPTION
Crash could be reproduced with e.g.:
```
people = realm.objects(Person);
peopleProxy = new Proxy(people, {get: () => {} });
Object.prototype.toString.call(peopleProxy);
```

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
