### PR TITLE
Split JSDoc workflow and fix uploading

### DIFF
--- a/.github/workflows/jsdoc-publish.yml
+++ b/.github/workflows/jsdoc-publish.yml
@@ -1,0 +1,48 @@
+# This workflow builds the JSDocs and publishes them to https://docs.mongodb.com/realm-sdks/js/latest/.
+# It also uploads them to a versioned directory for archival purposes.
+#
+# We only run this workflow for "vX.Y.Z" tags, not "vX.Y.Z-beta", as the docs are pushed to the
+# site as "latest" as part of the build and we don't want to publish beta docs to live
+
+name: JSDoc Publish
+on:
+  push:
+    tags:
+      - v[0-9]+\.[0-9]+\.[0-9]+
+
+env:
+  REALM_DISABLE_ANALYTICS: 1
+jobs:
+  jsdoc:
+    name: JSDoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - name: Install npm v7
+        run: npm install -g npm@7
+      # Install the root package (--ignore-scripts to avoid downloading or building the native module)
+      - name: Install root package dependencies
+        run: npm ci --ignore-scripts
+      - name: Run JSDoc documentation build
+        run: npm run jsdoc
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
+          aws-region: us-west-1
+      # Get the version number so we can specify the correct input path for uploading the docs -
+      # JSDoc outputs to docs/output/realm/<package.json version number>
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - name: Upload versioned docs (for archival)
+        run: aws s3 put --acl public-read docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}}/realm-sdks/js/${{ steps.package-version.outputs.current-version}}
+      - name: Upload latest docs (to live site)
+        run: aws s3 put --acl public-read docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}}/realm-sdks/js/latest

--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -1,4 +1,8 @@
-name: JSDoc
+# This workflow builds the JSDocs but does not publish them.
+# This runs on pull requests, so that any errors in the JSDoc will trigger
+# a build failure, but we do not want to publish the results to the live site.
+
+name: JSDoc Build
 on:
   pull_request:
     paths:
@@ -8,9 +12,6 @@ on:
       # changes to this workflow
       # seems there is no way to get this easily yet https://github.com/actions/runner/issues/853
       - ".github/workflows/jsdoc.yml"
-  push:
-    tags:
-      - v[0-9]*
 
 env:
   REALM_DISABLE_ANALYTICS: 1
@@ -33,13 +34,3 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Run JSDoc documentation build
         run: npm run jsdoc
-      - name: Configure AWS Credentials
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
-          aws-region: us-west-1
-      - name: Upload docs
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: aws s3 sync --acl public-read docs/output/realm s3://${{ secrets.DOCS_S3_BUCKET_NAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+* Fixed documentation publishing ([#4276](https://github.com/realm/realm-js/pull/4276))
 
 10.12.0 Release notes (2022-1-24)
 =============================================================


### PR DESCRIPTION

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

The current workflow uploads the docs to the wrong location for archival, and does not update the copy of the docs at /latest. This change splits the workflow in two - one which builds the JSDocs for every pull request but does not publish them, and one which only runs on vX.Y.Z tag builds, and uploads the docs both to /latest and for archival.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
