### PR TITLE
Update toJSON to gracefully handle invalid state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * JWT metadata is now populating `Realm.User.profile`. ([#3268](https://github.com/realm/realm-js/issues/3268), since v10.0.0)
 * Security upgrade of `prebuild-install`. ([#4281](https://github.com/realm/realm-js/issues/4281))
 * UserIdentity metadata table will no longer occationally grow indefinitely. ([realm/realm-core#5152](https://github.com/realm/realm-core/pull/5144), since v10.0.0)
+* Updated Realm.Object#toJSON and Realm.Collection#toJSON to more gracefully handle invalid state. It will now return empty object and array respectively. ([#4304](https://github.com/realm/realm-js/pull/4304))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -61,9 +61,14 @@ module.exports = function (realmConstructor) {
   realmConstructor._networkTransport = new DefaultNetworkTransport();
   Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
     value: function (_, cache = new Map()) {
-      return this.map((item, index) =>
-        item instanceof realmConstructor.Object ? item.toJSON(index.toString(), cache) : item,
-      );
+      if (this.isValid()) {
+        return this.map((item, index) =>
+          item instanceof realmConstructor.Object ? item.toJSON(index.toString(), cache) : item,
+        );
+      } else {
+        console.warn("Collection#toJSON was called on an invalid collection, returned []");
+        return [];
+      }
     },
 
     writable: true,
@@ -79,48 +84,56 @@ module.exports = function (realmConstructor) {
 
   Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
     value: function (_, cache = new Map()) {
-      // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
-      const id = getInternalCacheId(this);
+      if (this.isValid()) {
+        // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
+        const id = getInternalCacheId(this);
 
-      // Check if current objectId has already processed, to keep object references the same.
-      const existing = cache.get(id);
-      if (existing) {
-        return existing;
+        // Check if current objectId has already processed, to keep object references the same.
+        const existing = cache.get(id);
+        if (existing) {
+          return existing;
+        }
+
+        // Create new result, and store in cache.
+        const result = {};
+        cache.set(id, result);
+
+        // Add the generated reference-id, as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
+        Object.defineProperty(result, "$refId", { value: id, configurable: true });
+
+        // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
+        Object.keys(this)
+          .concat(Object.keys(Object.getPrototypeOf(this)))
+          .forEach((key) => {
+            const value = this[key];
+
+            // skip any functions & constructors (in case of class models).
+            if (typeof value === "function") {
+              return; // continue
+            }
+
+            // recursively trigger `toJSON` for Realm instances with the same cache.
+            if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
+              result[key] = value.toJSON(key, cache);
+            } else if (value instanceof realmConstructor.Dictionary) {
+              // Dictionary special case to share the "cache" for dictionary-values,
+              // in case of circular structures involving links.
+              result[key] = Object.fromEntries(
+                Object.entries(value).map(([k, v]) => [
+                  k,
+                  v instanceof realmConstructor.Object ? v.toJSON(k, cache) : v,
+                ]),
+              );
+            } else {
+              result[key] = value;
+            }
+          });
+
+        return result;
+      } else {
+        console.warn("Object#toJSON was called on an invalid collection, returned {}");
+        return {};
       }
-
-      // Create new result, and store in cache.
-      const result = {};
-      cache.set(id, result);
-
-      // Add the generated reference-id, as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
-      Object.defineProperty(result, "$refId", { value: id, configurable: true });
-
-      // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
-      Object.keys(this)
-        .concat(Object.keys(Object.getPrototypeOf(this)))
-        .forEach((key) => {
-          const value = this[key];
-
-          // skip any functions & constructors (in case of class models).
-          if (typeof value === "function") {
-            return; // continue
-          }
-
-          // recursively trigger `toJSON` for Realm instances with the same cache.
-          if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
-            result[key] = value.toJSON(key, cache);
-          } else if (value instanceof realmConstructor.Dictionary) {
-            // Dictionary special case to share the "cache" for dictionary-values,
-            // in case of circular structures involving links.
-            result[key] = Object.fromEntries(
-              Object.entries(value).map(([k, v]) => [k, v instanceof realmConstructor.Object ? v.toJSON(k, cache) : v]),
-            );
-          } else {
-            result[key] = value;
-          }
-        });
-
-      return result;
     },
 
     writable: true,


### PR DESCRIPTION
## What, How & Why?

This fixes an issue where an error would be thrown when trying to serialize an invalid object.

```
Error: Accessing object of type MixedClass which has been invalidated or deleted
```

Instead of erroring, i suggest simply returning an empty object / array and warn the user.

Note: We hit this error in our integration tests as the `Realm.Object` or `Realm.Collection` is getting stringified. This typically happens when a `Realm.Object` or `Realm.Collection` is stored on the Mocha context, either manually or when asserting something about an object and that assertion fails. When Mocha Remote tries to stringify the object or collection, it's been invalidated already since it sends off messages after the test has passed / failed and the after hooks have run (which close the realm, hence invalidates the object).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
