### PR TITLE
Upgraded Mocha Remote to fix serialization errors

### DIFF
--- a/integration-tests/environments/electron/package-lock.json
+++ b/integration-tests/environments/electron/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"fs-extra": "^9.1.0",
 				"mocha": "^8.3.2",
-				"mocha-remote-client": "^1.4.3",
+				"mocha-remote-client": "^1.5.0",
 				"node-fetch": "^2.6.1"
 			},
 			"devDependencies": {
@@ -21,7 +21,7 @@
 				"electron-builder": "^22.10.5",
 				"mocha-github-actions-reporter": "^0.2.3",
 				"mocha-junit-reporter": "^2.0.0",
-				"mocha-remote-cli": "^1.4.3"
+				"mocha-remote-cli": "^1.5.0"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -2280,9 +2280,9 @@
 			"dev": true
 		},
 		"node_modules/fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -2355,9 +2355,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
 		"node_modules/forever-agent": {
@@ -3574,14 +3574,14 @@
 			"dev": true
 		},
 		"node_modules/mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			},
 			"bin": {
@@ -3592,38 +3592,61 @@
 			}
 		},
 		"node_modules/mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"dependencies": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			}
 		},
 		"node_modules/mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"dependencies": {
 				"debug": "^4.3.1"
 			}
 		},
 		"node_modules/mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dev": true,
 			"dependencies": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"peerDependencies": {
 				"mocha": "^8"
 			}
+		},
+		"node_modules/mocha-remote-server/node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mocha-remote-server/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
@@ -5161,11 +5184,11 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"engines": {
-				"node": ">=8.3.0"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
@@ -7126,9 +7149,9 @@
 			"dev": true
 		},
 		"fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -7186,9 +7209,9 @@
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
 		},
 		"flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
 		"forever-agent": {
@@ -8144,46 +8167,63 @@
 			}
 		},
 		"mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			}
 		},
 		"mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"requires": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			}
 		},
 		"mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"requires": {
 				"debug": "^4.3.1"
 			}
 		},
 		"mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"ms": {
@@ -9395,9 +9435,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"requires": {}
 		},
 		"xdg-basedir": {

--- a/integration-tests/environments/electron/package.json
+++ b/integration-tests/environments/electron/package.json
@@ -27,14 +27,14 @@
     "electron-builder": "^22.10.5",
     "mocha-github-actions-reporter": "^0.2.3",
     "mocha-junit-reporter": "^2.0.0",
-    "mocha-remote-cli": "^1.4.3",
+    "mocha-remote-cli": "^1.5.0",
     "realm-app-importer": "*"
   },
   "dependencies": {
     "@realm/integration-tests": "*",
     "fs-extra": "^9.1.0",
     "mocha": "^8.3.2",
-    "mocha-remote-client": "^1.4.3",
+    "mocha-remote-client": "^1.5.0",
     "node-fetch": "^2.6.1",
     "realm": "*"
   },

--- a/integration-tests/environments/node/package-lock.json
+++ b/integration-tests/environments/node/package-lock.json
@@ -15,8 +15,8 @@
 				"mocha-cli": "^1.0.1",
 				"mocha-github-actions-reporter": "^0.2.3",
 				"mocha-junit-reporter": "^1.18.0",
-				"mocha-remote-cli": "^1.4.3",
-				"mocha-remote-client": "^1.4.3",
+				"mocha-remote-cli": "^1.5.0",
+				"mocha-remote-client": "^1.5.0",
 				"node-fetch": "^2.6.1"
 			},
 			"devDependencies": {
@@ -1027,9 +1027,9 @@
 			"dev": true
 		},
 		"node_modules/fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -1095,9 +1095,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"node_modules/forever-agent": {
 			"version": "0.6.1",
@@ -1891,13 +1891,13 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			},
 			"bin": {
@@ -1929,14 +1929,14 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"dependencies": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			}
 		},
 		"node_modules/mocha-remote-client/node_modules/debug": {
@@ -1961,17 +1961,17 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"dependencies": {
 				"debug": "^4.3.1"
 			}
 		},
 		"node_modules/mocha-remote-common/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1990,23 +1990,23 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dependencies": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"peerDependencies": {
 				"mocha": "^8"
 			}
 		},
 		"node_modules/mocha-remote-server/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -2898,11 +2898,11 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/ws": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"engines": {
-				"node": ">=8.3.0"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
@@ -3845,9 +3845,9 @@
 			"dev": true
 		},
 		"fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -3897,9 +3897,9 @@
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
 		},
 		"flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -4563,13 +4563,13 @@
 			}
 		},
 		"mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"requires": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			},
 			"dependencies": {
@@ -4589,14 +4589,14 @@
 			}
 		},
 		"mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"requires": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -4615,17 +4615,17 @@
 			}
 		},
 		"mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"requires": {
 				"debug": "^4.3.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -4638,20 +4638,20 @@
 			}
 		},
 		"mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"requires": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -5329,9 +5329,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"requires": {}
 		},
 		"xml": {

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -18,8 +18,8 @@
     "mocha-cli": "^1.0.1",
     "mocha-github-actions-reporter": "^0.2.3",
     "mocha-junit-reporter": "^1.18.0",
-    "mocha-remote-cli": "^1.4.3",
-    "mocha-remote-client": "^1.4.3",
+    "mocha-remote-cli": "^1.5.0",
+    "mocha-remote-client": "^1.5.0",
     "node-fetch": "^2.6.1",
     "realm": "*"
   },

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -29,7 +29,7 @@
     "@realm/integration-tests": "*",
     "mocha": "^8.3.2",
     "mocha-junit-reporter": "^2.0.0",
-    "mocha-remote-client": "^1.4.3",
+    "mocha-remote-client": "^1.5.0",
     "path-browserify": "^1.0.1",
     "react": "17.0.2",
     "react-native": "0.66.2",
@@ -44,7 +44,7 @@
     "concurrently": "^6.0.2",
     "metro-react-native-babel-preset": "^0.66.2",
     "mocha-github-actions-reporter": "^0.2.3",
-    "mocha-remote-cli": "^1.4.3",
+    "mocha-remote-cli": "^1.5.0",
     "pod-install": "^0.1.23",
     "puppeteer": "^9.0.0",
     "realm-app-importer": "*"

--- a/packages/realm-web-integration-tests/package-lock.json
+++ b/packages/realm-web-integration-tests/package-lock.json
@@ -12,7 +12,7 @@
 				"js-base64": "^3.4.5",
 				"jwt-encode": "^1.0.1",
 				"mocha": "^5",
-				"mocha-remote": "^1.4.3",
+				"mocha-remote": "^1.5.0",
 				"puppeteer": "^2.1.1",
 				"webpack": "^4.41.6",
 				"webpack-dev-server": "^3.10.3"
@@ -34,7 +34,7 @@
 				"webpack-cli": "^3.3.11"
 			},
 			"peerDependencies": {
-				"mocha-remote-client": "*"
+				"mocha-remote-client": "^1.5.0"
 			}
 		},
 		"node_modules/@types/anymatch": {
@@ -2524,9 +2524,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -2662,9 +2662,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"node_modules/flush-write-stream": {
 			"version": "1.1.1",
@@ -4304,33 +4304,33 @@
 			}
 		},
 		"node_modules/mocha-remote": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote/-/mocha-remote-1.4.3.tgz",
-			"integrity": "sha512-D86IVfH4imJo+hMtLvEsNCrbvU5wsZmqNJgikpyFk5/2kqAllHO3qcj12cFeKaUkJzbPF0rMVB4h2xuLLLX0zA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote/-/mocha-remote-1.5.0.tgz",
+			"integrity": "sha512-jW3WuQg9/yb2fncVZg0HGSW18/SmemwZ3XyX9el2+5jW/4rC+9IJFLpMx/4PPTydMbBAuK9btMcQukCQ51rdaA==",
 			"dependencies": {
-				"mocha-remote-cli": "^1.4.3",
-				"mocha-remote-client": "^1.4.3",
-				"mocha-remote-server": "^1.4.3"
+				"mocha-remote-cli": "^1.5.0",
+				"mocha-remote-client": "^1.5.0",
+				"mocha-remote-server": "^1.5.0"
 			},
 			"bin": {
 				"mocha-remote": "cli.js"
 			}
 		},
 		"node_modules/mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"dependencies": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			}
 		},
 		"node_modules/mocha-remote-client/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -4349,17 +4349,17 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"dependencies": {
 				"debug": "^4.3.1"
 			}
 		},
 		"node_modules/mocha-remote-common/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -4628,13 +4628,13 @@
 			}
 		},
 		"node_modules/mocha-remote/node_modules/mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			},
 			"bin": {
@@ -4645,18 +4645,39 @@
 			}
 		},
 		"node_modules/mocha-remote/node_modules/mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dependencies": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"peerDependencies": {
 				"mocha": "^8"
 			}
+		},
+		"node_modules/mocha-remote/node_modules/mocha-remote-server/node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mocha-remote/node_modules/mocha-remote-server/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mocha-remote/node_modules/ms": {
 			"version": "2.1.3",
@@ -7971,11 +7992,11 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/ws": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"engines": {
-				"node": ">=8.3.0"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
@@ -8050,9 +8071,9 @@
 			}
 		},
 		"node_modules/yargs-unparser/node_modules/camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"peer": true,
 			"engines": {
 				"node": ">=10"
@@ -10249,9 +10270,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -10367,9 +10388,9 @@
 			"peer": true
 		},
 		"flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
 		},
 		"flush-write-stream": {
 			"version": "1.1.1",
@@ -11639,13 +11660,13 @@
 			}
 		},
 		"mocha-remote": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote/-/mocha-remote-1.4.3.tgz",
-			"integrity": "sha512-D86IVfH4imJo+hMtLvEsNCrbvU5wsZmqNJgikpyFk5/2kqAllHO3qcj12cFeKaUkJzbPF0rMVB4h2xuLLLX0zA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote/-/mocha-remote-1.5.0.tgz",
+			"integrity": "sha512-jW3WuQg9/yb2fncVZg0HGSW18/SmemwZ3XyX9el2+5jW/4rC+9IJFLpMx/4PPTydMbBAuK9btMcQukCQ51rdaA==",
 			"requires": {
-				"mocha-remote-cli": "^1.4.3",
-				"mocha-remote-client": "^1.4.3",
-				"mocha-remote-server": "^1.4.3"
+				"mocha-remote-cli": "^1.5.0",
+				"mocha-remote-client": "^1.5.0",
+				"mocha-remote-server": "^1.5.0"
 			},
 			"dependencies": {
 				"ansi-colors": {
@@ -11824,25 +11845,40 @@
 					}
 				},
 				"mocha-remote-cli": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-					"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+					"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 					"requires": {
 						"chalk": "^4.1.0",
 						"debug": "^4.3.1",
-						"mocha-remote-server": "^1.4.3",
+						"mocha-remote-server": "^1.5.0",
 						"yargs": "^16.2.0"
 					}
 				},
 				"mocha-remote-server": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-					"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+					"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 					"requires": {
-						"debug": "^4.3.1",
-						"flatted": "^3.1.1",
-						"mocha-remote-common": "^1.4.3",
-						"ws": "^7.4.4"
+						"debug": "^4.3.3",
+						"flatted": "^3.2.5",
+						"mocha-remote-common": "^1.5.0",
+						"ws": "^8.4.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+							"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+						}
 					}
 				},
 				"ms": {
@@ -11957,20 +11993,20 @@
 			}
 		},
 		"mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"requires": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -11983,17 +12019,17 @@
 			}
 		},
 		"mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"requires": {
 				"debug": "^4.3.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -14586,9 +14622,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+			"integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
 			"requires": {}
 		},
 		"xtend": {
@@ -14645,9 +14681,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 					"peer": true
 				},
 				"decamelize": {

--- a/packages/realm-web-integration-tests/package.json
+++ b/packages/realm-web-integration-tests/package.json
@@ -15,7 +15,7 @@
     "js-base64": "^3.4.5",
     "jwt-encode": "^1.0.1",
     "mocha": "^5",
-    "mocha-remote": "^1.4.3",
+    "mocha-remote": "^1.5.0",
     "puppeteer": "^2.1.1",
     "realm-app-importer": "^0.1.0",
     "realm-web": "*",
@@ -23,7 +23,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "peerDependencies": {
-    "mocha-remote-client": "*"
+    "mocha-remote-client": "^1.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.9",


### PR DESCRIPTION
## What, How & Why?

This upgrades Mocha Remote to get rid of issues from `Realm.Object` and `Realm.Collection` instances being serialized: This typically happens when these objects are stored on the Mocha context. When Mocha Remote tries to stringify the object or collection, it's been invalidated already since it sends off messages after the test has passed / failed and the after hooks have run (which close the realm, hence invalidates the object).

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
