### PR TITLE
Refactored serialization tests to use `openRealmBefore`

### DIFF
--- a/integration-tests/environments/react-native/package-lock.json
+++ b/integration-tests/environments/react-native/package-lock.json
@@ -11,7 +11,7 @@
 				"@react-native-community/art": "^1.2.0",
 				"mocha": "^8.3.2",
 				"mocha-junit-reporter": "^2.0.0",
-				"mocha-remote-client": "^1.4.3",
+				"mocha-remote-client": "^1.5.0",
 				"path-browserify": "^1.0.1",
 				"react": "17.0.2",
 				"react-native": "0.66.2",
@@ -24,7 +24,7 @@
 				"concurrently": "^6.0.2",
 				"metro-react-native-babel-preset": "^0.66.2",
 				"mocha-github-actions-reporter": "^0.2.3",
-				"mocha-remote-cli": "^1.4.3",
+				"mocha-remote-cli": "^1.5.0",
 				"pod-install": "^0.1.23",
 				"puppeteer": "^9.0.0"
 			}
@@ -3238,9 +3238,9 @@
 			}
 		},
 		"node_modules/fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"node_modules/fb-watchman": {
 			"version": "2.0.1",
@@ -3332,9 +3332,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
 		"node_modules/flow-parser": {
@@ -5447,14 +5447,14 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			},
 			"bin": {
@@ -5465,37 +5465,101 @@
 			}
 		},
 		"node_modules/mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"dependencies": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
+			}
+		},
+		"node_modules/mocha-remote-client/node_modules/ws": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"dependencies": {
 				"debug": "^4.3.1"
 			}
 		},
 		"node_modules/mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dev": true,
 			"dependencies": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
 			},
 			"peerDependencies": {
 				"mocha": "^8"
+			}
+		},
+		"node_modules/mocha-remote-server/node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mocha-remote-server/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"node_modules/mocha-remote-server/node_modules/ws": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ms": {
@@ -10557,9 +10621,9 @@
 			}
 		},
 		"fast-equals": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
-			"integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+			"integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
 		},
 		"fb-watchman": {
 			"version": "2.0.1",
@@ -10635,9 +10699,9 @@
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
 		},
 		"flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
 		"flow-parser": {
@@ -12296,46 +12360,78 @@
 			}
 		},
 		"mocha-remote-cli": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.4.3.tgz",
-			"integrity": "sha512-shlGi8M0ZHOdNgPOwsoxQ4v1bnlFFqAPLgmfR3EoEPmCQ3vln7EBI+7NHa+I+AHs5B6tkrk4Ym3BCcFHNaEccw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-cli/-/mocha-remote-cli-1.5.0.tgz",
+			"integrity": "sha512-knim6jsUpzDdjJOTI/76TawFAa7PXlM02BjK/vzWcQvq/Bnrxx2ySvSZIEpXlmlC4mZ96Ntw7hB1tPH2H063RQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
-				"mocha-remote-server": "^1.4.3",
+				"mocha-remote-server": "^1.5.0",
 				"yargs": "^16.2.0"
 			}
 		},
 		"mocha-remote-client": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.4.3.tgz",
-			"integrity": "sha512-736U8wl6vJu/HS8TkbsaXtpWIwwa8WOQuQZB/4DrkW6ovmi5jQEPf8MNTkF0qHriXvsn1djytQmVyEkV1AoKSQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-client/-/mocha-remote-client-1.5.0.tgz",
+			"integrity": "sha512-BmywhIZDJkErLRoa5D2/QpMCyq5iSsLyXN+2CCPo5sY4z+DMWyu+YCuZIae+z+7AupJYMm3U6xw8o969ea4jZg==",
 			"requires": {
 				"debug": "^4.3.1",
-				"fast-equals": "^2.0.3",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"fast-equals": "^2.0.4",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+					"requires": {}
+				}
 			}
 		},
 		"mocha-remote-common": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.4.3.tgz",
-			"integrity": "sha512-4+XSpIl2NCiBgpBesFByRiglkrlbT6UbdWzssHelUXRD2hR9VbPjyQBjhab4+H98/zLoK5BBEagPGMAfKqk+7Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-common/-/mocha-remote-common-1.5.0.tgz",
+			"integrity": "sha512-d/E0Vnr8xw02gjPGqMwlppl+WdBLtYLgGndbDQMYyqFBP1eNd9kqSDNZn58cUp3pCuEThB5eOZPK92FS1OSUWA==",
 			"requires": {
 				"debug": "^4.3.1"
 			}
 		},
 		"mocha-remote-server": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.4.3.tgz",
-			"integrity": "sha512-me6CvUOmVENEN+We8Nn3kO4qbqrmY+fHLEMe5tHtC9oSE9lYeAfWzQDtJTV7HyoU1iIVRIM590CdeeHscrEx7w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mocha-remote-server/-/mocha-remote-server-1.5.0.tgz",
+			"integrity": "sha512-xZRkhhHHYJDLWOy9LQDWT2DONnkQFRWwDTCxrDiEtv3YoE/U5ZmYo5xseqWL9fpuvx/IelzEMkoz/kc/XTPePA==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.3.1",
-				"flatted": "^3.1.1",
-				"mocha-remote-common": "^1.4.3",
-				"ws": "^7.4.4"
+				"debug": "^4.3.3",
+				"flatted": "^3.2.5",
+				"mocha-remote-common": "^1.5.0",
+				"ws": "^8.4.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"ws": {
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+					"dev": true,
+					"requires": {}
+				}
 			}
 		},
 		"ms": {


### PR DESCRIPTION
## What, How & Why?

This refactors the "serialize" tests to use the `openRealmBefore` hook.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
