### PR TITLE
`deleteUser` extended

### DIFF
--- a/packages/realm-web-integration-tests/harness/index.ts
+++ b/packages/realm-web-integration-tests/harness/index.ts
@@ -40,6 +40,9 @@ const EXPECTED_ISSUES = [
   /was set with `SameSite=None` but without `Secure`/,
   // User / "refresh invalid access tokens" is posting an invalid token
   "Failed to load resource: the server responded with a status of 401 (Unauthorized)",
+  // User / "can be deleted" is deleting an invalid token and attempting a failing login
+  "Failed to load resource: the server responded with a status of 401 (Unauthorized)",
+  "Failed to load resource: the server responded with a status of 401 (Unauthorized)",
   // Closing the watch streams, might yield this error (we're doing that three times)
   "Failed to load resource: net::ERR_FAILED",
   "Failed to load resource: net::ERR_FAILED",

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -141,6 +141,31 @@ describe("User", () => {
     }
   });
 
+  it("can be deleted", async () => {
+    const app = createApp();
+    const now = new Date();
+    const nonce = now.getTime();
+    const email = `gilfoyle-${nonce}@testing.mongodb.com`;
+    const password = "v3ry-s3cret";
+    // Register a user and authenticate
+    await app.emailPasswordAuth.registerUser({ email, password });
+    const credentials = Credentials.emailPassword(email, password);
+    const user = await app.logIn(credentials);
+    // Delete the user
+    await app.deleteUser(user);
+    // Fail when logging in again
+    try {
+      await app.logIn(credentials);
+      throw new Error("Expected an error!");
+    } catch (err) {
+      if (err instanceof Error) {
+        expect(err.message).contains("invalid username/password");
+      } else {
+        throw err;
+      }
+    }
+  });
+
   describe("linking with Email/Password credentials", () => {
     it("reuse id in access token and adds identity", async () => {
       const app = createApp();

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -251,18 +251,11 @@ export class App<
    * @inheritdoc
    */
   public async deleteUser(user: User<FunctionsFactoryType, CustomDataType>): Promise<void> {
-    this.fetcher
-      .fetchJSON({
-        method: "DELETE",
-        path: routes.api().auth().delete().path,
-        tokenType: "none",
-      })
-      .then(() => {
-        return this.removeUser(user);
-      })
-      .catch((err) => {
-        throw err;
-      });
+    await this.fetcher.fetchJSON({
+      method: "DELETE",
+      path: routes.api().auth().delete().path,
+    });
+    await this.removeUser(user);
   }
 
   /**

--- a/packages/realm-web/src/User.ts
+++ b/packages/realm-web/src/User.ts
@@ -262,6 +262,12 @@ export class User<
           tokenType: "refresh",
         });
       }
+    } catch (err) {
+      // Ignore failing to delete a missing refresh token
+      // It might have expired or it might be gone due to the user being deleted
+      if (!(err instanceof Error) || !err.message.includes("failed to find refresh token")) {
+        throw err;
+      }
     } finally {
       // Forget the access and refresh token
       this.accessToken = null;


### PR DESCRIPTION
## What, How & Why?

Extends the Realm Web implementation of user deletion, including fixing the failing test and adding an integration test.
