### PR TITLE
Remove debug builds and add a timeout for node js jobs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,6 +29,7 @@ jobs:
   node:
     name: Node.js v${{ matrix.node }} on ${{ matrix.os.name }} (${{ matrix.type }})
     runs-on: ${{ matrix.os.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +41,7 @@ jobs:
           - name: macOS
             runner: macos-latest
         node: [14, 16]
-        type: [release, debug]
+        type: [release]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## What, How & Why?
Updates the workflow to remove the debug element from the node js matrix + limit runtime to 45 minutes as if the build takes more than that, it looks like it'll never complete.