### PR TITLE
Remove use of destructuring on update as it doesn't work on React Native

### DIFF
--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -70,8 +70,8 @@ function describeRoundtrip({
 
   async function setupTest(realm: Realm) {
     if (flexibleSync) {
-      realm.subscriptions.update(({ add }) => {
-        add(realm.objects("MixedClass"));
+      realm.subscriptions.update((mutableSubs) => {
+        mutableSubs.add(realm.objects("MixedClass"));
       });
       await realm.subscriptions.waitForSynchronization();
     }


### PR DESCRIPTION
Destructuring a method in JS will result in it becoming unbound - not sure why this works in Node!

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
