### PR TITLE
Enabling strict (except strictFunctionTypes) in integration tests

### DIFF
--- a/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
+++ b/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
@@ -40,11 +40,11 @@ export const PersonSchema: Realm.ObjectSchema = {
 };
 
 export class Person extends Realm.Object implements IPerson {
-  _id: Realm.BSON.ObjectId;
-  name: string;
-  age: number;
-  friends: Realm.List<Person>;
-  dogs: Realm.Collection<Dog>;
+  _id!: Realm.BSON.ObjectId;
+  name!: string;
+  age!: number;
+  friends!: Realm.List<Person>;
+  dogs!: Realm.Collection<Dog>;
 
   static schema: Realm.ObjectSchema = PersonSchema;
 }
@@ -68,10 +68,10 @@ export const DogSchema: Realm.ObjectSchema = {
 };
 
 export class Dog extends Realm.Object implements IDog {
-  _id: Realm.BSON.ObjectId;
-  name: string;
-  age: number;
-  owner: Person;
+  _id!: Realm.BSON.ObjectId;
+  name!: string;
+  age!: number;
+  owner!: Person;
 
   static schema: Realm.ObjectSchema = DogSchema;
 }

--- a/integration-tests/tests/src/schemas/person-and-dogs.ts
+++ b/integration-tests/tests/src/schemas/person-and-dogs.ts
@@ -40,8 +40,8 @@ export const PersonSchema: Realm.ObjectSchema = {
 export class Person extends Realm.Object {
   name: string;
   age: number;
-  friends: Realm.List<Person>;
-  dogs: Realm.Collection<Dog>;
+  friends!: Realm.List<Person>;
+  dogs!: Realm.Collection<Dog>;
 
   constructor(name: string, age: number) {
     super();

--- a/integration-tests/tests/src/schemas/playlist-with-songs-with-ids.ts
+++ b/integration-tests/tests/src/schemas/playlist-with-songs-with-ids.ts
@@ -39,10 +39,10 @@ export const PlaylistSchema: Realm.ObjectSchema = {
 };
 
 export class Playlist extends Realm.Object implements IPlaylist {
-  _id: number;
-  title: string;
-  songs: Realm.List<Song>;
-  related: Realm.List<Playlist>;
+  _id!: number;
+  title!: string;
+  songs!: Realm.List<Song>;
+  related!: Realm.List<Playlist>;
 
   static schema = PlaylistSchema;
 }
@@ -64,9 +64,9 @@ export const SongSchema: Realm.ObjectSchema = {
 };
 
 export class Song extends Realm.Object implements ISong {
-  _id: number;
-  artist: string;
-  title: string;
+  _id!: number;
+  artist!: string;
+  title!: string;
 
   static schema = SongSchema;
 }

--- a/integration-tests/tests/src/schemas/playlist-with-songs.ts
+++ b/integration-tests/tests/src/schemas/playlist-with-songs.ts
@@ -36,9 +36,9 @@ export const PlaylistSchema: Realm.ObjectSchema = {
 };
 
 export class Playlist extends Realm.Object implements IPlaylist {
-  title: string;
-  songs: Realm.List<Song>;
-  related: Realm.List<Playlist>;
+  title!: string;
+  songs!: Realm.List<Song>;
+  related!: Realm.List<Playlist>;
 
   static schema = PlaylistSchema;
 }
@@ -57,8 +57,8 @@ export const SongSchema: Realm.ObjectSchema = {
 };
 
 export class Song extends Realm.Object implements ISong {
-  artist: string;
-  title: string;
+  artist!: string;
+  title!: string;
 
   static schema = SongSchema;
 }

--- a/integration-tests/tests/src/utils/import-app.test.ts
+++ b/integration-tests/tests/src/utils/import-app.test.ts
@@ -26,7 +26,7 @@ describe.skipIf(environment.missingServer, "importApp utility", function () {
   it("can import an app", async () => {
     const app = await importApp("simple");
     expect(app).instanceOf(App);
-    expect(app.id.startsWith("simple")).equals(true);
+    expect(app.id.startsWith("simple")).to.be.true;
   }).timeout(10000);
 
   it("throws on unexpected app names", async () => {
@@ -35,7 +35,9 @@ describe.skipIf(environment.missingServer, "importApp utility", function () {
       await importApp("unexpected-app-name");
     } catch (err) {
       threw = true;
-      expect(err.message.includes("Unexpected app name")).equals(true);
+      if (err instanceof Error) {
+        expect(err.message).contains("Unexpected app name");
+      }
     } finally {
       expect(threw).equals(true);
     }

--- a/integration-tests/tests/tsconfig.json
+++ b/integration-tests/tests/tsconfig.json
@@ -3,6 +3,8 @@
 		"target": "es2018",
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"strict": true,
+		"strictFunctionTypes": false,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
 		"outDir": "dist",
@@ -17,8 +19,7 @@
 			"mocha",
 			"chai"
 		],
-		"noImplicitAny": true,
-		"strictNullChecks": true
+		"noImplicitAny": true
 	},
 	"include": [
 		"src/typings.d.ts",


### PR DESCRIPTION
## What, How & Why?

This enable more strict options in the integration tests.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
