### PR TITLE
Always call uploadAllLocalChanges/downloadAllServerChanges

### DIFF
--- a/integration-tests/tests/src/tests/sync/upload-delete-download.ts
+++ b/integration-tests/tests/src/tests/sync/upload-delete-download.ts
@@ -30,12 +30,7 @@ export function itUploadsDeletesAndDownloads(): void {
       throw new Error("Expected a 'syncSession' on the realm");
     }
 
-    // Ensure everything has been uploaded
-    // We don't call this if we are using flexible sync, as it currently will
-    // not resolve until an initial subscription set has been created (REALMC-11490)
-    if (!this.config.sync?.flexible) {
-      await this.realm.syncSession.uploadAllLocalChanges();
-    }
+    await this.realm.syncSession.uploadAllLocalChanges();
 
     this.realm = closeAndReopenRealm(this.realm, this.config);
 
@@ -43,10 +38,6 @@ export function itUploadsDeletesAndDownloads(): void {
       throw new Error("Expected a 'syncSession' on the realm");
     }
 
-    // We don't call this if we are using flexible sync, as it currently will
-    // not resolve until an initial subscription set has been created (REALMC-11490)
-    if (!this.config.sync?.flexible) {
-      await this.realm.syncSession.downloadAllServerChanges();
-    }
+    await this.realm.syncSession.downloadAllServerChanges();
   });
 }


### PR DESCRIPTION

## What, How & Why?

Realm cloud issue preventing this being called has been resolved


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
