### PR TITLE
Explicitly flush the React Native UI task queue whenever we call from C++ to JS

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -71,6 +71,24 @@ module.exports = function (realmConstructor) {
     enumerable: false,
   });
 
+  // React Native has its own JS task queue system of "microtasks". This queue is usually flushed
+  // whenever a native -> JS call is made via the React Native bridge (see `__callReactNativeMicrotasks`
+  // in `react-native/Libraries/BatchedBridge/MessageQueue.js`).
+  //
+  // As Realm does not pass messages via the RN bridge, but instead hooks directly in to the JS engine,
+  // we need to explicitly tell React Native to flush the task queue whenever anything happens in Realm
+  // which could cause a UI update – in practice, this means any time we call into JS from C++. If we don't
+  // do this, UI updates will not be flushed until some other event occurs which does cause a native -> JS
+  // call, for example touching the screen.
+  //
+  // This exposes the React Native internal `callReactNativeMicrotasks` function on the Realm constructor,
+  // so that we can call it from C++ whenever we make a function call into JS (see jsc_function.hpp)/
+  try {
+    realmConstructor._flushUiTaskQueue = require("react-native/Libraries/Core/Timers/JSTimers.js").callReactNativeMicrotasks;
+  } catch (e) {
+    realmConstructor._flushUiTaskQueue = function () {};
+  }
+
   const getInternalCacheId = (realmObj) => {
     const { name, primaryKey } = realmObj.objectSchema();
     const id = primaryKey ? realmObj[primaryKey] : realmObj._objectId();

--- a/src/jsc/jsc_function.hpp
+++ b/src/jsc/jsc_function.hpp
@@ -29,6 +29,17 @@ inline JSValueRef jsc::Function::call(JSContextRef ctx, const JSObjectRef& funct
 {
     JSValueRef exception = nullptr;
     JSValueRef result = JSObjectCallAsFunction(ctx, function, this_object, argc, arguments, &exception);
+
+    // Flush the React Native UI task queue whenever we call into JS from C++ – see `_flushUiTaskQueue` in
+    // `lib/extensions.js` for detailed explanation of why this is necessary.
+    JSObjectRef global_object = JSContextGetGlobalObject(ctx);
+    JSObjectRef realm_constructor = jsc::Object::validated_get_constructor(ctx, global_object, "Realm");
+    JSObjectRef flush_ui_task_queue =
+        jsc::Object::validated_get_function(ctx, realm_constructor, "_flushUiTaskQueue");
+    JSValueRef flush_ui_task_queue_exception = nullptr;
+    // Call it directly rather than via `call_method` to avoid an infinite loop
+    JSObjectCallAsFunction(ctx, flush_ui_task_queue, nullptr, 0, {}, &flush_ui_task_queue_exception);
+
     if (exception) {
         throw jsc::Exception(ctx, exception);
     }


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

React Native has its own JS "microtask" queue, implemented in https://github.com/facebook/react-native/blob/main/Libraries/Core/Timers/JSTimers.js. Any asynchronous work, e.g. `setTimeout` or `setImmediate`, is added to this queue, and the queue is flushed whenever a message is sent from React Native's native core to JS: https://github.com/facebook/react-native/blob/main/Libraries/BatchedBridge/MessageQueue.js#L108.

However, our native to JS messages are not being passed via this abstraction - instead, we hook directly into the JS engine. This means that React Native is not aware that when Realm has done some async work, we might need to update the UI (and therefore flush the task queue), and this can result in Realm-related UI updates not showing until some action is taken which causes React Native to send a message from the core to JS (e.g. touching the screen), which flushes this task queue, resolving pending promises and updating the UI.

Two solutions were considered for whenever Realm has performed some work which might require a UI update:
1. Make Realm JS "play by the rules" that React Native expects native code to use, and e.g. send a dummy message via React Native whenever we have done work.
2. Expose the internal `callReactNativeMicrotasks` function from React Native in a way that we can directly call that from C++ whenever we have done work.

We decided to go with option 2, as it is simpler to implement and we felt we can implement it in a reasonably clean way using the Realm constructor. This does mean we are depending on React Native internal implementation details, but as we already are potentially quite tightly coupled to RN versions, we didn't feel this was too much of an issue.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
