### PR TITLE
Switch docs publish script to use s3cmd tool

### DIFF
--- a/.github/workflows/jsdoc-publish.yml
+++ b/.github/workflows/jsdoc-publish.yml
@@ -31,18 +31,19 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Run JSDoc documentation build
         run: npm run jsdoc
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Set up S3cmd and configure AWS credentials
+        uses: s3-actions/s3cmd@v1.1
         with:
-          aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
-          aws-region: us-west-1
+          provider: aws
+          region: "us-west-1"
+          access_key: ${{ secrets.DOCS_S3_ACCESS_KEY }}
+          secret_key: ${{ secrets.DOCS_S3_SECRET_KEY }}
       # Get the version number so we can specify the correct input path for uploading the docs -
       # JSDoc outputs to docs/output/realm/<package.json version number>
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
       - name: Upload versioned docs (for archival)
-        run: aws s3 put --acl public-read docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}/realm-sdks/js/${{ steps.package-version.outputs.current-version}}
+        run: s3cmd put --acl-public docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}/realm-sdks/js/${{ steps.package-version.outputs.current-version}}
       - name: Upload latest docs (to live site)
-        run: aws s3 put --acl public-read docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}/realm-sdks/js/latest
+        run: s3cmd put --acl-public docs/output/realm/${{ steps.package-version.outputs.current-version}} s3://${{ secrets.DOCS_S3_BUCKET_NAME }}/realm-sdks/js/latest


### PR DESCRIPTION
## What, How & Why?

s3cmd has a "put" operation to delete then upload in one go. This is used by the Java team (https://github.com/realm/realm-java/blob/c43e40771bac610fb27795deb529e8f0967abfa9/build.gradle#L235-L261) so it probably makes sense to standardise on one tool for doing this.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
