### PR TITLE
Fix for Mixed binary roundtrip issue (#4278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed issue that could cause mangling of binary data on a roundtrip to/from the database ([#4278](https://github.com/realm/realm-js/issues/4278), since v10.1.4).
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -488,7 +488,7 @@ struct Unbox<JSEngine, Mixed> {
                       ObjKey)
     {
         return js::Value<JSEngine>::to_mixed(ctx->m_ctx, ctx->m_realm, value,
-                                             ctx->m_string_buffer); // no need to validate type for a mixed value
+                                             ctx->m_string_buffer, ctx->m_owned_binary_data); // no need to validate type for a mixed value
     }
 };
 

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -487,8 +487,8 @@ struct Unbox<JSEngine, Mixed> {
     static Mixed call(NativeAccessor<JSEngine>* ctx, typename JSEngine::Value const& value, realm::CreatePolicy,
                       ObjKey)
     {
-        return js::Value<JSEngine>::to_mixed(ctx->m_ctx, ctx->m_realm, value,
-                                             ctx->m_string_buffer, ctx->m_owned_binary_data); // no need to validate type for a mixed value
+        return js::Value<JSEngine>::to_mixed(ctx->m_ctx, ctx->m_realm, value, ctx->m_string_buffer,
+                                             ctx->m_owned_binary_data); // no need to validate type for a mixed value
     }
 };
 

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -203,8 +203,8 @@ struct Value {
     static String<T> to_string(ContextType, const ValueType&);
     static OwnedBinaryData to_binary(ContextType, const ValueType&);
     static bson::Bson to_bson(ContextType, ValueType);
-    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
-                          std::string& string_buffer);
+    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType &value,
+                          std::string &string_buffer, OwnedBinaryData &binary_buffer);
 
 #define VALIDATED(return_t, type)                                                                                    \
     static return_t validated_to_##type(ContextType ctx, const ValueType& value, const char* name = nullptr)         \
@@ -875,7 +875,7 @@ inline bson::Bson Value<T>::to_bson(typename T::Context ctx, ValueType value)
 
 template <typename T>
 typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
-                                         std::string& string_buffer)
+                                         std::string &string_buffer, OwnedBinaryData &binary_buffer)
 {
     if (is_null(ctx, value) || is_undefined(ctx, value)) {
         return Mixed(realm::null());
@@ -901,7 +901,8 @@ typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm>
         return Mixed(string_buffer);
     }
     else if (is_binary(ctx, value)) {
-        return Mixed(to_binary(ctx, value).get());
+        binary_buffer = std::move(to_binary(ctx, value));
+        return Mixed(binary_buffer.get());
     }
     else if (is_decimal128(ctx, value)) {
         return Mixed(to_decimal128(ctx, value));

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -203,8 +203,8 @@ struct Value {
     static String<T> to_string(ContextType, const ValueType&);
     static OwnedBinaryData to_binary(ContextType, const ValueType&);
     static bson::Bson to_bson(ContextType, ValueType);
-    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType &value,
-                          std::string &string_buffer, OwnedBinaryData &binary_buffer);
+    static Mixed to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
+                          std::string& string_buffer, OwnedBinaryData& binary_buffer);
 
 #define VALIDATED(return_t, type)                                                                                    \
     static return_t validated_to_##type(ContextType ctx, const ValueType& value, const char* name = nullptr)         \
@@ -875,7 +875,7 @@ inline bson::Bson Value<T>::to_bson(typename T::Context ctx, ValueType value)
 
 template <typename T>
 typename realm::Mixed Value<T>::to_mixed(ContextType ctx, std::shared_ptr<Realm> realm, const ValueType& value,
-                                         std::string &string_buffer, OwnedBinaryData &binary_buffer)
+                                         std::string& string_buffer, OwnedBinaryData& binary_buffer)
 {
     if (is_null(ctx, value) || is_undefined(ctx, value)) {
         return Mixed(realm::null());

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -264,7 +264,7 @@ inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value& 
 {
 
     // TODO:  this pointer is no good :(  It is never de-allocated
-    NodeBinary *node_binary = nullptr;
+    NodeBinary* node_binary = nullptr;
 
 
     if (value.IsDataView()) {

--- a/src/node/node_value.hpp
+++ b/src/node/node_value.hpp
@@ -263,7 +263,8 @@ template <>
 inline OwnedBinaryData node::Value::to_binary(Napi::Env env, const Napi::Value& value)
 {
 
-    NodeBinary* node_binary = nullptr;
+    // TODO:  this pointer is no good :(  It is never de-allocated
+    NodeBinary *node_binary = nullptr;
 
 
     if (value.IsDataView()) {

--- a/tests/js/mixed-tests.js
+++ b/tests/js/mixed-tests.js
@@ -224,4 +224,35 @@ module.exports = {
 
     realm.close();
   },
+
+  // test Nixed datatype with binary data contents
+  testMixedData() {
+    const buffer1 = new Uint8Array([1, 2, 4, 8]).buffer;
+    const buffer2 = new Uint8Array([255, 128, 64, 32, 16, 8]).buffer;
+
+    const MixedSchema = {
+      name: "MixedWithData",
+      properties: { value: "mixed" },
+    };
+
+    const realm = new Realm({ schema: [MixedSchema] });
+
+    realm.write(() => {
+      realm.create("MixedWithData", { value: buffer1 });
+    });
+
+    let mixedObjects = realm.objects("MixedWithData");
+    let returnedData = [...new Uint8Array(mixedObjects[0].value)];
+    TestCase.assertArraysEqual(returnedData, [1, 2, 4, 8]);
+
+    realm.write(() => {
+      mixedObjects[0].value = buffer2;
+    });
+
+    mixedObjects = realm.objects("MixedWithData");
+    returnedData = [...new Uint8Array(mixedObjects[0].value)];
+    TestCase.assertArraysEqual(returnedData, [255, 128, 64, 32, 16, 8]);
+
+    realm.close();
+  },
 };


### PR DESCRIPTION
## What, How & Why?
Fixed issue that could cause mangling of binary data on a roundtrip to/from the database

This closes #4278

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
