### PR TITLE
Add script to generate JS template apps from TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+* Added a script to generate JS template apps from TS, and updated JS templates [4374](https://github.com/realm/realm-js/pull/4374)
 
-10.13.0 Release notes (2022-2-11) 
+10.13.0 Release notes (2022-2-11)
 =============================================================
 ### Enhancements
 * Added `Realm.App#deleteUser(user)` to delete a sync user from a MongoDB Realm app. ([#4006](https://github.com/realm/realm-js/issues/4006))

--- a/templates/expo-template-js/App.js
+++ b/templates/expo-template-js/App.js
@@ -11,7 +11,8 @@ const { useRealm, useQuery, RealmProvider } = TaskContext;
 
 function App() {
   const realm = useRealm();
-  const result = useQuery("Task");
+  const result = useQuery(Task);
+
   const tasks = useMemo(() => result.sorted("createdAt"), [result]);
 
   const handleAddTask = useCallback(
@@ -28,7 +29,7 @@ function App() {
       // of sync participants to successfully sync everything in the transaction, otherwise
       // no changes propagate and the transaction needs to start over when connectivity allows.
       realm.write(() => {
-        realm.create("Task", new Task({description}));
+        realm.create("Task", Task.generate(description));
       });
     },
     [realm],

--- a/templates/expo-template-js/app/App.js
+++ b/templates/expo-template-js/app/App.js
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo } from "react";
 import { SafeAreaView, View, StyleSheet } from "react-native";
 
-import TaskContext, { Task } from "./app/models/Task";
-import IntroText from "./app/components/IntroText";
-import AddTaskForm from "./app/components/AddTaskForm";
-import TaskList from "./app/components/TaskList";
-import colors from "./app/styles/colors";
+import TaskContext, { Task } from "./models/Task";
+import IntroText from "./components/IntroText";
+import AddTaskForm from "./components/AddTaskForm";
+import TaskList from "./components/TaskList";
+import colors from "./styles/colors";
 
 const { useRealm, useQuery, RealmProvider } = TaskContext;
 
@@ -16,7 +16,7 @@ function App() {
   const tasks = useMemo(() => result.sorted("createdAt"), [result]);
 
   const handleAddTask = useCallback(
-    (description: string): void => {
+    (description) => {
       if (!description) {
         return;
       }
@@ -36,7 +36,7 @@ function App() {
   );
 
   const handleToggleTaskStatus = useCallback(
-    (task: Task): void => {
+    (task) => {
       realm.write(() => {
         // Normally when updating a record in a NoSQL or SQL database, we have to type
         // a statement that will later be interpreted and used as instructions for how
@@ -60,7 +60,7 @@ function App() {
   );
 
   const handleDeleteTask = useCallback(
-    (task: Task): void => {
+    (task) => {
       realm.write(() => {
         realm.delete(task);
 

--- a/templates/expo-template-js/app/components/AddTaskForm.js
+++ b/templates/expo-template-js/app/components/AddTaskForm.js
@@ -1,21 +1,14 @@
-import React, {useState} from 'react';
-import {
-  View,
-  Text,
-  TextInput,
-  Pressable,
-  Platform,
-  StyleSheet,
-} from 'react-native';
+import React, { useState } from "react";
+import { View, Text, TextInput, Pressable, Platform, StyleSheet } from "react-native";
 
-import colors from '../styles/colors';
+import colors from "../styles/colors";
 
-function AddTaskForm({onSubmit}) {
-  const [description, setDescription] = useState('');
+function AddTaskForm({ onSubmit }) {
+  const [description, setDescription] = useState("");
 
   const handleSubmit = () => {
     onSubmit(description);
-    setDescription('');
+    setDescription("");
   };
 
   return (
@@ -39,7 +32,7 @@ const styles = StyleSheet.create({
   form: {
     height: 50,
     marginBottom: 20,
-    flexDirection: 'row',
+    flexDirection: "row",
     ...Platform.select({
       ios: {
         shadowColor: colors.black,
@@ -58,25 +51,25 @@ const styles = StyleSheet.create({
   textInput: {
     flex: 1,
     paddingHorizontal: 15,
-    paddingVertical: Platform.OS === 'ios' ? 15 : 0,
+    paddingVertical: Platform.OS === "ios" ? 15 : 0,
     borderRadius: 5,
     backgroundColor: colors.white,
     fontSize: 17,
   },
   submit: {
-    height: '100%',
+    height: "100%",
     width: 50,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     marginLeft: 20,
     borderRadius: 5,
     backgroundColor: colors.purple,
   },
   icon: {
     color: colors.white,
-    textAlign: 'center',
+    textAlign: "center",
     fontSize: 17,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
 });
 

--- a/templates/expo-template-js/app/components/IntroText.js
+++ b/templates/expo-template-js/app/components/IntroText.js
@@ -1,30 +1,21 @@
-import React from 'react';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
-import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser'; // TODO: Replace library
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+// @ts-ignore openURLInBrowser will open the url in your machine browser. (This isn't currently typed in React Native)
+import openURLInBrowser from "react-native/Libraries/Core/Devtools/openURLInBrowser";
 
-import colors from '../styles/colors';
+import colors from "../styles/colors";
 
 function IntroText() {
   return (
     <View style={styles.content}>
+      <Text style={styles.paragraph}>Welcome to the Realm React Native TypeScript Template</Text>
       <Text style={styles.paragraph}>
-        Welcome to the Realm React Native JavaScript Template
+        Start adding a task using the form at the top of the screen to see how they are created in Realm. You can also
+        toggle the task status or remove it from the list.
       </Text>
-      <Text style={styles.paragraph}>
-        Start adding a task using the form at the top of the screen to see how
-        they are created in Realm. You can also toggle the task status or remove
-        it from the list.
-      </Text>
-      <Text style={styles.paragraph}>
-        Learn more about the React Native Realm SDK at:
-      </Text>
-      <Pressable
-        onPress={() =>
-          openURLInBrowser('https://docs.mongodb.com/realm/sdk/react-native/')
-        }>
-        <Text style={[styles.paragraph, styles.link]}>
-          docs.mongodb.com/realm/sdk/react-native
-        </Text>
+      <Text style={styles.paragraph}>Learn more about the React Native Realm SDK at:</Text>
+      <Pressable onPress={() => openURLInBrowser("https://docs.mongodb.com/realm/sdk/react-native/")}>
+        <Text style={[styles.paragraph, styles.link]}>docs.mongodb.com/realm/sdk/react-native</Text>
       </Pressable>
     </View>
   );
@@ -34,18 +25,18 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     marginHorizontal: 20,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   paragraph: {
     marginVertical: 10,
-    textAlign: 'center',
-    color: 'white',
+    textAlign: "center",
+    color: "white",
     fontSize: 17,
-    fontWeight: '500',
+    fontWeight: "500",
   },
   link: {
     color: colors.purple,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
 });
 

--- a/templates/expo-template-js/app/components/TaskItem.js
+++ b/templates/expo-template-js/app/components/TaskItem.js
@@ -1,15 +1,13 @@
-import React, {memo} from 'react';
-import {View, Text, Pressable, Platform, StyleSheet} from 'react-native';
+import React, { memo } from "react";
+import { View, Text, Pressable, Platform, StyleSheet } from "react-native";
 
-import colors from '../styles/colors';
+import colors from "../styles/colors";
 
-function TaskItem({description, isComplete, onToggleStatus, onDelete}) {
+function TaskItem({ description, isComplete, onToggleStatus, onDelete }) {
   return (
     <View style={styles.task}>
-      <Pressable
-        onPress={onToggleStatus}
-        style={[styles.status, isComplete && styles.completed]}>
-        <Text style={styles.icon}>{isComplete ? '✓' : '○'}</Text>
+      <Pressable onPress={onToggleStatus} style={[styles.status, isComplete && styles.completed]}>
+        <Text style={styles.icon}>{isComplete ? "✓" : "○"}</Text>
       </Pressable>
       <View style={styles.descriptionContainer}>
         <Text numberOfLines={1} style={styles.description}>
@@ -26,8 +24,8 @@ function TaskItem({description, isComplete, onToggleStatus, onDelete}) {
 const styles = StyleSheet.create({
   task: {
     height: 50,
-    alignSelf: 'stretch',
-    flexDirection: 'row',
+    alignSelf: "stretch",
+    flexDirection: "row",
     marginVertical: 8,
     backgroundColor: colors.white,
     borderRadius: 5,
@@ -48,7 +46,7 @@ const styles = StyleSheet.create({
   },
   descriptionContainer: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   description: {
     paddingHorizontal: 10,
@@ -57,8 +55,8 @@ const styles = StyleSheet.create({
   },
   status: {
     width: 50,
-    height: '100%',
-    justifyContent: 'center',
+    height: "100%",
+    justifyContent: "center",
     borderTopLeftRadius: 5,
     borderBottomLeftRadius: 5,
     backgroundColor: colors.gray,
@@ -67,7 +65,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.purple,
   },
   deleteButton: {
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   deleteText: {
     marginHorizontal: 10,
@@ -76,15 +74,14 @@ const styles = StyleSheet.create({
   },
   icon: {
     color: colors.white,
-    textAlign: 'center',
+    textAlign: "center",
     fontSize: 17,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
 });
 
 // We want to make sure only tasks that change are rerendered
 const shouldNotRerender = (prevProps, nextProps) =>
-  prevProps.description === nextProps.description &&
-  prevProps.isComplete === nextProps.isComplete;
+  prevProps.description === nextProps.description && prevProps.isComplete === nextProps.isComplete;
 
 export default memo(TaskItem, shouldNotRerender);

--- a/templates/expo-template-js/app/components/TaskList.js
+++ b/templates/expo-template-js/app/components/TaskList.js
@@ -1,15 +1,14 @@
-import React from 'react';
-import {View, FlatList, StyleSheet} from 'react-native';
+import React from "react";
+import { View, FlatList, StyleSheet } from "react-native";
+import TaskItem from "./TaskItem";
 
-import TaskItem from './TaskItem';
-
-function TaskList({tasks, onToggleTaskStatus, onDeleteTask}) {
+function TaskList({ tasks, onToggleTaskStatus, onDeleteTask }) {
   return (
     <View style={styles.listContainer}>
       <FlatList
         data={tasks}
-        keyExtractor={task => task._id.toString()}
-        renderItem={({item}) => (
+        keyExtractor={(task) => task._id.toString()}
+        renderItem={({ item }) => (
           <TaskItem
             description={item.description}
             isComplete={item.isComplete}
@@ -26,7 +25,7 @@ function TaskList({tasks, onToggleTaskStatus, onDeleteTask}) {
 const styles = StyleSheet.create({
   listContainer: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
 });
 

--- a/templates/expo-template-js/app/models/Task.js
+++ b/templates/expo-template-js/app/models/Task.js
@@ -1,27 +1,28 @@
-import { Realm, createRealmContext } from '@realm/react';
-
-export class Task {
-  constructor({id = new Realm.BSON.ObjectId(), description, isComplete = false}) {
-    this.description = description;
-    this.isComplete = isComplete;
-    this.createdAt = new Date();
-    this._id = id;
+import { Realm, createRealmContext } from "@realm/react";
+export class Task extends Realm.Object {
+  static generate(description) {
+    return {
+      _id: new Realm.BSON.ObjectId(),
+      description,
+      isComplete: false,
+      createdAt: new Date(),
+    };
   }
 
   // To use a class as a Realm object type, define the object schema on the static property "schema".
   static schema = {
-    name: 'Task',
-    primaryKey: '_id',
+    name: "Task",
+    primaryKey: "_id",
     properties: {
-      _id: 'objectId',
-      description: 'string',
-      isComplete: {type: 'bool', default: false},
-      createdAt: 'date'
+      _id: "objectId",
+      description: "string",
+      isComplete: { type: "bool", default: false },
+      createdAt: "date",
     },
   };
 }
 
 export default createRealmContext({
-  schema: [Task.schema],
+  schema: [Task],
   deleteRealmIfMigrationNeeded: true,
 });

--- a/templates/expo-template-js/app/styles/colors.js
+++ b/templates/expo-template-js/app/styles/colors.js
@@ -1,9 +1,9 @@
 const colors = {
-  darkBlue: '#2A3642',
-  purple: '#6E60F9',
-  gray: '#B5B5B5',
-  white: '#FFFFFF',
-  black: '#000000',
+  darkBlue: "#2A3642",
+  purple: "#6E60F9",
+  gray: "#B5B5B5",
+  white: "#FFFFFF",
+  black: "#000000",
 };
 
 export default colors;

--- a/templates/expo-template-ts/app/App.tsx
+++ b/templates/expo-template-ts/app/App.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useMemo } from "react";
+import { SafeAreaView, View, StyleSheet } from "react-native";
+
+import TaskContext, { Task } from "./models/Task";
+import IntroText from "./components/IntroText";
+import AddTaskForm from "./components/AddTaskForm";
+import TaskList from "./components/TaskList";
+import colors from "./styles/colors";
+
+const { useRealm, useQuery, RealmProvider } = TaskContext;
+
+function App() {
+  const realm = useRealm();
+  const result = useQuery(Task);
+
+  const tasks = useMemo(() => result.sorted("createdAt"), [result]);
+
+  const handleAddTask = useCallback(
+    (description: string): void => {
+      if (!description) {
+        return;
+      }
+
+      // Everything in the function passed to "realm.write" is a transaction and will
+      // hence succeed or fail together. A transcation is the smallest unit of transfer
+      // in Realm so we want to be mindful of how much we put into one single transaction
+      // and split them up if appropriate (more commonly seen server side). Since clients
+      // may occasionally be online during short time spans we want to increase the probability
+      // of sync participants to successfully sync everything in the transaction, otherwise
+      // no changes propagate and the transaction needs to start over when connectivity allows.
+      realm.write(() => {
+        realm.create("Task", Task.generate(description));
+      });
+    },
+    [realm],
+  );
+
+  const handleToggleTaskStatus = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        // Normally when updating a record in a NoSQL or SQL database, we have to type
+        // a statement that will later be interpreted and used as instructions for how
+        // to update the record. But in RealmDB, the objects are "live" because they are
+        // actually referencing the object's location in memory on the device (memory mapping).
+        // So rather than typing a statement, we modify the object directly by changing
+        // the property values. If the changes adhere to the schema, Realm will accept
+        // this new version of the object and wherever this object is being referenced
+        // locally will also see the changes "live".
+        task.isComplete = !task.isComplete;
+      });
+
+      // Alternatively if passing the ID as the argument to handleToggleTaskStatus:
+      // realm?.write(() => {
+      //   const task = realm?.objectForPrimaryKey('Task', id); // If the ID is passed as an ObjectId
+      //   const task = realm?.objectForPrimaryKey('Task', Realm.BSON.ObjectId(id));  // If the ID is passed as a string
+      //   task.isComplete = !task.isComplete;
+      // });
+    },
+    [realm],
+  );
+
+  const handleDeleteTask = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        realm.delete(task);
+
+        // Alternatively if passing the ID as the argument to handleDeleteTask:
+        // realm?.delete(realm?.objectForPrimaryKey('Task', id));
+      });
+    },
+    [realm],
+  );
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.content}>
+        <AddTaskForm onSubmit={handleAddTask} />
+        {tasks.length === 0 ? (
+          <IntroText />
+        ) : (
+          <TaskList tasks={tasks} onToggleTaskStatus={handleToggleTaskStatus} onDeleteTask={handleDeleteTask} />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.darkBlue,
+  },
+  content: {
+    flex: 1,
+    paddingTop: 20,
+    paddingHorizontal: 20,
+  },
+});
+
+function AppWrapper() {
+  if (!RealmProvider) {
+    return null;
+  }
+  return (
+    <RealmProvider>
+      <App />
+    </RealmProvider>
+  );
+}
+
+export default AppWrapper;

--- a/templates/react-native-template-realm-js/template/App.js
+++ b/templates/react-native-template-realm-js/template/App.js
@@ -1,21 +1,22 @@
-import React, { useCallback, useMemo } from "react";
-import { SafeAreaView, View, StyleSheet } from "react-native";
+import React, {useCallback, useMemo} from 'react';
+import {SafeAreaView, View, StyleSheet} from 'react-native';
 
-import TaskContext, { Task } from "./app/models/Task";
-import IntroText from "./app/components/IntroText";
-import AddTaskForm from "./app/components/AddTaskForm";
-import TaskList from "./app/components/TaskList";
-import colors from "./app/styles/colors";
+import TaskContext, {Task} from './app/models/Task';
+import IntroText from './app/components/IntroText';
+import AddTaskForm from './app/components/AddTaskForm';
+import TaskList from './app/components/TaskList';
+import colors from './app/styles/colors';
 
-const { useRealm, useQuery, RealmProvider } = TaskContext;
+const {useRealm, useQuery, RealmProvider} = TaskContext;
 
 function App() {
   const realm = useRealm();
-  const result = useQuery("Task");
-  const tasks = useMemo(() => result.sorted("createdAt"), [result]);
+  const result = useQuery(Task);
+
+  const tasks = useMemo(() => result.sorted('createdAt'), [result]);
 
   const handleAddTask = useCallback(
-    (description) => {
+    description => {
       if (!description) {
         return;
       }
@@ -28,14 +29,14 @@ function App() {
       // of sync participants to successfully sync everything in the transaction, otherwise
       // no changes propagate and the transaction needs to start over when connectivity allows.
       realm.write(() => {
-        realm.create("Task", new Task({description}));
+        realm.create('Task', Task.generate(description));
       });
     },
     [realm],
   );
 
   const handleToggleTaskStatus = useCallback(
-    (task) => {
+    task => {
       realm.write(() => {
         // Normally when updating a record in a NoSQL or SQL database, we have to type
         // a statement that will later be interpreted and used as instructions for how
@@ -59,7 +60,7 @@ function App() {
   );
 
   const handleDeleteTask = useCallback(
-    (task) => {
+    task => {
       realm.write(() => {
         realm.delete(task);
 
@@ -77,7 +78,11 @@ function App() {
         {tasks.length === 0 ? (
           <IntroText />
         ) : (
-          <TaskList tasks={tasks} onToggleTaskStatus={handleToggleTaskStatus} onDeleteTask={handleDeleteTask} />
+          <TaskList
+            tasks={tasks}
+            onToggleTaskStatus={handleToggleTaskStatus}
+            onDeleteTask={handleDeleteTask}
+          />
         )}
       </View>
     </SafeAreaView>

--- a/templates/react-native-template-realm-js/template/__tests__/App-test.js
+++ b/templates/react-native-template-realm-js/template/__tests__/App-test.js
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../app/App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/templates/react-native-template-realm-js/template/app/App.js
+++ b/templates/react-native-template-realm-js/template/app/App.js
@@ -1,22 +1,22 @@
-import React, { useCallback, useMemo } from "react";
-import { SafeAreaView, View, StyleSheet } from "react-native";
+import React, {useCallback, useMemo} from 'react';
+import {SafeAreaView, View, StyleSheet} from 'react-native';
 
-import TaskContext, { Task } from "./app/models/Task";
-import IntroText from "./app/components/IntroText";
-import AddTaskForm from "./app/components/AddTaskForm";
-import TaskList from "./app/components/TaskList";
-import colors from "./app/styles/colors";
+import TaskContext, {Task} from './models/Task';
+import IntroText from './components/IntroText';
+import AddTaskForm from './components/AddTaskForm';
+import TaskList from './components/TaskList';
+import colors from './styles/colors';
 
-const { useRealm, useQuery, RealmProvider } = TaskContext;
+const {useRealm, useQuery, RealmProvider} = TaskContext;
 
 function App() {
   const realm = useRealm();
   const result = useQuery(Task);
 
-  const tasks = useMemo(() => result.sorted("createdAt"), [result]);
+  const tasks = useMemo(() => result.sorted('createdAt'), [result]);
 
   const handleAddTask = useCallback(
-    (description: string): void => {
+    description => {
       if (!description) {
         return;
       }
@@ -29,14 +29,14 @@ function App() {
       // of sync participants to successfully sync everything in the transaction, otherwise
       // no changes propagate and the transaction needs to start over when connectivity allows.
       realm.write(() => {
-        realm.create("Task", Task.generate(description));
+        realm.create('Task', Task.generate(description));
       });
     },
     [realm],
   );
 
   const handleToggleTaskStatus = useCallback(
-    (task: Task): void => {
+    task => {
       realm.write(() => {
         // Normally when updating a record in a NoSQL or SQL database, we have to type
         // a statement that will later be interpreted and used as instructions for how
@@ -60,7 +60,7 @@ function App() {
   );
 
   const handleDeleteTask = useCallback(
-    (task: Task): void => {
+    task => {
       realm.write(() => {
         realm.delete(task);
 
@@ -78,7 +78,11 @@ function App() {
         {tasks.length === 0 ? (
           <IntroText />
         ) : (
-          <TaskList tasks={tasks} onToggleTaskStatus={handleToggleTaskStatus} onDeleteTask={handleDeleteTask} />
+          <TaskList
+            tasks={tasks}
+            onToggleTaskStatus={handleToggleTaskStatus}
+            onDeleteTask={handleDeleteTask}
+          />
         )}
       </View>
     </SafeAreaView>

--- a/templates/react-native-template-realm-js/template/app/components/IntroText.js
+++ b/templates/react-native-template-realm-js/template/app/components/IntroText.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Text, Pressable, StyleSheet} from 'react-native';
-import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser'; // TODO: Replace library
+// @ts-ignore openURLInBrowser will open the url in your machine browser. (This isn't currently typed in React Native)
+import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
 
 import colors from '../styles/colors';
 
@@ -8,7 +9,7 @@ function IntroText() {
   return (
     <View style={styles.content}>
       <Text style={styles.paragraph}>
-        Welcome to the Realm React Native JavaScript Template
+        Welcome to the Realm React Native TypeScript Template
       </Text>
       <Text style={styles.paragraph}>
         Start adding a task using the form at the top of the screen to see how

--- a/templates/react-native-template-realm-js/template/app/components/TaskList.js
+++ b/templates/react-native-template-realm-js/template/app/components/TaskList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {View, FlatList, StyleSheet} from 'react-native';
-
 import TaskItem from './TaskItem';
 
 function TaskList({tasks, onToggleTaskStatus, onDeleteTask}) {

--- a/templates/react-native-template-realm-js/template/app/models/Task.js
+++ b/templates/react-native-template-realm-js/template/app/models/Task.js
@@ -1,11 +1,12 @@
-import { Realm, createRealmContext } from '@realm/react';
-
-export class Task {
-  constructor({id = new Realm.BSON.ObjectId(), description, isComplete = false}) {
-    this.description = description;
-    this.isComplete = isComplete;
-    this.createdAt = new Date();
-    this._id = id;
+import {Realm, createRealmContext} from '@realm/react';
+export class Task extends Realm.Object {
+  static generate(description) {
+    return {
+      _id: new Realm.BSON.ObjectId(),
+      description,
+      isComplete: false,
+      createdAt: new Date(),
+    };
   }
 
   // To use a class as a Realm object type, define the object schema on the static property "schema".
@@ -16,12 +17,12 @@ export class Task {
       _id: 'objectId',
       description: 'string',
       isComplete: {type: 'bool', default: false},
-      createdAt: 'date'
+      createdAt: 'date',
     },
   };
 }
 
 export default createRealmContext({
-  schema: [Task.schema],
+  schema: [Task],
   deleteRealmIfMigrationNeeded: true,
 });

--- a/templates/react-native-template-realm-ts/template/__tests__/App-test.tsx
+++ b/templates/react-native-template-realm-ts/template/__tests__/App-test.tsx
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../app/App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/templates/react-native-template-realm-ts/template/app/App.tsx
+++ b/templates/react-native-template-realm-ts/template/app/App.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useMemo } from "react";
+import { SafeAreaView, View, StyleSheet } from "react-native";
+
+import TaskContext, { Task } from "./models/Task";
+import IntroText from "./components/IntroText";
+import AddTaskForm from "./components/AddTaskForm";
+import TaskList from "./components/TaskList";
+import colors from "./styles/colors";
+
+const { useRealm, useQuery, RealmProvider } = TaskContext;
+
+function App() {
+  const realm = useRealm();
+  const result = useQuery(Task);
+
+  const tasks = useMemo(() => result.sorted("createdAt"), [result]);
+
+  const handleAddTask = useCallback(
+    (description: string): void => {
+      if (!description) {
+        return;
+      }
+
+      // Everything in the function passed to "realm.write" is a transaction and will
+      // hence succeed or fail together. A transcation is the smallest unit of transfer
+      // in Realm so we want to be mindful of how much we put into one single transaction
+      // and split them up if appropriate (more commonly seen server side). Since clients
+      // may occasionally be online during short time spans we want to increase the probability
+      // of sync participants to successfully sync everything in the transaction, otherwise
+      // no changes propagate and the transaction needs to start over when connectivity allows.
+      realm.write(() => {
+        realm.create("Task", Task.generate(description));
+      });
+    },
+    [realm],
+  );
+
+  const handleToggleTaskStatus = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        // Normally when updating a record in a NoSQL or SQL database, we have to type
+        // a statement that will later be interpreted and used as instructions for how
+        // to update the record. But in RealmDB, the objects are "live" because they are
+        // actually referencing the object's location in memory on the device (memory mapping).
+        // So rather than typing a statement, we modify the object directly by changing
+        // the property values. If the changes adhere to the schema, Realm will accept
+        // this new version of the object and wherever this object is being referenced
+        // locally will also see the changes "live".
+        task.isComplete = !task.isComplete;
+      });
+
+      // Alternatively if passing the ID as the argument to handleToggleTaskStatus:
+      // realm?.write(() => {
+      //   const task = realm?.objectForPrimaryKey('Task', id); // If the ID is passed as an ObjectId
+      //   const task = realm?.objectForPrimaryKey('Task', Realm.BSON.ObjectId(id));  // If the ID is passed as a string
+      //   task.isComplete = !task.isComplete;
+      // });
+    },
+    [realm],
+  );
+
+  const handleDeleteTask = useCallback(
+    (task: Task): void => {
+      realm.write(() => {
+        realm.delete(task);
+
+        // Alternatively if passing the ID as the argument to handleDeleteTask:
+        // realm?.delete(realm?.objectForPrimaryKey('Task', id));
+      });
+    },
+    [realm],
+  );
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <View style={styles.content}>
+        <AddTaskForm onSubmit={handleAddTask} />
+        {tasks.length === 0 ? (
+          <IntroText />
+        ) : (
+          <TaskList tasks={tasks} onToggleTaskStatus={handleToggleTaskStatus} onDeleteTask={handleDeleteTask} />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.darkBlue,
+  },
+  content: {
+    flex: 1,
+    paddingTop: 20,
+    paddingHorizontal: 20,
+  },
+});
+
+function AppWrapper() {
+  if (!RealmProvider) {
+    return null;
+  }
+  return (
+    <RealmProvider>
+      <App />
+    </RealmProvider>
+  );
+}
+
+export default AppWrapper;

--- a/templates/react-native-template-realm-ts/template/index.js
+++ b/templates/react-native-template-realm-ts/template/index.js
@@ -4,7 +4,7 @@
 
 import 'react-native-get-random-values';
 import {AppRegistry} from 'react-native';
-import App from './App';
+import App from './app/App';
 import {name as appName} from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/templates/scripts/convert-ts-to-js.sh
+++ b/templates/scripts/convert-ts-to-js.sh
@@ -11,6 +11,8 @@ convert() {
   pushd $1
   # The Babel config causes detype to output non-ES2015 JS, so temporarily hide it
   mv babel.config.js babel.config.js.ignore
+  # Delete any generated JS files in the target directory in case we have renamed or deleted something
+  find $2/app -name "*.js" -exec rm {} +
   # Strip types from every .ts* file (except those in node_modules) and write the output
   # to the corresponding file in react-native-template-realm-js, with the extension changed
   # to ".js" (regardless of whether the original was ".tsx" or ".ts")

--- a/templates/scripts/convert-ts-to-js.sh
+++ b/templates/scripts/convert-ts-to-js.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script converts the TypeScript tempalte in `react-native-template-realm-ts` to plain
+# JavaScript, using detype (https://www.npmjs.com/package/detype) to preserve comments and
+# formatting (which tsc does not do)
+
+set -e
+set -o pipefail
+
+cd ../react-native-template-realm-ts/template
+# The Babel config causes detype to output non-ES2015 JS, so temporarily hide it
+mv babel.config.js babel.config.js.ignore
+# Strip types from every .ts* file (except those in node_modules) and write the output
+# to the corresponding file in react-native-template-realm-js, with the extension changed
+# to ".js" (regardless of whether the original was ".tsx" or ".ts")
+for i in `find . -path ./node_modules -prune -o -name "*.ts*" -print`; do npx detype $i ../../react-native-template-realm-js/template/${i/\.ts*/\.js} ; done
+# Move the Babel config back
+mv babel.config.js.ignore babel.config.js

--- a/templates/scripts/convert-ts-to-js.sh
+++ b/templates/scripts/convert-ts-to-js.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 
-# This script converts the TypeScript tempalte in `react-native-template-realm-ts` to plain
-# JavaScript, using detype (https://www.npmjs.com/package/detype) to preserve comments and
-# formatting (which tsc does not do)
+# This script converts the TypeScript template apps to plain JavaScript, using detype
+# (https://www.npmjs.com/package/detype) to preserve comments and formatting
+# (which tsc does not do)
 
 set -e
 set -o pipefail
 
-cd ../react-native-template-realm-ts/template
-# The Babel config causes detype to output non-ES2015 JS, so temporarily hide it
-mv babel.config.js babel.config.js.ignore
-# Strip types from every .ts* file (except those in node_modules) and write the output
-# to the corresponding file in react-native-template-realm-js, with the extension changed
-# to ".js" (regardless of whether the original was ".tsx" or ".ts")
-for i in `find . -path ./node_modules -prune -o -name "*.ts*" -print`; do npx detype $i ../../react-native-template-realm-js/template/${i/\.ts*/\.js} ; done
-# Move the Babel config back
-mv babel.config.js.ignore babel.config.js
+convert() {
+  pushd $1
+  # The Babel config causes detype to output non-ES2015 JS, so temporarily hide it
+  mv babel.config.js babel.config.js.ignore
+  # Strip types from every .ts* file (except those in node_modules) and write the output
+  # to the corresponding file in react-native-template-realm-js, with the extension changed
+  # to ".js" (regardless of whether the original was ".tsx" or ".ts")
+  for i in `find . -path ./node_modules -prune -o -name "*.ts*" -print`; do npx detype $i $2/${i/\.ts*/\.js} ; done
+  # Move the Babel config back
+  mv babel.config.js.ignore babel.config.js
+  popd
+}
+
+convert "../react-native-template-realm-ts/template" "../../react-native-template-realm-js/template"
+convert "../expo-template-ts" "../expo-template-js"


### PR DESCRIPTION
## What, How & Why?

Currently we have to manually sync our JS template apps with our TS template apps, which has led to them slipping out of sync. 

This PR adds a script which strips the types out of the TS apps and writes the output into the JS template apps, using the [detype](https://www.npmjs.com/package/detype) npm package (tsc does not preserve comments and whitespace).

It also updates the JS apps with the output of the script.

A future enhancement might be to have the `react-native-template-realm-ts` as the "master" app, then we copy the `app` directory from there into the Expo template as part of this script, and generate the JS apps. This would mean we only have to maintain one set of app code, but each template could have its own supporting code.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
