### PR TITLE
Resolve package.json relative to analytics script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
+* Fixed analytics to read the `realm/package.json` when installing from the root of the package.
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/scripts/submit-analytics.js
+++ b/scripts/submit-analytics.js
@@ -118,7 +118,8 @@ function isAnalyticsDisabled() {
 }
 
 function getRealmVersion() {
-  const packageJson = fse.readJsonSync([getProjectRoot(), "node_modules", "realm", "package.json"].join(path.sep));
+  const packageJsonPath = path.resolve(__dirname, "../package.json");
+  const packageJson = fse.readJsonSync(packageJsonPath);
   return packageJson["version"];
 }
 


### PR DESCRIPTION
## What, How & Why?

This fixes the following error which got thrown when installing the root package locally:

```
Error: /Users/kraen.hansen/Projects/realm-js/node_modules/realm/package.json: ENOENT: no such file or directory, open '/Users/kraen.hansen/Projects/realm-js/node_modules/realm/package.json'
    at Object.openSync (node:fs:585:3)
    at Object.readFileSync (node:fs:453:35)
    at Object.readFileSync (/Users/kraen.hansen/Projects/realm-js/node_modules/jsonfile/index.js:61:22)
    at getRealmVersion (/Users/kraen.hansen/Projects/realm-js/scripts/submit-analytics.js:132:27)
    at collectPlatformData (/Users/kraen.hansen/Projects/realm-js/scripts/submit-analytics.js:151:24)
    at async submitAnalytics (/Users/kraen.hansen/Projects/realm-js/scripts/submit-analytics.js:252:16) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/Users/kraen.hansen/Projects/realm-js/node_modules/realm/package.json'
}
```

Instead of traversing the `node_modules` simply resolve the `package.json` relative to the current scripts `__dirname`.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
