### PR TITLE
Manually split the output of the `pidof` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Fixed analytics to read the `realm/package.json` when installing from the root of the package.
+* Fixed React Native Android integration test harness to read only one pid when starting logcat.
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/integration-tests/environments/react-native/harness/android-cli.js
+++ b/integration-tests/environments/react-native/harness/android-cli.js
@@ -63,7 +63,11 @@ const adb = {
     return adb.exec(["shell", ...args]);
   },
   shellPidOf(packageName) {
-    return adb.exec(["shell", `pidof -s ${packageName}`], true, false).trim();
+    // Apparently the -s flag on pidof doesn't work - so we filter out the first pid manually
+    return adb
+      .exec(["shell", `pidof ${packageName}`], true, false)
+      .trim()
+      .split(" ")[0];
   },
 };
 


### PR DESCRIPTION
## What, How & Why?

This closes an issue in the React Native integration test harness, where logcat would be started with multiple pids.

Merge at will 👍 

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually - locally)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
