### PR TITLE
Increasing timeout the `importApp` utility test

### DIFF
--- a/integration-tests/tests/src/utils/import-app.test.ts
+++ b/integration-tests/tests/src/utils/import-app.test.ts
@@ -27,7 +27,7 @@ describe.skipIf(environment.missingServer, "importApp utility", function () {
     const app = await importApp("simple");
     expect(app).instanceOf(App);
     expect(app.id.startsWith("simple")).to.be.true;
-  }).timeout(10000);
+  }).timeout(2 * 60 * 1000); // This may take a long time when running against a real server
 
   it("throws on unexpected app names", async () => {
     let threw = false;


### PR DESCRIPTION
## What, How & Why?

This increase the timeout of the `importApp` utility test to cope with delays when testing against a production server.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually, locally)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
