### PR TITLE
Lint: Importing Realm to fix linting realm-react/testApp

### DIFF
--- a/packages/realm-react/testApp/App.tsx
+++ b/packages/realm-react/testApp/App.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 import React, { useCallback, useMemo } from "react";
 import { SafeAreaView, View, StyleSheet } from "react-native";
+import Realm from "realm";
 
 import TaskContext, { Task } from "./app/models/Task";
 import IntroText from "./app/components/IntroText";

--- a/packages/realm-react/testApp/app/components/TaskItem.tsx
+++ b/packages/realm-react/testApp/app/components/TaskItem.tsx
@@ -15,9 +15,11 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
-import { Task } from "app/models/Task";
 import React, { memo } from "react";
 import { View, Text, Pressable, Platform, StyleSheet } from "react-native";
+import Realm from "realm";
+
+import { Task } from "app/models/Task";
 
 import colors from "../styles/colors";
 

--- a/packages/realm-react/testApp/app/components/TaskList.tsx
+++ b/packages/realm-react/testApp/app/components/TaskList.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 import React from "react";
 import { View, FlatList, StyleSheet } from "react-native";
+import Realm from "realm";
 
 import { Task } from "../models/Task";
 import TaskItem from "./TaskItem";


### PR DESCRIPTION
## What, How & Why?

This fixes three lint errors in the `realm-react/testApp`:

```
realm-js/packages/realm-react/testApp/App.tsx
  56:19  error  'Realm' is not defined  no-undef
  80:19  error  'Realm' is not defined  no-undef

realm-js/packages/realm-react/testApp/app/components/TaskItem.tsx
  25:16  error  'Realm' is not defined  no-undef

realm-js/packages/realm-react/testApp/app/components/TaskList.tsx
  25:10  error  'Realm' is not defined  no-undef
  25:31  error  'Realm' is not defined  no-undef
  26:37  error  'Realm' is not defined  no-undef
  27:31  error  'Realm' is not defined  no-undef

✖ 7 problems (7 errors, 0 warnings)
```

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
