### PR TITLE
Fix crash when accessing out of bounds index of a collection

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,3 +1,17 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fixed bug when trying to access a collection result with an out of bounds index.
+
+### Compatibility
+* None
+
+### Internal
+* None
+
 0.2.0 Release notes (2022-03-07)
 =============================================================
 ### Enhancements

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -67,7 +67,7 @@ const testDataSet = [
   { _id: 6, name: "Sadie", color: "gold", gender: "female", age: 5 },
 ];
 
-describe("useQuery", () => {
+describe("useQueryHook", () => {
   beforeEach(() => {
     const realm = new Realm(configuration);
     realm.write(() => {
@@ -100,5 +100,11 @@ describe("useQuery", () => {
     expect(collection).not.toBeNull();
     expect(collection.length).toBe(6);
     expect(collection[0]).toEqual(collection?.[0]);
+  });
+  it("should return undefined indexes that are out of bounds", () => {
+    const { result } = renderHook(() => useQuery<IDog>("dog"));
+    const collection = result.current;
+
+    expect(collection[99]).toBe(undefined);
   });
 });

--- a/packages/realm-react/src/cachedCollection.ts
+++ b/packages/realm-react/src/cachedCollection.ts
@@ -24,8 +24,8 @@ function getCacheKey(id: string) {
 }
 
 /**
-  * Arguments object for {@link cachedCollection}.
-  */
+ * Arguments object for {@link cachedCollection}.
+ */
 type CachedCollectionArgs<T> = {
   /**
    * The {@link Realm.Collection} to proxy
@@ -40,7 +40,7 @@ type CachedCollectionArgs<T> = {
    * (derived) version of the collection to reuse the same cache, preventing excess new object
    * references being created.
    */
-  collectionCache?: Map<string, T>;
+  objectCache?: Map<string, T>;
   /**
    * Optional flag specifying that this is a derived (`sorted` or `filtered`) version of
    * an existing collection, so we should not create or remove listeners or clear the cache
@@ -66,12 +66,7 @@ export function createCachedCollection<T extends Realm.Object>({
   updateCallback,
   objectCache = new Map(),
   isDerived = false,
-}: {
-  collection: Realm.Collection<T>;
-  updateCallback: () => void;
-  objectCache?: Map<string, T>;
-  isDerived?: boolean;
-}): { collection: Realm.Collection<T>; tearDown: () => void } {
+}: CachedCollectionArgs<T>): { collection: Realm.Collection<T>; tearDown: () => void } {
   const cachedCollectionHandler: ProxyHandler<Realm.Collection<T & Realm.Object>> = {
     get: function (target, key) {
       // Pass functions through
@@ -100,6 +95,17 @@ export function createCachedCollection<T extends Realm.Object>({
       // If the key is numeric, check if we have a cached object for this key
       const index = Number(key);
       const object = target[index];
+
+      // If the collection is modeled in a way that objects can be null
+      // then we should return null instead of undefined to stay symantically
+      // correct
+      if (object === null) {
+        return null;
+      } else if (typeof object === "undefined") {
+        // If there is no object at this index, return undefined
+        return undefined;
+      }
+
       const objectId = object._objectId();
       const cacheKey = getCacheKey(objectId);
 

--- a/packages/realm-react/src/cachedCollection.ts
+++ b/packages/realm-react/src/cachedCollection.ts
@@ -97,7 +97,7 @@ export function createCachedCollection<T extends Realm.Object>({
       const object = target[index];
 
       // If the collection is modeled in a way that objects can be null
-      // then we should return null instead of undefined to stay symantically
+      // then we should return null instead of undefined to stay semantically
       // correct
       if (object === null) {
         return null;


### PR DESCRIPTION
Collection will now return `undefined` for out of bound indexes.
Added a test to cover this.


## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
