### PR TITLE
Class models: Enforce `extends Realm.Object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
+
+### Breaking change
+* Model classes passed as schema to the `Realm` constructor must now extend `Realm.Object`.
+
 ### Enhancements
 * None.
 

--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import Realm from "realm";
+
+describe("Class models", () => {
+  describe("as schema element", () => {
+    beforeEach(() => {
+      Realm.clearTestState();
+    });
+
+    it("fails without a schema static", () => {
+      class Person extends Realm.Object {}
+      expect(() => {
+        new Realm({ schema: [Person as any] });
+      }).throws("must have a 'schema' property");
+    });
+
+    it("fails without a schema.properties static", () => {
+      class Person extends Realm.Object {
+        static schema = { name: "Person" };
+      }
+      expect(() => {
+        new Realm({ schema: [Person as any] });
+      }).throws("properties must be of type 'object'");
+    });
+
+    it("fails if it doesn't extend Realm.Object", () => {
+      class Person {
+        name!: string;
+        static schema: Realm.ObjectSchema = {
+          name: "Person",
+          properties: { name: "string" },
+        };
+      }
+      expect(() => {
+        new Realm({ schema: [Person as any] });
+      }).throws("Class 'Person' must extend Realm.Object");
+
+      // Mutate the name of the object schema to produce a more detailed error
+      Person.schema.name = "Foo";
+      expect(() => {
+        new Realm({ schema: [Person as any] });
+      }).throws("Class 'Person' (declaring 'Foo' schema) must extend Realm.Object");
+    });
+
+    it("is allowed", () => {
+      class Person extends Realm.Object {
+        name!: string;
+        static schema: Realm.ObjectSchema = {
+          name: "Person",
+          properties: { name: "string" },
+        };
+      }
+      new Realm({ schema: [Person] });
+    });
+  });
+});

--- a/integration-tests/tests/src/tests/index.ts
+++ b/integration-tests/tests/src/tests/index.ts
@@ -22,8 +22,9 @@ import chai from "chai";
 chai.use(chaiAsPromised);
 
 import "./realm-constructor";
-import "./serialization";
 import "./objects";
+import "./class-models";
+import "./serialization";
 import "./iterators";
 import "./dynamic-schema-updates";
 import "./bson";

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -143,7 +143,7 @@ const testSetups: TestSetup[] = [
     },
   },
   {
-    name: "Class models (NO primaryKey)",
+    name: "Class model (NO primaryKey)",
     schema: [PlaylistNoId, SongNoId],
     testData(realm: Realm) {
       realm.write(() => {
@@ -287,7 +287,7 @@ const testSetups: TestSetup[] = [
     },
   },
   {
-    name: "Class models (Int primaryKey)",
+    name: "Class model (Int primaryKey)",
     schema: [PlaylistWithId, SongWithId],
     testData(realm: Realm) {
       realm.write(() => {

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -125,25 +125,7 @@ module.exports = {
     Object.setPrototypeOf(Car2.prototype, Realm.Object.prototype);
     Object.setPrototypeOf(Car2, Realm.Object);
 
-    //test class syntax support without extending Realm.Object
-    let car3ConstructorCalled = false;
-    class Car3 {
-      constructor() {
-        car3ConstructorCalled = true;
-      }
-    }
-
-    Car3.schema = {
-      name: "Car3",
-      properties: {
-        make: "string",
-        model: "string",
-        otherType: { type: "string", mapTo: "type", optional: true },
-        kilometers: { type: "int", default: 0 },
-      },
-    };
-
-    let realm = new Realm({ schema: [Car, Car2, Car3] });
+    let realm = new Realm({ schema: [Car, Car2] });
     realm.write(() => {
       let car = realm.create("Car", { make: "Audi", model: "A4", kilometers: 24 });
       TestCase.assertTrue(constructorCalled);
@@ -181,15 +163,6 @@ module.exports = {
       TestCase.assertEqual(car2_1.model, "Touareg");
       TestCase.assertEqual(car2_1.kilometers, 13);
       TestCase.assertInstanceOf(car2_1, Realm.Object, "car2_1 not an instance of Realm.Object");
-
-      let car3 = realm.create("Car3", { make: "Audi", model: "A4", kilometers: 24 });
-      TestCase.assertTrue(car3ConstructorCalled);
-      TestCase.assertEqual(car3.make, "Audi");
-      TestCase.assertEqual(car3.model, "A4");
-      TestCase.assertEqual(car3.kilometers, 24);
-
-      //methods from Realm.Objects should be present
-      TestCase.assertDefined(car3.addListener);
     });
     realm.close();
   },
@@ -1144,6 +1117,7 @@ module.exports = {
         intCol: "int",
       },
     };
+    Object.setPrototypeOf(CustomObject, Realm.Object);
 
     function InvalidObject() {
       return {};
@@ -1159,6 +1133,7 @@ module.exports = {
         intCol: "int",
       },
     };
+    Object.setPrototypeOf(InvalidObject, Realm.Object);
     let realm = new Realm({ schema: [CustomObject, InvalidObject] });
 
     realm.write(() => {
@@ -1206,6 +1181,7 @@ module.exports = {
         intCol: "int",
       },
     };
+    Object.setPrototypeOf(CustomObject, Realm.Object);
 
     let realm = new Realm({ schema: [CustomObject] });
     realm.write(() => {
@@ -1215,6 +1191,7 @@ module.exports = {
 
     function NewCustomObject() {}
     NewCustomObject.schema = CustomObject.schema;
+    Object.setPrototypeOf(NewCustomObject, Realm.Object);
 
     realm = new Realm({ schema: [NewCustomObject] });
     realm.write(() => {


### PR DESCRIPTION
## What, How & Why?

This closes #4412 by checking the prototype of constructors passed into the `Realm` constructor.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
