### PR TITLE
Quick Wins for Realm/React

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Allow `createRealmContext` to be called without an initial configuration
+* Add a `fallback` property to `RealmProvider` that is shown while realm is opening
 
 ### Fixed
 * Fixed bug when trying to access a collection result with an out of bounds index.([#4416](https://github.com/realm/realm-js/pull/4416), since v0.2.0)

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -60,7 +60,7 @@ export function createRealmProvider(
    * For example, to override the `path` config value, use a prop named `path`,
    * e.g. `path="newPath.realm"`
    */
-  return ({ children, fallback, ...restProps }) => {
+  return ({ children, fallback: Fallback, ...restProps }) => {
     const [realm, setRealm] = useState<Realm | null>(null);
     // We increment `configVersion` when a config override passed as a prop
     // changes, which triggers a `useEffect` to re-open the Realm with the
@@ -111,7 +111,10 @@ export function createRealmProvider(
     }, [configVersion, realm, setRealm]);
 
     if (!realm) {
-      return <>{fallback}</>;
+      if (typeof Fallback === "function") {
+        return <Fallback />;
+      }
+      return <>{Fallback}</>;
     }
 
     return <RealmContext.Provider value={realm} children={children} />;

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -20,7 +20,9 @@ import React, { useEffect, useState, useRef } from "react";
 import Realm from "realm";
 import { isEqual } from "lodash";
 
-type ProviderProps = Realm.Configuration;
+type ProviderProps = Realm.Configuration & {
+  fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+};
 
 /**
  * Generates a `RealmProvider` given a {@link Realm.Configuration} and {@link React.Context}.
@@ -58,7 +60,7 @@ export function createRealmProvider(
    * For example, to override the `path` config value, use a prop named `path`,
    * e.g. `path="newPath.realm"`
    */
-  return ({ children, ...restProps }) => {
+  return ({ children, fallback, ...restProps }) => {
     const [realm, setRealm] = useState<Realm | null>(null);
     // We increment `configVersion` when a config override passed as a prop
     // changes, which triggers a `useEffect` to re-open the Realm with the
@@ -109,7 +111,7 @@ export function createRealmProvider(
     }, [configVersion, realm, setRealm]);
 
     if (!realm) {
-      return null;
+      return <>{fallback}</>;
     }
 
     return <RealmContext.Provider value={realm} children={children} />;

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -49,6 +49,8 @@ const { RealmProvider, useRealm } = createRealmContext({
   path: "testArtifacts/realm-provider.realm",
 });
 
+const EmptyRealmContext = createRealmContext();
+
 describe("RealmProvider", () => {
   afterEach(() => {
     Realm.clearTestState();
@@ -68,6 +70,16 @@ describe("RealmProvider", () => {
       <RealmProvider schema={[catSchema]}>{children}</RealmProvider>
     );
     const { result, waitForNextUpdate } = renderHook(() => useRealm(), { wrapper });
+    await waitForNextUpdate();
+    const realm = result.current;
+    expect(realm).not.toBe(null);
+    expect(realm.schema[0].name).toBe("cat");
+  });
+  it("can be used with an initially empty realm context", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <EmptyRealmContext.RealmProvider schema={[catSchema]}>{children}</EmptyRealmContext.RealmProvider>
+    );
+    const { result, waitForNextUpdate } = renderHook(() => EmptyRealmContext.useRealm(), { wrapper });
     await waitForNextUpdate();
     const realm = result.current;
     expect(realm).not.toBe(null);

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -175,23 +175,44 @@ describe("RealmProvider", () => {
 
     expect(newSchemaNameContainer).toHaveTextContent("cat");
   });
-  it("initially renders a fallback, until realm exists", async () => {
-    const App = () => {
-      return (
-        <RealmProvider fallback={<View testID="fallbackContainer" />}>
-          <View testID="testContainer" />
-        </RealmProvider>
-      );
-    };
-    const { queryByTestId } = render(<App />);
+  describe("initially renders a fallback, until realm exists", () => {
+    it("as a component", async () => {
+      const App = () => {
+        return (
+          <RealmProvider fallback={() => <View testID="fallbackContainer" />}>
+            <View testID="testContainer" />
+          </RealmProvider>
+        );
+      };
+      const { queryByTestId } = render(<App />);
 
-    expect(queryByTestId("fallbackContainer")).not.toBeNull();
-    expect(queryByTestId("testContainer")).toBeNull();
+      expect(queryByTestId("fallbackContainer")).not.toBeNull();
+      expect(queryByTestId("testContainer")).toBeNull();
 
-    await waitFor(() => queryByTestId("testContainer"));
+      await waitFor(() => queryByTestId("testContainer"));
 
-    expect(queryByTestId("fallbackContainer")).toBeNull();
-    expect(queryByTestId("testContainer")).not.toBeNull();
+      expect(queryByTestId("fallbackContainer")).toBeNull();
+      expect(queryByTestId("testContainer")).not.toBeNull();
+    });
+    it("as an element", async () => {
+      const Fallback = <View testID="fallbackContainer" />;
+      const App = () => {
+        return (
+          <RealmProvider fallback={Fallback}>
+            <View testID="testContainer" />
+          </RealmProvider>
+        );
+      };
+      const { queryByTestId } = render(<App />);
+
+      expect(queryByTestId("fallbackContainer")).not.toBeNull();
+      expect(queryByTestId("testContainer")).toBeNull();
+
+      await waitFor(() => queryByTestId("testContainer"));
+
+      expect(queryByTestId("fallbackContainer")).toBeNull();
+      expect(queryByTestId("testContainer")).not.toBeNull();
+    });
   });
 });
 

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -175,6 +175,24 @@ describe("RealmProvider", () => {
 
     expect(newSchemaNameContainer).toHaveTextContent("cat");
   });
+  it("initially renders a fallback, until realm exists", async () => {
+    const App = () => {
+      return (
+        <RealmProvider fallback={<View testID="fallbackContainer" />}>
+          <View testID="testContainer" />
+        </RealmProvider>
+      );
+    };
+    const { queryByTestId } = render(<App />);
+
+    expect(queryByTestId("fallbackContainer")).not.toBeNull();
+    expect(queryByTestId("testContainer")).toBeNull();
+
+    await waitFor(() => queryByTestId("testContainer"));
+
+    expect(queryByTestId("fallbackContainer")).toBeNull();
+    expect(queryByTestId("testContainer")).not.toBeNull();
+  });
 });
 
 describe("mergeRealmConfiguration", () => {

--- a/packages/realm-react/src/cachedObject.ts
+++ b/packages/realm-react/src/cachedObject.ts
@@ -48,10 +48,7 @@ type CachedObjectArgs<T> = {
 export function createCachedObject<T extends Realm.Object>({
   object,
   updateCallback,
-}: {
-  object: T | null;
-  updateCallback: () => void;
-}): { object: T | null; tearDown: () => void } {
+}: CachedObjectArgs<T>): { object: T | null; tearDown: () => void } {
   const listCaches = new Map();
   const listTearDowns: Array<() => void> = [];
   // If the object doesn't exist, just return it with an noop tearDown

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -123,11 +123,11 @@ type RealmContext = {
  * @param realmConfig - {@link Realm.Configuration} used to open the Realm
  * @returns An object containing a `RealmProvider` component, and `useRealm`, `useQuery` and `useObject` hooks
  */
-export const createRealmContext: (realmConfig: Realm.Configuration) => RealmContext = (
-  realmConfig: Realm.Configuration,
+export const createRealmContext: (realmConfig?: Realm.Configuration) => RealmContext = (
+  realmConfig?: Realm.Configuration,
 ) => {
   const RealmContext = createContext<Realm | null>(null);
-  const RealmProvider = createRealmProvider(realmConfig, RealmContext);
+  const RealmProvider = createRealmProvider(realmConfig ?? {}, RealmContext);
 
   const useRealm = createUseRealm(RealmContext);
   const useQuery = createUseQuery(useRealm);

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -124,10 +124,10 @@ type RealmContext = {
  * @returns An object containing a `RealmProvider` component, and `useRealm`, `useQuery` and `useObject` hooks
  */
 export const createRealmContext: (realmConfig?: Realm.Configuration) => RealmContext = (
-  realmConfig?: Realm.Configuration,
+  realmConfig: Realm.Configuration = {},
 ) => {
   const RealmContext = createContext<Realm | null>(null);
-  const RealmProvider = createRealmProvider(realmConfig ?? {}, RealmContext);
+  const RealmProvider = createRealmProvider(realmConfig, RealmContext);
 
   const useRealm = createUseRealm(RealmContext);
   const useQuery = createUseQuery(useRealm);


### PR DESCRIPTION
## What, How & Why?
Two small improvements:
* Allow `createRealmContext` to be called without an initial configuration
* Add a `fallback` property to `RealmProvider` that is shown while realm is opening

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
