### PR TITLE
Fix Timeout Error for Logged out User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Logging out too fast can cause an error if the timeout behavior is set to `openLocalRealm` ([4453](https://github.com/realm/realm-js/issues/4453))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -257,9 +257,7 @@ module.exports = function (realmConstructor) {
                   return;
                 }
                 // Clear the fallback timeOut if it has been started
-                if (timeoutId) {
-                  clearTimeout(timeoutId);
-                }
+                clearTimeout(timeoutId);
                 if (error) {
                   reject(error);
                 } else {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -197,6 +197,10 @@ module.exports = function (realmConstructor) {
 
         // First configure any timeOut and corresponding behavior.
         let openPromises = [];
+
+        // Id of the timer triggering the timeout
+        let timeoutId = null;
+
         if (config.sync[behavior] !== undefined && config.sync[behavior].timeOut !== undefined) {
           let timeOut = config.sync[behavior].timeOut;
           if (typeof timeOut !== "number") {
@@ -223,7 +227,7 @@ module.exports = function (realmConstructor) {
 
           openPromises.push(
             new Promise((resolve, reject) => {
-              setTimeout(() => {
+              timeoutId = setTimeout(() => {
                 if (asyncOpenTask) {
                   asyncOpenTask.cancel();
                   asyncOpenTask = null;
@@ -251,6 +255,10 @@ module.exports = function (realmConstructor) {
                 // actually invoke this, so recheck here.
                 if (cancelled) {
                   return;
+                }
+                // Clear the fallback timeOut if it has been started
+                if (timeoutId) {
+                  clearTimeout(timeoutId);
                 }
                 if (error) {
                   reject(error);

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -357,8 +357,8 @@ module.exports = {
   },
 
   testNewFile_downloadBeforeOpen_openLocalOnTimeOut_existing: async function () {
-    //This is a regression test.  If one were to logout before the openLocalRealm timeout
-    //then the timeout would try to open a local realm with the timed out user
+    // This is a regression test.  If one were to logout before the openLocalRealm timeout
+    // then the timeout would try to open a local realm with the timed out user
 
     // 1. Add data to server Realm from User
     // 2. Open Realm again with User
@@ -383,8 +383,6 @@ module.exports = {
       };
 
       const realm = await Realm.open(config);
-
-      console.log(realm.path);
 
       realm.write(() => {
         realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Lola" });

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -357,7 +357,9 @@ module.exports = {
   },
 
   testNewFile_downloadBeforeOpen_openLocalOnTimeOut_existing: async function () {
-    // This is a regression test.  If one were to logout before the openLocalRealm timeout
+    // This is a regression test for the following issue:
+    // https://github.com/realm/realm-js/issues/4453
+    // If one were to logout before the openLocalRealm timeout
     // then the timeout would try to open a local realm with the timed out user
 
     // 1. Add data to server Realm from User

--- a/tests/js/open-behavior-tests.js
+++ b/tests/js/open-behavior-tests.js
@@ -356,6 +356,70 @@ module.exports = {
     }
   },
 
+  testNewFile_downloadBeforeOpen_openLocalOnTimeOut_existing: async function () {
+    //This is a regression test.  If one were to logout before the openLocalRealm timeout
+    //then the timeout would try to open a local realm with the timed out user
+
+    // 1. Add data to server Realm from User
+    // 2. Open Realm again with User
+    // 3. Logout User and run timeout
+    // 4. It should not crash
+
+    const app = new Realm.App(APP_CONFIG);
+    const partitionValue = Utils.genPartition();
+
+    const returningUserCredentials = await Utils.getRegisteredEmailPassCredentials(app);
+
+    {
+      // Add data to the realm with a different user
+      const user = await app.logIn(returningUserCredentials);
+      const config = {
+        schema: [schemas.DogForSync],
+        sync: {
+          user,
+          partitionValue,
+          _sessionStopPolicy: "immediately",
+        },
+      };
+
+      const realm = await Realm.open(config);
+
+      console.log(realm.path);
+
+      realm.write(() => {
+        realm.create(schemas.DogForSync.name, { _id: new ObjectId(), name: "Lola" });
+      });
+
+      await realm.syncSession.uploadAllLocalChanges();
+
+      realm.close();
+      await user.logOut();
+    }
+
+    {
+      const user = await app.logIn(returningUserCredentials);
+      const config = {
+        schema: [schemas.DogForSync],
+        sync: {
+          user,
+          partitionValue,
+          _sessionStopPolicy: "immediately",
+          existingRealmFileBehavior: {
+            type: "downloadBeforeOpen",
+            timeOut: 1000,
+            timeOutBehavior: "openLocalRealm",
+          },
+        },
+      };
+      await Realm.open(config);
+
+      await user.logOut();
+
+      // Wait for the timeout to run.  This used to crash, since it opens a local realm with a logged out user.
+      await new Promise((resolve) => setTimeout(() => resolve(), 2000));
+    }
+  },
+
   testExistingFile_downloadBeforeOpen_openLocalOnTimeOut: async function () {
     // 1. Open empty Realm
     // 2. Close Realm


### PR DESCRIPTION
## What, How & Why?

When opening Realm again with the same user and the timeOutBehaviour "openLocalRealm", logging the user out immediately would crash as the timeout event would try and open a local realm with the logged out user session.

This closes #4453

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
