### PR TITLE
Hermes: Adding an index.native.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Changed "react-native" main field to point to a `lib/index.native.js` file to help bundlers pick the right file when loading our library on React Native. ([#4459](https://github.com/realm/realm-js/issues/4459))
+
+### Compatibility
+* MongoDB Realm Cloud.
+* Realm Studio v11.0.0.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.
+* File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+
+### Internal
+* <Either mention core version or upgrade>
+* <Using Realm Core vX.Y.Z>
+* <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+
 10.20.0-beta.3 Release notes (2022-3-24)
 =============================================================
 ### Notes

--- a/lib/index.native.js
+++ b/lib/index.native.js
@@ -1,0 +1,20 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+const { Realm } = require("./react-native");
+module.exports = Realm;

--- a/lib/react-native/index.js
+++ b/lib/react-native/index.js
@@ -18,6 +18,9 @@
 
 import { Platform, NativeModules } from "react-native";
 
+import utils from "../utils";
+import extend from "../extensions";
+
 //switch how babel transpiled code creates children objects.
 //Inheriting from Realm.Object with class syntax does not support using Reflect.construct the way babel transpiles it.
 //Defining Reflect.construct.sham makes the transpiled code use different standard mechanism for inheriting. (Function.apply with setPrototypeOf)
@@ -39,7 +42,7 @@ if (Platform.OS === "android") {
 
 // TODO: Remove the need to store Realm as a global
 // @see https://github.com/realm/realm-js/issues/2126
-const Realm = globalThis.Realm;
+export const Realm = globalThis.Realm;
 
 // Otherwise, we must be in a "normal" react native situation.
 // In that case, the Realm type should have been injected by the native code.
@@ -50,10 +53,7 @@ if (typeof Realm === "undefined") {
   );
 }
 
-require("../extensions")(Realm);
+extend(Realm);
 
-const utils = require("../utils");
 const versions = utils.getVersions();
 Realm.App._setVersions(versions);
-
-module.exports = Realm;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "types": "types/index.d.ts",
   "main": "lib/index.js",
-  "react-native": "lib/react-native/index.js",
+  "react-native": "lib/index.native.js",
   "files": [
     "cmake",
     "lib",


### PR DESCRIPTION
## What, How & Why?

This closes #4459 by re-exporting the `lib/react-native/index.js` from `lib/index.native.js` to help bundler that does not respect the `react-native` main field but instead relies on ["Native-specific extensions"](https://reactnative.dev/docs/platform-specific-code).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually, locally)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
