### PR TITLE
@realm/react AppProvider and useApp

### DIFF
--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -1,10 +1,10 @@
 import React, {useEffect, useMemo} from 'react';
+import {useApp} from '@realm/react';
+import {StyleSheet, Text} from 'react-native';
 
 import {Task} from './models/Task';
 import {TaskRealmContext} from './models';
 import {TaskManager} from './components/TaskManager';
-import {useApp} from '@realm/react';
-import {StyleSheet, Text} from 'react-native';
 
 const {useRealm, useQuery} = TaskRealmContext;
 

--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -3,6 +3,8 @@ import React, {useEffect, useMemo} from 'react';
 import {Task} from './models/Task';
 import {TaskRealmContext} from './models';
 import {TaskManager} from './components/TaskManager';
+import {useApp} from '@realm/react';
+import {StyleSheet, Text} from 'react-native';
 
 const {useRealm, useQuery} = TaskRealmContext;
 
@@ -12,6 +14,7 @@ type AppProps = {
 
 export const AppSync: React.FC<AppProps> = ({userId}) => {
   const realm = useRealm();
+  const app = useApp();
   const result = useQuery(Task);
 
   const tasks = useMemo(() => result.sorted('createdAt'), [result]);
@@ -22,5 +25,17 @@ export const AppSync: React.FC<AppProps> = ({userId}) => {
     });
   }, [realm, result]);
 
-  return <TaskManager tasks={tasks} userId={userId} />;
+  return (
+    <>
+      <Text style={styles.idText}>Syncing with app id: {app.id}</Text>
+      <TaskManager tasks={tasks} userId={userId} />
+    </>
+  );
 };
+
+const styles = StyleSheet.create({
+  idText: {
+    color: '#999',
+    paddingHorizontal: 20,
+  },
+});

--- a/example/app/AppWrapperSync.tsx
+++ b/example/app/AppWrapperSync.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react';
-import {Realm} from '@realm/react';
+import {Realm, AppProvider} from '@realm/react';
 import {Pressable, SafeAreaView, StyleSheet, Text} from 'react-native';
 
 import {TaskRealmContext} from './models';
@@ -88,14 +88,16 @@ export const AppWrapperSync: React.FC<{
   // If we are logged in, add the sync configuration the the RealmProvider and render the app
   return (
     <SafeAreaView style={styles.screen}>
-      <RealmProvider sync={{user, flexible: true}}>
-        <AppSync userId={app.currentUser.id} />
-        <Pressable style={styles.authButton} onPress={handleLogout}>
-          <Text style={styles.authButtonText}>
-            Logout {app.currentUser.profile.email}
-          </Text>
-        </Pressable>
-      </RealmProvider>
+      <AppProvider id={appId}>
+        <RealmProvider sync={{user, flexible: true}}>
+          <AppSync userId={app.currentUser.id} />
+          <Pressable style={styles.authButton} onPress={handleLogout}>
+            <Text style={styles.authButtonText}>
+              Logout {app.currentUser.profile.email}
+            </Text>
+          </Pressable>
+        </RealmProvider>
+      </AppProvider>
     </SafeAreaView>
   );
 };

--- a/example/app/components/TaskList.tsx
+++ b/example/app/components/TaskList.tsx
@@ -6,9 +6,9 @@ import {Task} from '../models/Task';
 import {TaskItem} from './TaskItem';
 
 type TaskListProps = {
-  tasks: Realm.Results<Task> | [];
-  onToggleTaskStatus: (task: Task) => void;
-  onDeleteTask: (task: Task) => void;
+  tasks: Realm.Results<Task & Realm.Object>;
+  onToggleTaskStatus: (task: Task & Realm.Object) => void;
+  onDeleteTask: (task: Task & Realm.Object) => void;
 };
 
 export const TaskList: React.FC<TaskListProps> = ({

--- a/example/app/components/TaskManager.tsx
+++ b/example/app/components/TaskManager.tsx
@@ -36,7 +36,7 @@ export const TaskManager: React.FC<{
   );
 
   const handleToggleTaskStatus = useCallback(
-    (task: Task): void => {
+    (task: Task & Realm.Object): void => {
       realm.write(() => {
         // Normally when updating a record in a NoSQL or SQL database, we have to type
         // a statement that will later be interpreted and used as instructions for how
@@ -60,7 +60,7 @@ export const TaskManager: React.FC<{
   );
 
   const handleDeleteTask = useCallback(
-    (task: Task): void => {
+    (task: Task & Realm.Object): void => {
       realm.write(() => {
         realm.delete(task);
 

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: false,
+  enabled: true,
   // Add your Realm App ID here if sync is enabled.
-  appId: '<Your App ID>',
+  appId: 'realmtemplate-waxdf',
 };

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: true,
+  enabled: Boolean(process.env.TEMPLATE_SYNC_ENABLED) || false,
   // Add your Realm App ID here if sync is enabled.
-  appId: 'realmtemplate-waxdf',
+  appId: process.env.TEMPLATE_APP_ID || '<Your App ID>',
 };

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: Boolean(process.env.TEMPLATE_SYNC_ENABLED) || false,
+  enabled: process.env.TEMPLATE_SYNC_ENABLED === '1' || false,
   // Add your Realm App ID here if sync is enabled.
   appId: process.env.TEMPLATE_APP_ID || '<Your App ID>',
 };

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: process.env.TEMPLATE_SYNC_ENABLED === '1' || false,
+  enabled: false,
   // Add your Realm App ID here if sync is enabled.
-  appId: process.env.TEMPLATE_APP_ID || '<Your App ID>',
+  appId: '<Your App ID>',
 };

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,7 +1,26 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add AppProvider and useApp hook.  Usage example:
+```
+import {AppProvider} from '@realm/react'
+//...
+// Wrap your RealmProvider with the AppProvider and provide an appId
+<AppProvider id={appId}>
+	<RealmProvider sync={{user, flexible: true}}>
+	//...
+	</RealmProvider>
+</AppProvider>
+
+// Access the app instance using the useApp hook
+import {useApp} from '@realm/react'
+
+const SomeComponent = () => {
+	const app = useApp()
+
+	//...
+}
+```
 
 ### Fixed
 * Fixed potential "Cannot create asynchronous query while in a write transaction" error with `useObject` due to adding event listeners while in a write transaction ([#4375](https://github.com/realm/realm-js/issues/4375), since v0.1.0)

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -263,3 +263,32 @@ const [user, setUser] = useState()
 
 <RealmProvider sync={user, partition}>
 ```
+
+### `useApp` and the `AppProvider`
+
+The `useApp` hook can be used to access your Realm App instance as long as the `AppProvider` wraps your application.  This should be done outside of your `RealmProvider`.
+
+`AppProvider` usage:
+
+```tsx
+import { AppProvider } from '@realm/react'
+//...
+// Wrap your RealmProvider with the AppProvider and provide an appId
+<AppProvider id={appId}>
+	<RealmProvider sync={{user, flexible: true}}>
+	//...
+	</RealmProvider>
+</AppProvider>
+```
+
+`useApp` usage:
+```tsx
+// Access the app instance using the useApp hook
+import { useApp } from '@realm/react'
+
+const SomeComponent = () => {
+	const app = useApp();
+
+	//...
+}
+```

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -55,8 +55,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps 
   // Support for a possible change in configuration
   useEffect(() => {
     try {
-      const openApp = new Realm.App(configuration.current);
-      setApp(openApp);
+      const app = new Realm.App(configuration.current);
+      setApp(app);
     } catch (err) {
       console.error(err);
     }
@@ -72,7 +72,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps 
  */
 export const useApp = (): Realm.App => {
   const context = useContext(AppContext);
-  if (context == null) {
+  if (context === null) {
     throw new Error("AppContext not found.  Did you wrap your app in AppProvider?");
   }
   return context;

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -20,7 +20,7 @@ import React, { createContext, useContext, useEffect, useRef, useState } from "r
 import Realm from "realm";
 
 /**
- * Create a context to hold Realm.app.  Should be accessed with the useApp hook
+ * Create a context containing the Realm app.  Should be accessed with the useApp hook.
  */
 const AppContext = createContext<Realm.App | null>(null);
 

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+import { isEqual } from "lodash";
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import Realm from "realm";
+
+/**
+ * Create a context to hold Realm.app.  Should be accessed with the useApp hook
+ */
+const AppContext = createContext<Realm.App | null>(null);
+
+/**
+ * Props for the AppProvider component. These replicate the options which
+ * can be used to create a Realm.App instance:
+ * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
+ */
+type AppProviderProps = Realm.AppConfiguration;
+
+/**
+ * React component providing a Realm App instance on the context for the
+ * sync hooks to use. An `AppProvider` is required for an app to use the hooks.
+ */
+export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps }) => {
+  const configuration = useRef<Realm.AppConfiguration>(appProps);
+
+  const [app, setApp] = useState<Realm.App>(new Realm.App(configuration.current));
+
+  // We increment `configVersion` when a config override passed as a prop
+  // changes, which triggers a `useEffect` to overwrite the current App with the
+  // new config
+  const [configVersion, setConfigVersion] = useState(0);
+
+  useEffect(() => {
+    if (!isEqual(appProps, configuration.current)) {
+      configuration.current = appProps;
+      setConfigVersion((x) => x + 1);
+    }
+  }, [appProps]);
+
+  // Support for a possible change in configuration
+  useEffect(() => {
+    try {
+      const openApp = new Realm.App(configuration.current);
+      setApp(openApp);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [configVersion, setApp]);
+
+  return <AppContext.Provider value={app}>{children}</AppContext.Provider>;
+};
+
+/**
+ * Hook to access the current {@link Realm.App} from the {@link AppProvider} context.
+ *
+ * @throws if an AppProvider does not exist in the component’s ancestors
+ */
+export const useApp = (): Realm.App => {
+  const context = useContext(AppContext);
+  if (context == null) {
+    throw new Error("AppContext not found.  Did you wrap your app in AppProvider?");
+  }
+  return context;
+};

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -32,6 +32,12 @@ describe("AppProvider", () => {
     const app = result.current;
     expect(app.id).toBe("someId");
   });
+
+  it("throws useApp is used without having the AppProvider is rendered", () => {
+    const { result } = renderHook(() => useApp());
+    expect(() => result.current).toThrow();
+  });
+
   it("handle state changes to its configuration", async () => {
     const AppComponent = () => {
       const app = useApp();
@@ -61,7 +67,7 @@ describe("AppProvider", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    // Changing the realm provider configuration will cause a comlete new remount
+    // Changing the realm provider configuration will cause a remount
     // of the child component.  Therefore it must be retreived again
     const newSchemaNameContainer = getByTestId("appId");
 

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+import React, { useState } from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { AppProvider, useApp } from "../AppProvider";
+import { View, Text, Button } from "react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+
+describe("AppProvider", () => {
+  it("returns the configured app with useApp", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AppProvider id="someId" app={{ name: "someName", version: "42" }} baseUrl="someurl">
+        {children}
+      </AppProvider>
+    );
+    const { result } = renderHook(() => useApp(), { wrapper });
+    const app = result.current;
+    expect(app.id).toBe("someId");
+  });
+  it("handle state changes to its configuration", async () => {
+    const AppComponent = () => {
+      const app = useApp();
+      return <Text testID="appId">{app.id}</Text>;
+    };
+    const App = () => {
+      const [id, setId] = useState("someId");
+      return (
+        <>
+          <View testID="firstRealmProvider">
+            <AppProvider id={id}>
+              <AppComponent />
+            </AppProvider>
+          </View>
+          <Button testID="changeId" title="change app id" onPress={() => setId("newId")} />
+        </>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    const schemaNameContainer = await waitFor(() => getByTestId("appId"));
+    const changeSchemaButton = getByTestId("changeId");
+
+    expect(schemaNameContainer).toHaveTextContent("someId");
+
+    await act(async () => {
+      fireEvent.press(changeSchemaButton);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Changing the realm provider configuration will cause a comlete new remount
+    // of the child component.  Therefore it must be retreived again
+    const newSchemaNameContainer = getByTestId("appId");
+
+    expect(newSchemaNameContainer).toHaveTextContent("newId");
+  });
+});

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -142,3 +142,4 @@ export const createRealmContext: (realmConfig?: Realm.Configuration) => RealmCon
 };
 
 export { Realm };
+export * from "./AppProvider";

--- a/packages/realm-react/src/useRealm.tsx
+++ b/packages/realm-react/src/useRealm.tsx
@@ -39,7 +39,7 @@ export const createUseRealm = (RealmContext: React.Context<Realm | null>) => {
   return function useRealm(): Realm {
     // This is the context setup by `createRealmContext`
     const context = useContext(RealmContext);
-    if (context == null) {
+    if (context === null) {
       throw new Error("Realm context not found.  Did you call useRealm() within a <RealmProvider/>?");
     }
     return context;


### PR DESCRIPTION

## What, How & Why?
Create a provider component that opens a Realm.App with a given
configuration.
Create a hook to access the app component.

This closes # ???

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
