### PR TITLE
Update build script to use Xcode 12.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -163,7 +163,7 @@ jobs:
             build-configuration: catalyst
     env:
       # Pin the Xcode version
-      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * Fixed issue where React Native apps would sometimes show stale Realm data until the user interacted with the app UI ([#4389](https://github.com/realm/realm-js/issues/4389), since v10.0.0)
 * Fixed race condition leading to potential crash when hot reloading an app using Realm Sync ([4509](https://github.com/realm/realm-js/pull/4509), since v10.12.0)
+* Updated build script to use Xcode 12.4 to ensure xcframework is Bitcode compatibile with older versions ([#4462](https://github.com/realm/realm-js/issues/4462), since v10.0.0)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v10.10.1).
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,11 +259,14 @@ def buildWindows(nodeVersion, arch) {
 
 def buildiOS() {
   return buildMacOS {
-    sh './scripts/build-iOS.sh -c Release'
-      dir('react-native/ios') {
-      // Uncomment this when testing build changes if you want to be able to download pre-built artifacts from Jenkins.
-      // archiveArtifacts('realm-js-ios.xcframework/**')
-      stash includes: 'realm-js-ios.xcframework/**', name: 'realm-js-ios.xcframework'
+    withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
+          'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-12.4.app']) {
+      sh './scripts/build-iOS.sh -c Release'
+        dir('react-native/ios') {
+        // Uncomment this when testing build changes if you want to be able to download pre-built artifacts from Jenkins.
+        // archiveArtifacts('realm-js-ios.xcframework/**')
+        stash includes: 'realm-js-ios.xcframework/**', name: 'realm-js-ios.xcframework'
+      }
     }
   }
 }
@@ -494,7 +497,8 @@ def testLinux(target, postStep = null, Boolean enableSync = false) {
 def testMacOS(target, postStep = null) {
   return {
     node('osx_vegas') {
-      withEnv(['DEVELOPER_DIR=/Applications/Xcode-12.2.app/Contents/Developer',
+      withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
+               'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-12.4.app',
                'REALM_SET_NVM_ALIAS=1',
                'REALM_DISABLE_SYNC_TESTS=1',
                'npm_config_realm_local_prebuilds=prebuilds']) {

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -87,11 +87,11 @@ mkdir -p build
 pushd build
 
 # Configure CMake project
-cmake "$PROJECT_ROOT" -GXcode \
+SDKROOT="${SDK_ROOT_OVERRIDE:-/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/}" cmake "$PROJECT_ROOT" -GXcode \
     -DCMAKE_TOOLCHAIN_FILE="$PROJECT_ROOT/vendor/realm-core/tools/cmake/xcode.toolchain.cmake" \
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="$(pwd)/out/$<CONFIG>\$EFFECTIVE_PLATFORM_NAME" \
 
-xcodebuild build \
+DEVELOPER_DIR="${DEVELOPER_DIR_OVERRIDE:-/Applications/Xcode_12.4.app}" xcodebuild build \
     -scheme realm-js-ios \
     "${DESTINATIONS[@]}" \
     -configuration $CONFIGURATION \

--- a/tests/ReactTestApp/ios/ReactTestApp.xcodeproj/project.pbxproj
+++ b/tests/ReactTestApp/ios/ReactTestApp.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -461,6 +462,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -486,6 +488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -514,6 +517,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 12.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -533,7 +537,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "$(SRCROOT)/../../../scripts/ccache-clang.sh";
-				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -564,6 +567,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
@@ -598,7 +602,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CC = "$(SRCROOT)/../../../scripts/ccache-clang.sh";
-				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -629,6 +632,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				CXX = "$(SRCROOT)/../../../scripts/ccache-clang++.sh";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";


### PR DESCRIPTION
## What, How & Why?

We need to build our xcframework with the oldest version of Xcode which we support – Bitcode from a newer Xcode cannot be used with an old version. This aligns with the minimum Xcode version supported by the Swift team.
 
## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
