### PR TITLE
Update package.json to include a `unpkg` field

### DIFF
--- a/packages/realm-web/README.md
+++ b/packages/realm-web/README.md
@@ -19,7 +19,7 @@ npm install realm-web
 As a script-tag in the head of a browser:
 
 ```html
-<script src="https://unpkg.com/realm-web@1.7.0/dist/bundle.iife.js"></script>
+<script src="https://unpkg.com/realm-web@1.7.0"></script>
 ```
 
 ## Caveats / limitations

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.es.js",
   "types": "./dist/bundle.d.ts",
+  "unpkg": "./dist/bundle.iife.js",
   "browser": {
     "./dist/bundle.cjs.js": "./dist/bundle.dom.cjs.js",
     "./dist/bundle.es.js": "./dist/bundle.dom.es.js"

--- a/packages/realm-web/scripts/postversion.ts
+++ b/packages/realm-web/scripts/postversion.ts
@@ -30,7 +30,7 @@ const changelogPath = path.resolve(__dirname, "../CHANGELOG.md");
 
 // Update the readme file to use the new version in the script-tag.
 const readmeContent = fs.readFileSync(readmePath, "utf8");
-const readmeContentReplaced = readmeContent.replace(/realm-web@[^/]+/, `realm-web@${version}`);
+const readmeContentReplaced = readmeContent.replace(/realm-web@[^"/]+/, `realm-web@${version}`);
 fs.writeFileSync(readmePath, readmeContentReplaced);
 
 // Update the changelog with the current version and date


### PR DESCRIPTION
## What, How & Why?

This adds a `unpkg` field to the package.json to simplify the URL users need to paste when consuming the IIFE bundle using unpkg.com.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
