### PR TITLE
Make test ready for node 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
-* Improved documentation for `Realm.copyBundledRealmFiles`
+* Improved documentation for `Realm.copyBundledRealmFiles`.
+* Updated a test to be ready for node 18.
 
 10.16.0 Release notes (2022-4-12)
 =============================================================

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -72,9 +72,10 @@ module.exports = {
           return reject(`Able to log in with config ${JSON.stringify(conf)}`);
         })
         .catch((err) => {
-          TestCase.assertEqual(
-            err.message,
-            "request to http://localhost:9999/api/client/v2.0/app/smurf/location failed, reason: connect ECONNREFUSED 127.0.0.1:9999",
+          TestCase.assertTrue(
+            err.message.startsWith(
+              "request to http://localhost:9999/api/client/v2.0/app/smurf/location failed, reason: connect ECONNREFUSED",
+            ),
           );
           return resolve();
         });


### PR DESCRIPTION
## What, How & Why?
It looks like node 18 will report IPv6 addresses instead or IPv4 addresses in error messages.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
