### PR TITLE
Close sync sessions on hot reload to prevent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * Fixed issue where React Native apps would sometimes show stale Realm data until the user interacted with the app UI ([#4389](https://github.com/realm/realm-js/issues/4389), since v10.0.0)
+* Fixed race condition leading to potential crash when hot reloading an app using Realm Sync ([4509](https://github.com/realm/realm-js/pull/4509), since v10.12.0)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v10.10.1).
 

--- a/react-native/ios/RealmReact/RealmReact.mm
+++ b/react-native/ios/RealmReact/RealmReact.mm
@@ -30,6 +30,8 @@
 #import <netdb.h>
 #import <net/if.h>
 
+#import <thread>
+
 #if DEBUG
 #include <realm-js-ios/rpc.hpp>
 #import "GCDWebServer.h"
@@ -267,7 +269,14 @@ RCT_REMAP_METHOD(emit, emitEvent:(NSString *)eventName withObject:(id)object) {
 #endif
 
 - (void)invalidate {
+#if DEBUG
+    // Immediately close any open sync sessions to prevent race condition with new JS thread 
+    // when hot reloading
+    RJSCloseSyncSessions();
+#endif
+
     RJSInvalidateCaches();
+
 #if DEBUG
     // shutdown rpc if in chrome debug mode
     [self shutdownRPC];

--- a/src/jsc/jsc_init.cpp
+++ b/src/jsc/jsc_init.cpp
@@ -69,4 +69,14 @@ void RJSInvalidateCaches()
     realm::app::App::clear_cached_apps();
 }
 
+// Note: This must be called before RJSInvalidateCaches, otherwise the app cache
+// will have been cleared and so no sync sessions will be closed
+void RJSCloseSyncSessions()
+{
+    // Force all sync sessions to close immediately. This prevents the new JS thread
+    // from opening a new sync session while the old one is still active when reloading
+    // in dev mode.
+    realm::app::App::close_all_sync_sessions();
+}
+
 } // extern "C"

--- a/src/jsc/jsc_init.h
+++ b/src/jsc/jsc_init.h
@@ -28,6 +28,7 @@ extern "C" {
 JSObjectRef RJSConstructorCreate(JSContextRef ctx);
 void RJSInitializeInContext(JSContextRef ctx, std::function<void()> flush_ui_queue);
 void RJSInvalidateCaches();
+void RJSCloseSyncSessions();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## ⚠️ Note: This will need a new core release before merge

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes #4506.
 
This helps prevent a race condition when hot reloading a React Native app which uses sync which led to a `Multiple sync agents attempted to join the same session` exception, by immediately closing any sync sessions when the hot reload is requested (more details in the corresponding core PR, https://github.com/realm/realm-core/pull/5411).

There is still an issue where if you disable sync for your app and hot reload after the initial load, you hit the exception. This needs more investigation, no reference to the Realm is being kept around in the `RealmCoordinator` in that case – perhaps a core issue, but hopefully an edge case.

## How to test

To reproduce the problem prior to this change:
1. Open a sync app
2. Disable sync
3. Hot reload (press "R" in the React Native packager window)
4. You should hit the exception

After this change, the hot reload should be successful.

Note that this is just an easy way to trigger this condition, it can (and has) been hit in normal usage if the sync client takes longer to finish its current upload than the RN app takes to restart.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
