### PR TITLE
Add `--forceExit` to realm-react tests as they are sometimes hanging with open handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Improved documentation for `Realm.copyBundledRealmFiles`.
 * Updated a test to be ready for node 18.
+* @realm/react tests run with `--forceExit` to prevent them hanging ([#4531](https://github.com/realm/realm-js/pull/4531))
 
 10.16.0 Release notes (2022-4-12)
 =============================================================

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
-    "test": "jest",
+    "test": "jest --forceExit",
     "lint": "eslint --ext .tsx ."
   },
   "dependencies": {


### PR DESCRIPTION
## What, How & Why?

Brute force fix for https://github.com/realm/realm-js/issues/4530 as it is blocking us

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
