### PR TITLE
Remove deprecated keys from the React Native config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Added missing type definitions for `newRealmFileBehavior` and `existingRealmFileBehavior` when opening a flexible sync Realm ([#4467](https://github.com/realm/realm-js/issues/4467), since v10.12.0)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v10.10.1).
+* Fixed buildtime error where our package would be ignored due to use of the deprecated `podspecPath` and `sharedLibraries` keys in the `react-native.config.js`. ([#4553](https://github.com/realm/realm-js/issues/4553))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -18,8 +18,6 @@
 
 /* eslint-env node */
 
-const path = require("path");
-
 module.exports = {
   // config for a library is scoped under "dependency" key
   dependency: {

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -27,10 +27,7 @@ module.exports = {
       android: {
         sourceDir: "./react-native/android",
       },
-      ios: {
-        podspecPath: path.resolve(__dirname, "RealmJS.podspec"),
-        sharedLibraries: ["libc++", "libz"],
-      },
+      ios: {},
     },
   },
 };


### PR DESCRIPTION
## What, How & Why?

This closes #4553.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (I manually build an app with this config)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
