### PR TITLE
UserProvider and useUser

### DIFF
--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -1,19 +1,19 @@
-import React, {useEffect, useMemo} from 'react';
-import {useApp} from '@realm/react';
-import {StyleSheet, Text} from 'react-native';
+import React, {useCallback, useEffect, useMemo} from 'react';
+import {useApp, useUser} from '@realm/react';
+import {Pressable, StyleSheet, Text} from 'react-native';
 
 import {Task} from './models/Task';
 import {TaskRealmContext} from './models';
 import {TaskManager} from './components/TaskManager';
+import {buttonStyles} from './styles/button';
+import {shadows} from './styles/shadows';
+import colors from './styles/colors';
 
 const {useRealm, useQuery} = TaskRealmContext;
 
-type AppProps = {
-  userId: string;
-};
-
-export const AppSync: React.FC<AppProps> = ({userId}) => {
+export const AppSync: React.FC = () => {
   const realm = useRealm();
+  const user = useUser();
   const app = useApp();
   const result = useQuery(Task);
 
@@ -21,14 +21,22 @@ export const AppSync: React.FC<AppProps> = ({userId}) => {
 
   useEffect(() => {
     realm.subscriptions.update(mutableSubs => {
-      mutableSubs.add(result);
+      mutableSubs.add(realm.objects(Task));
     });
   }, [realm, result]);
+
+  const handleLogout = useCallback(() => {
+    user?.logOut();
+  }, [user]);
 
   return (
     <>
       <Text style={styles.idText}>Syncing with app id: {app.id}</Text>
-      <TaskManager tasks={tasks} userId={userId} />
+      <TaskManager tasks={tasks} userId={user?.id} />
+      <Pressable style={styles.authButton} onPress={handleLogout}>
+        <Text
+          style={styles.authButtonText}>{`Logout ${user?.profile.email}`}</Text>
+      </Pressable>
     </>
   );
 };
@@ -37,5 +45,13 @@ const styles = StyleSheet.create({
   idText: {
     color: '#999',
     paddingHorizontal: 20,
+  },
+  authButton: {
+    ...buttonStyles.button,
+    ...shadows,
+    backgroundColor: colors.purpleDark,
+  },
+  authButtonText: {
+    ...buttonStyles.text,
   },
 });

--- a/example/app/AppWrapperSync.tsx
+++ b/example/app/AppWrapperSync.tsx
@@ -1,102 +1,26 @@
-import React, {useCallback, useRef, useState} from 'react';
-import {Realm, AppProvider} from '@realm/react';
-import {Pressable, SafeAreaView, StyleSheet, Text} from 'react-native';
+import React from 'react';
+import {AppProvider, UserProvider} from '@realm/react';
+import {SafeAreaView, StyleSheet} from 'react-native';
 
 import {TaskRealmContext} from './models';
-import {LoginScreen, AuthState} from './components/LoginScreen';
+import {LoginScreen} from './components/LoginScreen';
 import colors from './styles/colors';
 import {AppSync} from './AppSync';
-import {buttonStyles} from './styles/button';
-import {shadows} from './styles/shadows';
 
 export const AppWrapperSync: React.FC<{
   appId: string;
 }> = ({appId}) => {
   const {RealmProvider} = TaskRealmContext;
 
-  // Set up the Realm app
-  const app = useRef(new Realm.App({id: appId})).current;
-
-  // Store the logged in user in state so that we know when to render the login screen and
-  // when to render the app. This will be null the first time you start the app, but on future
-  // startups, the logged in user will persist.
-  const [user, setUser] = useState<Realm.User | null>(app.currentUser);
-
-  const [authState, setAuthState] = useState(AuthState.None);
-  const [authVisible, setAuthVisible] = useState(false);
-
-  // If the user presses "login" from the auth screen, try to log them in
-  // with the supplied credentials
-  const handleLogin = useCallback(
-    async (email: string, password: string) => {
-      setAuthState(AuthState.Loading);
-      const credentials = Realm.Credentials.emailPassword(email, password);
-
-      try {
-        setUser(await app.logIn(credentials));
-        setAuthVisible(false);
-        setAuthState(AuthState.None);
-      } catch (e) {
-        console.log('Error logging in', e);
-        setAuthState(AuthState.LoginError);
-      }
-    },
-    [setAuthState, setUser, setAuthVisible, app],
-  );
-
-  // If the user presses "register" from the auth screen, try to register a
-  // new account with the  supplied credentials and login as the newly created user
-  const handleRegister = useCallback(
-    async (email: string, password: string) => {
-      setAuthState(AuthState.Loading);
-
-      try {
-        // Register the user...
-        await app.emailPasswordAuth.registerUser({email, password});
-        // ...then login with the newly created user
-        const credentials = Realm.Credentials.emailPassword(email, password);
-
-        setUser(await app.logIn(credentials));
-        setAuthVisible(false);
-        setAuthState(AuthState.None);
-      } catch (e) {
-        console.log('Error registering', e);
-        setAuthState(AuthState.RegisterError);
-      }
-    },
-    [setAuthState, app],
-  );
-
-  // If the user presses "logout", unset the user in state and log the user out
-  // of the Realm app
-  const handleLogout = useCallback(() => {
-    setUser(null);
-    app.currentUser?.logOut();
-  }, [setUser, app]);
-
-  // If we are not logged in show the login screen
-  if (authVisible || !user || !app.currentUser) {
-    return (
-      <LoginScreen
-        onLogin={handleLogin}
-        onRegister={handleRegister}
-        authState={authState}
-      />
-    );
-  }
-
   // If we are logged in, add the sync configuration the the RealmProvider and render the app
   return (
     <SafeAreaView style={styles.screen}>
       <AppProvider id={appId}>
-        <RealmProvider sync={{user, flexible: true}}>
-          <AppSync userId={app.currentUser.id} />
-          <Pressable style={styles.authButton} onPress={handleLogout}>
-            <Text style={styles.authButtonText}>
-              Logout {app.currentUser.profile.email}
-            </Text>
-          </Pressable>
-        </RealmProvider>
+        <UserProvider fallback={LoginScreen}>
+          <RealmProvider sync={{flexible: true}}>
+            <AppSync />
+          </RealmProvider>
+        </UserProvider>
       </AppProvider>
     </SafeAreaView>
   );
@@ -106,14 +30,6 @@ const styles = StyleSheet.create({
   screen: {
     flex: 1,
     backgroundColor: colors.darkBlue,
-  },
-  authButton: {
-    ...buttonStyles.button,
-    ...shadows,
-    backgroundColor: colors.purpleDark,
-  },
-  authButtonText: {
-    ...buttonStyles.text,
   },
 });
 

--- a/example/ios/RealmTsTemplate.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/RealmTsTemplate.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: false,
+  enabled: true,
   // Add your Realm App ID here if sync is enabled.
-  appId: '<Your App ID>',
+  appId: 'realmtemplate-waxdf',
 };

--- a/example/sync.config.js
+++ b/example/sync.config.js
@@ -1,6 +1,6 @@
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
-  enabled: true,
+  enabled: false,
   // Add your Realm App ID here if sync is enabled.
-  appId: 'realmtemplate-waxdf',
+  appId: '<Your App ID>',
 };

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,6 +1,29 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
+* Add UserProvider and useUser hook. Usage example:
+```
+import {AppProvider, UserProvider} from '@realm/react'
+//...
+// Wrap your RealmProvider with the AppProvider and provide an appId
+<AppProvider id={appId}>
+	<UserProvider fallback={LoginComponent}>
+		{/* After login, user will be automatically populated in realm configuration */}
+		<RealmProvider sync={{flexible: true}}>
+		//...
+		</RealmProvider>
+	</UserProvider>
+</AppProvider>
+
+// Access the app instance using the useApp hook
+import {useUser} from '@realm/react'
+
+const SomeComponent = () => {
+	const user = useUser()
+
+	//...
+}
+```
 * Add AppProvider and useApp hook.  Usage example:
 ```
 import {AppProvider} from '@realm/react'

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -292,3 +292,35 @@ const SomeComponent = () => {
 	//...
 }
 ```
+
+### `useUser` and the `UserProvider`
+
+With the introduction of the `UserProvider`, the `user` can be automatically populated into the underlying Realm configuration.  The `fallback` property can be used to provide a login component.
+The child components will be rendered as soon as a user has authenticated.  On logout, the fallback will be displayed again.
+
+`UserProvider` usage:
+
+```tsx
+import { AppProvider, UserProvider } from '@realm/react'
+//...
+<AppProvider id={appId}>
+	<UserProvider fallback={LoginComponent}>
+		{/* After login, user will be automatically populated in realm configuration */}
+		<RealmProvider sync={{flexible: true}}>
+		//...
+		</RealmProvider>
+	</UserProvider>
+</AppProvider>
+```
+
+`useUser` usage:
+```tsx
+// Access the app instance using the useApp hook
+import { useUser } from '@realm/react'
+
+const SomeComponent = () => {
+	const user = useUser();
+
+	//...
+}
+```

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "realm": ">=10"
+    "realm": ">=10.17.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "realm": ">=10"
+    "realm": ">=10.17.0"
   },
   "optionalDependencies": {
     "@babel/runtime": ">=7",

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -71,9 +71,10 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps 
  * @throws if an AppProvider does not exist in the component’s ancestors
  */
 export const useApp = (): Realm.App => {
-  const context = useContext(AppContext);
-  if (context === null) {
+  const app = useContext(AppContext);
+
+  if (app === null) {
     throw new Error("AppContext not found.  Did you wrap your app in AppProvider?");
   }
-  return context;
+  return app;
 };

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -21,9 +21,7 @@ import Realm from "realm";
 import { isEqual } from "lodash";
 import { useUser } from "./UserProvider";
 
-type PartialRealmConfiguration = {
-  [P in keyof Omit<Realm.Configuration, "sync">]?: Realm.Configuration[P];
-} & {
+type PartialRealmConfiguration = Omit<Partial<Realm.Configuration>, "sync"> & {
   sync?: Partial<Realm.SyncConfiguration>;
 };
 
@@ -92,9 +90,7 @@ export function createRealmProvider(
 
       // If there is a user in the current context and not one set by the props, then use the one from context
       const combinedConfigWithUser =
-        user && !combinedConfig.sync?.user
-          ? mergeRealmConfiguration(combinedConfig, { sync: { user } })
-          : combinedConfig;
+        combinedConfig?.sync && user ? mergeRealmConfiguration({ sync: { user } }, combinedConfig) : combinedConfig;
 
       if (!areConfigurationsIdentical(configuration.current, combinedConfigWithUser)) {
         configuration.current = combinedConfigWithUser;
@@ -151,7 +147,7 @@ export function createRealmProvider(
  * @returns Merged config object
  */
 export function mergeRealmConfiguration(
-  configA: Realm.Configuration,
+  configA: PartialRealmConfiguration,
   configB: PartialRealmConfiguration,
 ): Realm.Configuration {
   // In order to granularly update sync properties on the RealmProvider, sync must be

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+import { useApp } from "./AppProvider";
+
+/**
+ * Create a context containing the Realm app.  Should be accessed with the useApp hook.
+ */
+const UserContext = createContext<Realm.User | null>(null);
+
+type UserProviderProps = {
+  // Optional fallback component to render when unauthenticated
+  fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+};
+
+/**
+ * React component providing a Realm user on the context for the sync hooks
+ * to use. A `UserProvider` is required for an app to use the hooks.
+ */
+export const UserProvider: React.FC<UserProviderProps> = ({ fallback: Fallback, children }) => {
+  const app = useApp();
+  const [user, setUser] = useState<Realm.User | null>(null);
+
+  // Support for a possible change in configuration
+  useEffect(() => {
+    if (!app.currentUser || user != app.currentUser) {
+      setUser(app.currentUser);
+    }
+    // Ignoring updates to user, as this would cause a potential infinite loop
+  }, [app, setUser]);
+
+  useEffect(() => {
+    const event = () => {
+      if (app.currentUser !== user) {
+        setUser(app.currentUser);
+      }
+    };
+    user?.addListener(event);
+    app?.addListener(event);
+    return () => {
+      user?.removeListener(event);
+      app?.removeListener(event);
+    };
+  }, [user, app]);
+
+  if (!user) {
+    if (typeof Fallback === "function") {
+      return <Fallback />;
+    }
+    return <>{Fallback}</>;
+  }
+
+  return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+};
+
+/**
+ * Hook to access the currently authenticated Realm user from the
+ * {@link UserProvider} context. The user is stored as React state,
+ * so will trigger a re-render whenever it changes (e.g. logging in,
+ * logging out, switching user).
+ *
+ */
+export const useUser = (): Realm.User | null => {
+  const user = useContext(UserContext);
+
+  return user;
+};

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -143,3 +143,4 @@ export const createRealmContext: (realmConfig?: Realm.Configuration) => RealmCon
 
 export { Realm };
 export * from "./AppProvider";
+export * from "./UserProvider";


### PR DESCRIPTION
## What, How & Why?
Add UserProvider and useUser hook to allow access to the user within any place in the application.

Note: There are no tests, as this is unreasonable to test without actually spinning up a BAAS server.  This is an unrealistic expectation for this work and should be done in a greater effort to refactor tests.  I have, however, throughly tested this with the example application.  If we do start getting bugs, we should find a way to create regression tests.

We will also need a follow up PR to update the Realm dependency as soon as the new release is out, as this is dependent on the new App and User listener events.

This closes #4456

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
