### PR TITLE
Fix for Flexible Sync Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v10.10.1).
 * Fixed buildtime error where our package would be ignored due to use of the deprecated `podspecPath` and `sharedLibraries` keys in the `react-native.config.js`. ([#4553](https://github.com/realm/realm-js/issues/4553))
-* Fixed flexible sync configuration types to be compatible with `strict: false`. ([#4552](https://github.com/realm/realm-js/issues/4552))
+* Fixed flexible sync configuration types to be compatible with Typescript when `strict` mode is disabled. ([#4552](https://github.com/realm/realm-js/issues/4552))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v10.10.1).
 * Fixed buildtime error where our package would be ignored due to use of the deprecated `podspecPath` and `sharedLibraries` keys in the `react-native.config.js`. ([#4553](https://github.com/realm/realm-js/issues/4553))
+* Fixed flexible sync configuration types to be compatible with `strict: false`. ([#4552](https://github.com/realm/realm-js/issues/4552))
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -152,18 +152,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         }).to.throw("'partitionValue' cannot be specified when flexible sync is enabled");
       });
 
-      it("accepts { flexible: false } and a partition value", function () {
-        expect(() => {
-          new Realm({
-            sync: {
-              _sessionStopPolicy: SessionStopPolicy.Immediately,
-              flexible: false,
-              user: this.user,
-              partitionValue: "test",
-            },
-          });
-        }).to.not.throw();
-      });
+      // NOTE: This is not a compatible configuration anymore and will cause a typescript error
+      // it("accepts { flexible: false } and a partition value", function () {
+      //   expect(() => {
+      //     new Realm({
+      //       sync: {
+      //         _sessionStopPolicy: SessionStopPolicy.Immediately,
+      //         flexible: false,
+      //         user: this.user,
+      //         partitionValue: "test",
+      //       },
+      //     });
+      //   }).to.not.throw();
+      // });
 
       it("accepts { flexible: undefined } and a partition value", function () {
         expect(() => {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -152,19 +152,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         }).to.throw("'partitionValue' cannot be specified when flexible sync is enabled");
       });
 
-      // NOTE: This is not a compatible configuration anymore and will cause a typescript error
-      // it("accepts { flexible: false } and a partition value", function () {
-      //   expect(() => {
-      //     new Realm({
-      //       sync: {
-      //         _sessionStopPolicy: SessionStopPolicy.Immediately,
-      //         flexible: false,
-      //         user: this.user,
-      //         partitionValue: "test",
-      //       },
-      //     });
-      //   }).to.not.throw();
-      // });
+      it("accepts { flexible: false } and a partition value", function () {
+        expect(() => {
+          // @ts-expect-error This is not a compatible configuration anymore and will cause a typescript error
+          new Realm({
+            sync: {
+              _sessionStopPolicy: SessionStopPolicy.Immediately,
+              flexible: false,
+              user: this.user,
+              partitionValue: "test",
+            },
+          });
+        }).to.not.throw();
+      });
 
       it("accepts { flexible: undefined } and a partition value", function () {
         expect(() => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,8 +140,10 @@ declare namespace Realm {
         error?: ErrorCallback;
     }
 
-    // Note: Since there really is no use case for {flexible: false}, we are
-    // hard setting this to only allowing "true".
+    // We only allow `flexible` to be `true` or `undefined` - `{ flexible: false }`
+    // is not allowed. This is because TypeScript cannot discriminate that
+    // type correctly with `strictNullChecks` disabled, and there's no real use
+    // case for `{ flexible: false }`.
     interface FlexibleSyncConfiguration extends BaseSyncConfiguration {
         flexible: true;
         partitionValue?: never;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,12 +140,10 @@ declare namespace Realm {
         error?: ErrorCallback;
     }
 
-    // Note: {flexible: boolean} should rather be {flexible: true}, but this was
-    // incompatible with the default tsconfig in Expo (strict: false).
-    // It is possible to set flexible to `false`, but it is not possible to set
-    // flexible and partitionValue in the same config.
+    // Note: Since there really is no use case for {flexible: false}, we are
+    // hard setting this to only allowing "true".
     interface FlexibleSyncConfiguration extends BaseSyncConfiguration {
-        flexible: boolean;
+        flexible: true;
         partitionValue?: never;
         clientReset?: ClientResetConfiguration<ClientResetModeManualOnly>;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,9 +130,8 @@ declare namespace Realm {
         clientResetAfter?: ClientResetAfterCallback;
     }
 
-    interface BaseSyncConfiguration<ClientResetModeT = ClientResetMode>{
+    interface BaseSyncConfiguration{
         user: User;
-        flexible?: boolean | undefined;
         customHttpHeaders?: { [header: string]: string };
         ssl?: SSLConfiguration;
         _sessionStopPolicy?: SessionStopPolicy;
@@ -141,16 +140,18 @@ declare namespace Realm {
         error?: ErrorCallback;
     }
 
-    // Note: This type does not work correctly without strictNullChecks enabled –
-    // a config of { flexible: true } will incorrectly have a type error
+    // Note: {flexible: boolean} should rather be {flexible: true}, but this was
+    // incompatible with the default tsconfig in Expo (strict: false).
+    // It is possible to set flexible to `false`, but it is not possible to set
+    // flexible and partitionValue in the same config.
     interface FlexibleSyncConfiguration extends BaseSyncConfiguration {
-        flexible: true;
+        flexible: boolean;
         partitionValue?: never;
         clientReset?: ClientResetConfiguration<ClientResetModeManualOnly>;
     }
 
     interface PartitionSyncConfiguration extends BaseSyncConfiguration {
-        flexible?: false | undefined;
+        flexible?: never;
         partitionValue: Realm.App.Sync.PartitionValue;
         clientReset?: ClientResetConfiguration<ClientResetMode>;
     }


### PR DESCRIPTION
## What, How & Why?
This makes the flexible boolean incompatible with paritionValue,
without setting tsconfig to false.  It does however not allow,
flexible to be false, but that's a better tradeoff in the end.

This closes #4552

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
