### PR TITLE
Explicitly add children to provider props

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -46,6 +46,7 @@ const SomeComponent = () => {
 ```
 
 ### Fixed
+* Implicit children [was removed from `React.FC`](https://solverfox.dev/writing/no-implicit-children/).  Children has now been explicitly added to provider props. ([#4565](https://github.com/realm/realm-js/issues/4565))
 * Fixed potential "Cannot create asynchronous query while in a write transaction" error with `useObject` due to adding event listeners while in a write transaction ([#4375](https://github.com/realm/realm-js/issues/4375), since v0.1.0)
 
 ### Compatibility

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -29,7 +29,9 @@ const AppContext = createContext<Realm.App | null>(null);
  * can be used to create a Realm.App instance:
  * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
  */
-type AppProviderProps = Realm.AppConfiguration;
+type AppProviderProps = Realm.AppConfiguration & {
+  children: React.ReactNode;
+};
 
 /**
  * React component providing a Realm App instance on the context for the

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -27,6 +27,7 @@ type PartialRealmConfiguration = Omit<Partial<Realm.Configuration>, "sync"> & {
 
 type ProviderProps = PartialRealmConfiguration & {
   fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+  children: React.ReactNode;
 };
 
 /**

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -28,6 +28,7 @@ const UserContext = createContext<Realm.User | null>(null);
 type UserProviderProps = {
   // Optional fallback component to render when unauthenticated
   fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+  children: React.ReactNode;
 };
 
 /**

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -111,7 +111,9 @@ describe("RealmProvider", () => {
           </View>
           {toggleComponent && (
             <View testID="secondRealmProvider">
-              <RealmProvider></RealmProvider>
+              <RealmProvider>
+                <View />
+              </RealmProvider>
             </View>
           )}
           <Button testID="toggle" title="toggle" onPress={() => setToggleComponent(!toggleComponent)} />


### PR DESCRIPTION
## What, How & Why?
Explicitly add children to provider props, as they have been removed in React 18 from `React.FC`.  
More reading on this https://solverfox.dev/writing/no-implicit-children/

This closes #4565

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [x] Chrome debug API is updated if API is available on React Native
