### PR TITLE
Add `initialSubscriptions` sync config option to bootstrap initial set of flexible sync subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add ability to listen to changes to `Realm.App` and `Realm.User`. ([#4455](https://github.com/realm/realm-js/issues/4455))
+* Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function which bootstraps a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs) (#4561[https://github.com/realm/realm-js/pull/4561]).
 
 ### Fixed
 * Fixed issue where React Native apps would sometimes show stale Realm data until the user interacted with the app UI. ([#4389](https://github.com/realm/realm-js/issues/4389), since v10.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Enhancements
 * Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function to bootstrap a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs, using the `rerunOnOpen` flag). (#4561[https://github.com/realm/realm-js/pull/4561])
 
+    Example usage:
+    ```ts
+    const thirtyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 30));
+    const config = {
+      // ...
+      sync: {
+        flexible: true,
+        user,
+        initialSubscriptions: {
+          update: (realm) => {
+            realm.subscriptions.update((subs) => {
+              subs.add(
+                realm.objects("Person").filtered("dateOfBirth > $0", thirtyDaysAgo),
+                // This is a named subscription, so will replace any existing subscription with the same name
+                { name: "People30Days" }
+              );
+            });
+          },
+          rerunOnStartup: true,
+        },
+      },
+    };
+    ```
+
 ### Fixed
 * Flexible sync would not correctly resume syncing if a bootstrap was interrupted. ([realm/realm-core#5466](https://github.com/realm/realm-core/pull/5466), since v10.12.0)
 * The sync client may upload corrupted internal data leading to a fatal error from the sync server. ([realm/realm-core#5460](https://github.com/realm/realm-core/pull/5460), since v10.16.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function which bootstraps a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs). (#4561[https://github.com/realm/realm-js/pull/4561])
+* Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function to bootstrap a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs, using the `rerunOnOpen` flag). (#4561[https://github.com/realm/realm-js/pull/4561])
 
 ### Fixed
 * Flexible sync would not correctly resume syncing if a bootstrap was interrupted. ([realm/realm-core#5466](https://github.com/realm/realm-core/pull/5466), since v10.12.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function which bootstraps a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs). (#4561[https://github.com/realm/realm-js/pull/4561])
 
 ### Fixed
 * Flexible sync would not correctly resume syncing if a bootstrap was interrupted. ([realm/realm-core#5466](https://github.com/realm/realm-core/pull/5466), since v10.12.0)
@@ -22,7 +22,6 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add ability to listen to changes to `Realm.App` and `Realm.User`. ([#4455](https://github.com/realm/realm-js/issues/4455))
-* Added an `initialSubscriptions` option to the `sync` config, which allows users to specify a subscription update function which bootstraps a set of flexible sync subscriptions when the Realm is first opened (or every time the app runs) (#4561[https://github.com/realm/realm-js/pull/4561]).
 
 ### Fixed
 * Fixed issue where React Native apps would sometimes show stale Realm data until the user interacted with the app UI. ([#4389](https://github.com/realm/realm-js/issues/4389), since v10.0.0)

--- a/docs/flexible-sync.js
+++ b/docs/flexible-sync.js
@@ -345,10 +345,14 @@ class SubscriptionSet {
    * // `realm` will now return the expected results based on the updated subscriptions
    * ```
    *
-   * @param {function} callback A callback function which receives a {@link Realm.App.Sync.MutableSubscriptionSet}
-   * instance as its only argument, which can be used to add or remove subscriptions from
-   * the set.
-   * Note: this callback should not be asynchronous.
+   * @param {function} callback A callback function which receives a
+   * {@link Realm.App.Sync.MutableSubscriptionSet} instance as the first
+   * argument, which can be used to add or remove subscriptions from the set,
+   * and the Realm associated with the SubscriptionSet as the second argument
+   * (mainly useful when working with `initialSubscriptions` in
+   * {@link Realm.App.Sync~FlexibleSyncConfiguration}).
+   *
+   * Note: the callback should not be asynchronous.
    *
    * @returns {Promise<void>} A promise which resolves when the SubscriptionSet is synchronized, or is rejected
    * if there was an error during synchronization (see {@link waitForSynchronisation})

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -94,7 +94,7 @@
  * instance to allow you to setup the initial set of subscriptions. See
  * {@link Realm.App.Sync.SubscriptionSet#update} for more information.
  * @property {Boolean} rerunOnOpen - optional flag. If `true`, the
- * {@link updateCallback} will be rerun every time the Realm is opened (e.g.
+ * {@link update} callback will be rerun every time the Realm is opened (e.g.
  * every time a user opens your app), otherwise (by default) it will only be run
  * if the Realm does not yet exist.
  */

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -93,7 +93,7 @@
  * {@link Realm.App.Sync~MutableSubscriptionSet} instance and the {@link Realm}
  * instance to allow you to setup the initial set of subscriptions. See
  * {@link Realm.App.Sync.SubscriptionSet#update} for more information.
- * @property {Boolean} returnOnStartup - optional flag. If `true`, the
+ * @property {Boolean} rerunOnOpen - optional flag. If `true`, the
  * {@link updateCallback} will be rerun every time the Realm is opened (e.g.
  * every time a user opens your app), otherwise (by default) it will only be run
  * if the Realm does not yet exist.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -76,10 +76,8 @@
  *     user,
  *     flexible: true,
  *     initialSubscriptions: {
- *       update: realm => {
- *         realm.subscriptions.update(subs => {
- *           subs.add(realm.objects('Task'));
- *         })
+ *       update: (subs, realm) => {
+ *         subs.add(realm.objects('Task'));
  *       }
  *     }
  *   },
@@ -91,9 +89,9 @@
  * // subscriptions fully synchronised.
  * ```
  * @typedef {Object} Realm.App.Sync~InitialSubscriptionsConfiguration
- * @property {callback(realm)} update - callback called with the {@link Realm} instance
- * to allow you to setup the initial set of subscriptions by calling
- * `realm.subscriptions.update`. See
+ * @property {callback(realm)} update - callback called with a
+ * {@link Realm.App.Sync~MutableSubscriptionSet} instance and the {@link Realm}
+ * instance to allow you to setup the initial set of subscriptions. See
  * {@link Realm.App.Sync.SubscriptionSet#update} for more information.
  * @property {Boolean} returnOnStartup - optional flag. If `true`, the
  * {@link updateCallback} will be rerun every time the Realm is opened (e.g.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -48,7 +48,9 @@
  * @typedef {Object} Realm.App.Sync~SyncConfiguration
  * @property {Realm.User} user - A {@link Realm.User} object obtained by calling `Realm.App.logIn`.
  * @property {Realm.App.Sync~SSLConfiguration} [ssl] - SSL configuration.
- * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key.
+ * @property {boolean} flexible - Whether to use flexible sync (if `true`) or partition based sync (default)
+ * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key. Only valid if using partition based sync.
+ * @property {Realm.App.Sync~InitialSubscriptionsConfiguration} initialSubscriptions - Optional object to configure the setup of an initial set of flexible sync subscriptions to be used when opening the Realm. Only valid if using flexible sync. See {@link Realm.App.Sync~InitialSubscriptionsConfiguration}.
  * @property {callback(session, syncError)} [error] - A callback function which is called in error situations.
  *    The callback is passed two arguments: `session` and `syncError`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
  *    and `syncError.readOnly` is true (deprecated, see `Realm.App.Sync~ClientResetConfiguration`). Otherwise, `syncError` can have up to five properties:
@@ -59,6 +61,44 @@
  * @property {Realm.App.Sync~OpenRealmBehaviorConfiguration} [existingRealmFileBehavior] - Whether to open existing file and sync in background or wait for the sync of the
  *    file to complete and then open. If not set, the Realm will be downloaded before opened.
  * @property {Realm.App.Sync~ClientResetConfiguration|null} [clientReset] - Configuration of Client Reset
+ */
+
+/**
+ * Optional object to configure the setup of an initial set of flexible sync
+ * subscriptions to be used when opening the Realm. If this is specified,
+ * {@link Realm.open} will not resolve until this set of subscriptions has been
+ * fully synchronized with the server.
+ *
+ * Example:
+ * ```
+ * const config: Realm.Configuration = {
+ *   sync: {
+ *     user,
+ *     flexible: true,
+ *     initialSubscriptions: {
+ *       update: realm => {
+ *         realm.subscriptions.update(subs => {
+ *           subs.add(realm.objects('Task'));
+ *         })
+ *       }
+ *     }
+ *   },
+ *   // ... rest of config ...
+ * };
+ * const realm = await Realm.open(config);
+ *
+ * // At this point, the Realm will be open with the data for the initial set
+ * // subscriptions fully synchronised.
+ * ```
+ * @typedef {Object} Realm.App.Sync~InitialSubscriptionsConfiguration
+ * @property {callback(realm)} update - callback called with the {@link Realm} instance
+ * to allow you to setup the initial set of subscriptions by calling
+ * `realm.subscriptions.update`. See
+ * {@link Realm.App.Sync.SubscriptionSet#update} for more information.
+ * @property {Boolean} returnOnStartup - optional flag. If `true`, the
+ * {@link updateCallback} will be rerun every time the Realm is opened (e.g.
+ * every time a user opens your app), otherwise (by default) it will only be run
+ * if the Realm does not yet exist.
  */
 
 /**

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -78,8 +78,9 @@
  *     initialSubscriptions: {
  *       update: (subs, realm) => {
  *         subs.add(realm.objects('Task'));
- *       }
- *     }
+ *       },
+ *       rerunOnOpen: true,
+ *     },
  *   },
  *   // ... rest of config ...
  * };

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -230,7 +230,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             Realm.deleteFile(this.config);
           });
 
-          it("throws an error if no `update` function is provided", async function () {
+          it("throws an error if no update function is provided", async function () {
             this.config = getConfig(this.user, {} as any);
 
             await expect((Realm as any).open(this.config)).to.be.rejectedWith(
@@ -238,7 +238,17 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          it("throws an error if `update` is not a function", async function () {
+          it("throws an error if update is undefined", async function () {
+            this.config = getConfig(this.user, {
+              update: undefined,
+            } as any);
+
+            await expect((Realm as any).open(this.config)).to.be.rejectedWith(
+              "update must be of type 'function', got (undefined)",
+            );
+          });
+
+          it("throws an error if update is not a function", async function () {
             this.config = getConfig(this.user, {
               update: "Person",
             } as any);

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -154,8 +154,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
       it("does not accept { flexible: true } and a partition value", function () {
         expect(() => {
-          // Cast to any as Typescript will detect this as an error
-          new (Realm as any)({
+          // @ts-expect-error Intentionally testing the wrong type
+          new Realm({
             sync: {
               _sessionStopPolicy: SessionStopPolicy.Immediately,
               flexible: true,
@@ -195,8 +195,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
       it("throws an error if flexible sync is enabled and client reset mode is discardLocal", function () {
         expect(() => {
-          // Cast to any as Typescript will detect this as an error
-          new (Realm as any)({
+          // @ts-expect-error Intentionally testing the wrong type
+          new Realm({
             sync: {
               _sessionStopPolicy: SessionStopPolicy.Immediately,
               flexible: true,
@@ -231,31 +231,32 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           });
 
           it("throws an error if no update function is provided", async function (this: RealmContext) {
-            this.config = getConfig(this.user, {} as any);
+            // @ts-expect-error Intentionally testing the wrong type
+            this.config = getConfig(this.user, {});
 
-            await expect((Realm as any).open(this.config)).to.be.rejectedWith(
+            await expect(Realm.open(this.config)).to.be.rejectedWith(
               "update must be of type 'function', got (undefined)",
             );
           });
 
           it("throws an error if update is undefined", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
+              // @ts-expect-error Intentionally testing the wrong type
               update: undefined,
-            } as any);
+            });
 
-            await expect((Realm as any).open(this.config)).to.be.rejectedWith(
+            await expect(Realm.open(this.config)).to.be.rejectedWith(
               "update must be of type 'function', got (undefined)",
             );
           });
 
           it("throws an error if update is not a function", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
+              // @ts-expect-error Intentionally testing the wrong type
               update: "Person",
-            } as any);
+            });
 
-            await expect((Realm as any).open(this.config)).to.be.rejectedWith(
-              "update must be of type 'function', got (Person)",
-            );
+            await expect(Realm.open(this.config)).to.be.rejectedWith("update must be of type 'function', got (Person)");
           });
 
           it("throws an error if `rerunOnOpen` is not a boolean", async function (this: RealmContext) {
@@ -263,12 +264,11 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               update: () => {
                 // no-op
               },
+              // @ts-expect-error Intentionally testing the wrong type
               rerunOnOpen: "yes please",
-            } as any);
+            });
 
-            await expect((Realm as any).open(this.config)).to.be.rejectedWith(
-              /rerunOnOpen must be of type 'boolean', got.*/,
-            );
+            await expect(Realm.open(this.config)).to.be.rejectedWith(/rerunOnOpen must be of type 'boolean', got.*/);
           });
         });
 

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -258,16 +258,16 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          it("throws an error if `rerunOnStartup` is not a boolean", async function (this: RealmContext) {
+          it("throws an error if `rerunOnOpen` is not a boolean", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
               update: () => {
                 // no-op
               },
-              rerunOnStartup: "yes please",
+              rerunOnOpen: "yes please",
             } as any);
 
             await expect((Realm as any).open(this.config)).to.be.rejectedWith(
-              /rerunOnStartup must be of type 'boolean', got.*/,
+              /rerunOnOpen must be of type 'boolean', got.*/,
             );
           });
         });
@@ -329,19 +329,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm, config);
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is undefined", async function (this: RealmContext) {
+          it("updates the subscriptions on first open if rerunOnOpen is undefined", async function (this: RealmContext) {
             await testSuccess(this.user);
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is false", async function (this: RealmContext) {
-            await testSuccess(this.user, { rerunOnStartup: false });
+          it("updates the subscriptions on first open if rerunOnOpen is false", async function (this: RealmContext) {
+            await testSuccess(this.user, { rerunOnOpen: false });
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is true", async function (this: RealmContext) {
-            await testSuccess(this.user, { rerunOnStartup: true });
+          it("updates the subscriptions on first open if rerunOnOpen is true", async function (this: RealmContext) {
+            await testSuccess(this.user, { rerunOnOpen: true });
           });
 
-          it("does not update the subscriptions on second open if rerunOnStartup is undefined", async function (this: RealmContext) {
+          it("does not update the subscriptions on second open if rerunOnOpen is undefined", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, {}, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 
@@ -354,8 +354,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm2, config);
           });
 
-          it("does not update the subscriptions on second open if rerunOnStartup is false", async function (this: RealmContext) {
-            const realm = await testSuccess(this.user, { rerunOnStartup: false }, false);
+          it("does not update the subscriptions on second open if rerunOnOpen is false", async function (this: RealmContext) {
+            const realm = await testSuccess(this.user, { rerunOnOpen: false }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 
             await realm.subscriptions.update((subs) => subs.removeAll());
@@ -367,14 +367,14 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm2, config);
           });
 
-          it("does update the subscriptions on second open if rerunOnStartup is true", async function (this: RealmContext) {
-            const realm = await testSuccess(this.user, { rerunOnStartup: true }, false);
+          it("does update the subscriptions on second open if rerunOnOpen is true", async function (this: RealmContext) {
+            const realm = await testSuccess(this.user, { rerunOnOpen: true }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 
             await realm.subscriptions.update((subs) => subs.removeAll());
             realm.close();
 
-            await testSuccess(this.user, { rerunOnStartup: true });
+            await testSuccess(this.user, { rerunOnOpen: true });
           });
         });
       });

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -298,23 +298,26 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           ) {
             const { realm, config } = await openRealm(user, extraConfig);
 
-            expect(realm.subscriptions).to.have.length(1);
-            expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
-
-            if (closeRealmAfter) {
-              closeRealm(realm, config);
-              return undefined;
+            try {
+              expect(realm.subscriptions).to.have.length(1);
+              expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            } finally {
+              if (closeRealmAfter) {
+                closeRealm(realm, config);
+              }
             }
 
-            return realm;
+            return closeRealmAfter ? undefined : realm;
           }
 
           it("returns a promise", async function (this: RealmContext) {
             const result = openRealm(this.user, {});
-            expect(result).to.be.instanceOf(Promise);
-
-            const { realm, config } = await result;
-            closeRealm(realm, config);
+            try {
+              expect(result).to.be.instanceOf(Promise);
+            } finally {
+              const { realm, config } = await result;
+              closeRealm(realm, config);
+            }
           });
 
           it("can be used with the `new Realm` constructor", async function (this: RealmContext) {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -230,7 +230,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             Realm.deleteFile(this.config);
           });
 
-          it("throws an error if no update function is provided", async function () {
+          it("throws an error if no update function is provided", async function (this: RealmContext) {
             this.config = getConfig(this.user, {} as any);
 
             await expect((Realm as any).open(this.config)).to.be.rejectedWith(
@@ -238,7 +238,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          it("throws an error if update is undefined", async function () {
+          it("throws an error if update is undefined", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
               update: undefined,
             } as any);
@@ -248,7 +248,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          it("throws an error if update is not a function", async function () {
+          it("throws an error if update is not a function", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
               update: "Person",
             } as any);
@@ -258,7 +258,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          it("throws an error if `rerunOnStartup` is not a boolean", async function () {
+          it("throws an error if `rerunOnStartup` is not a boolean", async function (this: RealmContext) {
             this.config = getConfig(this.user, {
               update: () => {
                 // no-op
@@ -277,10 +277,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           function getSuccessConfig(user: Realm.User, extraConfig: ExtraConfig = {}) {
             return getConfig(user, {
-              update: (realm) => {
-                realm.subscriptions.update((subs) => {
-                  subs.add(realm.objects(FlexiblePersonSchema.name));
-                });
+              update: (subs, realm) => {
+                subs.add(realm.objects(FlexiblePersonSchema.name));
               },
               ...extraConfig,
             });
@@ -311,7 +309,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             return realm;
           }
 
-          it("returns a promise", async function () {
+          it("returns a promise", async function (this: RealmContext) {
             const result = openRealm(this.user, {});
             expect(result).to.be.instanceOf(Promise);
 
@@ -319,7 +317,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm, config);
           });
 
-          it("can be used with the `new Realm` constructor", async function () {
+          it("can be used with the `new Realm` constructor", async function (this: RealmContext) {
             const config = getSuccessConfig(this.user);
             const realm = new Realm(config);
 
@@ -331,19 +329,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm, config);
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is undefined", async function () {
+          it("updates the subscriptions on first open if rerunOnStartup is undefined", async function (this: RealmContext) {
             await testSuccess(this.user);
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is false", async function () {
+          it("updates the subscriptions on first open if rerunOnStartup is false", async function (this: RealmContext) {
             await testSuccess(this.user, { rerunOnStartup: false });
           });
 
-          it("updates the subscriptions on first open if rerunOnStartup is true", async function () {
+          it("updates the subscriptions on first open if rerunOnStartup is true", async function (this: RealmContext) {
             await testSuccess(this.user, { rerunOnStartup: true });
           });
 
-          it("does not update the subscriptions on second open if rerunOnStartup is undefined", async function () {
+          it("does not update the subscriptions on second open if rerunOnStartup is undefined", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, {}, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 
@@ -356,7 +354,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm2, config);
           });
 
-          it("does not update the subscriptions on second open if rerunOnStartup is false", async function () {
+          it("does not update the subscriptions on second open if rerunOnStartup is false", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, { rerunOnStartup: false }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 
@@ -369,7 +367,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             closeRealm(realm2, config);
           });
 
-          it("does update the subscriptions on second open if rerunOnStartup is true", async function () {
+          it("does update the subscriptions on second open if rerunOnStartup is true", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, { rerunOnStartup: true }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -285,7 +285,7 @@ module.exports = function (realmConstructor) {
           // and runs the actual update function, see `handle_initial_subscriptions`
           // in `js_realm.hpp`), we need to return a promise which waits for the
           // new subscriptions to be fully synchronised, then returns the Realm.
-          if (initialSubscriptions.rerunOnStartup || !realmExists) {
+          if (initialSubscriptions.rerunOnOpen || !realmExists) {
             return realm.subscriptions.waitForSynchronization().then(() => {
               return realm;
             });

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -168,8 +168,10 @@ module.exports = function (realmConstructor) {
           return openLocalRealm(realmConstructor, config);
         }
 
+        const realmExists = realmConstructor.exists(config);
+
         // Determine if we are opening an existing Realm or not.
-        let behavior = realmConstructor.exists(config) ? "existingRealmFileBehavior" : "newRealmFileBehavior";
+        let behavior = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
 
         // Define how the Realm file is opened
         let openLocalRealmImmediately = false; // Default is downloadBeforeOpen
@@ -268,8 +270,30 @@ module.exports = function (realmConstructor) {
           }),
         );
 
-        // Return wrapped promises, allowing the users to control them.
-        let openPromise = Promise.race(openPromises);
+        // Return wrapped promises, allowing the users to control them. Once one of the
+        // `openPromise`s has resolved, we may need to wait for initial subscriptions
+        // (if any) to be synchronised, so we return a chained promise to do this.
+        let openPromise = Promise.race(openPromises).then((realm) => {
+          const { initialSubscriptions } = config.sync;
+
+          // If `initialSubscriptions` was not specified, return the Realm immediately
+          if (!initialSubscriptions) {
+            return realm;
+          }
+
+          // If an update has been run by C++ (which performs all the validation
+          // and runs the actual update function, see `handle_initial_subscriptions`
+          // in `js_realm.hpp`), we need to return a promise which waits for the
+          // new subscriptions to be fully synchronised, then returns the Realm.
+          if (initialSubscriptions.rerunOnStartup || !realmExists) {
+            return realm.subscriptions.waitForSynchronization().then(() => {
+              return realm;
+            });
+          } else {
+            return realm;
+          }
+        });
+
         openPromise.cancel = () => {
           if (asyncOpenTask) {
             asyncOpenTask.cancel();

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -372,7 +372,7 @@ public:
     static void set_binding_context(ContextType ctx, std::shared_ptr<Realm> const& realm, bool schema_updated,
                                     ObjectDefaultsMap&& defaults, ConstructorMap&& constructors);
     static void handle_initial_subscriptions(ContextType ctx, size_t argc, const ValueType arguments[],
-                                             ObjectType realm_object, bool realm_exists);
+                                             SharedRealm realm_object, bool realm_exists);
 
     static void schema_version(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void clear_test_state(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -825,7 +825,7 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
  */
 template <typename T>
 void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, const ValueType arguments[],
-                                                 ObjectType realm_object, bool realm_exists)
+                                                 SharedRealm realm, bool realm_exists)
 {
     if (argc == 0) {
         return;
@@ -850,7 +850,7 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     ObjectType initial_subscriptions_object = Value::validated_to_object(ctx, initial_subscriptions_value);
 
     ValueType update_value = Object::get_property(ctx, initial_subscriptions_object, "update");
-    FunctionType update_function = Value::validated_to_function(ctx, update_value, "update");
+    FunctionType update_callback = Value::validated_to_function(ctx, update_value, "update");
 
     ValueType rerun_on_startup_value = Object::get_property(ctx, initial_subscriptions_object, "rerunOnStartup");
     bool rerun_on_startup = Value::is_undefined(ctx, rerun_on_startup_value)
@@ -860,8 +860,8 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     // Only run the update function if the Realm did not already exist, i.e. it's
     // the first time it has been opened, or if `rerunOnStartup` is true
     if (!realm_exists || rerun_on_startup) {
-        ValueType arguments[] = {realm_object};
-        Function<T>::call(ctx, update_function, 1, arguments);
+        auto subs = realm->get_latest_subscription_set();
+        SubscriptionSetClass<T>::update_impl(ctx, update_callback, subs, realm);
     }
 }
 
@@ -880,7 +880,7 @@ void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Argumen
 
     set_internal<T, RealmClass<T>>(ctx, this_object, new SharedRealm(realm));
 
-    handle_initial_subscriptions(ctx, args.count, args.value, this_object, realm_exists);
+    handle_initial_subscriptions(ctx, args.count, args.value, realm, realm_exists);
 }
 
 template <typename T>
@@ -1167,7 +1167,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
 
         try {
             ValueType unprotected_args = protected_args;
-            handle_initial_subscriptions(protected_ctx, args.count - 1, &unprotected_args, object, realm_exists);
+            handle_initial_subscriptions(protected_ctx, args.count - 1, &unprotected_args, realm, realm_exists);
         }
         catch (TypeErrorException e) {
             auto error = make_js_error<T>(ctx, e.what());
@@ -1737,8 +1737,8 @@ void RealmClass<T>::get_subscriptions(ContextType ctx, ObjectType this_object, R
             "and enable flexible sync, for example: { sync: { user, flexible: true } }");
     }
 
-    return_value.set(
-        SubscriptionSetClass<T>::create_instance(ctx, realm->get_latest_subscription_set(), realm->sync_session()));
+    return_value.set(SubscriptionSetClass<T>::create_instance(ctx, realm->get_latest_subscription_set(),
+                                                              realm->sync_session(), realm));
 }
 #endif
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -835,7 +835,7 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     if (!Value::is_object(ctx, config_value)) {
         return;
     }
-    ObjectType config_object = Value::validated_to_object(ctx, config_value);
+    ObjectType config_object = Value::to_object(ctx, config_value);
 
     ValueType sync_value = Object::get_property(ctx, config_object, "sync");
     if (Value::is_undefined(ctx, sync_value)) {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -371,6 +371,8 @@ public:
                                  ObjectDefaultsMap&, ConstructorMap&);
     static void set_binding_context(ContextType ctx, std::shared_ptr<Realm> const& realm, bool schema_updated,
                                     ObjectDefaultsMap&& defaults, ConstructorMap&& constructors);
+    static void handle_initial_subscriptions(ContextType ctx, size_t argc, const ValueType arguments[],
+                                             ObjectType realm_object, bool realm_exists);
 
     static void schema_version(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void clear_test_state(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -785,6 +787,84 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
     return schema_updated;
 }
 
+
+/**
+ * @brief Handle the `initialSubscriptions` object in the config, if any, which
+ * allows users to specify an initial set of flexible sync subscriptions to be
+ * bootstrapped when opening a Realm.
+ *
+ * If an `initialSubscriptions` object is provided in the config, it must be an
+ * object with an `update` property, which is a function (called with the Realm
+ * as an argument) which should update the Realm's subscriptions. If called from
+ * `Realm.open`, then the JS (in the `open` method in `lib/extensions.js`) will
+ * return a promise which resolves when the subscription update has been
+ * synchronised.
+ *
+ * If the object contains a `rerunOnStartup` property, this must be a boolean,
+ * which specifies that we should re-run the `update` function every time the
+ * Realm is opened rather than just the first time. This allows users to
+ * workaround the lack of "dynamic" date queries for synced data (e.g. "last 30
+ * days"), by creating the dynamic values in their lanaguge and passing them
+ * into the subscription's, which can then be updated (by using a named query)
+ * every time their app starts.
+ *
+ * This method is separate from `get_realm_config` because this functionality is
+ * not yet implemented in core, and the work needs to performed after the Realm
+ * has been opened in its own write transaction so `initialization_function` is
+ * not suitable.
+ *
+ * TODO remove this once functionality is implemented in core.
+ *
+ * @tparam T The JavaScript engine
+ * @param ctx The JavaScript context
+ * @param argc Number of arguments
+ * @param arguments Array of arguments (contains the config, if any)
+ * @param realm_object The Realm on which to subscribe, wrapped as an ObjectType
+ * @param realm_exists Boolean specifying whether the Realm already existed at
+ * the time of opening it or not
+ */
+template <typename T>
+void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, const ValueType arguments[],
+                                                 ObjectType realm_object, bool realm_exists)
+{
+    if (argc == 0) {
+        return;
+    }
+
+    ValueType config_value = arguments[0];
+    if (!Value::is_object(ctx, config_value)) {
+        return;
+    }
+    ObjectType config_object = Value::validated_to_object(ctx, config_value);
+
+    ValueType sync_value = Object::get_property(ctx, config_object, "sync");
+    if (Value::is_undefined(ctx, sync_value)) {
+        return;
+    }
+    ObjectType sync_object = Value::validated_to_object(ctx, sync_value);
+
+    ValueType initial_subscriptions_value = Object::get_property(ctx, sync_object, "initialSubscriptions");
+    if (Value::is_undefined(ctx, initial_subscriptions_value)) {
+        return;
+    }
+    ObjectType initial_subscriptions_object = Value::validated_to_object(ctx, initial_subscriptions_value);
+
+    ValueType update_value = Object::get_property(ctx, initial_subscriptions_object, "update");
+    FunctionType update_function = Value::validated_to_function(ctx, update_value, "update");
+
+    ValueType rerun_on_startup_value = Object::get_property(ctx, initial_subscriptions_object, "rerunOnStartup");
+    bool rerun_on_startup = Value::is_undefined(ctx, rerun_on_startup_value)
+                                ? false
+                                : Value::validated_to_boolean(ctx, rerun_on_startup_value, "rerunOnStartup");
+
+    // Only run the update function if the Realm did not already exist, i.e. it's
+    // the first time it has been opened, or if `rerunOnStartup` is true
+    if (!realm_exists || rerun_on_startup) {
+        ValueType arguments[] = {realm_object};
+        Function<T>::call(ctx, update_function, 1, arguments);
+    }
+}
+
 template <typename T>
 void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Arguments& args)
 {
@@ -792,10 +872,15 @@ void RealmClass<T>::constructor(ContextType ctx, ObjectType this_object, Argumen
     realm::Realm::Config config;
     ObjectDefaultsMap defaults;
     ConstructorMap constructors;
+
     bool schema_updated = get_realm_config(ctx, args.count, args.value, config, defaults, constructors);
+    bool realm_exists = realm::util::File::exists(config.path);
+
     auto realm = create_shared_realm(ctx, config, schema_updated, std::move(defaults), std::move(constructors));
 
     set_internal<T, RealmClass<T>>(ctx, this_object, new SharedRealm(realm));
+
+    handle_initial_subscriptions(ctx, args.count, args.value, this_object, realm_exists);
 }
 
 template <typename T>
@@ -1019,7 +1104,9 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
     Realm::Config config;
     ObjectDefaultsMap defaults;
     ConstructorMap constructors;
+
     bool schema_updated = get_realm_config(ctx, args.count - 1, args.value, config, defaults, constructors);
+    bool realm_exists = realm::util::File::exists(config.path);
 
     if (!config.sync_config) {
         throw std::logic_error("_asyncOpen can only be used on a synchronized Realm.");
@@ -1027,6 +1114,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
 
     Protected<FunctionType> protected_callback(ctx, callback_function);
     Protected<ObjectType> protected_this(ctx, this_object);
+    Protected<ValueType> protected_args(ctx, *(args.value));
     Protected<typename T::GlobalContext> protected_ctx(Context<T>::get_global_context(ctx));
 
     auto& user = config.sync_config->user;
@@ -1047,42 +1135,51 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
     std::shared_ptr<AsyncOpenTask> task;
     task = Realm::get_synchronized_realm(config);
 
-    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler(
-        [=, defaults = std::move(defaults), constructors = std::move(constructors)](ThreadSafeReference&& realm_ref,
-                                                                                    std::exception_ptr error) {
-            HANDLESCOPE(protected_ctx)
+    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, defaults = std::move(defaults),
+                                                                             constructors = std::move(constructors)](
+                                                                                ThreadSafeReference&& realm_ref,
+                                                                                std::exception_ptr error) {
+        HANDLESCOPE(protected_ctx)
 
-            if (error) {
-                try {
-                    std::rethrow_exception(error);
-                }
-                catch (const std::exception& e) {
-                    ObjectType object = Object::create_empty(protected_ctx);
-                    Object::set_property(protected_ctx, object, "message",
-                                         Value::from_string(protected_ctx, e.what()));
-                    Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
-
-                    ValueType callback_arguments[2] = {
-                        Value::from_undefined(protected_ctx),
-                        object,
-                    };
-                    Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, callback_arguments);
-                    return;
-                }
+        if (error) {
+            try {
+                std::rethrow_exception(error);
             }
+            catch (const std::exception& e) {
+                ObjectType object = Object::create_empty(protected_ctx);
+                Object::set_property(protected_ctx, object, "message", Value::from_string(protected_ctx, e.what()));
+                Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
 
-            auto def = std::move(defaults);
-            auto ctor = std::move(constructors);
-            const SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref), util::Scheduler::make_default());
-            set_binding_context(protected_ctx, realm, schema_updated, std::move(def), std::move(ctor));
-            ObjectType object = create_object<T, RealmClass<T>>(protected_ctx, new SharedRealm(realm));
+                ValueType callback_arguments[2] = {
+                    Value::from_undefined(protected_ctx),
+                    object,
+                };
+                Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, callback_arguments);
+                return;
+            }
+        }
 
-            ValueType callback_arguments[2] = {
-                object,
-                Value::from_null(protected_ctx),
-            };
-            Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
-        });
+        auto def = std::move(defaults);
+        auto ctor = std::move(constructors);
+        const SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref), util::Scheduler::make_default());
+        set_binding_context(protected_ctx, realm, schema_updated, std::move(def), std::move(ctor));
+        ObjectType object = create_object<T, RealmClass<T>>(protected_ctx, new SharedRealm(realm));
+
+        try {
+            ValueType unprotected_args = protected_args;
+            handle_initial_subscriptions(protected_ctx, args.count - 1, &unprotected_args, object, realm_exists);
+        }
+        catch (TypeErrorException e) {
+            auto error = make_js_error<T>(ctx, e.what());
+            Function<T>::callback(protected_ctx, protected_callback, {Value::from_undefined(protected_ctx), error});
+        }
+
+        ValueType callback_arguments[2] = {
+            object,
+            Value::from_null(protected_ctx),
+        };
+        Function<T>::callback(protected_ctx, protected_callback, 2, callback_arguments);
+    });
 
     task->start(callback_handler);
     return_value.set(create_object<T, AsyncOpenTaskClass<T>>(ctx, new std::shared_ptr<AsyncOpenTask>(task)));

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -800,7 +800,7 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
  * return a promise which resolves when the subscription update has been
  * synchronised.
  *
- * If the object contains a `rerunOnStartup` property, this must be a boolean,
+ * If the object contains a `rerunOnOpen` property, this must be a boolean,
  * which specifies that we should re-run the `update` function every time the
  * Realm is opened rather than just the first time. This allows users to
  * workaround the lack of "dynamic" date queries for synced data (e.g. "last 30
@@ -852,13 +852,13 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     ValueType update_value = Object::get_property(ctx, initial_subscriptions_object, "update");
     FunctionType update_callback = Value::validated_to_function(ctx, update_value, "update");
 
-    ValueType rerun_on_startup_value = Object::get_property(ctx, initial_subscriptions_object, "rerunOnStartup");
+    ValueType rerun_on_startup_value = Object::get_property(ctx, initial_subscriptions_object, "rerunOnOpen");
     bool rerun_on_startup = Value::is_undefined(ctx, rerun_on_startup_value)
                                 ? false
-                                : Value::validated_to_boolean(ctx, rerun_on_startup_value, "rerunOnStartup");
+                                : Value::validated_to_boolean(ctx, rerun_on_startup_value, "rerunOnOpen");
 
     // Only run the update function if the Realm did not already exist, i.e. it's
-    // the first time it has been opened, or if `rerunOnStartup` is true
+    // the first time it has been opened, or if `rerunOnOpen` is true
     if (!realm_exists || rerun_on_startup) {
         auto subs = realm->get_latest_subscription_set();
         SubscriptionSetClass<T>::update_impl(ctx, update_callback, subs, realm);

--- a/src/js_subscriptions.hpp
+++ b/src/js_subscriptions.hpp
@@ -31,6 +31,9 @@
 namespace realm {
 namespace js {
 
+// Forward declaration to avoid circular dependency
+template <typename T>
+class RealmClass;
 
 /**
  * @brief Wrapper class for a single flexible sync subscription

--- a/src/js_subscriptions.hpp
+++ b/src/js_subscriptions.hpp
@@ -646,7 +646,7 @@ void SubscriptionSetClass<T>::update(ContextType ctx, ObjectType this_object, Ar
     }
     else {
         auto error = make_js_error<T>(protected_ctx, "`update` called after the Realm went out of scope");
-        Function<T>::callback(protected_ctx, protected_callback, protected_this, {error});
+        Function<T>::callback(protected_ctx, protected_completion_callback, protected_this, {error});
     }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -148,6 +148,48 @@ declare namespace Realm {
         flexible: true;
         partitionValue?: never;
         clientReset?: ClientResetConfiguration<ClientResetModeManualOnly>;
+        /**
+         * Optional object to configure the setup of an initial set of flexible
+         * sync subscriptions to be used when opening the Realm. If this is specified,
+         * {@link Realm.open} will not resolve until this set of subscriptions has been
+         * fully synchronized with the server.
+         * 
+         * Example:
+         * ```
+         * const config: Realm.Configuration = {
+         *   sync: {
+         *     user,
+         *     flexible: true,
+         *     initialSubscriptions: {
+         *       update: realm => {
+         *         realm.subscriptions.update(subs => {
+         *           subs.add(realm.objects('Task'));
+         *         })
+         *       }
+         *     }
+         *   },
+         *   // ... rest of config ...
+         * };
+         * const realm = await Realm.open(config);
+         * 
+         * // At this point, the Realm will be open with the data for the initial set
+         * // subscriptions fully synchronised.
+         * ```
+         */
+        initialSubscriptions?: {
+            /**
+             * Callback called with the {@link Realm} instance to allow you to setup the
+             * initial set of subscriptions by calling `realm.subscriptions.update`.
+             * See {@link Realm.App.Sync.SubscriptionSet.update} for more information.
+             */
+            update: (realm: Realm) => void;
+            /**
+             * If `true`, the {@link updateCallback} will be rerun every time the Realm is
+             * opened (e.g. every time a user opens your app), otherwise (by default) it
+             * will only be run if the Realm does not yet exist.
+             */
+            rerunOnStartup?: boolean;
+        };
     }
 
     interface PartitionSyncConfiguration extends BaseSyncConfiguration {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -186,7 +186,7 @@ declare namespace Realm {
              * opened (e.g. every time a user opens your app), otherwise (by default) it
              * will only be run if the Realm does not yet exist.
              */
-            rerunOnStartup?: boolean;
+            rerunOnOpen?: boolean;
         };
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -163,8 +163,9 @@ declare namespace Realm {
          *     initialSubscriptions: {
          *       update: (subs, realm) => {
          *         subs.add(realm.objects('Task'));
-         *       }
-         *     }
+         *       },
+         *       rerunOnOpen: true,
+         *     },
          *   },
          *   // ... rest of config ...
          * };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -153,7 +153,7 @@ declare namespace Realm {
          * sync subscriptions to be used when opening the Realm. If this is specified,
          * {@link Realm.open} will not resolve until this set of subscriptions has been
          * fully synchronized with the server.
-         * 
+         *
          * Example:
          * ```
          * const config: Realm.Configuration = {
@@ -161,17 +161,15 @@ declare namespace Realm {
          *     user,
          *     flexible: true,
          *     initialSubscriptions: {
-         *       update: realm => {
-         *         realm.subscriptions.update(subs => {
-         *           subs.add(realm.objects('Task'));
-         *         })
+         *       update: (subs, realm) => {
+         *         subs.add(realm.objects('Task'));
          *       }
          *     }
          *   },
          *   // ... rest of config ...
          * };
          * const realm = await Realm.open(config);
-         * 
+         *
          * // At this point, the Realm will be open with the data for the initial set
          * // subscriptions fully synchronised.
          * ```
@@ -182,7 +180,7 @@ declare namespace Realm {
              * initial set of subscriptions by calling `realm.subscriptions.update`.
              * See {@link Realm.App.Sync.SubscriptionSet.update} for more information.
              */
-            update: (realm: Realm) => void;
+            update: (subs: Realm.App.Sync.MutableSubscriptionSet, realm: Realm) => void;
             /**
              * If `true`, the {@link updateCallback} will be rerun every time the Realm is
              * opened (e.g. every time a user opens your app), otherwise (by default) it
@@ -859,15 +857,18 @@ declare namespace Realm {
              * // `realm` will now return the expected results based on the updated subscriptions
              * ```
              *
-             * @param callback A callback function which receives a {@link MutableSubscriptionSet}
-             * instance as its only argument, which can be used to add or remove subscriptions from
-             * the set.
-             * Note: this callback should not be asynchronous.
+             * @param callback A callback function which receives a
+             * {@link Realm.App.Sync.MutableSubscriptionSet} instance as the
+             * first argument, which can be used to add or remove subscriptions
+             * from the set, and the {@link Realm} associated with the SubscriptionSet
+             * as the second argument (mainly useful when working with
+             * `initialSubscriptions` in
+             * {@link Realm.App.Sync.FlexibleSyncConfiguration}).
              *
              * @returns A promise which resolves when the SubscriptionSet is synchronized, or is rejected
              * if there was an error during synchronization (see {@link waitForSynchronisation})
              */
-            update: (callback: (mutableSubs: MutableSubscriptionSet) => void) => Promise<void>;
+            update: (callback: (mutableSubs: MutableSubscriptionSet, realm: Realm) => void) => Promise<void>;
         }
 
         const SubscriptionSet: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -182,7 +182,7 @@ declare namespace Realm {
              */
             update: (subs: Realm.App.Sync.MutableSubscriptionSet, realm: Realm) => void;
             /**
-             * If `true`, the {@link updateCallback} will be rerun every time the Realm is
+             * If `true`, the {@link update} callback will be rerun every time the Realm is
              * opened (e.g. every time a user opens your app), otherwise (by default) it
              * will only be run if the Realm does not yet exist.
              */


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->

This closes https://github.com/realm/realm-js/issues/4515, by introducing an `initialSubscriptions` option on the Realm's `sync` config, which allows you to bootstrap an initial set of subscriptions (using the same callback format as `subscriptions.update`). This will return a promise, resolved when the new subscriptions have been synchronised – i.e. if the user calls `await Realm.open`, it will not resolve until all the initial subscription data has been synchronised.

This is as part of the additive changes to flexible sync, in response to feedback that this a common use case. It's worth pointing out that this functionality should probably reside in core, but it was determined that there was not time to implement that, so for now each SDK is implementing it separately.

By default, the callback is only called when the Realm does not already exist, to allow the user to bootstrap an initial subscription set. The `rerunOnStartup` flag allows the user to rerun the callback every time the Realm is opened – the intended use case for this is that a user could implement e.g. a date range query in their subscription, which is updated every time the app is opened, in order to work around the lack of date range operators in RQL.

For example, to implement a subscription for "all people born in the last 30 days", which updates the date range every time you start the app, you could do something like:
```js
const thirtyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 30));
const config = {
  // ...
  sync: {
    flexible: true,
    user,
    initialSubscriptions: {
      update: (realm) => {
        realm.subscriptions.update((subs) => {
          subs.add(
            realm.objects("Person").filtered("dateOfBirth > $0", thirtyDaysAgo), 
            // This is a named subscription, so will replace any existing subscription with the same name
            { name: "People30Days" }
          );
        });
      },
      rerunOnStartup: true,
    },
  },
};
```

One gotcha to be aware of with this is that if you inline your config with the call to `Realm.open` and then try to use the `realm` variable that you are declaring inside the `update` callback, it won't work as it's not yet defined – you need to use the Realm instance provided as a callback argument. I'm not sure if there's anything we can do about this (except try to signpost it if we think it's a big issue?) and `onFirstOpen` presumably has the same issue.

```js
const realm = await Realm.open({
  // ...
  sync: {
    initialSubscriptions: {
      update: () => {
        realm.... // <-- realm is undefined
```  

### Alternatives considered 

I am open to feedback on the API for this, as I do feel it's perhaps a bit awkward that we are introducing a new concept that is actually quite similar to `onFirstOpen`. `initialSubscriptions.update` is presented as a callback for updating subscriptions, but in actual fact the user could do anything in this callback, so it could be a more generic thing. I felt like this was the "least bad" solution in the end – alternatives I considered, and the reasons for rejecting them are:

- Reusing the existing `onFirstOpen` config option and making it `await`able (right now it does not return a promise), and adding a counterpart `onOpen` which is called every time the Realm opens to cover the `rerunOnStartup` case
  - `onFirstOpen` does not work for calling `subscriptions.update`, because the call to `onFirstOpen` from [core](https://github.com/realm/realm-core/blob/master/src/realm/object-store/shared_realm.cpp#L470) is already in a write transaction. Therefore calling `subscriptions.update` from here fails, as `update` opens its own write transaction.
  - As `onFirstOpen` is implemented using [`initialization_function` in core](https://github.com/realm/realm-core/blob/master/src/realm/object-store/shared_realm.cpp#L470),  this would require changes to core to add the equivalent for `onOpen` (which requires touch a lot of files to pass it through the various configs and layers) and to make it `await`able. We would also need to change the semantics of `onFirstOpen` and/or `update` with regard to write transactions. 
  - This seemed like too complex a change, especially as the intention is for this initial subscription functionality to eventually be moved to core.
- Have the implementation in the SDK like it is in this PR, but make it a more generic solution (e.g. add a top level callback on the config called `onOpen`, with a `rerunOnOpenOnStartup` flag, which lets the user do initial work they want of any kind – essentially an SDK-side `await`able replacement for `onFirstOpen`)
  - This would create an awkward duplication with `onFirstOpen` – would it be a replacement for it? Or are there some semantic differences?
  - Is this even something we want to add? It would need some proper design and consideration before adding a new generic concept.
  - For the initial subscriptions use case (which is currently the only one, and the one we want to streamline), this would require users to remember to `return realm.subscriptions.waitForSynchronization();` from their `onOpen` callback, otherwise we wouldn't wait for synchronisation.
    - We could add a `waitForSynchronisation` flag to do this implicitly, but that feels messy.
- Implementing the solution purely in JS in `lib/extensions.js`
  - My initial implementation did this, which was simpler in terms of the code, but did not work for calls to `new Realm` – right now all our config options are supported for both `new Realm` and `Realm.open` so I thought we should uphold this.
 
One other idea I did have was:

- Make the `initialSubscriptions.update` callback internally wrapped in `subscriptions.update` and change its signature to `update: (subs: MutableSubscriptionSet, realm: Realm)`
  - This would perhaps make it a bit more ergonomic for users as they don't need to call `realm.subscriptions.update`, and it would guide them more clearly to just using this callback for updating subscriptions
  - I felt like this might be introducing unnecessary complexity and was somewhat redundant as you already have the `realm`, but looking at it with fresh eyes maybe this is actually a nicer solution? Thoughts welcome!

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
