### PR TITLE
Remove unnecessary steps from GHA workflow

### DIFF
--- a/.github/workflows/publish-realm-react.yml
+++ b/.github/workflows/publish-realm-react.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Bootstrap @realm/react
-        run: npm install realm --prefix packages/realm-react
+        run: npm install realm --prefix packages/realm-react --no-save
         env:
           npm_config_realm_local_prebuilds: ${{ github.workspace }}/prebuilds
 

--- a/.github/workflows/publish-realm-react.yml
+++ b/.github/workflows/publish-realm-react.yml
@@ -24,27 +24,8 @@ jobs:
       - name: Install npm v7
         run: npm install -g npm@7
 
-      # Caches
-      - uses: actions/cache@v2
-        name: cached node_modules
-        id: cache-node-modules
-        with:
-          path: node_modules
-          key: node-modules-${{ github.job }}-${{ hashFiles('package-lock.json') }}
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: realm-react
-
-      - name: Prepend ccache executables to the PATH
-        run: echo PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
-
       - name: Install realm node dependencies
         run: npm ci --ignore-scripts
-
-      - name: Prebuild release binary
-        run: npx prebuild
 
       - name: Bootstrap @realm/react
         run: npx lerna bootstrap --scope @realm/react --include-dependencies

--- a/.github/workflows/publish-realm-react.yml
+++ b/.github/workflows/publish-realm-react.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Bootstrap @realm/react
-        run: npx lerna bootstrap --scope @realm/react --include-dependencies
+        run: npm install realm --prefix packages/realm-react
         env:
           npm_config_realm_local_prebuilds: ${{ github.workspace }}/prebuilds
 


### PR DESCRIPTION
## What, How & Why?
Release publish workflow was taking too long.  The release binaries for Realm-JS were being built, which are not required for releasing @realm/react.  This PR removes these steps from the workflow

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
