### PR TITLE
Add 'asymmetric' to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Added schema parsing for asymmetric sync.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -193,7 +193,7 @@ class Realm {
   /**
    * Returns all objects of the given `type` in the Realm.
    * @param {Realm~ObjectType} type - The type of Realm objects to retrieve.
-   * @throws {Error} If type passed into this method is invalid or if the type is marked embedded.
+   * @throws {Error} If type passed into this method is invalid or if the type is marked embedded or asymmetric.
    * @returns {Realm.Results} that will live-update as objects are created and destroyed.
    */
   objects(type) {}
@@ -453,6 +453,8 @@ class Realm {
  *   that must be unique across all objects of this type within the same Realm.
  * @property {boolean} [embedded] - True if the object type is embedded. An embedded object
  *   can be linked to by at most one parent object. Default value: false.
+ * @property {boolean} [asymmetric] - True is the object type is for asymmetric sync only. This implies
+ *   that objects of the types are not stored locally and cannot be access locally.
  * @property {Object<string, (Realm~PropertyType|Realm~ObjectSchemaProperty|Realm~ObjectSchema)>} properties -
  *   An object where the keys are property names and the values represent the property type.
  *

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1100,6 +1100,9 @@ void RealmClass<T>::objects(ContextType ctx, ObjectType this_object, Arguments& 
     if (object_schema.is_embedded) {
         throw std::runtime_error("You cannot query an embedded object.");
     }
+    if (object_schema.is_asymmetric) {
+        throw std::runtime_error("You cannot query an asymmetric class.");
+    }
 
     return_value.set(ResultsClass<T>::create_instance(ctx, realm, object_schema.name));
 }
@@ -1582,27 +1585,27 @@ void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Argumen
         config = write_copy_to_helper_deprecated(ctx, this_object, args);
     }
 
-    bool realm_is_synced = static_cast<bool>(realm->sync_session());
-    bool copy_is_synced = static_cast<bool>(config.sync_config);
+    // bool realm_is_synced = static_cast<bool>(realm->sync_session());
+    // bool copy_is_synced = static_cast<bool>(config.sync_config);
 
-    if (realm_is_synced && !copy_is_synced) {
-        // case 3)
-        Group& group = realm->read_group();
-        group.write(config.path, config.encryption_key.empty() ? nullptr : config.encryption_key.data());
-        return;
-    }
-    else if (realm_is_synced && copy_is_synced) {
-        // case 4)
-        BinaryData binary_encryption_key;
-        if (!config.encryption_key.empty()) {
-            binary_encryption_key = std::move(BinaryData(config.encryption_key.data(), config.encryption_key.size()));
-        }
-        realm->write_copy(config.path, binary_encryption_key);
-        return;
-    }
+    // if (realm_is_synced && !copy_is_synced) {
+    //     // case 3)
+    //     Group& group = realm->read_group();
+    //     group.write(config.path, config.encryption_key.empty() ? nullptr : config.encryption_key.data());
+    //     return;
+    // }
+    // else if (realm_is_synced && copy_is_synced) {
+    //     // case 4)
+    //     BinaryData binary_encryption_key;
+    //     if (!config.encryption_key.empty()) {
+    //         binary_encryption_key = std::move(BinaryData(config.encryption_key.data(), config.encryption_key.size()));
+    //     }
+    //     realm->convert(config.path, binary_encryption_key);
+    //     return;
+    // }
 
-    // case 1), 2)
-    realm->export_to(config);
+    // // case 1), 2)
+    realm->convert(config);
 }
 
 template <typename T>

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -22,6 +22,7 @@
 #include "js_types.hpp"
 #include "dictionary_schema.hpp"
 #include <realm/object-store/schema.hpp>
+#include <stdexcept>
 
 namespace realm {
 namespace js {
@@ -309,6 +310,7 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
     static const String properties_string = "properties";
     static const String schema_string = "schema";
     static const String embedded_string = "embedded";
+    static const String asymmetric_string = "asymmetric";
 
     std::optional<FunctionType> object_constructor = {};
     if (Value::is_constructor(ctx, object_schema_object)) {
@@ -389,6 +391,18 @@ ObjectSchema Schema<T>::parse_object_schema(ContextType ctx, ObjectType object_s
         object_schema.is_embedded = false;
     }
 
+    ValueType asymmetric_value = Object::get_property(ctx, object_schema_object, asymmetric_string);
+    if (!Value::is_undefined(ctx, asymmetric_value)) {
+        object_schema.is_asymmetric = Value::validated_to_boolean(ctx, asymmetric_value);
+    }
+    else {
+        object_schema.is_asymmetric = false;
+    }
+
+    if (object_schema.is_asymmetric && object_schema.is_embedded) {
+        throw std::runtime_error("Schema named '" + object_schema.name + "' is asymmetric and embedded which is not supported.");
+    }
+
     // Store prototype so that objects of this type will have their prototype set to this prototype object.
     if (object_constructor) {
         constructors.emplace(object_schema.name, Protected<FunctionType>(ctx, *object_constructor));
@@ -454,6 +468,9 @@ typename T::Object Schema<T>::object_for_object_schema(ContextType ctx, const Ob
 
     static const String embedded_string = "embedded";
     Object::set_property(ctx, object, embedded_string, Value::from_boolean(ctx, object_schema.is_embedded));
+
+    static const String asymmetric_string = "asymmetric";
+    Object::set_property(ctx, object, asymmetric_string, Value::from_boolean(ctx, object_schema.is_asymmetric));
 
     return object;
 }

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -29,6 +29,7 @@
 #include "logger.hpp"
 
 #include "platform.hpp"
+#include "realm/version_id.hpp"
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
@@ -189,7 +190,7 @@ public:
         return m_func;
     }
 
-    void operator()(SharedRealm before_realm, SharedRealm after_realm)
+    void operator()(SharedRealm before_realm, SharedRealm after_realm, bool)
     {
         HANDLESCOPE(m_ctx)
 
@@ -1056,11 +1057,11 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
                 }
                 config.sync_config->notify_before_client_reset = std::move(client_reset_before_handler);
 
-                std::function<void(SharedRealm, SharedRealm)> client_reset_after_handler;
+                std::function<void(SharedRealm, SharedRealm, bool)> client_reset_after_handler;
                 ValueType client_reset_after_value =
                     Object::get_property(ctx, client_reset_object, "clientResetAfter");
                 if (!Value::is_undefined(ctx, client_reset_after_value)) {
-                    client_reset_after_handler = util::EventLoopDispatcher<void(SharedRealm, SharedRealm)>(
+                    client_reset_after_handler = util::EventLoopDispatcher<void(SharedRealm, SharedRealm, bool)>(
                         ClientResetAfterFunctor<T>(ctx, Value::validated_to_function(ctx, client_reset_after_value)));
                 }
                 config.sync_config->notify_after_client_reset = std::move(client_reset_after_handler);

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -267,4 +267,25 @@ module.exports = {
     TestCase.assertEqual(eventListener1Calls, 1);
     TestCase.assertEqual(eventListener2Calls, 1);
   },
+
+  testAsymmetricSchema() {
+    let schema = {
+      name: "AsymmetricPerson",
+      asymmetric: true,
+      properties: {
+        name: "string",
+        age: "int",
+      },
+    };
+
+    let realm = new Realm({ schema: [schema] });
+    TestCase.assertEqual(realm.schema.length, 1);
+    TestCase.assertTrue(realm.schema[0].asymmetric);
+    TestCase.assertFalse(realm.schema[0].embedded);
+
+    schema.embedded = true;
+    TestCase.assertThrowsContaining(() => {
+      new Realm({ schema: [schema]});
+    }, `Schema named '${schema.name}' is asymmetric and embedded which is not supported.`);
+  },
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,6 +71,7 @@ declare namespace Realm {
         name: string;
         primaryKey?: string;
         embedded?: boolean;
+        asymmetric?: boolean;
         properties: PropertiesTypes;
     }
 


### PR DESCRIPTION
## What, How & Why?
Basic schema support.

An example:

```js
{
    name: "AsymmetricPerson",
    asymmetric: true,
    properties: {
      name: "string",
      age: "int",
    },
}
```

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* [x] 🚦 Tests
* ~[ ] 🔀 Executed flexible sync tests locally if modifying flexible sync~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
