### PR TITLE
Expose realm ref when using RealmProvider in @realm/react

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add realmRef property to RealmProvider to access the configured realm outside of the provider component ([#4571](https://github.com/realm/realm-js/issues/4571))
+* Add realmRef property to `RealmProvider` to access the configured realm outside of the provider component ([#4571](https://github.com/realm/realm-js/issues/4571))
+  * Additionally appRef on `AppProvider` was added to provide access to `Realm.App` from outside the provider component
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,3 +1,23 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* Add realmRef property to RealmProvider to access the configured realm outside of the provider component ([#4571](https://github.com/realm/realm-js/issues/4571))
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* None.
+
+### Compatibility
+* MongoDB Realm Cloud.
+* Realm Studio v11.0.0.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.
+* File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+
+### Internal
+* <Either mention core version or upgrade>
+* <Using Realm Core vX.Y.Z>
+* <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+
 # 0.3.0 Release notes (2022-05-11)
 
 ### Enhancements

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -250,6 +250,20 @@ const AppWrapper = () => {
   )
 }
 ```
+
+In some cases, it may be necessary to access the configured Realm from outside of the `RealmProvider`, for instance, implementing a client reset fallback.  This can be done by creating a `ref` with `useRef` and setting the `realmRef` property of `RealmProvider`.
+
+```tsx
+const AppWrapper = () => {
+  const realmRef = useRef<Realm|null>(null)
+
+  return (
+    <RealmProvider realmRef={realmRef}>
+      <App/>
+    <RealmProvider>
+  )
+}
+```
 ### Dynamically Updating a Realm Configuration
 
 It is possible to update the realm configuration by setting props on the `RealmProvider`.  The `RealmProvider` takes props for all possible realm configuration properties.
@@ -290,6 +304,20 @@ const SomeComponent = () => {
 	const app = useApp();
 
 	//...
+}
+```
+
+It is also possible to receive a reference to the app outside of the `AppProvider`, through the `appRef` property.  This must be set to a React reference returned from `useRef`.
+
+```tsx
+const AppWrapper = () => {
+  const appRef = useRef<Realm.App|null>(null)
+
+  return (
+    <AppProvider appRef={appRef}>
+      <App/>
+    <AppProvider>
+  )
 }
 ```
 

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -31,13 +31,14 @@ const AppContext = createContext<Realm.App | null>(null);
  */
 type AppProviderProps = Realm.AppConfiguration & {
   children: React.ReactNode;
+  appRef?: React.MutableRefObject<Realm.App | null>;
 };
 
 /**
  * React component providing a Realm App instance on the context for the
  * sync hooks to use. An `AppProvider` is required for an app to use the hooks.
  */
-export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps }) => {
+export const AppProvider: React.FC<AppProviderProps> = ({ children, appRef, ...appProps }) => {
   const configuration = useRef<Realm.AppConfiguration>(appProps);
 
   const [app, setApp] = useState<Realm.App>(new Realm.App(configuration.current));
@@ -59,6 +60,9 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children, ...appProps 
     try {
       const app = new Realm.App(configuration.current);
       setApp(app);
+      if (appRef) {
+        appRef.current = app;
+      }
     } catch (err) {
       console.error(err);
     }

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -27,6 +27,7 @@ type PartialRealmConfiguration = Omit<Partial<Realm.Configuration>, "sync"> & {
 
 type ProviderProps = PartialRealmConfiguration & {
   fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+  realmRef?: React.MutableRefObject<Realm | null>;
   children: React.ReactNode;
 };
 
@@ -66,7 +67,7 @@ export function createRealmProvider(
    * For example, to override the `path` config value, use a prop named `path`,
    * e.g. `path="newPath.realm"`
    */
-  return ({ children, fallback: Fallback, ...restProps }) => {
+  return ({ children, fallback: Fallback, realmRef, ...restProps }) => {
     const [realm, setRealm] = useState<Realm | null>(null);
 
     // Automatically set the user in the configuration if its been set.
@@ -104,6 +105,9 @@ export function createRealmProvider(
 
     useEffect(() => {
       currentRealm.current = realm;
+      if (realmRef) {
+        realmRef.current = realm;
+      }
     }, [realm]);
 
     useEffect(() => {


### PR DESCRIPTION
## What, How & Why?
It was found that we were missing a critical feature to the `RealmProvider`, which was a way to access the configured realm from outside of the provider.  This is being done through a forwarded ref, which is passed as a property into the provider.
Upon implementation, it was also apparent that this would be a useful addition to `AppProvider` as well.  

This closes #4571

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
