### PR TITLE
Remove ObjectSchema from PropertiesTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed invalid type for schema properties([#4577](https://github.com/realm/realm-js/pull/4577)).
 
 ### Compatibility
 * MongoDB Realm Cloud.

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -453,7 +453,7 @@ class Realm {
  *   that must be unique across all objects of this type within the same Realm.
  * @property {boolean} [embedded] - True if the object type is embedded. An embedded object
  *   can be linked to by at most one parent object. Default value: false.
- * @property {Object<string, (Realm~PropertyType|Realm~ObjectSchemaProperty|Realm~ObjectSchema)>} properties -
+ * @property {Object<string, (Realm~PropertyType|Realm~ObjectSchemaProperty)>} properties -
  *   An object where the keys are property names and the values represent the property type.
  *
  * @example

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,7 @@ declare namespace Realm {
 
     // properties types
     interface PropertiesTypes {
-        [keys: string]: PropertyType | ObjectSchemaProperty | ObjectSchema;
+        [keys: string]: PropertyType | ObjectSchemaProperty;
     }
 
     enum UpdateMode {


### PR DESCRIPTION
This is no longer a valid input for schema properties.
The documentation has also been updated.

This is not really a broken change, since this was already broken.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
