### PR TITLE
Switch to building with Xcode 13

### DIFF
--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -34,7 +34,6 @@ jobs:
       matrix:
         # See https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
         xcode:
-          # - 12.5
           - 13.1
         npm:
           - 7

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -163,7 +163,7 @@ jobs:
             build-configuration: catalyst
     env:
       # Pin the Xcode version
-      DEVELOPER_DIR: /Applications/Xcode_12.4.app
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Switch to building xcframeworks with Xcode 13.1. Xcode 12 is no longer supported.
 
 ### Fixed
 * Flexible sync would not correctly resume syncing if a bootstrap was interrupted. ([realm/realm-core#5466](https://github.com/realm/realm-core/pull/5466), since v10.12.0)
@@ -27,7 +27,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Fixed
 * Fixed issue where React Native apps would sometimes show stale Realm data until the user interacted with the app UI. ([#4389](https://github.com/realm/realm-js/issues/4389), since v10.0.0)
 * Fixed race condition leading to potential crash when hot reloading an app using Realm Sync. ([4509](https://github.com/realm/realm-js/pull/4509), since v10.12.0)
-* Updated build script to use Xcode 12.4 to ensure xcframework is Bitcode compatibile with older versionsi. ([#4462](https://github.com/realm/realm-js/issues/4462), since v10.0.0)
+* Updated build script to use Xcode 12.4 to ensure xcframework is Bitcode compatibile with older versions. ([#4462](https://github.com/realm/realm-js/issues/4462), since v10.0.0)
 * Added missing type definitions for `newRealmFileBehavior` and `existingRealmFileBehavior` when opening a flexible sync Realm ([#4467](https://github.com/realm/realm-js/issues/4467), since v10.12.0)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since v10.5.0)
 * Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those filesi. (since v10.10.1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ def buildMacOS(workerFunction) {
   return {
     myNode('osx_vegas') {
       withEnv([
-        "DEVELOPER_DIR=/Applications/Xcode-12.2.app/Contents/Developer",
+        "DEVELOPER_DIR=/Applications/Xcode-13.app/Contents/Developer",
       ]) {
         unstash 'source'
         sh "bash ./scripts/utils.sh set-version ${dependencies.VERSION}"
@@ -221,7 +221,7 @@ def buildMacOSArm(workerFunction) {
   return {
     myNode('osx_vegas') {
       withEnv([
-        "DEVELOPER_DIR=/Applications/Xcode-12.2.app/Contents/Developer",
+        "DEVELOPER_DIR=/Applications/Xcode-13.app/Contents/Developer",
         "NODE_ARCH_ARM=1",
       ]) {
         unstash 'source'
@@ -259,8 +259,8 @@ def buildWindows(nodeVersion, arch) {
 
 def buildiOS() {
   return buildMacOS {
-    withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
-          'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-12.4.app']) {
+    withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-13.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
+          'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-13.app']) {
       sh './scripts/build-iOS.sh -c Release'
         dir('react-native/ios') {
         // Uncomment this when testing build changes if you want to be able to download pre-built artifacts from Jenkins.
@@ -497,8 +497,8 @@ def testLinux(target, postStep = null, Boolean enableSync = false) {
 def testMacOS(target, postStep = null) {
   return {
     node('osx_vegas') {
-      withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
-               'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-12.4.app',
+      withEnv(['SDK_ROOT_OVERRIDE=/Applications/Xcode-13.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/',
+               'DEVELOPER_DIR_OVERRIDE=/Applications/Xcode-13.app',
                'REALM_SET_NVM_ALIAS=1',
                'REALM_DISABLE_SYNC_TESTS=1',
                'npm_config_realm_local_prebuilds=prebuilds']) {

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -40,8 +40,8 @@
 
 The following dependencies are required. All except Xcode can be installed by following the [setup instructions for MacOS section](#setup-instructions-for-macos).
 
-- [Xcode](https://developer.apple.com/xcode/) 12+ with Xcode command line tools installed
-  - Newer versions may work but 12.2 is the current recommended version, which can be downloaded from [Apple](https://developer.apple.com/download/all/?q=xcode%2012.2)
+- [Xcode](https://developer.apple.com/xcode/) 13+ with Xcode command line tools installed
+  - Newer versions may work but 13.1 is the current recommended version, which can be downloaded from [Apple](https://developer.apple.com/download/all/?q=xcode%2013.1)
 - [Node.js](https://nodejs.org/en/) version 10.19 or later
   - Consider [using NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to enable fast switching between Node.js & NPM versions
 - [CMake](https://cmake.org/)


### PR DESCRIPTION
In preparation for dropping Xcode 12 support in core. I think I found all of the places where Xcode versions are mentioned.