### PR TITLE
Realm.Configuration.sync can be a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>
+* Fixed a bug preventing opening a synced Realm as a local Realm. (since v10.18.0)
 
 10.19.0 Release notes (2022-6-2)
 =============================================================

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1567,8 +1567,8 @@ realm::Realm::Config RealmClass<T>::write_copy_to_helper(ContextType ctx, Object
     // validate 5)
     // check whether a sync config exists -- it is optional
     ValueType syncConfigValue = Object::get_property(ctx, output_config, "sync");
-    if (!Value::is_undefined(ctx, syncConfigValue) && !Value::is_object(ctx, syncConfigValue)) {
-        throw std::invalid_argument("'sync' property must be an object");
+    if (!Value::is_undefined(ctx, syncConfigValue) && !Value::is_object(ctx, syncConfigValue) && !Value::is_boolean(ctx, syncConfigValue)) {
+        throw std::invalid_argument("if set, 'sync' property must be an object or a boolean");
     }
 
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1564,7 +1564,8 @@ realm::Realm::Config RealmClass<T>::write_copy_to_helper(ContextType ctx, Object
     // validate 5)
     // check whether a sync config exists -- it is optional
     ValueType syncConfigValue = Object::get_property(ctx, output_config, "sync");
-    if (!Value::is_undefined(ctx, syncConfigValue) && !Value::is_object(ctx, syncConfigValue) && !Value::is_boolean(ctx, syncConfigValue)) {
+    if (!Value::is_undefined(ctx, syncConfigValue) && !Value::is_object(ctx, syncConfigValue) &&
+        !Value::is_boolean(ctx, syncConfigValue)) {
         throw std::invalid_argument("if set, 'sync' property must be an object or a boolean");
     }
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -838,10 +838,7 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     ObjectType config_object = Value::to_object(ctx, config_value);
 
     ValueType sync_value = Object::get_property(ctx, config_object, "sync");
-    if (Value::is_undefined(ctx, sync_value)) {
-        return;
-    }
-    if (Value::is_boolean(ctx, sync_value)) {
+    if (!Value::is_object(ctx, sync_value)) {
         return;
     }
     ObjectType sync_object = Value::validated_to_object(ctx, sync_value);

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -841,6 +841,9 @@ void RealmClass<T>::handle_initial_subscriptions(ContextType ctx, size_t argc, c
     if (Value::is_undefined(ctx, sync_value)) {
         return;
     }
+    if (Value::is_boolean(ctx, sync_value)) {
+        return;
+    }
     ObjectType sync_object = Value::validated_to_object(ctx, sync_value);
 
     ValueType initial_subscriptions_value = Object::get_property(ctx, sync_object, "initialSubscriptions");


### PR DESCRIPTION
## What, How & Why?
Fixing a regression.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 🚦 Tests~
* ~[ ] 🔀 Executed flexible sync tests locally if modifying flexible sync~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
* ~[ ] Chrome debug API is updated if API is available on React Native~
