### PR TITLE
callFunction argument validation

### DIFF
--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -350,7 +350,7 @@ module.exports = {
     TestCase.assertEqual(err.message, "function not found: 'error'");
 
     // Regression tests for invalid inputs to function (non array)
-    TestCase.assertThrows(() => user.callFunction("sumFunc", 123));
+    TestCase.assertThrowsAsync(async () => await user.callFunction("sumFunc", 123));
   },
 
   async testMongoClient() {

--- a/tests/js/user-tests.js
+++ b/tests/js/user-tests.js
@@ -348,6 +348,9 @@ module.exports = {
 
     const err = await TestCase.assertThrowsAsync(async () => await user.functions.error());
     TestCase.assertEqual(err.message, "function not found: 'error'");
+
+    // Regression tests for invalid inputs to function (non array)
+    TestCase.assertThrows(() => user.callFunction("sumFunc", 123));
   },
 
   async testMongoClient() {


### PR DESCRIPTION
## What, How & Why?
A segmentation fault occurs when calling `callFunction` with invalid arguments.

This closes #4623

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
