### PR TITLE
Fixing: call to implicitly-deleted copy constructor of `Arguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,7 @@ realm.write(() => {
 ```
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed build error (call to implicitly-deleted copy constructor of 'realm::js::RealmClass<realm::js::realmjsi::Types>::Arguments') (follow up to [#4568](https://github.com/realm/realm-js/pull/4568))
 
 ### Compatibility
 * Atlas App Services.

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1165,10 +1165,10 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
         Function<T>::callback(protected_ctx, protected_callback, protected_this, 1, callback_arguments);
     }
 
-    std::shared_ptr<AsyncOpenTask> task;
-    task = Realm::get_synchronized_realm(config);
+    std::shared_ptr<AsyncOpenTask> task = Realm::get_synchronized_realm(config);
 
-    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, defaults = std::move(defaults),
+    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, args_count = args.count,
+                                                                             defaults = std::move(defaults),
                                                                              constructors = std::move(constructors)](
                                                                                 ThreadSafeReference&& realm_ref,
                                                                                 std::exception_ptr error) {
@@ -1200,7 +1200,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
 
         try {
             ValueType unprotected_args = protected_args;
-            handle_initial_subscriptions(protected_ctx, args.count - 1, &unprotected_args, realm, realm_exists);
+            handle_initial_subscriptions(protected_ctx, args_count - 1, &unprotected_args, realm, realm_exists);
         }
         catch (TypeErrorException e) {
             auto error = make_js_error<T>(ctx, e.what());


### PR DESCRIPTION
## What, How & Why?

I experienced this build error when v11 got rebased onto #4568.

```
realm-js/src/js_realm.hpp:1171:78: error: call to implicitly-deleted copy constructor of
      'realm::js::RealmClass<realm::js::realmjsi::Types>::Arguments' (aka 'Arguments<realm::js::realmjsi::Types>')
    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, defaults = std::move(defaults),
                                                                             ^
realm-js/src/js_realm.hpp:411:29: note: in instantiation of member function
      'realm::js::RealmClass<realm::js::realmjsi::Types>::async_open_realm' requested here
        {"_asyncOpen", wrap<async_open_realm>},
                            ^
realm-js/src/js_realm.hpp:549:68: note: in instantiation of member function
      'realm::js::realmjsi::ObjectWrap<realm::js::RealmClass<realm::js::realmjsi::Types>>::create_constructor' requested here
    FunctionType realm_constructor = ObjectWrap<T, RealmClass<T>>::create_constructor(ctx);
                                                                   ^
realm-js/src/jsi/jsi_init.cpp:49:74: note: in instantiation of member function
      'realm::js::RealmClass<realm::js::realmjsi::Types>::create_constructor' requested here
    fbjsi::Function realm_constructor = js::RealmClass<realmjsi::Types>::create_constructor(env);
                                                                         ^
In file included from realm-js/src/jsi/jsi_init.cpp:20:
In file included from realm-js/src/jsi/jsi_init.hpp:27:
realm-js/src/jsi/jsi_class.hpp:75:5: note: copy constructor is implicitly deleted because 'Arguments<realm::js::realmjsi::Types>' has
      a user-declared move constructor
    Arguments(Arguments&&) = delete;
```

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
