### PR TITLE
Refactored make_js_error into Object::create_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Upgrade Example to RN v0.68.2
 * Upgrade dependencies of the Realm Web integration tests
+* Throw instances of `Error` instead of plain objects on app errors.
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1170,7 +1170,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
             handle_initial_subscriptions(protected_ctx, args.count - 1, &unprotected_args, realm, realm_exists);
         }
         catch (TypeErrorException e) {
-            auto error = make_js_error<T>(ctx, e.what());
+            auto error = Object::create_error(ctx, e.what());
             Function<T>::callback(protected_ctx, protected_callback, {Value::from_undefined(protected_ctx), error});
         }
 

--- a/src/js_subscriptions.hpp
+++ b/src/js_subscriptions.hpp
@@ -506,12 +506,12 @@ void SubscriptionSetClass<T>::wait_for_synchronization_impl(ContextType ctx, Obj
                 current_subs->refresh();
 
                 auto result = state.is_ok() ? Value::from_undefined(protected_ctx)
-                                            : make_js_error<T>(protected_ctx, state.get_status().reason());
+                                            : Object::create_error(protected_ctx, state.get_status().reason());
 
                 Function<T>::callback(protected_ctx, protected_callback, protected_this, {result});
             }
             else {
-                auto error = make_js_error<T>(
+                auto error = Object::create_error(
                     protected_ctx, "`waitForSynchronisation` resolved after the `subscriptions` went out of scope");
                 Function<T>::callback(protected_ctx, protected_callback, protected_this, {error});
             }
@@ -525,7 +525,7 @@ void SubscriptionSetClass<T>::wait_for_synchronization_impl(ContextType ctx, Obj
     }
     catch (KeyNotFound const& ex) {
         // TODO Waiting on https://github.com/realm/realm-core/issues/5165 to remove this
-        auto error = make_js_error<T>(
+        auto error = Object::create_error(
             ctx, "`waitForSynchronisation` cannot be called before creating a SubscriptionSet using `update`");
         Function<T>::callback(protected_ctx, protected_callback, protected_this, {error});
     }
@@ -650,7 +650,7 @@ void SubscriptionSetClass<T>::update(ContextType ctx, ObjectType this_object, Ar
                                                                protected_completion_callback);
     }
     else {
-        auto error = make_js_error<T>(protected_ctx, "`update` called after the Realm went out of scope");
+        auto error = Object::create_error(protected_ctx, "`update` called after the Realm went out of scope");
         Function<T>::callback(protected_ctx, protected_completion_callback, protected_this, {error});
     }
 }

--- a/src/js_types.hpp
+++ b/src/js_types.hpp
@@ -421,6 +421,7 @@ public:
         }
         return obj;
     }
+    static ObjectType create_error(ContextType ctx, std::string message);
 
     static ObjectType create_array(ContextType, uint32_t, const ValueType[]);
     static ObjectType create_array(ContextType ctx, const std::vector<ValueType>& values)
@@ -669,12 +670,20 @@ inline typename T::Value Value<T>::from_timestamp(typename T::Context ctx, Times
 }
 
 template <typename T>
+inline typename T::Object Object<T>::create_error(ContextType ctx, const std::string message)
+{
+    using Value = Value<T>;
+    using Function = Function<T>;
+    auto error_ctor = Value::to_constructor(ctx, Object::get_global(ctx, "Error"));
+    return Function::construct(ctx, error_ctor, {Value::from_string(ctx, message)});
+}
+
+template <typename T>
 inline typename T::Object Object<T>::create_from_app_error(ContextType ctx, const app::AppError& error)
 {
-    return Object::create_obj(ctx, {
-                                       {"message", Value<T>::from_string(ctx, error.message)},
-                                       {"code", Value<T>::from_number(ctx, error.error_code.value())},
-                                   });
+    auto obj = Object::create_error(ctx, error.message);
+    Object::set_property(ctx, obj, "code", Value<T>::from_number(ctx, error.error_code.value()));
+    return obj;
 }
 
 template <typename T>

--- a/src/js_util.hpp
+++ b/src/js_util.hpp
@@ -160,17 +160,6 @@ void compute_aggregate_on_collection(typename T::ContextType ctx, typename T::Ob
     }
 }
 
-template <typename T>
-typename T::Object make_js_error(typename T::Context ctx, std::string message)
-{
-    using FunctionType = typename T::Function;
-    using Value = js::Value<T>;
-    using Object = js::Object<T>;
-
-    auto error_ctor = Value::to_constructor(ctx, Object::get_global(ctx, "Error"));
-    return Function<T>::construct(ctx, error_ctor, {Value::from_string(ctx, message)});
-}
-
 /**
  * @brief
  *


### PR DESCRIPTION
## What, How & Why?

This is a partial fix for #3476 as I refactored a utility function (`make_js_error`) into a static `create_error` on `Object`. 
`js_utils.hpp` (which defined `make_js_error`) had a dependency on `js_types.hpp` and I needed to create error objects from `js_types.hpp`. So I needed to refactor this and move the code into `js_types.hpp`.

I needed this when debugging another issue.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
