### PR TITLE
Defaulting to host ip when running integration tests on React Native Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Internal
 * Upgrade Example to RN v0.68.2
 * Upgrade dependencies of the Realm Web integration tests
+* Make integration tests on React Native Android connect to host machine by default
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/integration-tests/environments/react-native/src/App.js
+++ b/integration-tests/environments/react-native/src/App.js
@@ -171,6 +171,8 @@ export class App extends Component {
         global.fs = require("react-native-fs");
         global.path = require("path-browserify");
         global.environment = {
+          // Default to the host machine when running on Android
+          realmBaseUrl: Platform.OS === "android" ? "http://10.0.2.2:9090" : undefined,
           ...context,
           reactNative: Platform.OS,
           android: Platform.OS === "android",


### PR DESCRIPTION
## What, How & Why?

This closes an issue making the Android tests fail when ran locally.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
