### PR TITLE
Fix a typo in flexible sync tests

### DIFF
--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1154,7 +1154,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             ).to.not.be.rejected;
           }
 
-          it("does not throw, and updates the existing subscription, if a subscription with the same name but different query is added, and throwOnUpdate is true", async function (this: RealmContext) {
+          it("does not throw, and updates the existing subscription, if a subscription with the same name but different query is added, and throwOnUpdate is false", async function (this: RealmContext) {
             await testThrowOnUpdateFalse(this.realm, { throwOnUpdate: false });
           });
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

Spotted this while doing something else and wouldn't be able to sleep at night if I didn't fix it 🙃 

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
