### PR TITLE
Fix other uses of globalThis breaking iOS 11/12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed use of `globalThis` affecting iOS 11/12 support ([#4647](https://github.com/realm/realm-js/pull/4647))
 
 ### Compatibility
 * Atlas App Services.

--- a/lib/mongo-client.js
+++ b/lib/mongo-client.js
@@ -21,6 +21,8 @@ const { DefaultNetworkTransport } = require("realm-network-transport");
 
 const { cleanArguments, getEnvironment } = require("./utils");
 
+const globalThisOrWindow = typeof globalThis === "object" ? globalThis : window;
+
 /**
  * Iterates the global to ensure all globals needed for watching are available.
  */
@@ -29,7 +31,7 @@ function ensureWatchDependencies() {
   if (environment === "reactnative") {
     const EXPECTED_GLOBALS = ["fetch", "ReadableStream", "TextDecoder"];
     for (const name of EXPECTED_GLOBALS) {
-      if (!(name in globalThis)) {
+      if (!(name in globalThisOrWindow)) {
         throw new Error(
           `Realm expects the ${name} global: Please use https://www.npmjs.com/package/react-native-polyfill-globals`,
         );


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

https://github.com/realm/realm-js/issues/4350

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
