### PR TITLE
Pin BaaS in the Realm Web PR workflow

### DIFF
--- a/.github/workflows/pr-realm-web.yml
+++ b/.github/workflows/pr-realm-web.yml
@@ -53,4 +53,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.BAAS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BAAS_AWS_SECRET_ACCESS_KEY }}
-          MONGODB_REALM_TEST_SERVER: "latest"
+          MONGODB_REALM_TEST_SERVER: "2022-06-15"


### PR DESCRIPTION
## What, How & Why?

This updates the PR workflow to use the last know working version of the BaaS docker image.

This is to fix this error occurring on CI:

```
Starting MongoDB.../run.sh: line 10: mongo: command not found
```

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
