### PR TITLE
Update package.json to discard tag_prefix to make npm binary mirroring work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* Realm JS can now be installed in environments using npm binary mirroring ([#4672](https://github.com/realm/realm-js/pull/4672)).
+* Realm JS can now be installed in environments using npm binary mirroring ([#4672](https://github.com/realm/realm-js/pull/4672), since v10.0.0).
 * None.
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* Realm JS can now be installed in environments using npm binary mirroring ([#4672](https://github.com/realm/realm-js/pull/4672)).
 * None.
 
 ### Compatibility

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "set-version": "scripts/set-version.sh",
     "test": "scripts/test.sh",
     "package": "npm ci --ignore-scripts && prebuild",
-    "install": "prebuild-install -r napi || cmake-js build",
+    "install": "prebuild-install --tag-prefix= -r napi || cmake-js build",
     "rebuild": "npm run rebuild-changes",
     "build": "npm run build-changes",
     "build:arm": "npm run build-changes:arm",


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

A user reported in https://github.com/realm/realm-js/issues/4667 that they cannot install Realm using npm "binary mirroring", which allows it to work in an environment with no internet connection and instead, an internal artefact server – I guess quite a common set up in finance, etc. This happened since v10, it used to work in v6.

They did some [research](https://github.com/realm/realm-js/issues/4667#issuecomment-1163201076) and suggested that this change would fix the issue. They tested this branch and it did indeed fix the issue, but I have to confess I don't really understand the consequences of the change so would welcome any thoughts!

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
