### PR TITLE
Fix toJSON behaviour for Dictionary on JSC pre-v11 (fixes #4658)

### DIFF
--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -206,6 +206,30 @@ describe("Dictionary", () => {
     });
   });
 
+  describe("toJSON", function () {
+    openRealmBefore({
+      schema: [
+        {
+          name: "Item",
+          properties: { dict: "{}" },
+        },
+      ],
+    });
+
+    it("calling toJSON on an object with a Dictionary field removes the Proxy from the Dictionary", function (this: RealmContext) {
+      const object = this.realm.write(() => {
+        return this.realm.create<Item>("Item", { dict: { something: "test" } });
+      });
+      const jsonObject = object.toJSON();
+
+      // Previously this would throw on JSC, because the Dictionary was still a Proxy,
+      // so modifying it tried to write to the Realm outside of a write transaction
+      expect(() => {
+        jsonObject.dict.something = "test2";
+      }).to.not.throw();
+    });
+  });
+
   type ValueGenerator = (realm: Realm) => DictValues;
 
   type TypedDictionarySuite = {

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -16,8 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+const { symbols } = require("@realm.io/common");
+
 const dictionaryHandler = {
   get(target, key) {
+    // Allows us to detect if this is a proxied Dictionary on JSC pre-v11. See realm-common/symbols.ts for details.
+    if (key === symbols.IS_PROXIED_DICTIONARY) {
+      return true;
+    }
+
     if (key === "toJSON") {
       return function () {
         const keys = target._keys();

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+const { symbols } = require("@realm.io/common");
+
 let getOwnPropertyDescriptors =
   Object.getOwnPropertyDescriptors ||
   function (obj) {
@@ -109,7 +111,11 @@ module.exports = function (realmConstructor) {
           // recursively trigger `toJSON` for Realm instances with the same cache.
           if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
             result[key] = value.toJSON(key, cache);
-          } else if (value instanceof realmConstructor.Dictionary) {
+          } else if (
+            value instanceof realmConstructor.Dictionary ||
+            // Allows us to detect if this is a proxied Dictionary on JSC pre-v11. See realm-common/symbols.ts for details.
+            value[symbols.IS_PROXIED_DICTIONARY]
+          ) {
             // Dictionary special case to share the "cache" for dictionary-values,
             // in case of circular structures involving links.
             result[key] = Object.fromEntries(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "See the actual license in the file LICENSE",
       "dependencies": {
-        "@realm.io/common": "^0.1.3",
+        "@realm.io/common": "^0.1.4",
         "bindings": "^1.5.0",
         "bson": "4.4.1",
         "clang-format": "^1.6.0",
@@ -3211,9 +3211,9 @@
       "dev": true
     },
     "node_modules/@realm.io/common": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.3.tgz",
-      "integrity": "sha512-PezSt3ab0CwKJ54Cj3Qnv6RTFb2x+7nyXVmb0cthwjCA3Lu1VcDhqyOsWoZcl2lvucgj/rYgyn4X/bIoItU3TA=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.4.tgz",
+      "integrity": "sha512-+nI/fOa/G9idiZ7h9DVz5NmnrvVNI3AM/I0eB7vL/PxDCF8vH3vew8ZrWOSr08GT2bDliy1wB6IYRqezQ1H/Iw=="
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -16623,9 +16623,9 @@
       "dev": true
     },
     "@realm.io/common": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.3.tgz",
-      "integrity": "sha512-PezSt3ab0CwKJ54Cj3Qnv6RTFb2x+7nyXVmb0cthwjCA3Lu1VcDhqyOsWoZcl2lvucgj/rYgyn4X/bIoItU3TA=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.4.tgz",
+      "integrity": "sha512-+nI/fOa/G9idiZ7h9DVz5NmnrvVNI3AM/I0eB7vL/PxDCF8vH3vew8ZrWOSr08GT2bDliy1wB6IYRqezQ1H/Iw=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "postinstall": "node scripts/submit-analytics.js"
   },
   "dependencies": {
-    "@realm.io/common": "^0.1.3",
+    "@realm.io/common": "^0.1.4",
     "bindings": "^1.5.0",
     "bson": "4.4.1",
     "clang-format": "^1.6.0",

--- a/packages/realm-common/package.json
+++ b/packages/realm-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@realm.io/common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Cross-product common code used by Realm",
   "main": "./dist/bundle.cjs.js",
   "module": "./dist/bundle.es.js",

--- a/packages/realm-common/src/symbols.ts
+++ b/packages/realm-common/src/symbols.ts
@@ -19,3 +19,7 @@
 // Used as a key by Realm React in `useQuery`, to store the original object
 // which is being proxied, for compatibility with JSC pre-v11 (#4541)
 export const PROXY_TARGET = Symbol("PROXY_TARGET");
+
+// Used to indicate that an object is a proxied Realm.Dictionary, to allow us
+// to correctly detect Dictionaries in toJSON when using JSC pre-v11 (#4674)
+export const IS_PROXIED_DICTIONARY = Symbol("IS_PROXIED_DICTIONARY");

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -35,7 +35,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@realm.io/common": "^0.1.3",
+    "@realm.io/common": "^0.1.4",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.0"
   },

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "@realm.io/common": "^0.1.2"
+    "@realm.io/common": "^0.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -46,7 +46,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@realm.io/common": "^0.1.3",
+    "@realm.io/common": "^0.1.4",
     "bson": "^4.5.4",
     "detect-browser": "^5.2.1",
     "js-base64": "^3.7.2"


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This fixes the behaviour of `toJSON` on objects with Dictionary fields on JSC, reported in https://github.com/realm/realm-js/issues/4658. 

Before this fix, Dictionary fields would incorrectly not be converted to JSON, resulting in an exception if a field of the Dictionary of the JSONified object was modified, as it would try to write to the Realm outside of a write transaction.

The root cause of this is similar to https://github.com/realm/realm-js/pull/4541, in that Proxy objects do not seem to be properly "transparent" on JSC – in this case, `instanceof Realm.Dictionary` would return `false` for a proxied Dictionary, whereas it should return `true` (as JS `Proxy` objects are supposed to be totally transparent). This should be fixed with JSI/Hermes.

I searched the codebase for anywhere else that might be affected by this bug and couldn't see anywhere.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
