### PR TITLE
Downgrade expo templates to sdk 44

### DIFF
--- a/templates/expo-template-js/package.json
+++ b/templates/expo-template-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@realm/expo-template-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Expo Template Realm Js",
   "scripts": {
     "start": "expo start --dev-client",
@@ -9,16 +9,14 @@
   },
   "dependencies": {
     "@realm/react": "^0.3.1",
-    "expo": "^45.0.0",
-    "expo-dev-client": "~0.9.6",
-    "expo-splash-screen": "~0.15.1",
-    "expo-status-bar": "~1.3.0",
-    "expo-updates": "~0.13.2",
+    "expo": "^44.0.6",
+    "expo-dev-client": "~0.8.4",
+    "expo-splash-screen": "~0.14.2",
+    "expo-status-bar": "~1.2.0",
+    "expo-updates": "~0.11.6",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "0.68.2",
     "react-native-get-random-values": "~1.8.0",
-    "react-native-web": "0.17.7",
     "realm": "^10.19.0"
   },
   "devDependencies": {

--- a/templates/expo-template-ts/package.json
+++ b/templates/expo-template-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@realm/expo-template-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Expo Template Realm TS",
   "scripts": {
     "start": "expo start --dev-client",
@@ -9,16 +9,14 @@
   },
   "dependencies": {
     "@realm/react": "^0.3.1",
-    "expo": "^45.0.0",
-    "expo-dev-client": "~0.9.6",
-    "expo-splash-screen": "~0.15.1",
-    "expo-status-bar": "~1.3.0",
-    "expo-updates": "~0.13.2",
+    "expo": "^44.0.6",
+    "expo-dev-client": "~0.8.4",
+    "expo-splash-screen": "~0.14.2",
+    "expo-status-bar": "~1.2.0",
+    "expo-updates": "~0.11.6",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "0.68.2",
     "react-native-get-random-values": "~1.8.0",
-    "react-native-web": "0.17.7",
     "realm": "^10.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What, How & Why?
Expo 45 is not compatible with Realm in its current state.  Therefore the templates have been downgraded to SDK 44, while including the upgrades to `@realm/react`


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
