### PR TITLE
Fix null handling in toJSON (fixes #4682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* Fixed a bug with handling `null` values in `toJSON` ([[#4682](https://github.com/realm/realm-js/issues/4682), since 10.19.3)
 * None.
 
 ### Compatibility

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -538,4 +538,32 @@ describe("JSON serialization", () => {
       });
     });
   }
+
+  describe("toJSON edge case handling", function () {
+    interface EdgeCaseSchema {
+      maybeNull: null;
+    }
+
+    const EdgeCaseSchema = {
+      name: "EdgeCase",
+      properties: {
+        maybeNull: "string?",
+      },
+    };
+
+    openRealmBeforeEach({
+      inMemory: true,
+      schema: [EdgeCaseSchema],
+    });
+
+    it("handles null values", function (this: RealmContext) {
+      const object = this.realm.write(() => {
+        return this.realm.create<EdgeCaseSchema>(EdgeCaseSchema.name, {
+          maybeNull: null,
+        });
+      });
+
+      expect(object.toJSON()).deep.equals({ maybeNull: null });
+    });
+  });
 });

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -111,8 +111,8 @@ module.exports = function (realmConstructor) {
           if (value === null || value === undefined) {
             result[key] = value;
           }
-          // recursively trigger `toJSON` for Realm instances with the same cache.
           else if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
+            // recursively trigger `toJSON` for Realm instances with the same cache.
             result[key] = value.toJSON(key, cache);
           } else if (
             value instanceof realmConstructor.Dictionary ||

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -110,8 +110,7 @@ module.exports = function (realmConstructor) {
 
           if (value === null || value === undefined) {
             result[key] = value;
-          }
-          else if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
+          } else if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
             // recursively trigger `toJSON` for Realm instances with the same cache.
             result[key] = value.toJSON(key, cache);
           } else if (

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -108,8 +108,11 @@ module.exports = function (realmConstructor) {
             return; // continue
           }
 
+          if (value === null || value === undefined) {
+            result[key] = value;
+          }
           // recursively trigger `toJSON` for Realm instances with the same cache.
-          if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
+          else if (value instanceof realmConstructor.Object || value instanceof realmConstructor.Collection) {
             result[key] = value.toJSON(key, cache);
           } else if (
             value instanceof realmConstructor.Dictionary ||


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

We were missing a test case for handling null values in `toJSON`, which was broken as a result of https://github.com/realm/realm-js/pull/4674. Fixes #4682

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
