### PR TITLE
Fixing analytics tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
+* Fixed analytics tests to reflect the fact that framework versions are read from node_modules, not package.json. ([#4687](https://github.com/realm/realm-js/pull/4687))
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/integration-tests/tests/src/node/analytics.ts
+++ b/integration-tests/tests/src/node/analytics.ts
@@ -23,66 +23,54 @@ import { expect } from "chai";
 import { collectPlatformData } from "realm/scripts/submit-analytics";
 import { readJsonSync } from "fs-extra";
 
+type Fixture = "node" | "react-native" | "electron";
+
 describe("Analytics", () => {
-  function resolvePath(fileName: string) {
-    // tests are executed in directory `environments/node`
-    return ["..", "..", "tests", "src", "node", fileName].join(path.sep);
+  function resolvePath(fixture: Fixture) {
+    return path.resolve(__dirname, "fixtures", fixture);
   }
 
   function getRealmVersion() {
-    // tests are executed in directory `environments/node`
-    const rootPath = ["..", "..", "..", "package.json"].join(path.sep);
-    const realmPackageJson = readJsonSync(rootPath);
+    const realmPath = path.resolve(__dirname, "../../../../package.json");
+    const realmPackageJson = readJsonSync(realmPath);
     return realmPackageJson["version"];
   }
 
-  it("returns the expected version", async () => {
-    const packageJson = { version: "1.2.3" };
-    const data = await collectPlatformData(packageJson);
-
-    // common to all cases
+  function expectCommon(data: Record<string, unknown>) {
     expect(data["JS Analytics Version"]).equals(2);
     expect(data.Binding).equals("javascript");
     expect(data.Language).equals("javascript");
     expect(data["Host OS Type"]).equals(os.platform());
     expect(data["Host OS Version"]).equals(os.release());
     expect(data["Node.js version"]).equals(process.version);
+    expect(data["Realm Version"]).equals(getRealmVersion());
     expect(data.token).equals("ce0fac19508f6c8f20066d345d360fd0");
-
-    // specific to package.json
-    expect(data.Version).equals("1.2.3");
-  });
+  }
 
   it("parses node.js package.json", async () => {
-    const packageJson = readJsonSync(resolvePath("node-package.json"));
-
-    const data = await collectPlatformData(packageJson);
-    expect(data.Version).equals("1.11.1");
+    const data = await collectPlatformData(resolvePath("node"));
+    expectCommon(data);
+    expect(data.Version).equals("1.2.3");
     expect(data.Framework).equals("node.js");
     expect(data["Framework Version"]).equals(process.version);
     expect(data["JavaScript Engine"]).equals("v8");
-    expect(data["Realm Version"]).equals(getRealmVersion());
   });
 
   it("parses electron package.json", async () => {
-    const packageJson = readJsonSync(resolvePath("electron-package.json"));
-
-    const data = await collectPlatformData(packageJson);
-    expect(data.Version).equals("11.1.1");
+    const data = await collectPlatformData(resolvePath("electron"));
+    expectCommon(data);
+    expect(data.Version).equals("1.2.3");
     expect(data.Framework).equals("electron");
-    expect(data["Framework Version"]).equals("^16.0.4");
+    expect(data["Framework Version"]).equals("1.0.1");
     expect(data["JavaScript Engine"]).equals("v8");
-    expect(data["Realm Version"]).equals(getRealmVersion());
   });
 
   it("parses rn package.json", async () => {
-    const packageJson = readJsonSync(resolvePath("rn-package.json"));
-
-    const data = await collectPlatformData(packageJson);
-    expect(data.Version).equals("0.0.1");
+    const data = await collectPlatformData(resolvePath("react-native"));
+    expectCommon(data);
+    expect(data.Version).equals("1.2.3");
     expect(data.Framework).equals("react-native");
-    expect(data["Framework Version"]).equals("0.64.2");
+    expect(data["Framework Version"]).equals("1.0.1");
     expect(data["JavaScript Engine"]).equals("unknown");
-    expect(data["Realm Version"]).equals(getRealmVersion());
   });
 });

--- a/integration-tests/tests/src/node/fixtures/electron/node_modules/electron/package.json
+++ b/integration-tests/tests/src/node/fixtures/electron/node_modules/electron/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron",
+  "version": "1.0.1"
+}

--- a/integration-tests/tests/src/node/fixtures/electron/package.json
+++ b/integration-tests/tests/src/node/fixtures/electron/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fake-electron-package",
+  "version": "1.2.3",
+  "devDependencies": {
+    "electron": "^1.0.0"
+  }
+}

--- a/integration-tests/tests/src/node/fixtures/node/package.json
+++ b/integration-tests/tests/src/node/fixtures/node/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fake-node-package",
+  "version": "1.2.3"
+}

--- a/integration-tests/tests/src/node/fixtures/react-native/node_modules/react-native/package.json
+++ b/integration-tests/tests/src/node/fixtures/react-native/node_modules/react-native/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-native",
+  "version": "1.0.1"
+}

--- a/integration-tests/tests/src/node/fixtures/react-native/package.json
+++ b/integration-tests/tests/src/node/fixtures/react-native/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fake-react-native-package",
+  "version": "1.2.3",
+  "dependencies": {
+    "react-native": "^1.0.0"
+  }
+}

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -87,5 +87,5 @@ declare module "*.json" {
 }
 
 declare module "realm/scripts/submit-analytics" {
-  export function collectPlatformData(packageJson: Record<string, unknown>): Promise<Record<string, unknown>>;
+  export function collectPlatformData(packagePath: string): Promise<Record<string, unknown>>;
 }


### PR DESCRIPTION
## What, How & Why?

This is a refactor / fix of our analytics tests to read a fixture from a directory instead of a single package.json file to reflect the implementation. This also updates the analytics code to work from a package path argument, instead of a package.json object.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
