### PR TITLE
Adding type checking to the realm-app-importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Internal
 * Fixed analytics tests to reflect the fact that framework versions are read from node_modules, not package.json. ([#4687](https://github.com/realm/realm-js/pull/4687))
+* Adding response type checking to the realm-app-importer. ([#4688](https://github.com/realm/realm-js/pull/4688))
 * <Either mention core version or upgrade>
 * <Using Realm Core vX.Y.Z>
 * <Upgraded Realm Core from vX.Y.Z to vA.B.C>

--- a/packages/realm-app-importer/package-lock.json
+++ b/packages/realm-app-importer/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/body-parser": "^1.19.0",
 				"@types/fs-extra": "^8.1.0",
 				"@types/glob": "^7.1.3",
+				"@types/node": "^16",
 				"@types/node-fetch": "^2.5.5",
 				"@types/yargs": "^15.0.4"
 			}
@@ -74,9 +75,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.14.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-			"integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+			"version": "16.11.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+			"integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
 			"dev": true
 		},
 		"node_modules/@types/node-fetch": {
@@ -1106,9 +1107,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.14.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-			"integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+			"version": "16.11.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+			"integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
 			"dev": true
 		},
 		"@types/node-fetch": {

--- a/packages/realm-app-importer/package.json
+++ b/packages/realm-app-importer/package.json
@@ -47,6 +47,7 @@
     "@types/body-parser": "^1.19.0",
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.3",
+    "@types/node": "^16",
     "@types/node-fetch": "^2.5.5",
     "@types/yargs": "^15.0.4"
   }


### PR DESCRIPTION
## What, How & Why?

This adds type checking to the response objects returned from calling the admin API in the `realm-app-importer` package.
This was needed after an upgrade of `typescript` and `eslint` on the `kh/npm-workspaces` branch. Making this a separate PR to ease review.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
