### PR TITLE
Closing connections after calling `return` on `AsyncIntegrator` returned from `watch`

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed an issue where closing a watch stream, by calling `return` on the `AsyncIterator` wouldn't propagate to closing the underlying network connection. ([#4700](https://github.com/realm/realm-js/pull/4700))
 
 ### Internal
 * None

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None
 
 ### Fixed
-* Fixed an issue where closing a watch stream, by calling `return` on the `AsyncIterator` wouldn't propagate to closing the underlying network connection. ([#4700](https://github.com/realm/realm-js/pull/4700))
+* Fixed an issue where closing a watch stream, by calling `return` on the `AsyncIterator`, wouldn't propagate to closing the underlying network connection. ([#4700](https://github.com/realm/realm-js/pull/4700))
 
 ### Internal
 * None

--- a/packages/realm-web/src/Fetcher.ts
+++ b/packages/realm-web/src/Fetcher.ts
@@ -32,7 +32,7 @@ type StreamReader = {
   read<T>(): Promise<{ value: T | undefined; done: boolean }>;
   releaseLock(): void;
 };
-type ReadableStream = { getReader(): StreamReader };
+type ReadableStream = { getReader(): StreamReader; cancel: () => void };
 
 /**
  * @param body A possible resonse body.
@@ -292,7 +292,7 @@ export class Fetcher implements LocationUrlContext {
       const responseBody = await response.json();
       return deserialize(responseBody as SimpleObject) as ResponseBody;
     } else if (contentType === null) {
-      return (null as unknown) as ResponseBody;
+      return null as unknown as ResponseBody;
     } else {
       throw new Error(`Expected JSON response, got "${contentType}"`);
     }

--- a/packages/realm-web/src/Fetcher.ts
+++ b/packages/realm-web/src/Fetcher.ts
@@ -292,7 +292,7 @@ export class Fetcher implements LocationUrlContext {
       const responseBody = await response.json();
       return deserialize(responseBody as SimpleObject) as ResponseBody;
     } else if (contentType === null) {
-      return null as unknown as ResponseBody;
+      return (null as unknown) as ResponseBody;
     } else {
       throw new Error(`Expected JSON response, got "${contentType}"`);
     }

--- a/packages/realm-web/src/index.ts
+++ b/packages/realm-web/src/index.ts
@@ -20,8 +20,6 @@ export * as BSON from "bson";
 
 import { App } from "./App";
 
-console.log("Hello from realm-web");
-
 /**
  * Get or create a singleton Realm App from an id.
  * Calling this function multiple times with the same id will return the same instance.

--- a/packages/realm-web/src/index.ts
+++ b/packages/realm-web/src/index.ts
@@ -20,6 +20,8 @@ export * as BSON from "bson";
 
 import { App } from "./App";
 
+console.log("Hello from realm-web");
+
 /**
  * Get or create a singleton Realm App from an id.
  * Calling this function multiple times with the same id will return the same instance.


### PR DESCRIPTION
## What, How & Why?

This closes an issue, where calling `return` on the `AsyncIterator` returned by `watch` wouldn't free up the network connection.

The existing code was assuming that `return` would be called on the underlying iterator of a generator function, which is not explicit in the specification. The fix is to get a reference to the response body iterator and explicitly call `return` on this, while deferring all other implementation to a renamed `watchImpl` method.

The syntax involved in unwrapping and rewrapping the iterator is a bit involved, since `watch` must return synchronously while the response body iterator is obtained through a promise.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests (manually, locally)
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
