### PR TITLE
Update `RealmProvider.test.tsx` to ignore `testPath` realm file

### DIFF
--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -188,7 +188,7 @@ describe("RealmProvider", () => {
       return (
         <>
           <View testID="firstRealmProvider">
-            <RealmProvider realmRef={realmRef} schema={[dogSchema]} path="testPath">
+            <RealmProvider realmRef={realmRef} schema={[dogSchema]} path="testPath.realm">
               <RealmComponent />
             </RealmProvider>
           </View>
@@ -212,7 +212,7 @@ describe("RealmProvider", () => {
 
     const realmRefPathText = await waitFor(() => getByTestId("realmRefPath"));
 
-    expect(realmRefPathText).toHaveTextContent("testPath");
+    expect(realmRefPathText).toHaveTextContent("testPath.realm");
   });
   describe("initially renders a fallback, until realm exists", () => {
     it("as a component", async () => {


### PR DESCRIPTION
## What, How & Why?

The root .gitignore wasn't ignoring the `testPath.lock` produced by the test.
I'm appending `.realm` to get the result of this test ignored.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
