### PR TITLE
Fix types and add a test for flexible sync client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Adding response type checking to the realm-app-importer. ([#4688](https://github.com/realm/realm-js/pull/4688))
 * Updated integration test app to target Android SDK 31 ([#4686](https://github.com/realm/realm-js/pull/4686))
 * Enabled debugging Realm C++ code in integration test app ([#4696](https://github.com/realm/realm-js/pull/4696))
+* Fixed types for flexible sync client reset and added a test ([#4702](https://github.com/realm/realm-js/pull/4702))
 
 10.19.3 Release notes (2022-6-27)
 =============================================================

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -29,7 +29,7 @@
 // fraction too long.
 
 import { expect } from "chai";
-import Realm, { BSON, ClientResetMode, FlexibleSyncConfiguration, SessionStopPolicy, SyncError } from "realm";
+import Realm, { BSON, ClientResetMode, FlexibleSyncConfiguration, SessionStopPolicy } from "realm";
 
 import { authenticateUserBefore, importAppBefore, openRealmBeforeEach } from "../../hooks";
 import { DogSchema, IPerson, PersonSchema } from "../../schemas/person-and-dog-with-object-ids";

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -65,6 +65,7 @@ type UserContext = { user: Realm.User } & Mocha.Context;
 type RealmContext = {
   realm: Realm;
   config: Realm.Configuration;
+  user: Realm.User;
 } & Mocha.Context;
 type RealmObjectContext<T = Record<string, unknown>> = {
   object: Realm.Object & T;

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -65,7 +65,6 @@ type UserContext = { user: Realm.User } & Mocha.Context;
 type RealmContext = {
   realm: Realm;
   config: Realm.Configuration;
-  user: Realm.User;
 } & Mocha.Context;
 type RealmObjectContext<T = Record<string, unknown>> = {
   object: Realm.Object & T;

--- a/integration-tests/tests/src/utils/expect-sync-error.ts
+++ b/integration-tests/tests/src/utils/expect-sync-error.ts
@@ -19,7 +19,7 @@
 import { expect } from "chai";
 import { openRealm } from "./open-realm";
 
-type Error = Realm.SyncError | (Realm.ClientResetError & { message: string });
+type Error = Realm.SyncError | (Realm.ClientResetError & { message: string; code: number });
 
 /**
  * Open a new Realm and perform an action, expecting a sync error to occur. Will

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,10 +142,6 @@ declare namespace Realm {
         validateCallback?: SSLVerifyCallback;
     }
 
-    enum ClientResetModeManualOnly {
-        Manual = "manual",
-    }
-
     enum ClientResetMode {
         Manual = "manual",
         DiscardLocal = "discardLocal",
@@ -176,7 +172,7 @@ declare namespace Realm {
     interface FlexibleSyncConfiguration extends BaseSyncConfiguration {
         flexible: true;
         partitionValue?: never;
-        clientReset?: ClientResetConfiguration<ClientResetModeManualOnly>;
+        clientReset?: ClientResetConfiguration<ClientResetMode.Manual>;
         /**
          * Optional object to configure the setup of an initial set of flexible
          * sync subscriptions to be used when opening the Realm. If this is specified,


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

I wanted to confirm this was working after a question from the docs team. It turns out our TS definition to only allow "manual" mode was a bit incorrect so I fixed it, and added a simple test which replicates the PBS one in the old tests

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
