### PR TITLE
Add fix for older Android Gradle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fixed inadvertent change to minimum Android Gradle plugin version ([#4706](https://github.com/realm/realm-js/issues/4706), since v10.19.4)
 
 ### Compatibility
 * Atlas App Services.

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -53,11 +53,13 @@ android {
         compileTask -> compileTask.dependsOn forwardDebugPort
     }
 
-    // Do not strip debug symbols from debug builds of Realm
-    buildTypes {
-        debug {
-            packagingOptions {
-                jniLibs.keepDebugSymbols += "**/librealm.so"
+    if (com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION.compareTo("4.2") >= 0) {
+        // Do not strip debug symbols from debug builds of Realm
+        buildTypes {
+            debug {
+                packagingOptions {
+                    jniLibs.keepDebugSymbols += "**/librealm.so"
+                }
             }
         }
     }

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -53,12 +53,14 @@ android {
         compileTask -> compileTask.dependsOn forwardDebugPort
     }
 
-    if (com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION.compareTo("4.2") >= 0) {
-        // Do not strip debug symbols from debug builds of Realm
-        buildTypes {
-            debug {
-                packagingOptions {
+    // Do not strip debug symbols from debug builds of Realm
+    buildTypes {
+        debug {
+            packagingOptions {
+                if (com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION.compareTo("4.2") >= 0) {
                     jniLibs.keepDebugSymbols += "**/librealm.so"
+                } else {
+                    doNotStrip "**/librealm.so"
                 }
             }
         }

--- a/tests/ReactTestApp/android/build.gradle
+++ b/tests/ReactTestApp/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:4.2.2')
+        classpath('com.android.tools.build:gradle:4.1.2')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tests/ReactTestApp/android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/ReactTestApp/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What, How & Why?

#4697 inadvertently changed the minimum Android Gradle plugin version required when using Realm to 4.2.x. This change fixes that by wrapping the code in question in a version check, and adding a fallback to the old syntax for older Android Gradle versions (probably not strictly necessary but this would allow us to debug apps using the older Android Gradle version without modification).

I also reverted the test app back to the old version, so that we are still testing that version on CI

Fixes https://github.com/realm/realm-js/issues/4706
 
## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
