### PR TITLE
Add default logger for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Upgraded React Native integration tests app to React Native v0.68.2. ([#4583](https://github.com/realm/realm-js/pull/4583))
 * Upgraded React Native integration tests app to React Native v0.69.1. ([#4713](https://github.com/realm/realm-js/pull/4713))
 * Fixed a crash on Android when an error was thrown from the flexible sync `initialSubscriptions` call ([#4710](https://github.com/realm/realm-js/pull/4710), since v10.18.0)
+* Added a default sync logger for integration tests ([#4730](https://github.com/realm/realm-js/pull/4730))
 
 10.19.5 Release notes (2022-7-6)
 =============================================================

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -17,6 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 import { deleteApp, importApp, TemplateReplacements } from "../utils/import-app";
 
+const REALM_LOG_LEVELS = ["all", "trace", "debug", "detail", "info", "warn", "error", "fatal", "off"];
+
 export function importAppBefore(
   name: string,
   replacements?: TemplateReplacements,
@@ -30,6 +32,14 @@ export function importAppBefore(
     } else {
       this.app = await importApp(name, replacements);
       Realm.App.Sync.setLogLevel(this.app, logLevel);
+      // Set a default logger as Android does not forward stdout
+      Realm.App.Sync.setLogger(this.app, (level, message) => {
+        const magentaDate = `\x1b[35m${new Date().toISOString().replace("T", " ").replace("Z", "")}`;
+        const greenLogLevel = `\x1b[32m${REALM_LOG_LEVELS[level].toUpperCase()}`;
+        const whiteMessage = `\x1b[37m${message}}`;
+
+        console.log(`${magentaDate}: ${greenLogLevel}:\t${whiteMessage}`);
+      });
     }
   });
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This adds a default logger for the integration tests, as we currently get no output on Android as it forwards `stdout` to `/dev/null`. The log is colourised to help with reading it.

<img width="803" alt="image" src="https://user-images.githubusercontent.com/5458070/179244916-7a95b24b-e705-4e2d-a359-1fe2251ce34b.png">

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
