### PR TITLE
Fix for integration tests with skip_runner true on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Upgraded Realm Example app to React Native v0.69.1([#4722](https://github.com/realm/realm-js/pull/4722))
 * Fixed a crash on Android when an error was thrown from the flexible sync `initialSubscriptions` call ([#4710](https://github.com/realm/realm-js/pull/4710), since v10.18.0)
 * Added a default sync logger for integration tests ([#4730](https://github.com/realm/realm-js/pull/4730))
+* Fixed an issue starting the integration test runner on iOS ([#4742](https://github.com/realm/realm-js/pull/4742]))
 
 10.19.5 Release notes (2022-7-6)
 =============================================================

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -189,7 +189,9 @@ function optionalStringToBoolean(value) {
 
 if (module.parent === null) {
   if (SKIP_RUNNER === "true") {
-    ensureAndroidReversePorts();
+    if (PLATFORM === "android") {
+      ensureAndroidReversePorts();
+    }
     console.log("Skipping the runner - you're on your own");
     process.exit(0);
   }


### PR DESCRIPTION
Currently we try to adb reverse ports which fails, we only need do this for android

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
