### PR TITLE
Fix ccache on M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
+* Updated ccache build scripts to be location agnostic([#4764](https://github.com/realm/realm-js/pull/4764))
 * Upgraded Realm Core from v12.3.0 to v12.4.0. ([#4753](https://github.com/realm/realm-js/issues/4753)
 * Upgraded React Native integration tests app to React Native v0.68.2. ([#4583](https://github.com/realm/realm-js/pull/4583))
 * Upgrading `react-native-fs` to avoid a peer dependency failure. ([#4709](https://github.com/realm/realm-js/pull/4709))
@@ -28,7 +29,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fixed a crash on Android when an error was thrown from the flexible sync `initialSubscriptions` call. ([#4710](https://github.com/realm/realm-js/pull/4710), since v10.18.0)
 * Added a default sync logger for integration tests. ([#4730](https://github.com/realm/realm-js/pull/4730))
 * Fixed an issue starting the integration test runner on iOS. ([#4742](https://github.com/realm/realm-js/pull/4742]))
-* Migrated to `std::optional` and `std::nullopt`. 
+* Migrated to `std::optional` and `std::nullopt`.
 
 10.19.5 Release notes (2022-7-6)
 =============================================================

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -3,38 +3,38 @@
 <!-- TOC generated with https://github.com/ekalinin/github-markdown-toc : gh-md-toc --insert --no-backup --hide-footer contrib/building.md -->
 
 <!--ts-->
-* [Building Realm JS](#building-realm-js)
-   * [Pre-Requisites](#pre-requisites)
-      * [Setup instructions for MacOS](#setup-instructions-for-macos)
-         * [All platforms](#all-platforms)
-         * [iOS](#ios)
-         * [Android](#android)
-         * [Optional extras](#optional-extras)
-            * [ccache](#ccache)
-   * [Cloning the repository](#cloning-the-repository)
-      * [Cloning the repository on Windows](#cloning-the-repository-on-windows)
-      * [Visual Studio Code setup](#visual-studio-code-setup)
-         * [TypeScript](#typescript)
-         * [C++](#c)
-   * [Building Realm JS](#building-realm-js-1)
-      * [Building for iOS](#building-for-ios)
-      * [Building for Android](#building-for-android)
-      * [Building for Node.js](#building-for-nodejs)
-         * [Additional steps for Windows](#additional-steps-for-windows)
-      * [Building the documentation](#building-the-documentation)
-   * [Installing the project's sub-packages](#installing-the-projects-sub-packages)
-   * [Running the tests](#running-the-tests)
-      * [Modern tests](#modern-tests)
-      * [Legacy tests](#legacy-tests)
-      * [Linting the source code](#linting-the-source-code)
-         * [JS](#js)
-         * [C++](#c-1)
-         * [Testing on Windows](#testing-on-windows)
-         * [Node version setup](#node-version-setup)
-   * [Testing against real apps](#testing-against-real-apps)
-   * [Debugging](#debugging)
-      * [Debugging failing Github Actions CI tests](#debugging-failing-github-actions-ci-tests)
-   * [Updating the Android JNI headers](#updating-the-android-jni-headers)
+- [Building Realm JS](#building-realm-js)
+  - [Pre-Requisites](#pre-requisites)
+    - [Setup instructions for MacOS](#setup-instructions-for-macos)
+      - [All platforms](#all-platforms)
+      - [iOS](#ios)
+      - [Android](#android)
+      - [Optional extras](#optional-extras)
+        - [ccache](#ccache)
+  - [Cloning the repository](#cloning-the-repository)
+    - [Cloning the repository on Windows](#cloning-the-repository-on-windows)
+    - [Visual Studio Code setup](#visual-studio-code-setup)
+      - [TypeScript](#typescript)
+      - [C++](#c)
+  - [Building Realm JS](#building-realm-js-1)
+    - [Building for iOS](#building-for-ios)
+    - [Building for Android](#building-for-android)
+    - [Building for Node.js](#building-for-nodejs)
+      - [Additional steps for Windows](#additional-steps-for-windows)
+    - [Building the documentation](#building-the-documentation)
+  - [Installing the project's sub-packages](#installing-the-projects-sub-packages)
+  - [Running the tests](#running-the-tests)
+    - [Modern tests](#modern-tests)
+    - [Legacy tests](#legacy-tests)
+    - [Linting the source code](#linting-the-source-code)
+      - [JS](#js)
+      - [C++](#c-1)
+      - [Testing on Windows](#testing-on-windows)
+      - [Node version setup](#node-version-setup)
+  - [Testing against real apps](#testing-against-real-apps)
+  - [Debugging](#debugging)
+    - [Debugging failing Github Actions CI tests](#debugging-failing-github-actions-ci-tests)
+  - [Updating the Android JNI headers](#updating-the-android-jni-headers)
 <!--te-->
 
 ## Pre-Requisites
@@ -134,8 +134,11 @@ To improve compilation speed. you can use [ccache](https://ccache.dev/):
 # Install ccache
 brew install ccache
 
+# check path of ccache
+which ccache
+
 # Export the ccache variants of compilation tools
-export PATH=/usr/local/opt/ccache/libexec:$PATH
+export PATH=<ccache location>/libexec:$PATH
 ```
 
 ## Cloning the repository

--- a/scripts/ccache-clang++.sh
+++ b/scripts/ccache-clang++.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
-if type -p /usr/local/bin/ccache >/dev/null 2>&1; then
+if command -v ccache &> /dev/null; then
   export CCACHE_MAXSIZE=10G
   export CCACHE_CPP2=true
   export CCACHE_HARDLINK=true
   export CCACHE_SLOPPINESS=file_macro,time_macros,include_file_mtime,include_file_ctime,file_stat_matches
-  exec /usr/local/bin/ccache /usr/bin/clang++ "$@"
+  exec ccache clang++ "$@"
 else
   exec clang++ "$@"
 fi
-

--- a/scripts/ccache-clang.sh
+++ b/scripts/ccache-clang.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
-if type -p /usr/local/bin/ccache >/dev/null 2>&1; then
+if command -v ccache &> /dev/null; then
   export CCACHE_MAXSIZE=10G
   export CCACHE_CPP2=true
   export CCACHE_HARDLINK=true
   export CCACHE_SLOPPINESS=file_macro,time_macros,include_file_mtime,include_file_ctime,file_stat_matches
-  exec /usr/local/bin/ccache /usr/bin/clang "$@"
+  exec ccache clang "$@"
 else
   exec clang "$@"
 fi
-


### PR DESCRIPTION
Homebrew installs ccache in a different directory on the M1.
This checks if ccache exists in the path rather then a specific location.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
