### PR TITLE
Remove values array from `Realm.Object#create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@
 * File format: generates Realms with format v23 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Removed an internal API used to create objects from an array of values. ([#4769](https://github.com/realm/realm-js/pull/4769))
 
 ## 11.7.0 (2023-03-26)
 

--- a/src/js_object_accessor.hpp
+++ b/src/js_object_accessor.hpp
@@ -597,8 +597,7 @@ struct Unbox<JSEngine, Obj> {
         }
 
         if (Value::is_array(native_accessor->m_ctx, js_object)) {
-            js_object = Schema<JSEngine>::dict_for_property_array(native_accessor->m_ctx,
-                                                                  *native_accessor->m_object_schema, js_object);
+            throw std::runtime_error("Expected an object with property values, not an array");
         }
 
         auto child = realm::Object::create<ValueType>(*native_accessor, native_accessor->m_realm,

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1346,7 +1346,7 @@ void RealmClass<T>::create(ContextType ctx, ObjectType this_object, Arguments& a
 
     ObjectType object = Value::validated_to_object(ctx, args[1], "properties");
     if (Value::is_array(ctx, args[1])) {
-        object = Schema<T>::dict_for_property_array(ctx, object_schema, object);
+        throw std::runtime_error("Expected an object with property values, not an array");
     }
 
     if (Object::template is_instance<RealmObjectClass<T>>(ctx, object)) {

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -41,7 +41,6 @@ struct Schema {
     using ObjectDefaultsMap = std::map<std::string, ObjectDefaults>;
     using ConstructorMap = std::map<std::string, Protected<FunctionType>>;
 
-    static ObjectType dict_for_property_array(ContextType, const ObjectSchema&, ObjectType);
     static Property parse_property(ContextType, ValueType, StringData, std::string, ObjectDefaults&);
     static ObjectSchema parse_object_schema(ContextType, ObjectType, ObjectDefaultsMap&, ConstructorMap&);
     static realm::Schema parse_schema(ContextType, ObjectType, ObjectDefaultsMap&, ConstructorMap&);
@@ -50,27 +49,6 @@ struct Schema {
     static ObjectType object_for_object_schema(ContextType, const ObjectSchema&);
     static ObjectType object_for_property(ContextType, const Property&);
 };
-
-template <typename T>
-typename T::Object Schema<T>::dict_for_property_array(ContextType ctx, const ObjectSchema& object_schema,
-                                                      ObjectType array)
-{
-    size_t count = object_schema.persisted_properties.size();
-
-    if (count != Object::validated_get_length(ctx, array)) {
-        throw std::runtime_error("Array must contain values for all object properties");
-    }
-
-    ObjectType dict = Object::create_empty(ctx);
-
-    for (uint32_t i = 0; i < count; i++) {
-        ValueType value = Object::get_property(ctx, array, i);
-        Property prop = object_schema.persisted_properties[i];
-        Object::set_property(ctx, dict, !prop.public_name.empty() ? prop.public_name : prop.name, value);
-    }
-
-    return dict;
-}
 
 static inline void parse_property_type(StringData object_name, Property& prop, StringData type)
 {


### PR DESCRIPTION
## What, How & Why?

This feature was never documented and it depends on the order of properties in the schema, which feels like an implementation detail to me.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
