### PR TITLE
Fix end-to-end tests

### DIFF
--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1391,7 +1391,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         return realm.create<IPerson>(FlexiblePersonSchema.name, { _id: new BSON.ObjectId(), name: "Tom", age: 36 });
       });
 
-      await realm.subscriptions.waitForSynchronization();
+      await realm?.syncSession?.uploadAllLocalChanges();
 
       return { person, id: person._id };
     }
@@ -1425,6 +1425,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
       expect(newRealm.objectForPrimaryKey(FlexiblePersonSchema.name, id)).to.be.undefined;
 
       await newRealm.subscriptions.update((mutableSubs) => subsUpdateFn(mutableSubs, newRealm));
+
+      // This was added to ensure all server changes are downloaded before any tests assertions
+      await newRealm?.syncSession?.downloadAllServerChanges();
 
       return { id, newRealm };
     }
@@ -1480,6 +1483,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         mutableSubs.add(newRealm.objects(FlexiblePersonSchema.name).filtered("age > 30"));
       });
 
+      await newRealm?.syncSession?.uploadAllLocalChanges();
+
       newRealm.addListener("change", () => {
         expect(newRealm.objectForPrimaryKey(FlexiblePersonSchema.name, id)).to.not.be.undefined;
       });
@@ -1500,6 +1505,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         mutableSubs.removeAll();
         mutableSubs.add(newRealm.objects(FlexiblePersonSchema.name).filtered("age > 30"));
       });
+
+      await newRealm?.syncSession?.uploadAllLocalChanges();
 
       newRealm.addListener("change", () => {
         expect(newRealm.objectForPrimaryKey(FlexiblePersonSchema.name, id)).to.not.be.undefined;


### PR DESCRIPTION
It would seem the assumption that waitForSynchronization would
allow the latest data to propogate is no longer valid.
We now require a call to downloadAllServerChanges before we make assertions.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
