### PR TITLE
Andrew/fix dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fixed a crash on Android when an error was thrown from the flexible sync `initialSubscriptions` call. ([#4710](https://github.com/realm/realm-js/pull/4710), since v10.18.0)
 * Added a default sync logger for integration tests. ([#4730](https://github.com/realm/realm-js/pull/4730))
 * Fixed an issue starting the integration test runner on iOS. ([#4742](https://github.com/realm/realm-js/pull/4742]))
+* Fixed dark mode logo in README.md. ([#4780](https://github.com/realm/realm-js/pull/4780))
 * Migrated to `std::optional` and `std::nullopt`.
 
 10.19.5 Release notes (2022-7-6)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![realm by MongoDB](./logo.svg#gh-light-mode-only)](https://realm.io#gh-light-mode-only)
-[![realm by MongoDB](./logo-dark.svg#gh-dark-mode-only)](https://realm.io#gh-dark-mode-only)
+<picture>
+    <source srcset="./logo-dark.svg" media="(prefers-color-scheme: dark)" alt="realm by MongoDB">
+    <img src="./logo.svg" alt="realm by MongoDB">
+</picture>
 
 Realm is a mobile database that runs directly inside phones, tablets or wearables.
 This project hosts the JavaScript versions of [Realm](https://realm.io/). Currently we support React Native (both iOS & Android), Node.js and Electron (on Windows, MacOS and Linux).


### PR DESCRIPTION
## What, How & Why?

Github now supports an html version of darkmode logos ([https://github.blog/changelog/2022-08-15-specify-theme-context-for-images-in-markdown-ga/](reference))
This updates our readme.  It should fix the double logo on npmjs.com.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
