### PR TITLE
Extend Cleanup Action

### DIFF
--- a/.github/workflows/cleanup-clusters.yml
+++ b/.github/workflows/cleanup-clusters.yml
@@ -8,8 +8,16 @@ jobs:
     name: Wipe all clusters and apps
     steps:
     - uses: realm/ci-actions/mdb-realm/deleteAllClusters@3d95b9f473d06ef0f56e1a5d8c5981743dc4fed9
+      name: "on realm.dev"
       with:
         realmUrl: ${{ secrets.REALM_BASE_URL }}
         projectId: ${{ secrets.ATLAS_PROJECT_ID }}
         apiKey: ${{ secrets.ATLAS_PUBLIC_API_KEY }}
         privateApiKey: ${{ secrets.ATLAS_PRIVATE_API_KEY }}
+    - uses: realm/ci-actions/mdb-realm/deleteAllClusters@3d95b9f473d06ef0f56e1a5d8c5981743dc4fed9
+      name: "on realm.qa"
+      with:
+        realmUrl: ${{ secrets.REALM_QA_BASE_URL }}
+        projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
+        apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+        privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}


### PR DESCRIPTION
The cleanup action was only cleaning realm.dev, but not realm.qa

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
