### PR TITLE
[Jenkins] Disable iOS and Catalyst testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fixed an issue starting the integration test runner on iOS. ([#4742](https://github.com/realm/realm-js/pull/4742]))
 * Fixed dark mode logo in README.md. ([#4780](https://github.com/realm/realm-js/pull/4780))
 * Migrated to `std::optional` and `std::nullopt`.
+* Disabled testing on iOS and Catalyst on legacy CI system.
 
 10.19.5 Release notes (2022-7-6)
 =============================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,8 +141,8 @@ stage('test') {
   parallelExecutors["Windows node ${nodeTestVersion}"] = testWindows(nodeTestVersion)
 
   parallelExecutors["React Native Android Release"] = inAndroidContainer { testAndroid('test-android') }
-  parallelExecutors["React Native iOS Release"] = testMacOS('react-tests Release')
-  parallelExecutors["React Native Catalyst Release"] = testMacOS('catalyst-tests Release')
+  // parallelExecutors["React Native iOS Release"] = testMacOS('react-tests Release')
+  // parallelExecutors["React Native Catalyst Release"] = testMacOS('catalyst-tests Release')
 
   parallelExecutors["macOS Electron Debug"] = testMacOS('electron Debug')
   parallelExecutors["macOS Electron Release"] = testMacOS('electron Release')


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

We are consistently seeing issues with iOS and Catalyst. https://github.com/realm/realm-js/issues/4814 is created to remember to enable the testing once we understand how.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
