### PR TITLE
Added exit on missing emulator

### DIFF
--- a/integration-tests/environments/react-native/harness/logcat.js
+++ b/integration-tests/environments/react-native/harness/logcat.js
@@ -22,6 +22,10 @@ function getProcessId(packageName) {
   try {
     return android.adb.shellPidOf(packageName);
   } catch (err) {
+    if (err instanceof Error && err.message.includes("no devices/emulators found")) {
+      console.error("The emulator disappeared - exiting the runner!");
+      process.exit(1);
+    }
     // We'll consider the pid unavailable on any failure
     return undefined;
   }


### PR DESCRIPTION
## What, How & Why?

Adds a check on the error message from retrieval of the app process id, to test if the emulator has gone away and exit the runner if it did.

I verified that this indeed exists when terminating the emulator while running locally.
