### PR TITLE
Remove the type for the `Object#_objectId`

### DIFF
--- a/.github/workflows/pr-realm-react.yml
+++ b/.github/workflows/pr-realm-react.yml
@@ -52,7 +52,10 @@ jobs:
         run: echo PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 
       - name: Install realm node dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Build realm for node
+        run: npm run prebuild:node -- --arch=${{matrix.variant.arch}}
 
       - name: Bootstrap @realm.io/react
         run: npx lerna bootstrap --scope @realm/react --include-dependencies

--- a/.github/workflows/pr-realm-react.yml
+++ b/.github/workflows/pr-realm-react.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Install realm node dependencies
         run: npm ci --ignore-scripts
 
-      - name: Build realm for node
-        run: npm run prebuild:node -- --arch=${{matrix.variant.arch}}
+      - name: Build realm
+        run: npm run build
 
       - name: Bootstrap @realm.io/react
         run: npx lerna bootstrap --scope @realm/react --include-dependencies

--- a/.github/workflows/publish-realm-react.yml
+++ b/.github/workflows/publish-realm-react.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
 
       - name: Bootstrap @realm/react
-        run: npm install realm --prefix packages/realm-react --no-save
+        run: npx lerna bootstrap --scope=@realm/react
         env:
           npm_config_realm_local_prebuilds: ${{ github.workspace }}/prebuilds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Notes
 Based on Realm JS v10.21.1: See changelog below for details on enhancements and fixes introduced between this and the previous pre release (which was based on Realm JS v10.19.5).
 
+<<<<<<< HEAD
 ### Breaking changes
 * Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
    * `Realm.Credentials#serverApiKey`
@@ -10,6 +11,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
 * When no object is found calling `Realm#objectForPrimaryKey`, `null` is returned instead of `undefined`
 * Replaced `Realm#empty` with `Realm#isEmpty`
 * Replaced `Realm#readOnly` with `Realm#isReadOnly`
+* Removed `Object#_objectId`, which is now replaced by `Object#_objectKey`
 * Removed deprecated positional arguments to Email/Password authentication functions
     * The following functions now only accept object arguments:
     ```javascript

--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -111,7 +111,7 @@ describe("Class models", () => {
         expect(alice.name).equals("Alice");
         // Expect the first element to be the object we just added
         expect(persons.length).equals(1);
-        expect(persons[0]._objectId()).equals(alice._objectId());
+        expect(persons[0]._objectKey()).equals(alice._objectKey());
         expect(persons[0].name).equals("Alice");
         // Property value fallback to the default
         expect(persons[0].age).equals(32);

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -75,7 +75,7 @@ module.exports = function (realmConstructor) {
 
   const getInternalCacheId = (realmObj) => {
     const { name, primaryKey } = realmObj.objectSchema();
-    const id = primaryKey ? realmObj[primaryKey] : realmObj._objectId();
+    const id = primaryKey ? realmObj[primaryKey] : realmObj._objectKey();
     return `${name}#${id}`;
   };
 

--- a/packages/realm-react/src/cachedCollection.ts
+++ b/packages/realm-react/src/cachedCollection.ts
@@ -112,7 +112,7 @@ export function createCachedCollection<T extends Realm.Object>({
         return undefined;
       }
 
-      const objectId = object._objectId();
+      const objectId = object._objectKey();
       const cacheKey = getCacheKey(objectId);
 
       // If we do, return it...
@@ -141,7 +141,7 @@ export function createCachedCollection<T extends Realm.Object>({
 
       // Possible solutions:
       // a. the listenerCollection is a frozen copy of the collection before the deletion,
-      // allowing accessing the _objectId() using listenerCollection[index]._objectId()
+      // allowing accessing the _objectKey() using listenerCollection[index]._objectKey()
       // b. the callback provides an array of changed objectIds
 
       if (changes.deletions.length > 0) {
@@ -150,7 +150,7 @@ export function createCachedCollection<T extends Realm.Object>({
 
       // Item(s) were modified, just clear them from the cache so that we return new instances for them
       changes.newModifications.forEach((index) => {
-        const objectId = listenerCollection[index]._objectId();
+        const objectId = listenerCollection[index]._objectKey();
         if (objectId) {
           const cacheKey = getCacheKey(objectId);
           if (objectCache.has(cacheKey)) {

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -110,7 +110,6 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
         {"linkingObjectsCount", wrap<linking_objects_count>},
         {"_isSameObject", wrap<is_same_object>},
         {"_objectKey", wrap<get_object_key>},
-        {"_objectId", wrap<get_object_id>},
         {"_setLink", wrap<set_link>},
         {"addListener", wrap<add_listener>},
         {"removeListener", wrap<remove_listener>},
@@ -351,22 +350,6 @@ void RealmObjectClass<T>::get_object_key(ContextType ctx, ObjectType object, Arg
     const Obj& obj = realm_object->obj();
     auto obj_key = obj.get_key();
     return_value.set(std::to_string(obj_key.value));
-}
-
-template <typename T>
-void RealmObjectClass<T>::get_object_id(ContextType ctx, ObjectType object, Arguments& args,
-                                        ReturnValue& return_value)
-{
-    args.validate_maximum(0);
-
-    auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
-    if (!realm_object) {
-        throw std::runtime_error("Invalid 'this' object");
-    }
-
-    const Obj& obj = realm_object->obj();
-    auto obj_id = obj.get_object_id();
-    return_value.set(obj_id.to_string());
 }
 
 template <typename T>

--- a/tests/js/linkingobjects-tests.js
+++ b/tests/js/linkingobjects-tests.js
@@ -213,21 +213,21 @@ module.exports = {
     TestCase.assertEqual(john.linkingObjectsCount(), 0);
 
     var olivier;
-    var id;
+    var key;
     realm.write(function () {
       olivier = realm.create("PersonObject", { name: "Olivier", age: 0 });
-      id = olivier._objectId();
+      key = olivier._objectKey();
       realm.create("PersonObject", { name: "Christine", age: 25, children: [olivier] });
     });
 
     TestCase.assertEqual(olivier.linkingObjectsCount(), 1);
-    TestCase.assertEqual(olivier._objectId(), id);
+    TestCase.assertEqual(olivier._objectKey(), key);
 
     realm.write(function () {
       john.children.push(olivier);
     });
 
-    TestCase.assertEqual(olivier._objectId(), id);
+    TestCase.assertEqual(olivier._objectKey(), key);
     TestCase.assertEqual(john.children.length, 1);
     TestCase.assertEqual(john.children[0]["name"], "Olivier");
     TestCase.assertEqual(realm.objects("PersonObject").length, 3);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -320,8 +320,6 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
-        _objectId(): string;
-
         /**
          * @returns void
          */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -320,6 +320,8 @@ declare namespace Realm {
          */
         linkingObjectsCount(): number;
 
+        _objectKey(): string;
+
         /**
          * @returns void
          */


### PR DESCRIPTION
## What, How & Why?

This closes #4820

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] Migrate this over to the `_objectKey` introduced on master (after v11 has been rebased):
  * [ ] [tests/js/linkingobjects-tests.js#L219-L230](https://github.com/realm/realm-js/blob/kh/remove-objects-objectId/tests/js/linkingobjects-tests.js#L219-L230)
  * [ ] [integration-tests/tests/src/tests/class-models.ts#L114](https://github.com/realm/realm-js/blob/kh/remove-objects-objectId/integration-tests/tests/src/tests/class-models.ts#L114)
  * [ ] [lib/extensions.js#L78](https://github.com/realm/realm-js/blob/kh/remove-objects-objectId/lib/extensions.js#L78)
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
