### PR TITLE
Fixed an offset error in Node buffer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: This version is unrelated to the v10.20.0-alpha and v10.20.0-beta prerelea
 * Fixed an incorrect git merge in the Xcode project from RN iOS. ([#4756](https://github.com/realm/realm-js/issues/4756), since v10.19.5)
 * Fixed detection of emulator environments to be more robust.  Thanks to [Ferry Kranenburg](https://github.com/fkranenburg) for identifying the issue and supplying a PR. ([#4784](https://github.com/realm/realm-js/issues/4784))
 * Opening a read-only synced Realm for the first time could lead to `m_schema_version != ObjectStore::NotVersioned` assertion.
+* Fixed an offset error in Node buffer handling ([#3781](https://github.com/realm/realm-js/issues/3781), since v10.0.0)
 
 ### Compatibility
 * Atlas App Services.

--- a/src/node/node_buffer.hpp
+++ b/src/node/node_buffer.hpp
@@ -48,15 +48,15 @@ auto get_data(ArrayBuffer buffer)
 template <>
 auto get_data<DataView>(DataView data_view)
 {
-    auto buffer = data_view.ArrayBuffer();
-    return static_cast<const char*>(buffer.Data());
+    Napi::ArrayBuffer buffer = data_view.ArrayBuffer();
+    return (static_cast<const char*>(buffer.Data()) + data_view.ByteOffset());
 }
 
 template <>
 auto get_data<TypedArray>(TypedArray typed_array)
 {
-    auto buffer = typed_array.ArrayBuffer();
-    return static_cast<const char*>(buffer.Data());
+    Napi::ArrayBuffer buffer = typed_array.ArrayBuffer();
+    return (static_cast<const char*>(buffer.Data())) + typed_array.ByteOffset();
 }
 
 class NodeBinary {


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

Fix an error on our type conversion of Node's binary buffers where the target type's `byteOffset` wouldn't be respected.
Note:  this code is never called at present. 

This closes #3781.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
