### PR TITLE
Update Minimum React Native Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: This version is unrelated to the v10.20.0-alpha and v10.20.0-beta prerelea
 * Opening a read-only synced Realm for the first time could lead to `m_schema_version != ObjectStore::NotVersioned` assertion.
 
 ### Compatibility
+* React Native >= v0.64.0
 * Atlas App Services.
 * Realm Studio v12.0.0.
 * APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "url-parse": "^1.4.4"
   },
   "peerDependencies": {
-    "react-native": ">=0.60"
+    "react-native": ">=0.64"
   },
   "peerDependenciesMeta": {
     "react-native": {

--- a/scripts/changelog-header.sh
+++ b/scripts/changelog-header.sh
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * None.
 
 ### Compatibility
+* React Native >= v0.64.0
 * Atlas App Services.
 * Realm Studio v12.0.0.
 * APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.


### PR DESCRIPTION
Our release 10.20.0 is not compatible with React Native < 0.64.

This closes #[4834](https://github.com/realm/realm-js/issues/4834)

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
