### PR TITLE
Fix the type of PropertyType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
+### Breaking change
+* Fix the type of PropertyType ([#4840](https://github.com/realm/realm-js/pull/4840))
+      * Example:
+    ```typescript
+      const schema : Realm.ObjectSchema = {
+        name: "MySchema",
+        properties:{
+          name: 'string' // the type will now autocomplete
+          thing: 'invalid' // this will be shown as a type error
+        }
+      }
+    ```
+
 ### Enhancements
 * None.
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,7 +36,7 @@ declare namespace Realm {
      * PropertyType
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.html#~PropertyType }
      */
-    type PropertyType = string | 'bool' | 'int' | 'float' | 'double' | 'decimal128' | 'objectId' | 'string' | 'data' | 'date' | 'list' | 'linkingObjects';
+    type PropertyType = 'bool' | 'int' | 'float' | 'double' | 'decimal128' | 'objectId' | 'string' | 'data' | 'date' | 'list' | 'linkingObjects';
 
     /**
      * ObjectSchemaProperty


### PR DESCRIPTION
# Fix the type of PropertyType
The typings for a property type did not allow for autocompletion or
showing an error with an invalid type.

This closes #4181 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
