### PR TITLE
Fix TypeScript errors in @realm/react

### DIFF
--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -38,7 +38,8 @@
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-native": "^0.65.1",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "^17.0.2",
+    "realm": "*"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -61,7 +61,7 @@ export function createUseObject(useRealm: () => Realm) {
       // When this is implemented, remove `?? null`
       () =>
         createCachedObject({
-          object: realm.objectForPrimaryKey(type, primaryKey) ?? null,
+          object: realm.objectForPrimaryKey<unknown>(type, primaryKey) ?? null,
           realm,
           updateCallback: forceRerender,
         }),
@@ -79,6 +79,6 @@ export function createUseObject(useRealm: () => Realm) {
     }
 
     // Wrap object in a proxy to update the reference on rerender ( should only rerender when something has changed )
-    return new Proxy(object, {});
+    return new Proxy(object, {}) as T & Realm.Object<T>;
   };
 }


### PR DESCRIPTION
## What, How & Why?
Changes to class based models caused @realm/react to break.
This addresses these changes.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
