### PR TITLE
Update flexible sync tests after 10.19.4

### DIFF
--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -193,22 +193,6 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         }).to.not.throw();
       });
 
-      it("throws an error if flexible sync is enabled and client reset mode is discardLocal", function () {
-        expect(() => {
-          // @ts-expect-error Intentionally testing the wrong type
-          new Realm({
-            sync: {
-              _sessionStopPolicy: SessionStopPolicy.Immediately,
-              flexible: true,
-              user: this.user,
-              clientReset: {
-                mode: ClientResetMode.DiscardLocal,
-              },
-            },
-          });
-        }).to.throw("Only manual client resets are supported with flexible sync");
-      });
-
       describe("initialSubscriptions option", function () {
         function getConfig(
           user: Realm.User,


### PR DESCRIPTION
## What, How & Why?

As of Realm JS 10.19.4 an update in Realm Core now allows for discardLocal client reset mode.
This PR is removing a test that now fails as it was testing to ensure an error was thrown.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
