### PR TITLE
Fix normalisation of `embedded` and `asymmetric` on `Realm#schema`

### DIFF
--- a/integration-tests/tests/src/tests/sync/asymmetric.ts
+++ b/integration-tests/tests/src/tests/sync/asymmetric.ts
@@ -44,8 +44,7 @@ describe.skipIf(environment.missingServer, "Asymmetric sync", function () {
       },
     });
 
-    // TODO: Look into what caused this test to fail
-    it.skip("Schema with asymmetric = true and embedded = false", function () {
+    it("Schema with asymmetric = true and embedded = false", function () {
       const schema = this.realm.schema;
       expect(schema.length).to.equal(1);
       expect(schema[0].asymmetric).to.equal(true);

--- a/src/js_schema.hpp
+++ b/src/js_schema.hpp
@@ -475,8 +475,10 @@ typename T::Object Schema<T>::object_for_object_schema(ContextType ctx, const Ob
     switch (object_schema.table_type) {
         case ObjectSchema::ObjectType::Embedded:
             Object::set_property(ctx, object, embedded_string, Value::from_boolean(ctx, true));
+            Object::set_property(ctx, object, asymmetric_string, Value::from_boolean(ctx, false));
             break;
         case ObjectSchema::ObjectType::TopLevelAsymmetric:
+            Object::set_property(ctx, object, embedded_string, Value::from_boolean(ctx, false));
             Object::set_property(ctx, object, asymmetric_string, Value::from_boolean(ctx, true));
             break;
         default:


### PR DESCRIPTION
## What, How & Why?

This updates the values of a `Realm#schema` to include `embedded` and `asymmetric` even if they're not set.

This fixes #4833

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
