### PR TITLE
Statically cache the String value of g_internal_field for a small performance gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
+* Small improvement to performance by caching JSI property String object [#4862](https://github.com/realm/realm-js/pull/4862)
 * None.
 
 ### Fixed

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -490,9 +490,7 @@ public:
 
     static Internal* get_internal(JsiEnv env, const JsiObj& object)
     {
-        static const auto js_internal_field = fbjsi::String::createFromAscii(env, g_internal_field);
-
-        auto internal = object->getProperty(env, js_internal_field);
+        auto internal = object->getProperty(env, g_internal_field);
         if (internal.isUndefined()) {
             // In the case of a user opening a Realm with a class-based model,
             // the user defined constructor will get called before the "internal" property has been set.
@@ -665,8 +663,7 @@ private:
 } // namespace realmjsi
 
 template <typename ClassType>
-class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {
-};
+class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {};
 
 template <realmjsi::ArgumentsMethodType F>
 fbjsi::Value wrap(fbjsi::Runtime& rt, const fbjsi::Value& thisVal, const fbjsi::Value* args, size_t count)

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -490,7 +490,9 @@ public:
 
     static Internal* get_internal(JsiEnv env, const JsiObj& object)
     {
-        auto internal = object->getProperty(env, g_internal_field);
+        static const auto js_internal_field = fbjsi::String::createFromAscii(env, g_internal_field);
+
+        auto internal = object->getProperty(env, js_internal_field);
         if (internal.isUndefined()) {
             // In the case of a user opening a Realm with a class-based model,
             // the user defined constructor will get called before the "internal" property has been set.
@@ -663,7 +665,8 @@ private:
 } // namespace realmjsi
 
 template <typename ClassType>
-class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {};
+class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {
+};
 
 template <realmjsi::ArgumentsMethodType F>
 fbjsi::Value wrap(fbjsi::Runtime& rt, const fbjsi::Value& thisVal, const fbjsi::Value* args, size_t count)


### PR DESCRIPTION
## What, How & Why?
This optimisation yields a small (~5% with Hermes disabled, ~2% with Hermes enabled) performance improvement with our benchmark suite, as it avoids the overhead of repeatedly creating the JSI String object.

![image](https://user-images.githubusercontent.com/5458070/188429670-0f925023-cc94-4d6c-8533-f0f54ded0398.png)

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
