### PR TITLE
Statically cache the String value of g_internal_field for a small performance gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
+* Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 * None.
 
 ### Fixed

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -672,8 +672,7 @@ private:
 } // namespace realmjsi
 
 template <typename ClassType>
-class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {
-};
+class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {};
 
 template <realmjsi::ArgumentsMethodType F>
 fbjsi::Value wrap(fbjsi::Runtime& rt, const fbjsi::Value& thisVal, const fbjsi::Value* args, size_t count)

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -145,7 +145,10 @@ inline void copyProperty(JsiEnv env, const fbjsi::Object& from, const fbjsi::Obj
     defineProperty(env, to, name, *prop);
 }
 
-inline constexpr const char g_internal_field[] = "__Realm_internal";
+// The name used for the property on the JS object which stores the reference to the corresponding C++ object.
+// We use an empty string as testing showed it was 1% faster with JSC and 4% faster with Hermes than using
+// an actual string, and also has the benefit that it is not a valid Realm object key name.
+inline constexpr const char g_internal_field[] = "";
 
 template <typename T>
 using ClassDefinition = js::ClassDefinition<js::realmjsi::Types, T>;

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -495,7 +495,7 @@ public:
 
     static Internal* get_internal(JsiEnv env, const JsiObj& object)
     {
-        if (!s_js_internal_field_name) {
+        if (REALM_UNLIKELY(!s_js_internal_field_name)) {
             s_js_internal_field_name = fbjsi::String::createFromAscii(env, g_internal_field);
         }
 

--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -315,7 +315,7 @@ public:
 
         js::Context<js::realmjsi::Types>::register_invalidator([] {
             // Ensure the static constructor and JSI String reference are destructed when the runtime goes away.
-            // This is to avoid the reassignment throwing because the runtime has disappeared.
+            // This is to avoid reassignment and destruction throwing because the runtime has disappeared.
             s_ctor.reset();
             s_js_internal_field_name.reset();
         });


### PR DESCRIPTION
## What, How & Why?
This optimisation yields a small (~5% with Hermes disabled, ~2% with Hermes enabled) performance improvement with our benchmark suite, as it avoids the overhead of repeatedly creating the JSI String object.

![image](https://user-images.githubusercontent.com/5458070/188429670-0f925023-cc94-4d6c-8533-f0f54ded0398.png)

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
