### PR TITLE
WIP using JSI's NativeState class for faster access to native C++ object when Hermes enabled

### DIFF
--- a/src/jsi/jsi_class.hpp
+++ b/src/jsi/jsi_class.hpp
@@ -170,6 +170,20 @@ public:
     T obj;
 };
 
+// Class extending JSI's NativeState, used to store the native C++ object associated
+// with a JS object when Hermes is being used. See set_internal for more info.
+template <typename T>
+class WrappedState : public fbjsi::NativeState {
+public:
+    template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<T, Args...>>>
+    WrappedState(Args&&... args)
+        : obj(std::forward<Args>(args)...)
+    {
+    }
+
+    T obj;
+};
+
 template <typename T>
 inline T& unwrap(Wrapper<T>& wrapper)
 {
@@ -490,26 +504,54 @@ public:
 
     static Internal* get_internal(JsiEnv env, const JsiObj& object)
     {
-        auto internal = object->getProperty(env, g_internal_field);
-        if (internal.isUndefined()) {
-            // In the case of a user opening a Realm with a class-based model,
-            // the user defined constructor will get called before the "internal" property has been set.
-            if constexpr (std::is_same_v<T, RealmObjectClass<realmjsi::Types>>)
-                return nullptr;
-            throw fbjsi::JSError(env, "no internal field");
+        Internal* internal;
+
+        try {
+            internal = (Internal*)(object->getNativeState<WrappedState<Internal*>>(env)).get();
+
+            if (!internal) {
+                // In the case of a user opening a Realm with a class-based model,
+                // the user defined constructor will get called before the "internal" property has been set.
+                if constexpr (std::is_same_v<T, RealmObjectClass<realmjsi::Types>>)
+                    return nullptr;
+                throw fbjsi::JSError(env, "no internal field");
+            }
         }
+        catch (std::logic_error) {
+            // Fallback to property access (see set_internal)
+            auto internal_property = object->getProperty(env, g_internal_field);
+
+            if (internal_property.isUndefined()) {
+                // Duplicated logic from try block
+                if constexpr (std::is_same_v<T, RealmObjectClass<realmjsi::Types>>)
+                    return nullptr;
+                throw fbjsi::JSError(env, "no internal field");
+            }
+
+            internal = unwrapUnique<Internal>(env, std::move(internal));
+        }
+
         // The following check is disabled to support user defined classes that doesn't extend Realm.Object
         // if (!JsiObj(object)->instanceOf(env, *s_ctor)) {
         //     throw fbjsi::JSError(env, "calling method on wrong type of object");
         // }
-        return unwrapUnique<Internal>(env, std::move(internal));
+
+        return internal;
     }
+
     static void set_internal(JsiEnv env, const JsiObj& object, Internal* data)
     {
-        auto desc = fbjsi::Object(env);
-        desc.setProperty(env, "value", wrapUnique(env, data));
-        desc.setProperty(env, "configurable", true);
-        defineProperty(env, object, g_internal_field, desc);
+        try {
+            object->setNativeState(env, std::make_shared<WrappedState<Internal*>>(data));
+        }
+        catch (std::logic_error) {
+            // NativeState API is not implemented for the JSC Runtime and will throw a logic_error,
+            // so fall back to storing the object as a property (which is much slower, but works)
+            auto desc = fbjsi::Object(env);
+            desc.setProperty(env, "value", wrapUnique(env, data));
+            desc.setProperty(env, "configurable", true);
+            defineProperty(env, object, g_internal_field, desc);
+        }
     }
 
 private:
@@ -663,7 +705,8 @@ private:
 } // namespace realmjsi
 
 template <typename ClassType>
-class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {};
+class ObjectWrap<realmjsi::Types, ClassType> : public realm::js::realmjsi::ObjectWrap<ClassType> {
+};
 
 template <realmjsi::ArgumentsMethodType F>
 fbjsi::Value wrap(fbjsi::Runtime& rt, const fbjsi::Value& thisVal, const fbjsi::Value* args, size_t count)


### PR DESCRIPTION

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
