### PR TITLE
Reverting a bad merge in "import-app-before" hook of the integration tests

### DIFF
--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -31,11 +31,7 @@ export function importAppBefore(
       throw new Error("Unexpected app on context, use only one importAppBefore per test");
     } else {
       this.app = await importApp(name, replacements);
-      Realm.App.Sync.setLogger(this.app, (level, message) => {
-        const date = new Date();
-        console.log(date.toString(), date.getMilliseconds(), level, message);
-      });
-
+      Realm.App.Sync.setLogLevel(this.app, logLevel);
       // Set a default logger as Android does not forward stdout
       Realm.App.Sync.setLogger(this.app, (level, message) => {
         const time = new Date().toISOString().split("T")[1].replace("Z", "");


### PR DESCRIPTION
## What, How & Why?

This reverts [a bad merge](https://github.com/realm/realm-js/pull/4609/files#diff-3808b3cd352cad877eb22a1ee9a2bb7e09a4cf738d5ca39e599792aaade53971R34-R38) which removed a call to `setLogLevel` (effectively defaulting to "info" level, which is too verbose) with a call that registers a log callback that gets overridden later.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
