### PR TITLE
Stable roundtrip tests

### DIFF
--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -123,8 +123,16 @@ function describeRoundtrip({
     it("reads", async function (this: RealmContext) {
       await setupTest(this.realm);
 
-      const obj = this.realm.objectForPrimaryKey<MixedClass>("MixedClass", this._id);
-      if (!obj) throw new Error("Object not found");
+      const obj = await new Promise<MixedClass>((resolve) => {
+        this.realm
+          .objects<MixedClass>("MixedClass")
+          .filtered("_id = $0", this._id)
+          .addListener(([obj]) => {
+            if (obj) {
+              resolve(obj);
+            }
+          });
+      });
 
       expect(typeof obj).equals("object");
       // Test the single value

--- a/integration-tests/tests/src/utils/sleep.ts
+++ b/integration-tests/tests/src/utils/sleep.ts
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+declare function setTimeout(cb: () => void, ms: number): void;
+
+/**
+ * @param ms For how long should the promise be pending?
+ * @returns A promise that returns after `ms` milliseconds.
+ */
+export function sleep(ms = 1000): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## What, How & Why?

This awaits the existence of an object instead of using `objectForPrimaryKey` in the roundtrip tests.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
