### PR TITLE
Refactored manual transaction tests

### DIFF
--- a/integration-tests/tests/src/tests/transaction.ts
+++ b/integration-tests/tests/src/tests/transaction.ts
@@ -41,6 +41,7 @@ describe("Realm transactions", () => {
 
       realm.cancelTransaction();
       expect(persons.length).equals(0);
+      expect(realm.isInTransaction).to.be.false;
     });
 
     it("throws on an invalid object", function (this: RealmContext) {


### PR DESCRIPTION
## What, How & Why?

This refactors manual transaction tests.

The first test didn't really test anything other than roll back when `cancelTransaction` gets called, so I renamed it. The other actually verifies something that I think is unexpected (creating an invalid object throws but leaves an object in a strange state), which I noted with a TODO. We should create an issue to track fixing that.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
