### PR TITLE
Update prepare-release GHA workflow to override version

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,6 +1,12 @@
 name: Prepare Release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Use this to provide a version, instead of deriving it from the changelog.
+        required: false
+        type: string
 
 jobs:
   prepare-release:
@@ -12,8 +18,9 @@ jobs:
       # action is at https://github.com/realm/ci-actions/tree/main/update-changelog
       - name: Update Changelog
         id: update-changelog
-        uses: realm/ci-actions/update-changelog@v2
+        uses: realm/ci-actions/update-changelog@master
         with:
+          version: ${{ inputs.version }} 
           changelog: ${{ github.workspace }}/CHANGELOG.md
 
       - name: Update package.json


### PR DESCRIPTION
## What, How & Why?

This use the newly merged feature of the `update-changelog` action to allow us to provide an override of the version when preparing a new version.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
