### PR TITLE
[CI] Use a more specific cache key for vcpkg

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -66,13 +66,19 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Get vcpkg submodule commit sha
+        id: vcpkg_cache_key
+        working-directory: vendor/realm-core/tools/vcpkg/ports
+        shell: bash
+        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
+
       - name: Setup Vcpkg
         if: ${{ runner.os == 'Windows' }}
         uses: friendlyanon/setup-vcpkg@v1
         with:
           path: vendor/realm-core/tools/vcpkg/ports
-          cache-key: vcpkg-windows-${{ matrix.variant.arch }}
-          cache-restore-keys: vcpkg-windows-${{ matrix.variant.arch }}
+          cache-key: vcpkg-windows-${{ matrix.variant.arch }}-${{ steps.vcpkg_cache_key.outputs.commit }}-${{ hashFiles('./vendor/realm-core/tools/vcpkg/vcpkg.json') }}
+          cache-restore-keys: vcpkg-windows-${{ matrix.variant.arch }}-${{ steps.vcpkg_cache_key.outputs.commit }}-${{ hashFiles('./vendor/realm-core/tools/vcpkg/vcpkg.json') }}
 
       # ninja-build is used by default if available and results in faster build times
       # On linux, electron requires a connected display.  We fake this by giving it a headless environment using xvfb


### PR DESCRIPTION
If Core picks up a newer vcpkg submodule or changes its vcpkg manifest we need to invalidate any existing vcpkg caches.