### PR TITLE
Improving "publish release" workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -77,10 +77,11 @@ jobs:
 #        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Find Release PR
-      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
+      uses: sharesight/find-github-pull-request@v1.1.2
       id: find-pull-request
       with:
-        branch: ${{ github.ref }}
+        commitSha: ${{ github.sha }}
+        failIfNotFound: true
 
     - name: Dump PR context
       env:
@@ -118,7 +119,7 @@ jobs:
       with:
         changelog: ExtractedChangelog.md
         sdk: JS
-        webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+        webhook-url: ${{ secrets.SLACK_TEST_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
       # This job might fail due to failed markdown-to-slack conversion.
       continue-on-error: true
@@ -135,7 +136,7 @@ jobs:
         body: Update Changelog for vNext
         delete-branch: true
         commit-message: Prepare for vNext
-        base: master
+        base: ${{ steps.find-pull-request.outputs.base-ref }}
 
 #    - name: Merge Pull Request
 #      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -77,11 +77,10 @@ jobs:
 #        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Find Release PR
-      uses: sharesight/find-github-pull-request@v1.1.2
+      uses: kraenhansen/find-pull-request-action@master
       id: find-pull-request
       with:
-        commitSha: ${{ github.sha }}
-        failIfNotFound: true
+        branch: ${{ github.ref }}
 
     - name: Dump PR context
       env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,7 +93,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-        ref: ${{ github.base_ref }}
+        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Extract Changelog
       run: scripts/extract-changelog.sh ${{ steps.get-version.outputs.version }} > ExtractedChangelog.md

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         changelog: EXTRACTED_CHANGELOG.md
         sdk: JavaScript
-        webhook-url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+        webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
       # This job might fail due to failed markdown-to-slack conversion.
       continue-on-error: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,15 +51,15 @@ jobs:
     - name: Install node modules
       run: npm ci --ignore-scripts
 
-    - name: Download prebuild PR artifacts
-      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
-      with:
-        workflow: pr-realm-js.yml
-        commit: ${{ inputs.commit || github.sha }}
-        path: ${{ github.workspace }}
-        workflow_conclusion: completed
-        github_token: ${{ secrets.REALM_CI_PAT }}
-        name: realm-js-prebuilds
+#    - name: Download prebuild PR artifacts
+#      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
+#      with:
+#        workflow: pr-realm-js.yml
+#        commit: ${{ inputs.commit || github.sha }}
+#        path: ${{ github.workspace }}
+#        workflow_conclusion: completed
+#        github_token: ${{ secrets.REALM_CI_PAT }}
+#        name: realm-js-prebuilds
 
     - name: Read version
       id: get-version
@@ -71,36 +71,42 @@ jobs:
         echo "::set-output name=prerelease::$prerelease"
       shell: bash
 
-    - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
-      run: npm publish --tag '${{ inputs.tag}}'
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+#    - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
+#      run: npm publish --tag '${{ inputs.tag}}'
+#      env:
+#        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    - name: Find Release PR
-      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
-      id: find-pull-request
-      with:
-        branch: ${{ github.ref }}
+#    - name: Find Release PR
+#      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
+#      id: find-pull-request
+#      with:
+#        branch: ${{ github.ref }}
 
-    - name: Merge Pull Request
-      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+#    - name: Merge Pull Request
+#      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+#      with:
+#        github-token: ${{ secrets.GITHUB_TOKEN }}
+#        number: ${{ steps.find-pull-request.outputs.number }}
+#        method: squash
+
+    - name: Checkout base branch (after merge)
+      uses: actions/checkout@v3
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        number: ${{ steps.find-pull-request.outputs.number }}
-        method: squash
+        submodules: recursive
+        ref: ${{ github.base_ref }}
 
     - name: Extract Changelog
       run: scripts/extract-changelog.sh ${{ steps.get-version.outputs.version }} > ExtractedChangelog.md
 
-    - name: Create Github Release
-      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
-      with:
-        bodyFile: ExtractedChangelog.md
-        name: ${{ steps.get-version.outputs.version }}
-        tag: v${{ steps.get-version.outputs.version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        draft: false
-        prerelease: ${{ steps.get-version.outputs.prerelease }}
+#    - name: Create Github Release
+#      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
+#      with:
+#        bodyFile: ExtractedChangelog.md
+#        name: ${{ steps.get-version.outputs.version }}
+#        tag: v${{ steps.get-version.outputs.version }}
+#        token: ${{ secrets.GITHUB_TOKEN }}
+#        draft: false
+#        prerelease: ${{ steps.get-version.outputs.prerelease }}
 
     - name: 'Post to #realm-releases'
       uses: realm/ci-actions/release-to-slack@v3
@@ -126,9 +132,9 @@ jobs:
         commit-message: Prepare for vNext
         base: master
 
-    - name: Merge Pull Request
-      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        number: ${{ steps.vnext-pr.outputs.pull-request-number }}
-        method: squash
+#    - name: Merge Pull Request
+#      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+#      with:
+#        github-token: ${{ secrets.GITHUB_TOKEN }}
+#        number: ${{ steps.vnext-pr.outputs.pull-request-number }}
+#        method: squash

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,11 +24,6 @@ jobs:
         submodules: recursive
         ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-
     - name: Setup node version
       uses: actions/setup-node@v3
       with:
@@ -81,11 +76,16 @@ jobs:
 #      env:
 #        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-#    - name: Find Release PR
-#      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
-#      id: find-pull-request
-#      with:
-#        branch: ${{ github.ref }}
+    - name: Find Release PR
+      uses: juliangruber/find-pull-request-action@f9f7484f8237cf8485e5ab826e542ba5dd9e9c6e
+      id: find-pull-request
+      with:
+        branch: ${{ github.ref }}
+
+    - name: Dump PR context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(steps.find-pull-request.outputs) }}
+      run: echo "$GITHUB_CONTEXT"
 
 #    - name: Merge Pull Request
 #      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -117,7 +117,7 @@ jobs:
       uses: realm/ci-actions/release-to-slack@v3
       with:
         changelog: ExtractedChangelog.md
-        sdk: JS
+        sdk: JavaScript
         webhook-url: ${{ secrets.SLACK_TEST_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
       # This job might fail due to failed markdown-to-slack conversion.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,6 +24,11 @@ jobs:
         submodules: recursive
         ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
     - name: Setup node version
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,15 +51,15 @@ jobs:
     - name: Install node modules
       run: npm ci --ignore-scripts
 
-#    - name: Download prebuild PR artifacts
-#      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
-#      with:
-#        workflow: pr-realm-js.yml
-#        commit: ${{ inputs.commit || github.sha }}
-#        path: ${{ github.workspace }}
-#        workflow_conclusion: completed
-#        github_token: ${{ secrets.REALM_CI_PAT }}
-#        name: realm-js-prebuilds
+    - name: Download prebuild PR artifacts
+      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
+      with:
+        workflow: pr-realm-js.yml
+        commit: ${{ inputs.commit || github.sha }}
+        path: ${{ github.workspace }}
+        workflow_conclusion: completed
+        github_token: ${{ secrets.REALM_CI_PAT }}
+        name: realm-js-prebuilds
 
     - name: Read version
       id: get-version
@@ -71,10 +71,10 @@ jobs:
         echo "::set-output name=prerelease::$prerelease"
       shell: bash
 
-#    - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
-#      run: npm publish --tag '${{ inputs.tag}}'
-#      env:
-#        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
+      run: npm publish --tag '${{ inputs.tag}}'
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Find Release PR
       uses: kraenhansen/find-pull-request-action@master
@@ -82,17 +82,12 @@ jobs:
       with:
         branch: ${{ github.ref }}
 
-    - name: Dump PR context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(steps.find-pull-request.outputs) }}
-      run: echo "$GITHUB_CONTEXT"
-
-#    - name: Merge Pull Request
-#      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
-#      with:
-#        github-token: ${{ secrets.GITHUB_TOKEN }}
-#        number: ${{ steps.find-pull-request.outputs.number }}
-#        method: squash
+    - name: Merge Pull Request
+      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        number: ${{ steps.find-pull-request.outputs.number }}
+        method: squash
 
     - name: Checkout base branch (after merge)
       uses: actions/checkout@v3
@@ -101,22 +96,22 @@ jobs:
         ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Extract Changelog
-      run: node scripts/extract-changelog.js ${{ steps.get-version.outputs.version }} > ExtractedChangelog.md
+      run: node scripts/extract-changelog.js ${{ steps.get-version.outputs.version }} > EXTRACTED_CHANGELOG.md
 
-#    - name: Create Github Release
-#      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
-#      with:
-#        bodyFile: ExtractedChangelog.md
-#        name: ${{ steps.get-version.outputs.version }}
-#        tag: v${{ steps.get-version.outputs.version }}
-#        token: ${{ secrets.GITHUB_TOKEN }}
-#        draft: false
-#        prerelease: ${{ steps.get-version.outputs.prerelease }}
+    - name: Create Github Release
+      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e
+      with:
+        bodyFile: EXTRACTED_CHANGELOG.md
+        name: ${{ steps.get-version.outputs.version }}
+        tag: v${{ steps.get-version.outputs.version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: false
+        prerelease: ${{ steps.get-version.outputs.prerelease }}
 
     - name: 'Post to #realm-releases'
       uses: realm/ci-actions/release-to-slack@v3
       with:
-        changelog: ExtractedChangelog.md
+        changelog: EXTRACTED_CHANGELOG.md
         sdk: JavaScript
         webhook-url: ${{ secrets.SLACK_TEST_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
@@ -137,9 +132,9 @@ jobs:
         commit-message: Prepare for vNext
         base: ${{ steps.find-pull-request.outputs.base-ref }}
 
-#    - name: Merge Pull Request
-#      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
-#      with:
-#        github-token: ${{ secrets.GITHUB_TOKEN }}
-#        number: ${{ steps.vnext-pr.outputs.pull-request-number }}
-#        method: squash
+    - name: Merge Pull Request
+      uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        number: ${{ steps.vnext-pr.outputs.pull-request-number }}
+        method: squash

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,7 +101,7 @@ jobs:
         ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Extract Changelog
-      run: scripts/extract-changelog.sh ${{ steps.get-version.outputs.version }} > ExtractedChangelog.md
+      run: node scripts/extract-changelog.js ${{ steps.get-version.outputs.version }} > ExtractedChangelog.md
 
 #    - name: Create Github Release
 #      uses: ncipollo/release-action@10c84d509b28aae3903113151bfd832314964f2e

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -77,6 +77,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Find Release PR
+      # TODO: Revert this to upstream action once https://github.com/juliangruber/find-pull-request-action/pull/33 gets merged
       uses: kraenhansen/find-pull-request-action@master
       id: find-pull-request
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ vendor/realm-*
 !vendor/realm-core
 
 # extracted changelog
-ExtractedChangelog.md
+EXTRACTED_CHANGELOG.md
 
 # jsdoc
 /docs/output

--- a/scripts/extract-changelog.js
+++ b/scripts/extract-changelog.js
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2022 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function extractRelease(changelog, expectedVersion) {
+  // Inspired by https://github.com/realm/ci-actions/blob/main/update-changelog/src/helpers.ts
+  const changelogRegex = /^## (?<version>[^\s]+) \((?<date>[^)]+)\)\s+(?<body>.*?)\s+(?=^## )/gms;
+  let match;
+  while ((match = changelogRegex.exec(changelog))) {
+    const release = match.groups;
+    if (!expectedVersion || expectedVersion === release.version) {
+      return release;
+    }
+  }
+  throw new Error("Unable to extract release");
+}
+
+if (require.main === module) {
+  const changelogPath = path.resolve(__dirname, "../CHANGELOG.md");
+  const changelog = fs.readFileSync(changelogPath, { encoding: "utf8" });
+  const version = process.argv[2];
+  const release = extractRelease(changelog, version);
+  console.log(release.body);
+}

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-VERSION="$1"
-ESCAPED_VERSION="$(echo -n "$VERSION" | sed -e 's|\.|\\.|g')"
-sed '/^## '"${ESCAPED_VERSION}"'/,/^## /!d;/## /d' CHANGELOG.md


### PR DESCRIPTION
## What, How & Why?

This is an attempt at improving the publish release workflow.
- Replaces a broken shell script, used to extract changelog with a JS script to do the same.
- Use a for of the `juliangruber/find-pull-request-action` to output the base branch of the PR (created an upstream PR for that https://github.com/juliangruber/find-pull-request-action/pull/33).

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
