### PR TITLE
Publish prebuilds to S3

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -80,7 +80,7 @@ jobs:
         secret_key: ${{ secrets.PREBUILDS_S3_SECRET_KEY }}
 
     - name: Upload prebuilds to S3
-      run: s3cmd put --recursive --acl-public prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/realm-js-prebuilds/${{ steps.get-version.outputs.version }}
+      run: s3cmd put --recursive --acl-public prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/${{ steps.get-version.outputs.version }}
 
     - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
       run: npm publish --tag '${{ inputs.tag}}'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,6 +71,17 @@ jobs:
         echo "::set-output name=prerelease::$prerelease"
       shell: bash
 
+    - name: Set up S3cmd and configure AWS credentials
+      uses: s3-actions/s3cmd@v1.1
+      with:
+        provider: aws
+        region: "us-east-1"
+        access_key: ${{ secrets.PREBUILDS_S3_ACCESS_KEY }}
+        secret_key: ${{ secrets.PREBUILDS_S3_SECRET_KEY }}
+
+    - name: Upload prebuilds to S3
+      run: s3cmd put --recursive --acl-public prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/realm-js-prebuilds/${{ steps.get-version.outputs.version }}
+
     - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
       run: npm publish --tag '${{ inputs.tag}}'
       env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,8 +76,8 @@ jobs:
       with:
         provider: aws
         region: "us-east-1"
-        access_key: ${{ secrets.PREBUILDS_S3_ACCESS_KEY }}
-        secret_key: ${{ secrets.PREBUILDS_S3_SECRET_KEY }}
+        access_key: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+        secret_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
 
     - name: Upload prebuilds to S3
       run: s3cmd put --recursive --acl-public prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
Publishing prebuilds to S3 requires three more secrets similar to the ones used for publishing docs.