### PR TITLE
Align How Enums are Defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
     user.callFunction("sum", 1, 2, 3); // Valid
     user.callFunction("sum", [1, 2, 3]); // Invalid
     ```
+* Replace string unions with enums where it makes sense.
+  * Following functions and properties will be effected by this change:
+  ```typescript
+  Realm.App.Sync.Session.State : SessionState
+  Realm.App.Sync.Session.addProgressNotification(direction: ProgressDirection, mode: ProgressMode, progressCallback: ProgressNotificationCallback): void;
+  ```
+  * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
+  * `Realm.Services.MongoDB.OperationType` is now enumerated and can be checked against `watch` events
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
   Realm.App.Sync.Session.addProgressNotification(direction: ProgressDirection, mode: ProgressMode, progressCallback: ProgressNotificationCallback): void;
   ```
   * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
-  * `Realm.Services.MongoDB.OperationType` is now enumerated and can be checked against `watch` events
+  
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -486,6 +486,22 @@ module.exports = function (realmConstructor) {
       Connected: "connected",
     };
 
+    realmConstructor.App.Sync.SessionState = {
+      Invalid: "invalid",
+      Active: "active",
+      Inactive: "inactive",
+    };
+
+    realmConstructor.App.Sync.ProgressDirection = {
+      Download: "download",
+      Upload: "upload",
+    };
+
+    realmConstructor.App.Sync.ProgressMode = {
+      ReportIndefinitely: "reportIndefinitely",
+      ForCurrentlyOutstandingWork: "forCurrentlyOutstandingWork",
+    };
+
     realmConstructor.App.Sync.ClientResyncMode = {
       Discard: "discard",
       Manual: "manual",
@@ -497,6 +513,25 @@ module.exports = function (realmConstructor) {
       Complete: "complete",
       Error: "error",
       Superseded: "superseded",
+    };
+
+    realmConstructor.Services.MongoDB.OperationType = {
+      /** A document got inserted into the collection. */
+      Insert: "insert",
+      /** A document got deleted from the collection. */
+      Delete: "delete",
+      /** A document got replaced in the collection. */
+      Replace: "replace",
+      /** A document got updated in the collection. */
+      Update: "update",
+      /** Occurs when a collection is dropped from a database. */
+      Drop: "drop",
+      /** Occurs when a collection is renamed. */
+      Rename: "rename",
+      /** Occurs when a database is dropped. */
+      DropDatabase: "dropDatabase",
+      /** Invalidate events close the change stream cursor. */
+      Invalidate: "invalidate",
     };
   }
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -514,25 +514,6 @@ module.exports = function (realmConstructor) {
       Error: "error",
       Superseded: "superseded",
     };
-
-    realmConstructor.Services.MongoDB.OperationType = {
-      /** A document got inserted into the collection. */
-      Insert: "insert",
-      /** A document got deleted from the collection. */
-      Delete: "delete",
-      /** A document got replaced in the collection. */
-      Replace: "replace",
-      /** A document got updated in the collection. */
-      Update: "update",
-      /** Occurs when a collection is dropped from a database. */
-      Drop: "drop",
-      /** Occurs when a collection is renamed. */
-      Rename: "rename",
-      /** Occurs when a database is dropped. */
-      DropDatabase: "dropDatabase",
-      /** Invalidate events close the change stream cursor. */
-      Invalidate: "invalidate",
-    };
   }
 
   // TODO: Remove this now useless object.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -613,16 +613,30 @@ declare namespace Realm {
         Connected = "connected",
     }
 
+    enum SessionState {
+        Invalid = "invalid",
+        Active = "active",
+        Inactive = "inactive",
+    }
+
+    enum ProgressDirection {
+        Download = "download",
+        Upload = "upload",
+    }
+
+    enum ProgressMode {
+        ReportIndefinitely = "reportIndefinitely",
+        ForCurrentlyOutstandingWork = "forCurrentlyOutstandingWork",
+    }
+
     type ProgressNotificationCallback = (transferred: number, transferable: number) => void;
-    type ProgressDirection = 'download' | 'upload';
-    type ProgressMode = 'reportIndefinitely' | 'forCurrentlyOutstandingWork';
 
     type ConnectionNotificationCallback = (newState: ConnectionState, oldState: ConnectionState) => void;
 
     namespace App.Sync {
         class Session {
             readonly config: SyncConfiguration;
-            readonly state: 'invalid' | 'active' | 'inactive';
+            readonly state: SessionState;
             readonly url: string;
             readonly user: User;
             readonly connectionState: ConnectionState;
@@ -763,7 +777,7 @@ declare namespace Realm {
              * of the `Subscriptions`. You should not use a superseded SubscriptionSet,
              * and instead obtain a new instance from {@link Realm.subscriptions}.
              */
-            Superseded = "Superseded",
+            Superseded = "superseded",
         }
 
         /**

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -213,24 +213,23 @@ declare namespace Realm {
       /**
        * An operation performed on a document.
        */
-      enum OperationType {
+      type OperationType =
         /** A document got inserted into the collection. */
-        Insert = "insert",
+        | "insert"
         /** A document got deleted from the collection. */
-        Delete = "delete",
+        | "delete"
         /** A document got replaced in the collection. */
-        Replace = "replace",
+        | "replace"
         /** A document got updated in the collection. */
-        Update = "update",
+        | "update"
         /** Occurs when a collection is dropped from a database. */
-        Drop = "drop",
+        | "drop"
         /** Occurs when a collection is renamed. */
-        Rename = "rename",
+        | "rename"
         /** Occurs when a database is dropped. */
-        DropDatabase = "dropDatabase",
+        | "dropDatabase"
         /** Invalidate events close the change stream cursor. */
-        Invalidate = "invalidate",
-      }
+        | "invalidate";
 
       /**
        * The namespace of a document.
@@ -299,7 +298,7 @@ declare namespace Realm {
         documentKey: DocumentKey<T["_id"]>;
         /** The new document created by the operation */
         fullDocument: T;
-      } & BaseChangeEvent<OperationType.Insert>;
+      } & BaseChangeEvent<"insert">;
 
       /**
        * A document got updated in the collection.
@@ -315,7 +314,7 @@ declare namespace Realm {
          * For change streams opened with the `fullDocument: updateLookup` option, this will represents the most current majority-committed version of the document modified by the update operation.
          */
         fullDocument?: T;
-      } & BaseChangeEvent<OperationType.Update>;
+      } & BaseChangeEvent<"update">;
 
       /**
        * A document got replaced in the collection.
@@ -327,7 +326,7 @@ declare namespace Realm {
         documentKey: DocumentKey<T["_id"]>;
         /** The document after the insert of the replacement document. */
         fullDocument: T;
-      } & BaseChangeEvent<OperationType.Replace>;
+      } & BaseChangeEvent<"replace">;
 
       /**
        * A document got deleted from the collection.
@@ -337,7 +336,7 @@ declare namespace Realm {
         ns: DocumentNamespace;
         /** A document that contains the _id of the deleted document. */
         documentKey: DocumentKey<T["_id"]>;
-      } & BaseChangeEvent<OperationType.Delete>;
+      } & BaseChangeEvent<"delete">;
 
       /**
        * Occurs when a collection is dropped from a database.
@@ -345,7 +344,7 @@ declare namespace Realm {
       type DropEvent = {
         /** The namespace (database and collection) of the collection that got dropped. */
         ns: DocumentNamespace;
-      } & BaseChangeEvent<OperationType.Drop>;
+      } & BaseChangeEvent<"drop">;
 
       /**
        * Occurs when a collection is renamed.
@@ -355,7 +354,7 @@ declare namespace Realm {
         ns: DocumentNamespace;
         /** The namespace (database and collection) going forward. */
         to: DocumentNamespace;
-      } & BaseChangeEvent<OperationType.Rename>;
+      } & BaseChangeEvent<"rename">;
 
       /**
        * Occurs when a database is dropped.
@@ -363,12 +362,12 @@ declare namespace Realm {
       type DropDatabaseEvent = {
         /** The namespace (specifying only the database name) of the database that got dropped. */
         ns: Omit<DocumentNamespace, "coll">;
-      } & BaseChangeEvent<OperationType.DropDatabase>;
+      } & BaseChangeEvent<"dropDatabase">;
 
       /**
        * Invalidate events close the change stream cursor.
        */
-      type InvalidateEvent = BaseChangeEvent<OperationType.Invalidate>;
+      type InvalidateEvent = BaseChangeEvent<"invalidate">;
 
       /**
        * Represents a change event communicated via a MongoDB change stream.

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -213,23 +213,24 @@ declare namespace Realm {
       /**
        * An operation performed on a document.
        */
-      type OperationType =
+      enum OperationType {
         /** A document got inserted into the collection. */
-        | "insert"
+        Insert = "insert",
         /** A document got deleted from the collection. */
-        | "delete"
+        Delete = "delete",
         /** A document got replaced in the collection. */
-        | "replace"
+        Replace = "replace",
         /** A document got updated in the collection. */
-        | "update"
+        Update = "update",
         /** Occurs when a collection is dropped from a database. */
-        | "drop"
+        Drop = "drop",
         /** Occurs when a collection is renamed. */
-        | "rename"
+        Rename = "rename",
         /** Occurs when a database is dropped. */
-        | "dropDatabase"
+        DropDatabase = "dropDatabase",
         /** Invalidate events close the change stream cursor. */
-        | "invalidate";
+        Invalidate = "invalidate",
+      }
 
       /**
        * The namespace of a document.
@@ -298,7 +299,7 @@ declare namespace Realm {
         documentKey: DocumentKey<T["_id"]>;
         /** The new document created by the operation */
         fullDocument: T;
-      } & BaseChangeEvent<"insert">;
+      } & BaseChangeEvent<OperationType.Insert>;
 
       /**
        * A document got updated in the collection.
@@ -314,7 +315,7 @@ declare namespace Realm {
          * For change streams opened with the `fullDocument: updateLookup` option, this will represents the most current majority-committed version of the document modified by the update operation.
          */
         fullDocument?: T;
-      } & BaseChangeEvent<"update">;
+      } & BaseChangeEvent<OperationType.Update>;
 
       /**
        * A document got replaced in the collection.
@@ -326,7 +327,7 @@ declare namespace Realm {
         documentKey: DocumentKey<T["_id"]>;
         /** The document after the insert of the replacement document. */
         fullDocument: T;
-      } & BaseChangeEvent<"replace">;
+      } & BaseChangeEvent<OperationType.Replace>;
 
       /**
        * A document got deleted from the collection.
@@ -336,7 +337,7 @@ declare namespace Realm {
         ns: DocumentNamespace;
         /** A document that contains the _id of the deleted document. */
         documentKey: DocumentKey<T["_id"]>;
-      } & BaseChangeEvent<"delete">;
+      } & BaseChangeEvent<OperationType.Delete>;
 
       /**
        * Occurs when a collection is dropped from a database.
@@ -344,7 +345,7 @@ declare namespace Realm {
       type DropEvent = {
         /** The namespace (database and collection) of the collection that got dropped. */
         ns: DocumentNamespace;
-      } & BaseChangeEvent<"drop">;
+      } & BaseChangeEvent<OperationType.Drop>;
 
       /**
        * Occurs when a collection is renamed.
@@ -354,7 +355,7 @@ declare namespace Realm {
         ns: DocumentNamespace;
         /** The namespace (database and collection) going forward. */
         to: DocumentNamespace;
-      } & BaseChangeEvent<"rename">;
+      } & BaseChangeEvent<OperationType.Rename>;
 
       /**
        * Occurs when a database is dropped.
@@ -362,12 +363,12 @@ declare namespace Realm {
       type DropDatabaseEvent = {
         /** The namespace (specifying only the database name) of the database that got dropped. */
         ns: Omit<DocumentNamespace, "coll">;
-      } & BaseChangeEvent<"dropDatabase">;
+      } & BaseChangeEvent<OperationType.DropDatabase>;
 
       /**
        * Invalidate events close the change stream cursor.
        */
-      type InvalidateEvent = BaseChangeEvent<"invalidate">;
+      type InvalidateEvent = BaseChangeEvent<OperationType.Invalidate>;
 
       /**
        * Represents a change event communicated via a MongoDB change stream.


### PR DESCRIPTION


## What, How & Why?
This addresses a breaking change we want to make where typed "string" unions are replaced with respective enums.

This closes #1955

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
