### PR TITLE
Fixing Android read only

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       npm_config_realm_local_prebuilds: ${{github.workspace}}/prebuilds
       REALM_DISABLE_ANALYTICS: 1
-      ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/21.4.7075529
+      NDK_VERSION: 21.0.6113669
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +93,21 @@ jobs:
         if: ${{ (matrix.variant.runner == 'ubuntu-latest') }}
         run: sudo apt-get install ccache ninja-build
 
+      - name: Setup Java
+        if: ${{ matrix.variant.os == 'android' }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu' # See 'Supported distributions' for available options
+          java-version: '11'
+
+      - name: Setup Android SDK
+        if: ${{ matrix.variant.os == 'android' }}
+        uses: android-actions/setup-android@v2
+  
+      - name: Install NDK
+        if: ${{ matrix.variant.os == 'android' }}
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         #TODO: figure out using ccache or equivalent on windows
@@ -129,6 +144,8 @@ jobs:
       - name: Build Android
         if: ${{ (matrix.variant.os == 'android') }}
         run: npm run prebuild:android -- --arch=${{matrix.variant.arch}}
+        env:
+          ANDROID_NDK: ${{ env.ANDROID_SDK_ROOT }}/ndk/${{ env.NDK_VERSION }}
 
       - name: Install the node dependencies in the test folder
         working-directory: ./tests
@@ -156,7 +173,6 @@ jobs:
       SPAWN_LOGCAT: true
       # Pin the Xcode version
       DEVELOPER_DIR: /Applications/Xcode_12.5.1.app
-      ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/21.4.7075529
     runs-on: ${{ matrix.variant.runner }}
     strategy:
       fail-fast: false
@@ -308,7 +324,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           arch: x86
-          ndk: 21.0.6113669
+          ndk: ${{ env.NDK_VERSION }}
           cmake: 3.10.2.4988404
           script: npm run ${{ matrix.variant.target}} --prefix integration-tests/environments/${{ matrix.variant.environment }}
 

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -162,7 +162,8 @@ async function run(headless, spawnLogcat, retries, retryDelay) {
         logcat.start("com.realmreactnativetests", true).catch(console.error);
       }
       // Ask React Native to build and run the app
-      rn.sync("run-android", "--no-packager");
+      // Using --active-arch-only as per https://reactnative.dev/docs/build-speed#build-only-one-abi-during-development-android-only
+      rn.sync("run-android", "--no-packager", "--active-arch-only");
     } else if (PLATFORM === "ios") {
       // Ask React Native to build and run the app
       rn.sync("run-ios", "--no-packager", "--simulator", IOS_DEVICE_NAME);


### PR DESCRIPTION
## What, How & Why?

This is an attempt at closing the failing tests on `v11`.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
