### PR TITLE
Append ClusterName to AppName for CI Tests

### DIFF
--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,1 @@
+legacy-apps

--- a/integration-tests/tests/src/utils/import-app.ts
+++ b/integration-tests/tests/src/utils/import-app.ts
@@ -56,8 +56,10 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
   // When running on CI we connect through mongodb-atlas instead of local-mongodb
   const { mongodbClusterName } = environment;
   if (typeof mongodbClusterName === "string") {
+    const replacements = { "config.json": { name: `${name}-${mongodbClusterName}` } };
     if (name === "with-db") {
       return {
+        ...replacements,
         "services/mongodb/config.json": {
           type: "mongodb-atlas",
           config: {
@@ -72,6 +74,8 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
       };
     } else if (name === "with-db-flx") {
       return {
+        ...replacements,
+        "config.json": { name: `${name}-${mongodbClusterName}` },
         "services/mongodb/config.json": {
           type: "mongodb-atlas",
           config: {
@@ -85,6 +89,7 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
         },
       };
     }
+    return replacements;
   }
   return {};
 }

--- a/integration-tests/tests/src/utils/import-app.ts
+++ b/integration-tests/tests/src/utils/import-app.ts
@@ -56,10 +56,12 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
   // When running on CI we connect through mongodb-atlas instead of local-mongodb
   const { mongodbClusterName } = environment;
   if (typeof mongodbClusterName === "string") {
-    const replacements = { "config.json": { name: `${name}-${mongodbClusterName}` } };
+    const appName = `${name}-${mongodbClusterName}`;
+    const appNameReplacement = { "config.json": { name: appName } };
+
     if (name === "with-db") {
       return {
-        ...replacements,
+        ...appNameReplacement,
         "services/mongodb/config.json": {
           type: "mongodb-atlas",
           config: {
@@ -74,8 +76,7 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
       };
     } else if (name === "with-db-flx") {
       return {
-        ...replacements,
-        "config.json": { name: `${name}-${mongodbClusterName}` },
+        ...appNameReplacement,
         "services/mongodb/config.json": {
           type: "mongodb-atlas",
           config: {
@@ -89,7 +90,7 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
         },
       };
     }
-    return replacements;
+    return appNameReplacement;
   }
   return {};
 }

--- a/packages/realm-app-importer/src/AppImporter.ts
+++ b/packages/realm-app-importer/src/AppImporter.ts
@@ -236,7 +236,7 @@ export class AppImporter {
   private loadAppConfigJson(appTemplatePath: string, replacements: TemplateReplacements = {}): AppConfig {
     const configJsonPath = path.resolve(appTemplatePath, "config.json");
     const configJson = this.loadJson(configJsonPath);
-    return replacements["config.json"] ? { ...configJson, ...replacements["config.json"] } : configJson;
+    return { ...configJson, ...replacements["config.json"] };
   }
 
   private loadSecretsJson(appTemplatePath: string) {

--- a/packages/realm-app-importer/src/AppImporter.ts
+++ b/packages/realm-app-importer/src/AppImporter.ts
@@ -168,7 +168,7 @@ export class AppImporter {
    * @returns A promise of an object containing the app id.
    */
   public async importApp(appTemplatePath: string, replacements: TemplateReplacements = {}): Promise<{ appId: string }> {
-    const { name: appName, security } = this.loadAppConfigJson(appTemplatePath);
+    const { name: appName, security } = this.loadAppConfigJson(appTemplatePath, replacements);
 
     await this.logIn();
 
@@ -233,9 +233,10 @@ export class AppImporter {
     }
   }
 
-  private loadAppConfigJson(appTemplatePath: string): AppConfig {
+  private loadAppConfigJson(appTemplatePath: string, replacements: TemplateReplacements = {}): AppConfig {
     const configJsonPath = path.resolve(appTemplatePath, "config.json");
-    return this.loadJson(configJsonPath);
+    const configJson = this.loadJson(configJsonPath);
+    return replacements["config.json"] ? { ...configJson, ...replacements["config.json"] } : configJson;
   }
 
   private loadSecretsJson(appTemplatePath: string) {


### PR DESCRIPTION
## What, How & Why?
This change appends the `clusterName` to any deployed apps when deploying against the BaaS in Atlas.  This was done to ensure the apps are cleaned up properly when the tests are finished.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
