### PR TITLE
Update pr-realm-js to ignore scripts when building

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -129,6 +129,7 @@ jobs:
           ccache --show-config
 
       - name: Install dependencies
+        # Ignoring scripts to prevent a prebuilt from getting fetched / built
         run: npm ci --ignore-scripts
 
       # build the c++ library for standard targets

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -129,7 +129,7 @@ jobs:
           ccache --show-config
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       # build the c++ library for standard targets
       - name: Build node


### PR DESCRIPTION
## What, How & Why?

As seen with https://github.com/realm/realm-js/actions/runs/3059216385/jobs/4936336473 the prebuilt binary will be fetched or built if the version hasn't been published. This is not needed.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
