### PR TITLE
Mobile SDK is missing Realm.Credentials.apiKey() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 Based on Realm JS v10.21.1: See changelog below for details on enhancements and fixes introduced between this and the previous pre release (which was based on Realm JS v10.19.5).
 
 ### Breaking changes
+* Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
+   * `Realm.Credentials#serverApiKey`
+   * `Realm.Credentials#userApiKey`
 * When no object is found calling `Realm#objectForPrimaryKey`, `null` is returned instead of `undefined`
 * Removed deprecated positional arguments to Email/Password authentication functions
     * The following functions now only accept object arguments:

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -493,18 +493,11 @@ class Credentials {
   static function(payload) {}
 
   /**
-   * Creates credentials from a user API key.
-   * @param {string} key A string identifying the user by API key.
+   * Creates credentials from an API key.
+   * @param {string} key A string identifying the API key.
    * @return {Credentials} An instance of `Credentials` that can be used in {@linkcode Realm.App.logIn}.
    */
-  static userApiKey(token) {}
-
-  /**
-   * Creates credentials from a server API key.
-   * @param {string} key A string identifying the user by API key.
-   * @return {Credentials} An instance of `Credentials` that can be used in {@linkcode Realm.App.logIn}.
-   */
-  static serverApiKey(token) {}
+  static apiKey(token) {}
 
   /**
    * Creates credentials based on an Apple login.

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,3 +1,20 @@
+?.?.? Release notes (2020-??-??)
+=============================================================
+
+### Breaking Changes
+* Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
+   * `Realm.Credentials#serverApiKey`
+   * `Realm.Credentials#userApiKey`
+
+### Enhancements
+* None
+
+### Fixed
+* None
+
+### Internal
+* None
+
 1.7.1 Release notes (2022-07-04)
 =============================================================
 

--- a/packages/realm-web/src/Credentials.ts
+++ b/packages/realm-web/src/Credentials.ts
@@ -63,28 +63,6 @@ export class Credentials<PayloadType extends SimpleObject = SimpleObject> implem
   /**
    * Creates credentials that logs in using the [API Key Provider](https://docs.mongodb.com/realm/authentication/api-key/).
    *
-   * @deprecated Use `Credentials.apiKey`.
-   * @param key The secret content of the API key.
-   * @returns The credentials instance, which can be passed to `app.logIn`.
-   */
-  static userApiKey(key: string): Credentials<ApiKeyPayload> {
-    return new Credentials<ApiKeyPayload>("api-key", "api-key", { key });
-  }
-
-  /**
-   * Creates credentials that logs in using the [API Key Provider](https://docs.mongodb.com/realm/authentication/api-key/).
-   *
-   * @deprecated Use `Credentials.apiKey`.
-   * @param key The secret content of the API key.
-   * @returns The credentials instance, which can be passed to `app.logIn`.
-   */
-  static serverApiKey(key: string): Credentials<ApiKeyPayload> {
-    return new Credentials<ApiKeyPayload>("api-key", "api-key", { key });
-  }
-
-  /**
-   * Creates credentials that logs in using the [API Key Provider](https://docs.mongodb.com/realm/authentication/api-key/).
-   *
    * @param key The secret content of the API key.
    * @returns The credentials instance, which can be passed to `app.logIn`.
    */

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -77,8 +77,6 @@ describe("App", () => {
   it("expose a static Credentials factory", () => {
     expect(typeof App.Credentials).not.equals("undefined");
     expect(typeof App.Credentials.anonymous).equals("function");
-    expect(typeof App.Credentials.userApiKey).equals("function");
-    expect(typeof App.Credentials.serverApiKey).equals("function");
     expect(typeof App.Credentials.apiKey).equals("function");
     expect(typeof App.Credentials.emailPassword).equals("function");
   });

--- a/src/js_app_credentials.hpp
+++ b/src/js_app_credentials.hpp
@@ -48,15 +48,19 @@ public:
     static void apple(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void email_password(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void function(ContextType, ObjectType, Arguments&, ReturnValue&);
-    static void user_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
-    static void server_api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void api_key(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void google(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void jwt(ContextType, ObjectType, Arguments&, ReturnValue&);
 
     MethodMap<T> const static_methods = {
-        {"facebook", wrap<facebook>},       {"anonymous", wrap<anonymous>},          {"apple", wrap<apple>},
-        {"google", wrap<google>},           {"emailPassword", wrap<email_password>}, {"_function", wrap<function>},
-        {"userApiKey", wrap<user_api_key>}, {"serverApiKey", wrap<server_api_key>},  {"jwt", wrap<jwt>},
+        {"facebook", wrap<facebook>},
+        {"anonymous", wrap<anonymous>},
+        {"apple", wrap<apple>},
+        {"google", wrap<google>},
+        {"emailPassword", wrap<email_password>},
+        {"_function", wrap<function>},
+        {"apiKey", wrap<api_key>},
+        {"jwt", wrap<jwt>},
     };
 
     static void get_payload(ContextType, ObjectType, ReturnValue&);
@@ -195,23 +199,13 @@ void CredentialsClass<T>::function(ContextType ctx, ObjectType this_object, Argu
 }
 
 template <typename T>
-void CredentialsClass<T>::user_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments,
-                                       ReturnValue& return_value)
+void CredentialsClass<T>::api_key(ContextType ctx, ObjectType this_object, Arguments& arguments,
+                                  ReturnValue& return_value)
 {
     arguments.validate_count(1);
-    const std::string user_api_key = Value::validated_to_string(ctx, arguments[0], "user API key");
+    const std::string api_key = Value::validated_to_string(ctx, arguments[0], "user API key");
 
-    auto credentials = realm::app::AppCredentials::user_api_key(user_api_key);
-    return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
-}
-template <typename T>
-void CredentialsClass<T>::server_api_key(ContextType ctx, ObjectType this_object, Arguments& arguments,
-                                         ReturnValue& return_value)
-{
-    arguments.validate_count(1);
-    const std::string server_api_key = Value::validated_to_string(ctx, arguments[0], "server API key");
-
-    auto credentials = realm::app::AppCredentials::server_api_key(server_api_key);
+    auto credentials = realm::app::AppCredentials::user_api_key(api_key);
     return_value.set(create_object<T, CredentialsClass<T>>(ctx, new app::AppCredentials(credentials)));
 }
 

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -174,20 +174,10 @@ declare namespace Realm {
     /**
      * Factory for `Credentials` which authenticate using the [API Key Provider](https://docs.mongodb.com/realm/authentication/api-key/).
      *
-     * @deprecated Use `Credentials.apiKey`.
      * @param key The secret content of the API key.
      * @returns A `Credentials` object for logging in using `app.logIn`.
      */
-    static userApiKey(key: string): Credentials<Credentials.ApiKeyPayload>;
-
-    /**
-     * Factory for `Credentials` which authenticate using the [API Key Provider](https://docs.mongodb.com/realm/authentication/api-key/).
-     *
-     * @deprecated Use `Credentials.apiKey`.
-     * @param key The secret content of the API key.
-     * @returns A `Credentials` object for logging in using `app.logIn`.
-     */
-    static serverApiKey(key: string): Credentials<Credentials.ApiKeyPayload>;
+    static apiKey(key: string): Credentials<Credentials.ApiKeyPayload>;
 
     /**
      * Factory for `Credentials` which authenticate using the [Email/Password Provider](https://docs.mongodb.com/realm/authentication/email-password/).


### PR DESCRIPTION
## What, How & Why?
The `apiKey` method was created to replace `userApiKey` and `serverApiKey`, as these performed the same function.  This unifies all usage to `apiKey` and removes the old functions.
    * Create an `Realm.Credentials#apiKey` method and remove `Realm.Credentials#userApiKey` and `Realm.Credentials#serverApiKey`
    * Remove same methods in `realm-web`
    * Unify Changelog in `realm-web` and prepare `vNext`

This closes #4127

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
