### PR TITLE
objectForPrimaryKey should return null instead of undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Notes
 Based on Realm JS v10.21.1: See changelog below for details on enhancements and fixes introduced between this and the previous pre release (which was based on Realm JS v10.19.5).
 
-### Breaking change
+### Breaking changes
+* When no object is found calling `Realm#objectForPrimaryKey`, `null` is returned instead of `undefined`
 * Removed deprecated positional arguments to Email/Password authentication functions
     * The following functions now only accept object arguments:
     ```javascript

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -205,7 +205,7 @@ class Realm {
    * @param {number|string} key - The primary key value of the object to search for.
    * @throws {Error} If type passed into this method is invalid or if the object type did
    *   not have a `primaryKey` specified in its {@link Realm~ObjectSchema ObjectSchema}.
-   * @returns {Realm.Object|undefined} if no object is found.
+   * @returns {Realm.Object|null} if no object is found.
    * @since 0.14.0
    */
   objectForPrimaryKey(type, key) {}

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1286,7 +1286,7 @@ void RealmClass<T>::object_for_primary_key(ContextType ctx, ObjectType this_obje
         return_value.set(RealmObjectClass<T>::create_instance(ctx, std::move(realm_object)));
     }
     else {
-        return_value.set_undefined();
+        return_value.set_null();
     }
 }
 

--- a/tests/js/query-tests.js
+++ b/tests/js/query-tests.js
@@ -307,7 +307,7 @@ module.exports = {
 
     // objectForPrimaryKey tests
     const nonExisting = realm.objectForPrimaryKey(primUuidSchema.name, new UUID(nonExistingStringUuid));
-    TestCase.assertUndefined(
+    TestCase.assertNull(
       nonExisting,
       `objectForPrimaryKey should return undefined for new UUID("${nonExistingStringUuid}")`,
     );

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -1393,11 +1393,11 @@ module.exports = {
       realm.create("TestObject", { doubleCol: 0 });
     });
 
-    TestCase.assertEqual(realm.objectForPrimaryKey("IntPrimaryObject", -1), undefined);
+    TestCase.assertEqual(realm.objectForPrimaryKey("IntPrimaryObject", -1), null);
     TestCase.assertEqual(realm.objectForPrimaryKey("IntPrimaryObject", 0).valueCol, "val0");
     TestCase.assertEqual(realm.objectForPrimaryKey("IntPrimaryObject", 1).valueCol, "val1");
 
-    TestCase.assertEqual(realm.objectForPrimaryKey("StringPrimaryObject", "invalid"), undefined);
+    TestCase.assertEqual(realm.objectForPrimaryKey("StringPrimaryObject", "invalid"), null);
     TestCase.assertEqual(realm.objectForPrimaryKey("StringPrimaryObject", "").valueCol, -1);
     TestCase.assertEqual(realm.objectForPrimaryKey("StringPrimaryObject", "val0").valueCol, 0);
     TestCase.assertEqual(realm.objectForPrimaryKey("StringPrimaryObject", "val1").valueCol, 1);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1164,9 +1164,9 @@ declare class Realm {
     /**
      * @param  {string} type
      * @param  {number|string|ObjectId|UUID} key
-     * @returns {T | undefined}
+     * @returns {T | null}
      */
-    objectForPrimaryKey<T>(type: string, key: Realm.PrimaryKey): (T & Realm.Object) | undefined;
+    objectForPrimaryKey<T>(type: string, key: Realm.PrimaryKey): (T & Realm.Object) | null;
 
     /**
      * @param  {Class} type


### PR DESCRIPTION
## What, How & Why?
`Realm#objectForPrimaryKey` now returns `null` instead of `undefined` when no object is found

This closes #3966

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
