### PR TITLE
Fix `inMemory` test - follow-up to #4911

### DIFF
--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -402,14 +402,14 @@ module.exports = {
     realm1.write(() => {
       realm1.create("TestObject", [1]);
     });
-    TestCase.assertEqual(realm1.inMemory, true);
+    TestCase.assertEqual(realm1.isInMemory, true);
 
     // open a second instance of the same realm and check that they share data
     const realm2 = new Realm({ inMemory: true });
     const objects = realm2.objects("TestObject");
     TestCase.assertEqual(objects.length, 1);
     TestCase.assertEqual(objects[0].doubleCol, 1.0);
-    TestCase.assertEqual(realm2.inMemory, true);
+    TestCase.assertEqual(realm2.isInMemory, true);
 
     // Close both realms (this should delete the realm since there are no more
     // references to it.


### PR DESCRIPTION
## What, How & Why?

This fixes a test which broke when merging #4911.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
