### PR TITLE
Fix #4513

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -4,15 +4,10 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fix non-realm re-renders events from creating a new instance of collections and objects returned from `useObject` and `useQuery` ([#4513](https://github.com/realm/realm-js/issues/4513), since v0.2.0, special thanks to @mfbx9da4 for the PR)
 
 ### Compatibility
-* React Native >= v0.64.0
-* Atlas App Services.
-* Realm Studio v12.0.0.
-* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.
-* File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+* Tested with React Native v0.70.1 and React v18.1.0
 
 ### Internal
 * Update devDependencies for testing:

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -61,7 +61,10 @@ export function createUseObject(useRealm: () => Realm) {
       () => {
         const updateCallback = () => {
           // Wrap object in a proxy to update the reference on rerender ( should only rerender when something has changed )
-          objectRef.current = cachedObject.object ? new Proxy(cachedObject.object, {}) : null;
+          const objectProxy = objectRef.current ? new Proxy(objectRef.current, {}) : null;
+          objectRef.current = objectProxy;
+
+          // Force rerender to return the new proxy object
           forceRerender();
         };
         const cachedObject = createCachedObject({

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import Realm from "realm";
-import { useEffect, useReducer, useMemo } from "react";
+import { useEffect, useReducer, useMemo, useRef } from "react";
 import { createCachedObject } from "./cachedObject";
 
 // In order to make @realm/react work with older version of realms
@@ -52,16 +52,26 @@ export function createUseObject(useRealm: () => Realm) {
     // the cachedObject can force the component using this hook to re-render when a change occurs.
     const [, forceRerender] = useReducer((x) => x + 1, 0);
 
+    const objectRef = useRef<(T & Realm.Object) | null>(null);
+
     // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `primaryKey` or `type` change
     const { object, tearDown } = useMemo(
       // TODO: There will be an upcoming breaking change that makes objectForPrimaryKey return null
       // When this is implemented, remove `?? null`
-      () =>
-        createCachedObject({
+      () => {
+        const updateCallback = () => {
+          // Wrap object in a proxy to update the reference on rerender ( should only rerender when something has changed )
+          objectRef.current = cachedObject.object ? new Proxy(cachedObject.object, {}) : null;
+          forceRerender();
+        };
+        const cachedObject = createCachedObject({
           object: realm.objectForPrimaryKey(type, primaryKey) ?? null,
           realm,
-          updateCallback: forceRerender,
-        }),
+          updateCallback,
+        });
+        objectRef.current = cachedObject.object;
+        return cachedObject;
+      },
       [type, realm, primaryKey],
     );
 
@@ -75,7 +85,7 @@ export function createUseObject(useRealm: () => Realm) {
       return null;
     }
 
-    // Wrap object in a proxy to update the reference on rerender ( should only rerender when something has changed )
-    return new Proxy(object, {});
+    // Return the current object reference, which should only cause a rerender when something has changed
+    return objectRef.current;
   };
 }

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -61,13 +61,13 @@ export function createUseQuery(useRealm: () => Realm) {
       const updateCallback = () => {
         // This makes sure the collection has a different reference on a rerender
         // Also we are ensuring the type returned is Realm.Results, as this is known in this context
-        const proxy = new Proxy(cachedCollection.collection as Realm.Results<T & Realm.Object>, {});
+        const collectionProxy = new Proxy(collectionRef.current as Realm.Results<T & Realm.Object>, {});
 
         // Store the original, unproxied result as a non-enumerable field with a symbol
         // key on the proxy object, so that we can check for this and get the original results
         // when passing the result of `useQuery` into the subscription mutation methods
         // (see `lib/mutable-subscription-set.js` for more details)
-        Object.defineProperty(proxy, symbols.PROXY_TARGET, {
+        Object.defineProperty(collectionProxy, symbols.PROXY_TARGET, {
           value: realm.objects(type),
           enumerable: false,
           configurable: false,
@@ -75,7 +75,7 @@ export function createUseQuery(useRealm: () => Realm) {
         });
         // This makes sure the collection has a different reference on a rerender
         // Also we are ensuring the type returned is Realm.Results, as this is known in this context
-        collectionRef.current = proxy;
+        collectionRef.current = collectionProxy;
         forceRerender();
       };
       const cachedCollection = createCachedCollection({ collection: realm.objects(type), realm, updateCallback });

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
-import { useEffect, useReducer, useMemo } from "react";
+import { useEffect, useMemo, useRef, useReducer } from "react";
 import { createCachedCollection } from "./cachedCollection";
 import { symbols } from "@realm.io/common";
 
@@ -54,33 +54,41 @@ export function createUseQuery(useRealm: () => Realm) {
     // Create a forceRerender function for the cachedCollection to use as its updateCallback, so that
     // the cachedCollection can force the component using this hook to re-render when a change occurs.
     const [, forceRerender] = useReducer((x) => x + 1, 0);
+    const collectionRef = useRef({} as Realm.Results<T & Realm.Object>);
 
     // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `primaryKey` or `type` change
-    const { collection, tearDown } = useMemo(
-      () => createCachedCollection({ collection: realm.objects(type), realm, updateCallback: forceRerender }),
-      [type, realm],
-    );
+    const { tearDown } = useMemo(() => {
+      const updateCallback = () => {
+        // This makes sure the collection has a different reference on a rerender
+        // Also we are ensuring the type returned is Realm.Results, as this is known in this context
+        const proxy = new Proxy(cachedCollection.collection as Realm.Results<T & Realm.Object>, {});
+
+        // Store the original, unproxied result as a non-enumerable field with a symbol
+        // key on the proxy object, so that we can check for this and get the original results
+        // when passing the result of `useQuery` into the subscription mutation methods
+        // (see `lib/mutable-subscription-set.js` for more details)
+        Object.defineProperty(proxy, symbols.PROXY_TARGET, {
+          value: realm.objects(type),
+          enumerable: false,
+          configurable: false,
+          writable: true,
+        });
+        // This makes sure the collection has a different reference on a rerender
+        // Also we are ensuring the type returned is Realm.Results, as this is known in this context
+        collectionRef.current = proxy;
+        forceRerender();
+      };
+      const cachedCollection = createCachedCollection({ collection: realm.objects(type), realm, updateCallback });
+      collectionRef.current = cachedCollection.collection as Realm.Results<T & Realm.Object>;
+      return cachedCollection;
+    }, [type, realm]);
 
     // Invoke the tearDown of the cachedCollection when useQuery is unmounted
     useEffect(() => {
       return tearDown;
     }, [tearDown]);
 
-    // This makes sure the collection has a different reference on a rerender
-    // Also we are ensuring the type returned is Realm.Results, as this is known in this context
-    const proxy = new Proxy(collection as Realm.Results<T & Realm.Object>, {});
-
-    // Store the original, unproxied result as a non-enumerable field with a symbol
-    // key on the proxy object, so that we can check for this and get the original results
-    // when passing the result of `useQuery` into the subscription mutation methods
-    // (see `lib/mutable-subscription-set.js` for more details)
-    Object.defineProperty(proxy, symbols.PROXY_TARGET, {
-      value: realm.objects(type),
-      enumerable: false,
-      configurable: false,
-      writable: true,
-    });
-
-    return proxy;
+    // Return the current collection reference, which should only cause a rerender when something in the visible collection has changed
+    return collectionRef.current;
   };
 }


### PR DESCRIPTION

## What, How & Why?
Update useObject and useQuery to wrap their return value with proxy only when it needs to be rerendered


This closes #4513

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
