### PR TITLE
Test case: Dictionary set corner cases

### DIFF
--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -148,6 +148,27 @@ describe("Dictionary", () => {
       });
     });
 
+    it("can store dictionary values using string keys", function (this: RealmContext) {
+      const item = this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+        const item2 = this.realm.create<Item>("Item", {});
+        item2.dict.key1 = "Hello";
+        item.dict.key1 = item2.dict;
+        return item;
+      });
+      // @ts-expect-error We expect a dictionary inside dictionary
+      expect(item.dict.key1.dict.key1).equals("hello");
+    });
+
+    it("can store a reference to itself using string keys", function (this: RealmContext) {
+      const item = this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+        item.dict.key1 = item;
+        return item;
+      });
+      expect(item.dict.key1).equals(item);
+    });
+
     it("is spreadable", function (this: RealmContext) {
       const item = this.realm.write(() => this.realm.create<Item>("Item", { dict: { key1: "hi" } }));
       expect({ ...item.dict, key2: "hello" }).deep.equals({ key1: "hi", key2: "hello" });

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -148,7 +148,8 @@ describe("Dictionary", () => {
       });
     });
 
-    it("can store dictionary values using string keys", function (this: RealmContext) {
+    // This is currently not supported
+    it.skip("can store dictionary values using string keys", function (this: RealmContext) {
       const item = this.realm.write(() => {
         const item = this.realm.create<Item>("Item", {});
         const item2 = this.realm.create<Item>("Item", {});
@@ -166,7 +167,12 @@ describe("Dictionary", () => {
         item.dict.key1 = item;
         return item;
       });
-      expect(item.dict.key1).equals(item);
+      const value = item.dict.key1;
+      if (value instanceof Realm.Object) {
+        expect(value._objectKey()).equals(item._objectKey());
+      } else {
+        throw new Error("Expected a Realm.Object");
+      }
     });
 
     it("is spreadable", function (this: RealmContext) {

--- a/packages/realm/src/types.ts
+++ b/packages/realm/src/types.ts
@@ -22,6 +22,7 @@ import { assert } from "./assert";
 import * as binding from "./binding";
 import { ClassHelpers } from "./ClassHelpers";
 import { TypeAssertionError } from "./errors";
+import { Collection } from "./Collection";
 import { getInternal } from "./internal";
 import { Object as RealmObject, UpdateMode } from "./Object";
 import type { Realm } from "./Realm";
@@ -187,6 +188,8 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
           return binding.Timestamp.fromDate(value);
         } else if (value instanceof RealmObject) {
           return getInternal(value);
+        } else if (value instanceof Collection) {
+          throw new Error(`Using a ${value.constructor.name} as Mixed value, is not yet supported`);
         } else {
           return value as binding.Mixed;
         }


### PR DESCRIPTION
## What, How & Why?
Some possible corner cases regarding dictionaries, including:
- setting a dictionary key value to another dictionary
- setting a dictionary key value to itself

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
