### PR TITLE
Remove Deprecated Methods:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ### Notes
 Based on Realm JS v10.21.1: See changelog below for details on enhancements and fixes introduced between this and the previous pre release (which was based on Realm JS v10.19.5).
 
-<<<<<<< HEAD
 ### Breaking changes
+* The following deprecated methods have been removed:
+    * `Realm#automaticSyncConfiguration`
+    * `Realm.Credentials#google` with `authCode` parameter (use `authObject`)
+* `Realm#writeCopyTo` now only accepts an output Realm configuration as a parameter.
 * Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
-   * `Realm.Credentials#serverApiKey`
-   * `Realm.Credentials#userApiKey`
+    * `Realm.Credentials#serverApiKey`
+    * `Realm.Credentials#userApiKey`
 * When no object is found calling `Realm#objectForPrimaryKey`, `null` is returned instead of `undefined`
 * Replaced `Realm#empty` with `Realm#isEmpty`
 * Replaced `Realm#readOnly` with `Realm#isReadOnly`
@@ -35,7 +38,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
   Realm.App.Sync.Session.addProgressNotification(direction: ProgressDirection, mode: ProgressMode, progressCallback: ProgressNotificationCallback): void;
   ```
   * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
-  
+
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -127,17 +127,6 @@ class Realm {
   static open(config) {}
 
   /**
-   * Return a configuration for a default synced Realm. The server URL for the user will be used as base for
-   * the URL for the synced Realm. If no user is supplied, the current user will be used.
-   * @param {Realm.User} - an optional sync user
-   * @throws {Error} if zero or multiple users are logged in
-   * @returns {Realm~Configuration} - a configuration matching a default synced Realm.
-   * @since 2.3.0
-   * @deprecated use {@link Sync.User.createConfiguration()} instead.
-   */
-  static automaticSyncConfiguration(user) {}
-
-  /**
    * Creates a template object for a Realm model class where all optional fields are `undefined` and all required
    * fields have the default value for the given data type, either the value set by the `default` property in the
    * schema or the default value for the datatype if the schema doesn't specify one, i.e. `0`, false and `""`.
@@ -308,27 +297,17 @@ class Realm {
   compact() {}
 
   /**
-   * Writes a compacted copy of the Realm α) to the given path or β) with the given output
-   *
-   * For invocation with α):
-   *   * Input Realms may be local or synced, encrypted or non-encrypted
-   *   * Output Realms will be local only, encrypted or non-encrypted
-   * Deprecation Warning: Invoking `writeCopyTo` with a path string is deprecated and will be removed in the next breaking release.
-   * Please invoke `writeCopyTo` with a {@link Realm~Configuration | Configuration}.
-   *
-   * For invocation with β):
+   * Writes a compacted copy of the Realm with the given output configuration:
    *   * Input Realms may be local or synced, encrypted or non-encrypted
    *   * Output Realms will be local or synced, encrypted or non-encrypted, depending on the configuration passed to the function
    *
-   * The destination file cannot already exist.
+   * The destination Realm path cannot already exist.
    *
    * Note that if this method is called from within a write transaction, the current data is written,
    * not the data from the point when the previous write transaction was committed.
-   * @param {string|Realm~Configuration} pathOrConfig a α) path to save the Realm to, OR β) {@link Realm~Configuration | Configuration} that describes the output realm.
-   * @param {ArrayBuffer|ArrayBufferView} [encryptionKey] - Optional 64-byte encryption key to encrypt the new file with.  Must not be present when
-   * β) a {@link Realm~Configuration | Configuration} is given as first parameter, in which case encryptionKey can be set in {@link Realm~Configuration#encryptionKey}.
+   * @param {@link Realm~Configuration | Configuration} that describes the output Realm.
    */
-  writeCopyTo(pathOrConfig, encryptionKey) {}
+  writeCopyTo(pathOrConfig) {}
 
   /**
    * Get the current schema version of the Realm at the given path.

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -457,14 +457,6 @@ class Credentials {
 
   /**
    * Creates credentials based on a Google login.
-   * @param {string} authCode A Google authentication code, obtained by logging into Google.
-   * @return {Credentials} An instance of `Credentials` that can be used in {@linkcode Realm.App.logIn}.
-   * @deprecated
-   */
-  static google(authCode) {}
-
-  /**
-   * Creates credentials based on a Google login.
    * @param {object} An object with either an `authCode` or `idToken` property.
    * @return {Credentials} An instance of `Credentials` that can be used in {@linkcode Realm.App.logIn}.
    */

--- a/lib/email-password-auth-methods.js
+++ b/lib/email-password-auth-methods.js
@@ -20,12 +20,6 @@ const { EJSON } = require("bson");
 
 const { promisify } = require("./utils.js");
 
-// TODO for v11: change all signatures to methodName(argsObject) and remove handleDeprecatedPositionalArgs call
-//
-// Example post-v11:
-// registerUser(argsObject) {
-//   return promisify((cb) => this._registerUser(argsObject, cb));
-// },
 const instanceMethods = {
   registerUser(details) {
     return promisify((cb) => this._registerUser(details, cb));

--- a/packages/realm-web-integration-tests/src/credentials.test.ts
+++ b/packages/realm-web-integration-tests/src/credentials.test.ts
@@ -99,7 +99,8 @@ describe("Credentials", () => {
       this.timeout(60 * 1000); // 1 min
       const app = createApp();
       // Log in
-      const credentials = Credentials.google("http://localhost:8080/google-callback");
+      const credentials = Credentials.google({ redirectUrl: "http://localhost:8080/google-callback" });
+
       const user = await app.logIn(credentials);
       expect(user).to.be.instanceOf(User);
     });

--- a/packages/realm-web-integration-tests/src/google-login.ts
+++ b/packages/realm-web-integration-tests/src/google-login.ts
@@ -34,9 +34,9 @@ const app = createApp();
 
 function onSuccess(googleUser: any) {
   const response = googleUser.getAuthResponse();
-  const idToken = response.id_token;
+  const idToken = response.id_token as string;
   // Try authenticating with Atlas App Services
-  const credentials = Credentials.google(idToken);
+  const credentials = Credentials.google({ idToken });
   app.logIn(credentials).then(
     (user) => {
       console.log("Successfully authenticated as", user);

--- a/packages/realm-web-integration-tests/src/user.test.ts
+++ b/packages/realm-web-integration-tests/src/user.test.ts
@@ -214,7 +214,7 @@ describe("User", () => {
         }
 
         // Link user
-        const googleCredentials = Credentials.google("http://localhost:8080/google-callback");
+        const googleCredentials = Credentials.google({ redirectUrl: "http://localhost:8080/google-callback" });
         await user.linkCredentials(googleCredentials);
 
         // Expect the ids from the user object and tokens to match

--- a/packages/realm-web/src/Credentials.ts
+++ b/packages/realm-web/src/Credentials.ts
@@ -115,7 +115,7 @@ export class Credentials<PayloadType extends SimpleObject = SimpleObject> implem
    * @param payload The URL that users should be redirected to, the auth code or id token from Google.
    * @returns The credentials instance, which can be passed to `app.logIn`.
    */
-  static google<P extends OAuth2RedirectPayload | GooglePayload>(payload: string | GoogleOptions): Credentials<P> {
+  static google<P extends OAuth2RedirectPayload | GooglePayload>(payload: GoogleOptions): Credentials<P> {
     return new Credentials<P>("oauth2-google", "oauth2-google", Credentials.derivePayload(payload) as P);
   }
 
@@ -123,17 +123,9 @@ export class Credentials<PayloadType extends SimpleObject = SimpleObject> implem
    * @param payload The payload string.
    * @returns A payload object based on the string.
    */
-  private static derivePayload(payload: string | GoogleOptions): SimpleObject {
+  private static derivePayload(payload: GoogleOptions): SimpleObject {
     if (typeof payload === "string") {
-      if (payload.includes("://")) {
-        return this.derivePayload({ redirectUrl: payload });
-      } else if (payload.startsWith("4/")) {
-        return this.derivePayload({ authCode: payload });
-      } else if (payload.startsWith("ey")) {
-        return this.derivePayload({ idToken: payload });
-      } else {
-        throw new Error(`Unexpected payload: ${payload}`);
-      }
+      throw new Error("`google(<tokenString>)` has been deprecated.  Please use `google(<authCodeObject>).");
     } else if (Object.keys(payload).length === 1) {
       if ("authCode" in payload || "redirectUrl" in payload) {
         return payload;

--- a/packages/realm-web/src/tests/Credentials.test.ts
+++ b/packages/realm-web/src/tests/Credentials.test.ts
@@ -43,32 +43,6 @@ describe("Credentials", () => {
       expect(typeof Credentials.google).equals("function");
     });
 
-    it("produce a redirectUrl payload from a string", () => {
-      const credentials = Credentials.google("https://localhost:1337/google-redirect");
-      expect(credentials).to.be.instanceOf(Credentials);
-      expect(credentials.payload).deep.equals({
-        redirectUrl: "https://localhost:1337/google-redirect",
-      });
-    });
-
-    it("produce an OAuth 2.0 auth code payload from a string", () => {
-      const credentials = Credentials.google("4/some-auth-code");
-      expect(credentials).to.be.instanceOf(Credentials);
-      expect(credentials.payload).deep.equals({
-        authCode: "4/some-auth-code",
-      });
-    });
-
-    it("produce an OAuth 2.0 OpenID Connect id token payload from a string", () => {
-      const credentials = Credentials.google(
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U",
-      );
-      expect(credentials).to.be.instanceOf(Credentials);
-      expect(credentials.payload).deep.equals({
-        id_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U",
-      });
-    });
-
     it("produce redirect payloads payloads", () => {
       const credentials = Credentials.google({
         redirectUrl: "some-redirect-url",
@@ -101,8 +75,9 @@ describe("Credentials", () => {
 
     it("throws if an unexpected format is encountered", () => {
       expect(() => {
+        //@ts-expect-error test a bad argument
         Credentials.google("whatever");
-      }).throws("Unexpected payload: whatever");
+      }).throws("`google(<tokenString>)` has been deprecated.  Please use `google(<authCodeObject>).");
     });
 
     it("throws if called with multiple properties", () => {

--- a/packages/realm-web/src/tests/OAuth2Helper.test.ts
+++ b/packages/realm-web/src/tests/OAuth2Helper.test.ts
@@ -43,7 +43,9 @@ describe("OAuth2Helper", () => {
       return null;
     });
 
-    const credentials = Credentials.google<Realm.Credentials.OAuth2RedirectPayload>("http://localhost:1337/callback");
+    const credentials = Credentials.google<Realm.Credentials.OAuth2RedirectPayload>({
+      redirectUrl: "http://localhost:1337/callback",
+    });
     expect(typeof credentials.payload.redirectUrl).equals("string");
 
     const state = helper.generateState();

--- a/src/js_app_credentials.hpp
+++ b/src/js_app_credentials.hpp
@@ -20,6 +20,7 @@
 
 #include <stdexcept>
 #include "js_class.hpp"
+#include "js_util.hpp"
 #include <realm/object-store/sync/app_credentials.hpp>
 
 namespace realm {
@@ -126,13 +127,9 @@ void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Argume
         // the bare string is deprecated but we keep it until next major version
         // auth_code begins with "4/" while we assume all other cases are id_tokens
         if (Value::is_string(ctx, arguments[0])) {
-            std::string token = Value::validated_to_string(ctx, arguments[0]);
-            if (token.substr(0, 2) == "4/") {
-                return app::AppCredentials::google(app::AuthCode(token));
-            }
-            else if (token.substr(0, 2) == "ey") {
-                return app::AppCredentials::google(app::IdToken(token));
-            }
+            log_to_console<T>(ctx,
+                              "`google(<tokenString>)` has been deprecated.  Please use `google(<authCodeObject>).",
+                              JSLogFunction::Error);
         }
 
         if (Value::is_object(ctx, arguments[0])) {

--- a/src/js_app_credentials.hpp
+++ b/src/js_app_credentials.hpp
@@ -129,7 +129,7 @@ void CredentialsClass<T>::google(ContextType ctx, ObjectType this_object, Argume
         if (Value::is_string(ctx, arguments[0])) {
             log_to_console<T>(ctx,
                               "`google(<tokenString>)` has been deprecated.  Please use `google(<authCodeObject>).",
-                              JSLogFunction::Error);
+                              JSLogFunction::Warning);
         }
 
         if (Value::is_object(ctx, arguments[0])) {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -391,8 +391,6 @@ public:
 
     // helper methods
     static realm::Realm::Config write_copy_to_helper(ContextType ctx, ObjectType this_object, Arguments& args);
-    static realm::Realm::Config write_copy_to_helper_deprecated(ContextType ctx, ObjectType this_object,
-                                                                Arguments& args);
 
 
     // static properties
@@ -1643,85 +1641,23 @@ realm::Realm::Config RealmClass<T>::write_copy_to_helper(ContextType ctx, Object
     return config;
 }
 
-/**
- * @brief Helper function for `writeCopyTo()` -- parses parameters for the deprecated <path, [encryption key]>
- * invocation
- *
- * @param ctx JS context
- * @param this_object JS's object holding the `RealmClass`
- * @param args Arguments passed to `writeCopyTo()` from JS
- * @return realm::Realm::Config A new `Realm::Config` containing the given parameters
- */
-template <typename T>
-realm::Realm::Config RealmClass<T>::write_copy_to_helper_deprecated(ContextType ctx, ObjectType this_object,
-                                                                    Arguments& args)
-{
-    /* Validation rules:
-     * 1) there must be one or two parameters
-     * 2) first parameter must be a string
-     * 3) second parameter, if present, must be a binary
-     */
-
-    // log deprecation warning to console.warn
-    log_to_console<T>(
-        ctx, "`writeCopyTo(<path>, [encryption key])` has been deprecated.  Please use `writeCopyTo(<config>).",
-        JSLogFunction::Warning);
-
-    realm::Realm::Config config;
-    // validate 1)
-    if (args.count != 1 && args.count != 2) {
-        throw std::invalid_argument("`writeCopyTo(<path>, [encryption key])` accepts exactly one or two parameters");
-    }
-
-    // validate 2)
-    // make sure that `path` parameter exists and that it is a string
-    ValueType pathValue = args[0];
-    if (!Value::is_string(ctx, pathValue)) {
-        throw std::invalid_argument("`path` parameter must be a string");
-    }
-
-    config.path = Value::to_string(ctx, pathValue);
-
-    // validate 3)
-    if (args.count == 2) {
-        // a second parameter is given -- it must be an encryption key for the destination Realm
-        ValueType encKeyValue = args[1];
-        if (!Value::is_binary(ctx, encKeyValue)) {
-            throw std::invalid_argument("Encryption key for 'writeCopyTo' must be an ArrayBuffer or ArrayBufferView");
-        }
-
-        OwnedBinaryData encryption_key = Value::to_binary(ctx, encKeyValue);
-        config.encryption_key.assign(encryption_key.data(), encryption_key.data() + encryption_key.size());
-    }
-
-    SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
-    if (static_cast<bool>(realm->sync_session())) {
-        // input realm is synced, and we're in deprecated mode.
-        // copy the sync config
-        config.sync_config = realm->config().sync_config;
-    }
-
-    return config;
-}
 
 /**
  * @brief Create a copy of one realm file to another realm file.
  *  Conversion between synced and non-synced realms is supported.
- *  Invocation of `writeCopyTo` is overloaded to two scenarios:
- *  1) `writeCopyTo(<path: string>, [encryption key: string])`, which supports copying a local realm
- *    to another local realm, or converting a synced realm to a local realm.
- *  2) `writeCopyTo(<config: object>)`, which, in addition to the above, supports conversion of a local
+ *  Invocation of `writeCopyTo` is:
+ *  * `writeCopyTo(<config: object>)`, which supports conversion of a local
  *    realm to a synced realm if the `sync` section is present in `config`.
  *
  * @param ctx JS enviroment context
  * @param this_object Realm object passed from JS
- * @param args Either `<string>, [string]`, or `object` -- see function brief.
+ * @param args `object` -- see function brief.
  * @param return_value none
  */
 template <typename T>
 void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Arguments& args, ReturnValue& return_value)
 {
-    args.validate_maximum(2);
+    args.validate_maximum(1);
 
     SharedRealm realm = *get_internal<T, RealmClass<T>>(ctx, this_object);
 
@@ -1734,14 +1670,15 @@ void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Argumen
     realm::Realm::Config config;
     if (args.count == 0) {
         throw std::invalid_argument(
-            "`writeCopyTo` requires <output configuration> or <path, [encryptionKey]> parameters");
+            "`writeCopyTo` requires <output configuration> as a parameter. See documentation for details.");
     }
 
     if (args.count == 1 && !Value::is_string(ctx, args[0])) {
         config = write_copy_to_helper(ctx, this_object, args);
     }
     else {
-        config = write_copy_to_helper_deprecated(ctx, this_object, args);
+        throw std::invalid_argument("`writeCopyTo` requires <output configuration> parameter. <path, "
+                                    "[encryptionKey]> parameters are not supported");
     }
 
     realm->convert(config);

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1669,16 +1669,14 @@ void RealmClass<T>::writeCopyTo(ContextType ctx, ObjectType this_object, Argumen
 
     realm::Realm::Config config;
     if (args.count == 0) {
-        throw std::invalid_argument(
-            "`writeCopyTo` requires <output configuration> as a parameter. See documentation for details.");
+        throw std::invalid_argument("Expected a config object");
     }
 
     if (args.count == 1 && !Value::is_string(ctx, args[0])) {
         config = write_copy_to_helper(ctx, this_object, args);
     }
     else {
-        throw std::invalid_argument("`writeCopyTo` requires <output configuration> parameter. <path, "
-                                    "[encryptionKey]> parameters are not supported");
+        throw std::invalid_argument("Expected a config object. <path, [encryptionKey]> parameters are not supported");
     }
 
     realm->convert(config);

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -2033,56 +2033,6 @@ module.exports = {
     realm.close();
   },
 
-  testWriteCopyTo: function () {
-    const realm = new Realm({
-      schema: [schemas.IntPrimary, schemas.AllTypes, schemas.TestObject, schemas.LinkToAllTypes],
-    });
-
-    realm.write(() => {
-      realm.create("TestObject", { doubleCol: 1 });
-    });
-    TestCase.assertEqual(1, realm.objects("TestObject").length);
-
-    TestCase.assertThrowsContaining(() => {
-      realm.writeCopyTo();
-    }, "`writeCopyTo` requires <output configuration> or <path, [encryptionKey]> parameters");
-
-    TestCase.assertThrowsContaining(() => {
-      realm.writeCopyTo(34);
-    }, "`config` parameter must be an object");
-
-    // make sure that copies are in the same directory as the original file
-    // that is important for running tests on mobile devices,
-    // so we don't have issues with permissisons
-    const copyName = realm.path + ".copy.realm";
-
-    realm.writeCopyTo(copyName);
-
-    const copyConfig = { path: copyName };
-    const realmCopy = new Realm(copyConfig);
-    TestCase.assertEqual(1, realmCopy.objects("TestObject").length);
-    realmCopy.close();
-
-    TestCase.assertThrowsContaining(() => {
-      realm.writeCopyTo(realm.path + ".copy-invalid-key.realm", "hello");
-    }, "Encryption key for 'writeCopyTo' must be an ArrayBuffer or ArrayBufferView");
-
-    const encryptedCopyName = realm.path + ".copy-encrypted.realm";
-
-    var encryptionKey = new Int8Array(64);
-    for (let i = 0; i < 64; i++) {
-      encryptionKey[i] = 1;
-    }
-    realm.writeCopyTo(encryptedCopyName, encryptionKey);
-
-    const encryptedCopyConfig = { path: encryptedCopyName, encryptionKey: encryptionKey };
-    const encryptedRealmCopy = new Realm(encryptedCopyConfig);
-    TestCase.assertEqual(1, encryptedRealmCopy.objects("TestObject").length);
-    encryptedRealmCopy.close();
-
-    realm.close();
-  },
-
   testObjectWithoutProperties: function () {
     const realm = new Realm({ schema: [schemas.ObjectWithoutProperties] });
     realm.write(() => {

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -228,7 +228,7 @@ declare namespace Realm {
      */
     static google(payload: {
       /**
-       *
+       * The id token from Google.
        */
       idToken: string;
     }): Credentials<Credentials.GoogleIdTokenPayload>;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -208,14 +208,6 @@ declare namespace Realm {
     static jwt(token: string): Credentials<Credentials.JWTPayload>;
 
     /**
-     * Factory for `Credentials` which authenticate using the [Google Provider](https://docs.mongodb.com/realm/authentication/google/).
-     *
-     * @param authCode The auth code returned from Google.
-     * @returns A `Credentials` object for logging in using `app.logIn`.
-     */
-    static google(authCodeOrIdToken: string): Credentials<Credentials.GooglePayload>;
-
-    /**
      * Factory for `Credentials` which authenticate using the Auth Token OAuth 2.0 [Google Provider](https://docs.mongodb.com/realm/authentication/google/).
      *
      * @param payload.authCode The auth code from Google.


### PR DESCRIPTION
## What, How & Why?
* The following deprecated methods have been removed: * `Realm#automaticSyncConfiguration` * `Realm.Credentials#google` with `authCode` parameter (use `authObject`)
* `Realm#writeCopyTo` now only accepts an output Realm configuration as a parameter.

This closes #4825 and #4831

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
