### PR TITLE
Change callback names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
     * `Realm#automaticSyncConfiguration`
     * `Realm.Credentials#google` with `authCode` parameter (use `authObject`)
 * `Realm#writeCopyTo` now only accepts an output Realm configuration as a parameter.
+* Following callbacks were renamed:
+    * `Realm.Config#migration` -> `Realm.Config#onMigration`
+        ``` typescript
+        // before
+        Realm.open({migration:() => {}})
+        // after
+        Realm.open({onMigration:() => {}})
+        ```
+    * `Realm.Config#shouldCompactOnLaunch` -> `Realm.Config#shouldCompact`
+    * `Realm.App.Sync~SyncConfiguration.error` -> `Realm.App.Sync~SyncConfiguration.onError`
+    * `Realm.App.Sync~SyncConfiguration.clientReset.clientResetBefore` -> `Realm.App.Sync~SyncConfiguration.clientReset.onBefore`
+    * `Realm.App.Sync~SyncConfiguration.clientReset.clientResetAfter` -> `Realm.App.Sync~SyncConfiguration.clientReset.onAfter`
+    * `Realm.App.Sync~SyncConfiguration.ssl.validateCallback` -> `Realm.App.Sync~SyncConfiguration.ssl.validateCertificates`
+        ``` typescript
+        // before
+        Realm.open({
+          sync: {
+            shouldCompactOnLaunch: /**/
+            error: /**/
+            clientReset: {
+              clientResetBefore: /**/
+              clientResetAfter: /**/
+            }
+            ssl:{
+              validateCallback: /**/
+            }
+          }
+        })
+        // after
+        Realm.open({
+          sync: {
+            shouldCompact: /**/
+            onError: /**/
+            clientReset: {
+              onBefore: /**/
+              onAfter: /**/
+            }
+            ssl:{
+              validateCertificates: /**/
+            }
+          }
+        })
+        ```
 * Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
     * `Realm.Credentials#serverApiKey`
     * `Realm.Credentials#userApiKey`

--- a/docs/realm.js
+++ b/docs/realm.js
@@ -371,7 +371,7 @@ class Realm {
  * @type {Object}
  * @property {ArrayBuffer|ArrayBufferView} [encryptionKey] - The 512-bit (64-byte) encryption
  *   key used to encrypt and decrypt all data in the Realm.
- * @property {callback(Realm, Realm)} [migration] - The function to run if a migration is needed.
+ * @property {callback(Realm, Realm)} [onMigration] - The function to run if a migration is needed.
  *   This function should provide all the logic for converting data models from previous schemas
  *   to the new schema. This option is incompatible with `sync`.
  *   This function takes two arguments:
@@ -380,7 +380,7 @@ class Realm {
  * @property {boolean} [deleteRealmIfMigrationNeeded=false] - Specifies if this Realm should be deleted
  *   if a migration is needed.
  *   This option is not available on synced realms.
- * @property {callback(number, number)} [shouldCompactOnLaunch] - The function called when opening
+ * @property {callback(number, number)} [shouldCompact] - The function called when opening
  *   a Realm for the first time during the life of a process to determine if it should be compacted
  *   before being returned to the user. The function takes two arguments:
  *     - `totalSize` - The total file size (data + free space)

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -38,8 +38,8 @@
  * This describes the options to configure client reset.
  * @typedef {Object} Realm.App.Sync~ClientResetConfiguration
  * @property {string} mode - Either "manual" (deprecated, see also `Realm.App.Sync.initiateClientReset()`) or "discardLocal" (download a fresh copy from the server).
- * @property {callback(realm)|null} [clientResetBefore] - called before sync initiates a client reset.
- * @property {callback(beforeRealm, afterRealm)|null} [clientResetAfter] - called after client reset has been executed; `beforeRealm` and `afterRealm` are instances of the Realm before and after the client reset.
+ * @property {callback(realm)|null} [onBefore] - called before sync initiates a client reset.
+ * @property {callback(beforeRealm, afterRealm)|null} [onAfter] - called after client reset has been executed; `beforeRealm` and `afterRealm` are instances of the Realm before and after the client reset.
  * @since {10.11.0}
  */
 
@@ -51,7 +51,7 @@
  * @property {boolean} flexible - Whether to use flexible sync (if `true`) or partition based sync (default)
  * @property {string|number|BSON.ObjectId|null} partitionValue - The value of the partition key. Only valid if using partition based sync.
  * @property {Realm.App.Sync~InitialSubscriptionsConfiguration} initialSubscriptions - Optional object to configure the setup of an initial set of flexible sync subscriptions to be used when opening the Realm. Only valid if using flexible sync. See {@link Realm.App.Sync~InitialSubscriptionsConfiguration}.
- * @property {callback(session, syncError)} [error] - A callback function which is called in error situations.
+ * @property {callback(session, syncError)} [onError] - A callback function which is called in error situations.
  *    The callback is passed two arguments: `session` and `syncError`. If `syncError.name == "ClientReset"`, `syncError.path` and `syncError.config` are set
  *    and `syncError.readOnly` is true (deprecated, see `Realm.App.Sync~ClientResetConfiguration`). Otherwise, `syncError` can have up to five properties:
  *    `name`, `message`, `isFatal`, `category`, and `code`.
@@ -105,7 +105,7 @@
  * @typedef {Object} Realm.App.Sync~SSLConfiguration
  * @property {boolean} validate - Indicating if SSL certificates must be validated. Default is `true`.
  * @property {string} certificatePath - A path where to find trusted SSL certificates.
- * @property {Realm.Sync~sslValidateCallback} validateCallback - A callback function used to accept or reject the server's SSL certificate.
+ * @property {Realm.Sync~sslValidateCallback} validateCertificates - A callback function used to accept or reject the server's SSL certificate.
  */
 
 /**

--- a/integration-tests/tests/src/utils/expect-sync-error.ts
+++ b/integration-tests/tests/src/utils/expect-sync-error.ts
@@ -48,7 +48,7 @@ export async function expectSyncError(
       ...config,
       sync: {
         ...config.sync,
-        error(_, error: Error) {
+        onError(_, error: Error) {
           try {
             expectation(error);
             resolve();

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -316,8 +316,8 @@ describe("areConfigurationsIdentical", () => {
 
     expect(areConfigurationsIdentical(configA, configB)).toBeFalsy();
 
-    configA = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, migration: () => undefined };
-    configB = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, migration: () => undefined };
+    configA = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, onMigration: () => undefined };
+    configB = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, onMigration: () => undefined };
 
     expect(areConfigurationsIdentical(configA, configB)).toBeFalsy();
 
@@ -333,10 +333,10 @@ describe("areConfigurationsIdentical", () => {
 
     expect(areConfigurationsIdentical(configA, configB)).toBeTruthy();
 
-    const migration = () => undefined;
+    const onMigration = () => undefined;
 
-    configA = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, migration };
-    configB = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, migration };
+    configA = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, onMigration };
+    configB = { schema: [catSchema], deleteRealmIfMigrationNeeded: true, onMigration };
 
     expect(areConfigurationsIdentical(configA, configB)).toBeTruthy();
   });

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -718,15 +718,15 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 config.schema_version = 0;
             }
 
-            static const String compact_on_launch_string = "shouldCompactOnLaunch";
+            static const String compact_on_launch_string = "shouldCompact";
             ValueType compact_value = Object::get_property(ctx, object, compact_on_launch_string);
             if (!Value::is_undefined(ctx, compact_value)) {
                 if (config.schema_mode == SchemaMode::Immutable) {
-                    throw std::invalid_argument("Cannot set 'shouldCompactOnLaunch' when 'readOnly' is set.");
+                    throw std::invalid_argument("Cannot set 'shouldCompact' when 'readOnly' is set.");
                 }
 
                 FunctionType should_compact_on_launch_function =
-                    Value::validated_to_function(ctx, compact_value, "shouldCompactOnLaunch");
+                    Value::validated_to_function(ctx, compact_value, "shouldCompact");
                 ShouldCompactOnLaunchFunctor<T> should_compact_on_launch_functor{ctx,
                                                                                  should_compact_on_launch_function};
                 config.should_compact_on_launch_function = std::move(should_compact_on_launch_functor);
@@ -755,18 +755,18 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 };
             }
 
-            static const String migration_string = "migration";
+            static const String migration_string = "onMigration";
             ValueType migration_value = Object::get_property(ctx, object, migration_string);
             if (!Value::is_undefined(ctx, migration_value)) {
                 if (config.force_sync_history || config.sync_config) {
-                    throw std::invalid_argument("Options 'migration' and 'sync' are mutual exclusive.");
+                    throw std::invalid_argument("Options 'onMigration' and 'sync' are mutual exclusive.");
                 }
 
-                FunctionType migration_function = Value::validated_to_function(ctx, migration_value, "migration");
+                FunctionType migration_function = Value::validated_to_function(ctx, migration_value, "onMigration");
 
                 if (config.schema_mode == SchemaMode::SoftResetFile) {
                     throw std::invalid_argument(
-                        "Cannot include 'migration' when 'deleteRealmIfMigrationNeeded' is set.");
+                        "Cannot include 'onMigration' when 'deleteRealmIfMigrationNeeded' is set.");
                 }
 
                 config.migration_function = [=](SharedRealm old_realm, SharedRealm realm, realm::Schema&) {

--- a/tests/js/app-tests.js
+++ b/tests/js/app-tests.js
@@ -186,7 +186,7 @@ module.exports = {
     const partition = Utils.genPartition();
     const realmConfig = {
       schema: [schemas.PersonForSync, schemas.DogForSync],
-      shouldCompactOnLaunch: (t, u) => {
+      shouldCompact: (t, u) => {
         nCalls++;
         return true;
       },

--- a/tests/js/download-api-helper.js
+++ b/tests/js/download-api-helper.js
@@ -47,7 +47,7 @@ function createObjects(user) {
     sync: {
       user: user,
       partitionValue: partition,
-      error: (err) => console.log(err),
+      onError: (err) => console.log(err),
     },
     schema: [
       {

--- a/tests/js/migration-tests.js
+++ b/tests/js/migration-tests.js
@@ -30,18 +30,18 @@ module.exports = {
     }
 
     // no migration should be run
-    var realm = new Realm({ schema: [], migration: migrationFunction });
+    var realm = new Realm({ schema: [], onMigration: migrationFunction });
     TestCase.assertEqual(0, count);
     realm.close();
 
     // migration should be run
-    realm = new Realm({ schema: [Schemas.TestObject], migration: migrationFunction, schemaVersion: 1 });
+    realm = new Realm({ schema: [Schemas.TestObject], onMigration: migrationFunction, schemaVersion: 1 });
     TestCase.assertEqual(1, count);
     realm.close();
 
     // invalid migration function
     TestCase.assertThrows(function () {
-      new Realm({ schema: [], schemaVersion: 2, migration: "invalid" });
+      new Realm({ schema: [], schemaVersion: 2, onMigration: "invalid" });
     });
 
     // migration function exceptions should propogate
@@ -51,7 +51,7 @@ module.exports = {
       realm = new Realm({
         schema: [],
         schemaVersion: 3,
-        migration: function () {
+        onMigration: function () {
           throw exception;
         },
       });
@@ -60,14 +60,14 @@ module.exports = {
     TestCase.assertEqual(Realm.schemaVersion(Realm.defaultPath), 1);
 
     // migration function shouldn't run if nothing changes
-    realm = new Realm({ schema: [Schemas.TestObject], migration: migrationFunction, schemaVersion: 1 });
+    realm = new Realm({ schema: [Schemas.TestObject], onMigration: migrationFunction, schemaVersion: 1 });
     TestCase.assertEqual(1, count);
     realm.close();
 
     // migration function should run if only schemaVersion changes
     realm = new Realm({
       schema: [Schemas.TestObject],
-      migration: function () {
+      onMigration: function () {
         count++;
       },
       schemaVersion: 2,
@@ -104,7 +104,7 @@ module.exports = {
         },
       ],
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         var oldObjects = oldRealm.objects("TestObject");
         var newObjects = newRealm.objects("TestObject");
         TestCase.assertEqual(oldObjects.length, 1);
@@ -160,7 +160,7 @@ module.exports = {
     var realm2 = new Realm({
       schema: [FirstObjectType, SecondObjectType],
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         var oldObjects_1 = oldRealm.objects("FirstObjectType");
         var newObjects_1 = newRealm.objects("FirstObjectType");
         var newObjects_2 = newRealm.objects("SecondObjectType");
@@ -210,7 +210,7 @@ module.exports = {
         },
       ],
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         var oldSchema = oldRealm.schema;
         var newSchema = newRealm.schema;
         TestCase.assertEqual(oldSchema.length, 1);
@@ -259,7 +259,7 @@ module.exports = {
     realm = new Realm({
       schemaVersion: 1,
       schema: [schemaV1],
-      migration: (oldRealm, newRealm) => {
+      onMigration: (oldRealm, newRealm) => {
         newRealm.create("Person", { name: "Freddy Bloggson", firstName: "Freddy" });
         newRealm.create("Person", { name: "Blogs Fredson" });
       },
@@ -312,7 +312,7 @@ module.exports = {
     realm = new Realm({
       schema: [],
       schemaVersion: 3,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         newRealm.deleteModel("TestObject");
       },
     });
@@ -352,7 +352,7 @@ module.exports = {
     realm = new Realm({
       schema: schema,
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         newRealm.deleteModel("TestObject");
       },
     });
@@ -391,7 +391,7 @@ module.exports = {
     realm = new Realm({
       schema: schema,
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         newRealm.deleteModel("NonExistingModel");
       },
     });
@@ -442,7 +442,7 @@ module.exports = {
     realm = new Realm({
       schema: [ShipSchema, CaptainSchema],
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         TestCase.assertThrows(function (e) {
           // deleting a model which is target of linkingObjects results in an exception
           newRealm.deleteModel("Captain");
@@ -459,7 +459,7 @@ module.exports = {
     realm = new Realm({
       schema: [ShipSchema, CaptainSchema],
       schemaVersion: 2,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         // deleting a model which isn't target of linkingObjects works fine
         newRealm.deleteModel("Ship");
       },
@@ -488,7 +488,7 @@ module.exports = {
     realm = new Realm({
       schema: [{ name: "TestObject", properties: { values: "int[]" } }],
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         const oldObjects = oldRealm.objects("TestObject");
         const newObjects = newRealm.objects("TestObject");
         TestCase.assertEqual(oldObjects.length, 2);

--- a/tests/js/realm-tests.js
+++ b/tests/js/realm-tests.js
@@ -502,12 +502,12 @@ module.exports = {
 
   testRealmOpenShouldCompactOnLaunch: function () {
     let called = false;
-    const shouldCompactOnLaunch = (total, used) => {
+    const shouldCompact = (total, used) => {
       called = true;
       return true;
     };
 
-    return Realm.open({ schema: [schemas.TestObject], shouldCompactOnLaunch: shouldCompactOnLaunch }).then((realm) => {
+    return Realm.open({ schema: [schemas.TestObject], shouldCompact }).then((realm) => {
       TestCase.assertTrue(called);
       realm.close();
     });
@@ -1687,7 +1687,7 @@ module.exports = {
       const fiveHundredKB = 500 * 1024;
       return totalBytes > fiveHundredKB && usedBytes / totalBytes < 0.2;
     };
-    const realm2 = new Realm({ schema: [schemas.StringOnly], shouldCompactOnLaunch: shouldCompact });
+    const realm2 = new Realm({ schema: [schemas.StringOnly], shouldCompact });
     TestCase.assertTrue(wasCalled);
     TestCase.assertEqual(realm2.objects("StringOnlyObject").length, count + 2);
     // we don't check if the file is smaller as we assume that Object Store does it
@@ -1817,7 +1817,7 @@ module.exports = {
 
     realm.close();
 
-    realm = new Realm({ schema: schema, deleteRealmIfMigrationNeeded: true, schemaVersion: 1, migration: undefined });
+    realm = new Realm({ schema: schema, deleteRealmIfMigrationNeeded: true, schemaVersion: 1, onMigration: undefined });
 
     // object should be gone as Realm should get deleted
     TestCase.assertEqual(realm.objects("TestObject").length, 0);
@@ -1834,7 +1834,7 @@ module.exports = {
       schema: schema,
       deleteRealmIfMigrationNeeded: false,
       schemaVersion: 2,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         migrationWasCalled = true;
       },
     });
@@ -1904,7 +1904,11 @@ module.exports = {
 
     TestCase.assertThrows(function (e) {
       // updating schema without changing schemaVersion OR setting deleteRealmIfMigrationNeeded = true should raise an error
-      new Realm({ schema: schema2, deleteRealmIfMigrationNeeded: false, migration: function (oldRealm, newRealm) {} });
+      new Realm({
+        schema: schema2,
+        deleteRealmIfMigrationNeeded: false,
+        onMigration: function (oldRealm, newRealm) {},
+      });
     });
 
     var migrationWasCalled = false;
@@ -1914,7 +1918,7 @@ module.exports = {
       schema: schema2,
       deleteRealmIfMigrationNeeded: false,
       schemaVersion: 1,
-      migration: function (oldRealm, newRealm) {
+      onMigration: function (oldRealm, newRealm) {
         migrationWasCalled = true;
       },
     });
@@ -1943,8 +1947,8 @@ module.exports = {
     }, "Cannot set 'deleteRealmIfMigrationNeeded' when 'readOnly' is set.");
 
     TestCase.assertThrows(function () {
-      new Realm({ schema: schema, deleteRealmIfMigrationNeeded: true, migration: function (oldRealm, newRealm) {} });
-    }, "Cannot include 'migration' when 'deleteRealmIfMigrationNeeded' is set.");
+      new Realm({ schema: schema, deleteRealmIfMigrationNeeded: true, onMigration: function (oldRealm, newRealm) {} });
+    }, "Cannot include 'onMigration' when 'deleteRealmIfMigrationNeeded' is set.");
   },
 
   testDisableFileFormatUpgrade: function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,7 +140,7 @@ declare namespace Realm {
     interface SSLConfiguration {
         validate?: boolean;
         certificatePath?: string;
-        validateCallback?: SSLVerifyCallback;
+        validateCertificates?: SSLVerifyCallback;
     }
 
     enum ClientResetMode {
@@ -152,8 +152,8 @@ declare namespace Realm {
     type ClientResetAfterCallback = (localRealm: Realm, remoteRealm: Realm) => void;
     interface ClientResetConfiguration<ClientResetModeT = ClientResetMode> {
         mode: ClientResetModeT;
-        clientResetBefore?: ClientResetBeforeCallback;
-        clientResetAfter?: ClientResetAfterCallback;
+        onBefore?: ClientResetBeforeCallback;
+        onAfter?: ClientResetAfterCallback;
     }
 
     interface BaseSyncConfiguration{
@@ -163,7 +163,7 @@ declare namespace Realm {
         _sessionStopPolicy?: SessionStopPolicy;
         newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
         existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
-        error?: ErrorCallback;
+        onError?: ErrorCallback;
     }
 
     // We only allow `flexible` to be `true` or `undefined` - `{ flexible: false }`
@@ -229,7 +229,7 @@ declare namespace Realm {
         encryptionKey?: ArrayBuffer | ArrayBufferView | Int8Array;
         schema?: (ObjectClass | ObjectSchema)[];
         schemaVersion?: number;
-        shouldCompactOnLaunch?: (totalBytes: number, usedBytes: number) => boolean;
+        shouldCompact?: (totalBytes: number, usedBytes: number) => boolean;
         onFirstOpen?: (realm: Realm) => void;
         path?: string;
         fifoFilesFallbackPath?: string;
@@ -238,7 +238,7 @@ declare namespace Realm {
 
     interface ConfigurationWithSync extends BaseConfiguration {
         sync: SyncConfiguration;
-        migration?: never;
+        onMigration?: never;
         inMemory?: never;
         deleteRealmIfMigrationNeeded?: never;
         disableFormatUpgrade?: never;
@@ -246,7 +246,7 @@ declare namespace Realm {
 
     interface ConfigurationWithoutSync extends BaseConfiguration {
         sync?: never;
-        migration?: MigrationCallback;
+        onMigration?: MigrationCallback;
         inMemory?: boolean;
         deleteRealmIfMigrationNeeded?: boolean;
         disableFormatUpgrade?: boolean;


### PR DESCRIPTION

## What, How & Why?
* Following callbacks were renamed:
    * `Realm.Config#migration` -> `Realm.Config#onMigration`
        ``` typescript
        // before
        Realm.open({migration:() => {}})
        // after
        Realm.open({onMigration:() => {}})
        ```
    * `Realm.Config#shouldCompactOnLaunch` -> `Realm.Config#shouldCompact`
    * `Realm.App.Sync~SyncConfiguration.error` -> `Realm.App.Sync~SyncConfiguration.onError`
    * `Realm.App.Sync~SyncConfiguration.clientReset.clientResetBefore` -> `Realm.App.Sync~SyncConfiguration.clientReset.onBefore`
    * `Realm.App.Sync~SyncConfiguration.clientReset.clientResetAfter` -> `Realm.App.Sync~SyncConfiguration.clientReset.onAfter`
    * `Realm.App.Sync~SyncConfiguration.ssl.validateCallback` -> `Realm.App.Sync~SyncConfiguration.ssl.validateCertificates`
        ``` typescript
        // before
        Realm.open({
          sync: {
            shouldCompactOnLaunch: /**/
            error: /**/
            clientReset: {
              clientResetBefore: /**/
              clientResetAfter: /**/
            }
            ssl:{
              validateCallback: /**/
            }
          }
        })
        // after
        Realm.open({
          sync: {
            shouldCompact: /**/
            onError: /**/
            clientReset: {
              onBefore: /**/
              onAfter: /**/
            }
            ssl:{
              validateCertificates: /**/
            }
          }
        })
        ```
This closes #4447
## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [x] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
