### PR TITLE
Change default client reset mode to 'discardLocal'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Notes
 Based on Realm JS v10.21.1: See changelog below for details on enhancements and fixes introduced between this and the previous pre release (which was based on Realm JS v10.19.5).
 
-<<<<<<< HEAD
 ### Breaking changes
 * Removal of deprecated functions, which should be replaced with `Realm.Credentials#apiKey`:
    * `Realm.Credentials#serverApiKey`
@@ -35,7 +34,8 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
   Realm.App.Sync.Session.addProgressNotification(direction: ProgressDirection, mode: ProgressMode, progressCallback: ProgressNotificationCallback): void;
   ```
   * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
-  
+* `"discardLocal"` is now the default client reset mode. ([#4382](https://github.com/realm/realm-js/issues/4382))
+
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/docs/sync.js
+++ b/docs/sync.js
@@ -37,7 +37,7 @@
 /**
  * This describes the options to configure client reset.
  * @typedef {Object} Realm.App.Sync~ClientResetConfiguration
- * @property {string} mode - Either "manual" (deprecated, see also `Realm.App.Sync.initiateClientReset()`) or "discardLocal" (download a fresh copy from the server).
+ * @property {string} mode - Either "manual" (see also `Realm.App.Sync.initiateClientReset()`) or "discardLocal" (download a fresh copy from the server). Default is "discardLocal".
  * @property {callback(realm)|null} [clientResetBefore] - called before sync initiates a client reset.
  * @property {callback(beforeRealm, afterRealm)|null} [clientResetAfter] - called after client reset has been executed; `beforeRealm` and `afterRealm` are instances of the Realm before and after the client reset.
  * @since {10.11.0}

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -1015,11 +1015,11 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         // i)  manual: the error handler is called with the proper error code and a client reset is initiated
         // ii) discardLocal: the sync client handles it but notifications are send before and after
         //
-        // The default setting is manual
+        // The default setting is discardLocal
 
         const std::string client_reset_manual = "manual";
         const std::string client_reset_discard_local = "discardLocal";
-        config.sync_config->client_resync_mode = realm::ClientResyncMode::Manual;
+        config.sync_config->client_resync_mode = realm::ClientResyncMode::DiscardLocal;
         ValueType client_reset_value = Object::get_property(ctx, sync_config_object, "clientReset");
         if (!Value::is_undefined(ctx, client_reset_value)) {
             auto client_reset_object = Value::validated_to_object(ctx, client_reset_value);

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -584,6 +584,9 @@ module.exports = {
             _reject(e);
           }
         };
+        config.sync.clientReset = {
+          mode: "manual",
+        };
         realm = new Realm(config);
         const session = realm.syncSession;
 
@@ -1283,6 +1286,9 @@ module.exports = {
         user: user3,
         partitionValue: otherPartition,
         _sessionStopPolicy: "immediately", // Make it safe to delete files after realm.close()
+        clientReset: {
+          mode: "manual",
+        },
       },
       schema: [schemas.PersonForSync, schemas.DogForSync],
       path: realm3Path,


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes #4382

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 📝 Update `COMPATIBILITY.md`~
* ~[ ] 🚦 Tests~
* ~[ ] 🔀 Executed flexible sync tests locally if modifying flexible sync~
* ~[ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* [x] jsdoc files updated
* ~[ ] Chrome debug API is updated if API is available on React Native~
