### PR TITLE
Improve toJSON functionality and remove JSONSerializerReplacer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
 
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
-* Small improvement to performance for `toJSON` which should make it useful for cases where a plain representations of Realm entities are needed, e.g. when inspecting them for debugging purposes through `console.log(realmObj.toJSON())`.  
+* Small improvement to performance for `toJSON` which should make it useful for cases where a plain representations of Realm entities are needed, e.g. when inspecting them for debugging purposes through `console.log(realmObj.toJSON())`. ([#4997](https://github.com/realm/realm-js/pull/4997)) 
 
 ### Fixed
 * None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
   ```
   * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
 * `"discardLocal"` is now the default client reset mode. ([#4382](https://github.com/realm/realm-js/issues/4382))
-
+* Removed `Realm.JsonSerializationReplacer`. Use circular JSON serialization libraries such as [@ungap/structured-clone](https://www.npmjs.com/package/@ungap/structured-clone) and [flatted](https://www.npmjs.com/package/flatted) for stringifying Realm entities that have circular structures. The Realm entities' `toJSON` method returns plain objects and arrays (with circular references if applicable) which makes them compatible with any serialization library that supports stringifying plain JavaScript types. ([#4997](https://github.com/realm/realm-js/pull/4997))
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
 
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
+* Small improvement to performance for `toJSON` which should make it useful for cases where a plain representations of Realm entities are needed, e.g. when inspecting them for debugging purposes through `console.log(realmObj.toJSON())`.  
 
 ### Fixed
 * None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Based on Realm JS v10.21.1: See changelog below for details on enhancements and 
   * A typo was fixed in the `SubscriptionsState` enum, in which `SubscriptionsState.Superseded` now returns `superseded` in place of `Superseded`
 * `"discardLocal"` is now the default client reset mode. ([#4382](https://github.com/realm/realm-js/issues/4382))
 * Removed `Realm.JsonSerializationReplacer`. Use circular JSON serialization libraries such as [@ungap/structured-clone](https://www.npmjs.com/package/@ungap/structured-clone) and [flatted](https://www.npmjs.com/package/flatted) for stringifying Realm entities that have circular structures. The Realm entities' `toJSON` method returns plain objects and arrays (with circular references if applicable) which makes them compatible with any serialization library that supports stringifying plain JavaScript types. ([#4997](https://github.com/realm/realm-js/pull/4997))
+
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
 

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -64,6 +64,7 @@ describe("Dictionary", () => {
       "addListener",
       "removeListener",
       "removeAllListeners",
+      "toJSON",
     ];
     for (const name of methodNames) {
       it(`exposes a method named '${name}'`, function (this: RealmContext) {

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -226,6 +226,7 @@ describe("Dictionary", () => {
       // Previously this would throw on JSC, because the Dictionary was still a Proxy,
       // so modifying it tried to write to the Realm outside of a write transaction
       expect(() => {
+        // @ts-expect-error We know the field is a dict.
         jsonObject.dict.something = "test2";
       }).to.not.throw();
     });

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -144,7 +144,7 @@ describe("toJSON functionality", () => {
       this.birthdaysSerialized.dict.grandparent = this.birthdaysSerialized;
 
       // Define the structures for the common test suite.
-      this.this.commonTests = {
+      this.commonTests = {
         Object: {
           type: Realm.Object,
           subject: p1,
@@ -164,7 +164,7 @@ describe("toJSON functionality", () => {
     });
   });
   describe(`common tests`, () => {
-    for (const name in commonTestsTypes) {
+    for (const name of commonTestsTypes) {
       describe(`with Realm.${name}`, () => {
         it("implements toJSON", function (this: TestContext) {
           const test = this.commonTests[name];

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -25,15 +25,6 @@ const dictionaryHandler = {
       return true;
     }
 
-    if (key === "toJSON") {
-      return function () {
-        const keys = target._keys();
-        let obj = {};
-        keys.forEach((key) => (obj[key] = target.getter(key)));
-        return obj;
-      };
-    }
-
     if (typeof target[key] === "function") {
       return function () {
         return target[key].apply(target, arguments);

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -61,6 +61,25 @@ module.exports = function (realmConstructor) {
   realmConstructor._UUID = realmConstructor.BSON.UUID;
   const { DefaultNetworkTransport } = require("@realm/network-transport");
   realmConstructor._networkTransport = new DefaultNetworkTransport();
+
+  // Adds to cache when serializing an object for toJSON
+  const addToCache = (cache, realmObj, value) => {
+    const tableKey = realmObj._tableKey();
+    let cachedMap = cache.get(tableKey);
+    if (!cachedMap) {
+      cachedMap = new Map();
+      cache.set(tableKey, cachedMap);
+    }
+    cachedMap.set(realmObj._objectKey(), value);
+  };
+
+  // Adds to cache when serializing an object for toJSON
+  const getFromCache = (cache, realmObj) => {
+    const tableKey = realmObj._tableKey();
+    let cachedMap = cache.get(tableKey);
+    return cachedMap ? cachedMap.get(realmObj._objectKey()) : undefined;
+  };
+
   Object.defineProperty(realmConstructor.Collection.prototype, "toJSON", {
     value: function toJSON(_, cache = new Map()) {
       return this.map((item, index) =>
@@ -73,29 +92,31 @@ module.exports = function (realmConstructor) {
     enumerable: false,
   });
 
-  const getInternalCacheId = (realmObj) => {
-    const { name, primaryKey } = realmObj.objectSchema();
-    const id = primaryKey ? realmObj[primaryKey] : realmObj._objectKey();
-    return `${name}#${id}`;
-  };
+  Object.defineProperty(realmConstructor.Dictionary.prototype, "toJSON", {
+    value: function toJSON(_, cache = new Map()) {
+      const result = {};
+      for (const k of this._keys()) {
+        const v = this.getter(k);
+        result[k] = v instanceof realmConstructor.Object ? v.toJSON(k, cache) : v;
+      }
+      return result;
+    },
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
 
   Object.defineProperty(realmConstructor.Object.prototype, "toJSON", {
     value: function (_, cache = new Map()) {
-      // Construct a reference-id of table-name & primaryKey if it exists, or fall back to objectId.
-      const id = getInternalCacheId(this);
-
       // Check if current objectId has already processed, to keep object references the same.
-      const existing = cache.get(id);
+      const existing = getFromCache(cache, this);
       if (existing) {
         return existing;
       }
 
       // Create new result, and store in cache.
       const result = {};
-      cache.set(id, result);
-
-      // Add the generated reference-id, as a non-enumerable prop '$refId', for later exposure though e.g. Realm.JsonSerializationReplacer.
-      Object.defineProperty(result, "$refId", { value: id, configurable: true });
+      addToCache(cache, this, result);
 
       // Move all enumerable keys to result, triggering any specific toJSON implementation in the process.
       Object.keys(this)
@@ -545,54 +566,4 @@ module.exports = function (realmConstructor) {
     },
     configurable: true,
   });
-
-  if (!realmConstructor.JsonSerializationReplacer) {
-    Object.defineProperty(realmConstructor, "JsonSerializationReplacer", {
-      get: function () {
-        const seen = [];
-
-        return function (_, value) {
-          // Only check for circular references when dealing with objects & arrays.
-          if (value === null || typeof value !== "object") {
-            return value;
-          }
-
-          // 'this' refers to the object or array containing the the current key/value.
-          const parent = this;
-
-          if (value.$refId) {
-            // Expose the non-enumerable prop $refId for circular serialization, if it exists.
-            Object.defineProperty(value, "$refId", { enumerable: true });
-          }
-
-          if (!seen.length) {
-            // If we haven't seen anything yet, we only push the current value (root element/array).
-            seen.push(value);
-            return value;
-          }
-
-          const pos = seen.indexOf(parent);
-          if (pos !== -1) {
-            // If we have seen the parent before, we have already traversed a sibling in the array.
-            // We then discard information gathered for the sibling (zero back to the current array).
-            seen.splice(pos + 1);
-          } else {
-            // If we haven't seen the parent before, we add it to the seen-path.
-            // Note that this is done both for objects & arrays, to detect when we go to the next item in an array (see above).
-            seen.push(parent);
-          }
-
-          if (seen.includes(value)) {
-            // If we have seen the current value before, return a reference-structure if possible.
-            if (value.$refId) {
-              return { $ref: value.$refId };
-            }
-            return "[Circular reference]";
-          }
-
-          return value;
-        };
-      },
-    });
-  }
 };

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -85,6 +85,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
     static void linking_objects(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void linking_objects_count(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void get_object_key(ContextType, ObjectType, Arguments&, ReturnValue&);
+    static void get_table_key(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void get_object_id(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void is_same_object(ContextType, ObjectType, Arguments&, ReturnValue&);
     static void set_link(ContextType, ObjectType, Arguments&, ReturnValue&);
@@ -110,6 +111,7 @@ struct RealmObjectClass : ClassDefinition<T, realm::js::RealmObject<T>> {
         {"linkingObjectsCount", wrap<linking_objects_count>},
         {"_isSameObject", wrap<is_same_object>},
         {"_objectKey", wrap<get_object_key>},
+        {"_tableKey", wrap<get_table_key>},
         {"_setLink", wrap<set_link>},
         {"addListener", wrap<add_listener>},
         {"removeListener", wrap<remove_listener>},
@@ -350,6 +352,22 @@ void RealmObjectClass<T>::get_object_key(ContextType ctx, ObjectType object, Arg
     const Obj& obj = realm_object->obj();
     auto obj_key = obj.get_key();
     return_value.set(std::to_string(obj_key.value));
+}
+
+template <typename T>
+void RealmObjectClass<T>::get_table_key(ContextType ctx, ObjectType object, Arguments& args,
+                                         ReturnValue& return_value)
+{
+    args.validate_maximum(0);
+
+    auto realm_object = get_internal<T, RealmObjectClass<T>>(ctx, object);
+    if (!realm_object) {
+        throw std::runtime_error("Invalid 'this' object");
+    }
+
+    const Obj& obj = realm_object->obj();
+    auto table_key = obj.get_table()->get_key();
+    return_value.set(std::to_string(table_key.value));
 }
 
 template <typename T>

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -356,7 +356,7 @@ void RealmObjectClass<T>::get_object_key(ContextType ctx, ObjectType object, Arg
 
 template <typename T>
 void RealmObjectClass<T>::get_table_key(ContextType ctx, ObjectType object, Arguments& args,
-                                         ReturnValue& return_value)
+                                        ReturnValue& return_value)
 {
     args.validate_maximum(0);
 

--- a/src/js_realm_object.hpp
+++ b/src/js_realm_object.hpp
@@ -367,7 +367,7 @@ void RealmObjectClass<T>::get_table_key(ContextType ctx, ObjectType object, Argu
 
     const Obj& obj = realm_object->obj();
     auto table_key = obj.get_table()->get_key();
-    return_value.set(std::to_string(table_key.value));
+    return_value.set(table_key.value);
 }
 
 template <typename T>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -336,13 +336,6 @@ declare namespace Realm {
          */
         getPropertyType(propertyName: string): string;
     }
-
-    /**
-     * JsonSerializationReplacer solves circular structures when serializing Realm entities
-     * @example JSON.stringify(realm.objects("Person"), Realm.JsonSerializationReplacer)
-     */
-    const JsonSerializationReplacer: (key: string, val: any) => any;
-
     /**
      * SortDescriptor
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Collection.html#~SortDescriptor }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -296,9 +296,9 @@ declare namespace Realm {
         entries(): [string, any][];
 
         /**
-         * @returns An object for JSON serialization.
+         * @returns A plain object for JSON serialization.
          */
-        toJSON(): any;
+        toJSON(): Record<string, any>;
 
         /**
          * @returns boolean
@@ -383,6 +383,11 @@ declare namespace Realm {
         addListener(callback: DictionaryChangeCallback): void;
         removeListener(callback: DictionaryChangeCallback): void;
         removeAllListeners(): void;
+
+        /**
+         * @returns A plain object for JSON serialization.
+         */
+        toJSON(): Record<string, any>;
     }
 
     /**
@@ -394,9 +399,9 @@ declare namespace Realm {
         readonly optional: boolean;
 
         /**
-         * @returns An object for JSON serialization.
+         * @returns An array of plain objects for JSON serialization.
          */
-        toJSON(): Array<any>;
+        toJSON(): Array<Record<string, any>>;
 
         description(): string;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -298,7 +298,7 @@ declare namespace Realm {
         /**
          * @returns A plain object for JSON serialization.
          */
-        toJSON(): Record<string, any>;
+        toJSON(): Record<string, unknown>;
 
         /**
          * @returns boolean
@@ -387,7 +387,7 @@ declare namespace Realm {
         /**
          * @returns A plain object for JSON serialization.
          */
-        toJSON(): Record<string, any>;
+        toJSON(): Record<string, unknown>;
     }
 
     /**
@@ -401,7 +401,7 @@ declare namespace Realm {
         /**
          * @returns An array of plain objects for JSON serialization.
          */
-        toJSON(): Array<Record<string, any>>;
+        toJSON(): Array<Record<string, unknown>>;
 
         description(): string;
 


### PR DESCRIPTION
## What, How & Why?
This is a breaking change that removes `JSONSerializerReplacer` and improves the current `toJSON` functionality. It also improves current tests, organizing them better and adding cases for dictionaries. 
With removal `JSONSerializerReplacer`, users are advised to use external libraries such as [flatted](https://www.npmjs.com/package/flatted) and [@ungap/structured-clone](https://github.com/ungap/structured-clone/#readme) if they need to deal with serialising objects with circular references into a JSON string.
The expected functionality of `toJSON` is therefore to generate valid, plain JavaScript objects with correct circular references so those can be used by the packages mentioned above. `toJSON` is implemented by Realm Object, Dictionary, and Collection.

Related to https://github.com/realm/realm-js/pull/4966.

## ☑️ ToDos
<!-- Add your own todos here -->
* [X] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [X] 🚦 Tests
* [X] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [X] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [X] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [X] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [X] typescript definitions file is updated
* [X] jsdoc files updated
* [X] Chrome debug API is updated if API is available on React Native
