### PR TITLE
Allow specifying required fields on Realm.Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Add support for using functions as default property values, in order to allow dynamic defaults [#5001](https://github.com/realm/realm-js/pull/5001), [#2393](https://github.com/realm/realm-js/issues/2393)
+* All fields of a `Realm.Object` treated as optional by TypeScript when constructing a new class-based model, unless specified in the second type parameter [#5000](https://github.com/realm/realm-js/pull/5000)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
@@ -241,7 +242,6 @@ realm.write(() => {
     ```
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
-* All fields of a `Realm.Object` treated as optional by TypeScript when constructing a new class-based model, unless specified in the second type parameter [#5000](https://github.com/realm/realm-js/pull/5000)
 
 ### Compatibility
 * React Native >= v0.70.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ realm.write(() => {
     ```
 ### Enhancements
 * Small improvement to performance by caching JSI property String object [#4863](https://github.com/realm/realm-js/pull/4863)
+* All fields of a `Realm.Object` treated as optional by TypeScript when constructing a new class-based model, unless specified in the second type parameter [#5000](https://github.com/realm/realm-js/pull/5000)
 
 ### Compatibility
 * React Native >= v0.70.0

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -296,7 +296,7 @@ declare namespace Realm {
      * `T` should also be `Person` - this duplication is required due to how
      * TypeScript works)
      *
-     * @typeParam `RequiredProperties`  - The names of any properties of this
+     * @typeParam `RequiredProperties` - The names of any properties of this
      * class which are required when an instance is constructed with `new`. Any
      * properties not specified will be optional, and will default to a sensible
      * null value if no default is specified elsewhere.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -276,14 +276,36 @@ declare namespace Realm {
     type ObjectChangeCallback<T> = (object: T, changes: ObjectChangeSet<T>) => void;
 
     /**
-     * Object
-     * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Object.html }
+     * Base class for a Realm Object.
+     * @see
+     * {@link https://realm.io/docs/javascript/latest/api/Realm.Object.html}
+     *
+     * @example
+     * To define a class `Person` which requires the `name` and `age` properties to be
+     * specified when it is being constructed, using the Realm Babel plugin to allow
+     * Typescript-only model definitions (otherwise it would require a `static` schema):
+     * ```
+     * class Person extends Realm.Object<Person, "name" | "age"> {
+     *   _id = new Realm.Types.ObjectId();
+     *   name: string;
+     *   age: Realm.Types.Int;
+     * }
+     * ```
+     *
+     * @typeParam `T` - The type of this class (e.g. if your class is `Person`,
+     * `T` should also be `Person` - this duplication is required due to how
+     * TypeScript works)
+     *
+     * @typeParam `RequiredProperties`  - The names of any properties of this
+     * class which are required when an instance is constructed with `new`. Any
+     * properties not specified will be optional, and will default to a sensible
+     * null value if no default is specified elsewhere.
      */
-    abstract class Object<T = unknown, RequiredFields extends keyof T = never> {
+    abstract class Object<T = unknown, RequiredProperties extends keyof OmittedRealmTypes<T> = never> {
         /**
          * Creates a new object in the database.
          */
-        constructor(realm: Realm, values: Unmanaged<T, RequiredFields>);
+        constructor(realm: Realm, values: Unmanaged<T, RequiredProperties>);
 
         /**
          * @returns An array of the names of the object's properties.
@@ -1036,10 +1058,10 @@ type OptionalExcept<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 
 /**
  * Omits all properties of a model which are not defined by the schema,
- * making all properties optional except those specified in RequiredFields.
+ * making all properties optional except those specified in RequiredProperties.
  */
-type OmittedRealmTypesWithRequired<T, RequiredFields extends keyof OmittedRealmTypes<T>> =
-    OptionalExcept<OmittedRealmTypes<T>, RequiredFields>;
+type OmittedRealmTypesWithRequired<T, RequiredProperties extends keyof OmittedRealmTypes<T>> =
+    OptionalExcept<OmittedRealmTypes<T>, RequiredProperties>;
 
 /** Remaps realm types to "simpler" types (arrays and objects) */
 type RemappedRealmTypes<T> =
@@ -1049,10 +1071,10 @@ type RemappedRealmTypes<T> =
 /**
  * Joins T stripped of all keys which value extends Realm.Collection and all inherited from Realm.Object,
  * with only the keys which value extends Realm.List, remapped as Arrays. All properties are optional
- * except those specified in RequiredFields.
+ * except those specified in RequiredProperties.
  */
-type Unmanaged<T, RequiredFields extends keyof OmittedRealmTypes<T>> =
-    OmittedRealmTypesWithRequired<T, RequiredFields> & RemappedRealmTypes<T>;
+type Unmanaged<T, RequiredProperties extends keyof OmittedRealmTypes<T>> =
+    OmittedRealmTypesWithRequired<T, RequiredProperties> & RemappedRealmTypes<T>;
 
 declare class Realm {
     static defaultPath: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -279,11 +279,11 @@ declare namespace Realm {
      * Object
      * @see { @link https://realm.io/docs/javascript/latest/api/Realm.Object.html }
      */
-    abstract class Object<T = unknown> {
+    abstract class Object<T = unknown, RequiredFields extends keyof T = never> {
         /**
          * Creates a new object in the database.
          */
-        constructor(realm: Realm, values: Unmanaged<T>);
+        constructor(realm: Realm, values: Unmanaged<T, RequiredFields>);
 
         /**
          * @returns An array of the names of the object's properties.
@@ -1031,6 +1031,16 @@ type OmittedRealmTypes<T> = Omit<T,
     ExtractPropertyNamesOfType<T, Realm.Dictionary>
 >;
 
+/** Make all fields optional except those specified in K */
+type OptionalExcept<T, K extends keyof T> = Partial<T> & Pick<T, K>;
+
+/**
+ * Omits all properties of a model which are not defined by the schema,
+ * making all properties optional except those specified in RequiredFields.
+ */
+type OmittedRealmTypesWithRequired<T, RequiredFields extends keyof OmittedRealmTypes<T>> =
+    OptionalExcept<OmittedRealmTypes<T>, RequiredFields>;
+
 /** Remaps realm types to "simpler" types (arrays and objects) */
 type RemappedRealmTypes<T> =
     RealmListsRemappedModelPart<T> &
@@ -1038,9 +1048,12 @@ type RemappedRealmTypes<T> =
 
 /**
  * Joins T stripped of all keys which value extends Realm.Collection and all inherited from Realm.Object,
- * with only the keys which value extends Realm.List, remapped as Arrays.
+ * with only the keys which value extends Realm.List, remapped as Arrays. All properties are optional
+ * except those specified in RequiredFields.
  */
-type Unmanaged<T> = OmittedRealmTypes<T> & RemappedRealmTypes<T>;
+type Unmanaged<T, RequiredFields extends keyof OmittedRealmTypes<T>> =
+    OmittedRealmTypesWithRequired<T, RequiredFields> & RemappedRealmTypes<T>;
+
 declare class Realm {
     static defaultPath: string;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1073,7 +1073,7 @@ type RemappedRealmTypes<T> =
  * with only the keys which value extends Realm.List, remapped as Arrays. All properties are optional
  * except those specified in RequiredProperties.
  */
-type Unmanaged<T, RequiredProperties extends keyof OmittedRealmTypes<T>> =
+type Unmanaged<T, RequiredProperties extends keyof OmittedRealmTypes<T> = never> =
     OmittedRealmTypesWithRequired<T, RequiredProperties> & RemappedRealmTypes<T>;
 
 declare class Realm {


### PR DESCRIPTION
## What, How & Why?

The current types for `Realm.Object` (post-class based models) make it so that when you construct an object with `new MyObject(realm: Realm, objectValues: Record<string, whatever>)`, you are required to specify a value for _every_ property of the schema in `objectValues`.

In the case of schemas with default values specified, this means you would need to work around type errors if you do not want to specify an explicit value for the properties with defaults – e.g. you could specify `fieldName: undefined` which would result in the default being used, which works but is a little clumsy. 

This is likely to become a more common use case post-Typescript models, as we are making it very natural to specify schema defaults.

This change makes it so that all fields of the schema are optional, unless explicitly specified as part of a union type for the second type parameter: `class MyObject extends Realm.Object<MyObject, 'requiredField1' | 'requiredField2'>` – so users should specify any required fields (i.e. ones which do not have a default value) in this type parameter. 

If required fields are not specified in the type parameter, TypeScript will treat them as optional, which could lead to errors where required fields are not being passed in. On the other hand, this will not break existing code as we are by default relaxing the strictness of the type. 

The reason behind making all fields optional by default rather than required is that core has an internal default value for all types, so this will not lead to runtime errors. It would of course be much nicer to be able to infer which fields have a default value being assigned but I don't think there's any way to express this in TypeScript.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
