### PR TITLE
Support importing values with the app importer

### DIFF
--- a/integration-tests/tests/src/utils/import-app.ts
+++ b/integration-tests/tests/src/utils/import-app.ts
@@ -59,7 +59,9 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
     const appName = `${name}-${mongodbClusterName}`;
     const appNameReplacement = { "config.json": { name: appName } };
 
-    if (name === "with-db") {
+    if (name === "with-db" || name === "with-db-flx") {
+      // Generate a unique database name to limit crosstalk between runs
+      const databaseName = `test-database-${new BSON.ObjectID().toHexString()}`;
       return {
         ...appNameReplacement,
         "services/mongodb/config.json": {
@@ -68,23 +70,8 @@ export function getDefaultReplacements(name: string): TemplateReplacements {
             clusterName: mongodbClusterName,
             readPreference: "primary",
             wireProtocolEnabled: false,
-            sync: {
-              database_name: `test-database-${new BSON.ObjectID().toHexString()}`,
-            },
-          },
-        },
-      };
-    } else if (name === "with-db-flx") {
-      return {
-        ...appNameReplacement,
-        "services/mongodb/config.json": {
-          type: "mongodb-atlas",
-          config: {
-            clusterName: mongodbClusterName,
-            readPreference: "primary",
-            wireProtocolEnabled: false,
-            flexible_sync: {
-              database_name: `test-database-${new BSON.ObjectID().toHexString()}`,
+            [name === "with-db" ? "sync" : "flexible_sync"]: {
+              database_name: databaseName,
             },
           },
         },


### PR DESCRIPTION
## What, How & Why?

This adds the ability for the app importer to import values, plus a small simplification of the import-app utility.
I added this while debugging another issue and thought I would get it in instead of simply deleting the code.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
