### PR TITLE
Removing `writeCopyTo` overload from types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1254,17 +1254,6 @@ declare class Realm {
     compact(): boolean;
 
     /**
-     * Write a copy of a realm at the destination path.  Any user will be able to open and use
-     * the new copy.  Copying a synced realm will create a snapshot of the realm that can be
-     * opened to resume syncing from the server.  Synced realms must be fully synchronized with
-     * the server before calling `writeCopyTo`.
-     * @param path destination path
-     * @param encryptionKey encryption key to use
-     * @returns void
-     */
-    writeCopyTo(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): void;
-
-    /**
      * Writes a compacted copy of the Realm with the given configuration.
      *
      * The destination file cannot already exist.


### PR DESCRIPTION
## What, How & Why?

This removes the types for the overload that got removed with https://github.com/realm/realm-js/pull/4987

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
