### PR TITLE
Use MacOS 11 runner to have Xcode 12.5.1

### DIFF
--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -28,7 +28,7 @@ defaults:
 jobs:
   install:
     name: Installing Realm → React Native (using Xcode v${{matrix.xcode}}, node v${{ matrix.node }}, npm v${{ matrix.npm }})
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -23,9 +23,9 @@ jobs:
           - { os: android, runner: ubuntu-latest, arch: armeabi-v7a, artifact-path: react-native/android/src/main/jniLibs }
           - { os: android, runner: ubuntu-latest, arch: arm64-v8a, artifact-path: react-native/android/src/main/jniLibs }
           - { os: android, runner: ubuntu-latest, arch: x86, artifact-path: react-native/android/src/main/jniLibs }
-          - { os: darwin, runner: macos-latest, arch: x64, artifact-path: prebuilds, test-node: true, test-electron: true }
-          - { os: darwin, runner: macos-latest, arch: arm64, artifact-path: prebuilds, test-node: true, test-electron: true }
-          - { os: ios, runner: macos-latest, arch: apple, artifact-path: react-native/ios/realm-js-ios.xcframework }
+          - { os: darwin, runner: macos-11, arch: x64, artifact-path: prebuilds, test-node: true, test-electron: true }
+          - { os: darwin, runner: macos-11, arch: arm64, artifact-path: prebuilds, test-node: true, test-electron: true }
+          - { os: ios, runner: macos-11, arch: apple, artifact-path: react-native/ios/realm-js-ios.xcframework }
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -178,12 +178,12 @@ jobs:
           #- { os: windows, target: test, runner: windows-latest, environment: node}
           #- { os: windows, target: "test:main", runner: windows-latest, environment: electron }
           #- { os: windows, target: "test:renderer", runner: windows-latest, environment: electron }
-          - { os: darwin, target: "test:main", runner: macos-latest, environment: electron }
-          - { os: darwin, target: "test:renderer", runner: macos-latest, environment: electron }
-          - { os: darwin, target: test, runner: macos-latest, environment: node }
-          - { os: android, target: "test:android", runner: macos-latest, environment: react-native }
-          - { os: ios, target: "test:ios", runner: macos-latest, environment: react-native }
-          #- { os: ios, target: "test:catalyst", runner: macos-latest, environment: react-native }
+          - { os: darwin, target: "test:main", runner: macos-11, environment: electron }
+          - { os: darwin, target: "test:renderer", runner: macos-11, environment: electron }
+          - { os: darwin, target: test, runner: macos-11, environment: node }
+          - { os: android, target: "test:android", runner: macos-11, environment: react-native }
+          - { os: ios, target: "test:ios", runner: macos-11, environment: react-native }
+          #- { os: ios, target: "test:catalyst", runner: macos-11, environment: react-native }
     timeout-minutes: 60
     steps:
       - name: Generate Cluster Differentiator


### PR DESCRIPTION
## What, How & Why?
`macos-latest` is now MacOS 12 and has not Xcode 12.5.1 installed. Pinning to MacOS 11 until we are ready to upgrade Xcode.

See also https://github.com/realm/realm-js/issues/5024