### PR TITLE
Add better documentation for bindgen.

### DIFF
--- a/packages/realm/CONTRIBUTING.md
+++ b/packages/realm/CONTRIBUTING.md
@@ -35,3 +35,6 @@ npx turbo run build
 ```
 
 This will incrementally generate & build any dependencies.
+
+## Documentation
+See `DOCUMENTATION.md` for general principles to follow when adding JSDocs annotations to Realm classes.

--- a/packages/realm/DOCUMENTATION.md
+++ b/packages/realm/DOCUMENTATION.md
@@ -10,11 +10,12 @@ Here are all the tags Realm class methods are likely to have, **listed in the or
 
 - **Description**
     - Description of the method should go first.
+- `@readonly`?
+    - Include this tag if the field is read-only, this is only relevant for getter methods.
 - `@param {name} {description}`
     - ✅ `@param `**config**` The configuration of the app.`
     - ❌ `@param {boolean} config - the config`
     - Should **not** have a dash after param. name (some of the legacy documentation and is actually ignored by JSDoc but for sake of consistency it would be good to avoid this)
-
 - `@throws {errorType} {If / When + description}`
     - ✅ `@throws {Error} If no app id is provided.`
     - ✅ `@throws {RuntimeError} When Realm closes.`
@@ -27,7 +28,7 @@ Here are all the tags Realm class methods are likely to have, **listed in the or
     - ❌ `@returns appId`
     - For **boolean** return values, use `@returns` \`true\` `if X,` \`false\` `if not.`
 - `@see, etc. ... `
-    - Tags such as `@see` can be decided on case-by-case basis. For example, if `@see` is used instead of description to refer to external documentation, it can be in place of description. If it is used as more of a "learn more by looking here", `@see` can be included after `@returns`.
+    - Tags such as `@see` can be decided on case-by-case basis. For example, if `@see` is used instead of description to refer to external documentation, it can be in place of description. If it is used as more of a "if interested, learn more by looking here", `@see` can be included after `@returns`.
 - `@example`
 - `@since`
     - Kept because of old documenation, not necessarily useful. 

--- a/packages/realm/DOCUMENTATION.md
+++ b/packages/realm/DOCUMENTATION.md
@@ -10,6 +10,7 @@ Here are all the tags Realm class methods are likely to have, **listed in the or
 
 - **Description**
     - Description of the method should go first.
+    - `@link / @linkcode` seems to have often broken behavior, at least in VSCode, so generally from legacy docs it has been replaced with *** {link} *** (i.e. see ***Realm.Collections***) to make what those links bold. In the future one would probably want to replace these with URL links to Realm documentation.
 - `@readonly`?
     - Include this tag if the field is read-only, this is only relevant for getter methods.
 - `@param {name} {description}`

--- a/packages/realm/DOCUMENTATION.md
+++ b/packages/realm/DOCUMENTATION.md
@@ -1,0 +1,79 @@
+For sake of consistency, here are some general principles to follow when writing JSDoc for Realm classes' properties and methods.
+
+### Methods:
+Here are all the tags Realm class methods are likely to have, **listed in the order that they should be described in**.
+- **ALL TAGS**
+    - Should have description start with an uppercase letter. 
+    - Should have description end with a period.
+    - Should **not** have types that are already obvious with TypeScript.
+    - All methods that override built-in JS parent class methods (i.e. `forEach`, `map`) should avoid unnecesary comments (if reasonable) as they will likely already have built-in documentation that is inherited.
+
+- **Description**
+    - Description of the method should go first.
+- `@param {name} {description}`
+    - ✅ `@param `**config**` The configuration of the app.`
+    - ❌ `@param {boolean} config - the config`
+    - Should **not** have a dash after param. name (some of the legacy documentation and is actually ignored by JSDoc but for sake of consistency it would be good to avoid this)
+
+- `@throws {errorType} {If / When + description}`
+    - ✅ `@throws {Error} If no app id is provided.`
+    - ✅ `@throws {RuntimeError} When Realm closes.`
+    - ❌ `@throws no app id is provided.`
+    - Should have description **start with If or When**.
+    - Should include error type, i.e. `{Error}`, `{TypeError}`.
+- `@returns {description}`
+    - ✅ `@returns The last value or undefined if the list is empty.`
+    - ✅ `@returns `**true**`  if the value exists in the Set, ` **false**` if not.`
+    - ❌ `@returns appId`
+    - For **boolean** return values, use `@returns` \`true\` `if X,` \`false\` `if not.`
+- `@see, etc. ... `
+    - Tags such as `@see` can be decided on case-by-case basis. For example, if `@see` is used instead of description to refer to external documentation, it can be in place of description. If it is used as more of a "learn more by looking here", `@see` can be included after `@returns`.
+- `@example`
+- `@since`
+    - Kept because of old documenation, not necessarily useful. 
+
+Some examples of annotations following the principles above:
+```ts
+/**
+   * Returns the maximum value of the values in the collection or of the
+   * given property among all the objects in the collection, or `undefined`
+   * if the collection is empty.
+   *
+   * Only supported for int, float, double and date properties. `null` values
+   * are ignored entirely by this method and will not be returned.
+   *
+   * @param property For a collection of objects, the property to take the maximum of.
+   * @throws {Error} If no property with the name exists or if property is not numeric/date.
+   * @returns The maximum value.
+   * @since 1.12.1
+*/
+max(property?: string): number | Date | undefined;
+
+/**
+   * Check for existence of a value in the Set
+   * @param value Value to search for in the Set
+   * @throws {TypeError} If a `value` is not of a type which can be stored in
+   *   the Set, or if an object being added to the Set does not match the
+   *   **object schema** for the Set.
+   * @returns `true` if the value exists in the Set, `false` if not.
+*/
+has(value: T): boolean;
+
+/**
+   * This is the same method as the {@link Collection.values} method.
+   * Its presence makes collections _iterable_, thus able to be used with ES6
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of `for-of`}
+   * loops,
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator `...`}
+   * spread operators, and more.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator Symbol.iterator}
+   *   and the {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable iterable protocol}
+   * @returns Iterable of each value in the collection
+   * @example
+   * for (let object of collection) {
+   *   // do something with each object
+   * }
+   * @since 0.11.0
+   */
+abstract [Symbol.iterator](): Iterator<T>;
+```

--- a/packages/realm/src/Collection.ts
+++ b/packages/realm/src/Collection.ts
@@ -18,6 +18,22 @@
 
 import { CallbackRegistrator, IllegalConstructorError, Listeners, binding } from "./internal";
 
+/**
+ * Abstract base class containing methods shared by Realm **List**, **Dictionary**, and **Results**.
+ *
+ * A Realm Collection is a homogenous sequence of values of any of the types
+ * that can be stored as properties of Realm objects. A collection can be
+ * accessed in any of the ways that a normal Javascript Array can, including
+ * subscripting, enumerating with `for-of` and so on.
+ *
+ * A Collection always reflect the current state of the Realm. The one exception to this is
+ * when using `for...in` or `for...of` enumeration, which will always enumerate over the
+ * objects which matched the query when the enumeration is begun, even if some of them are
+ * deleted or modified to be excluded by the filter during the enumeration.
+ *
+ * @memberof Realm
+ * @since 0.11.0
+ */
 export abstract class Collection<
   KeyType = unknown,
   ValueType = unknown,
@@ -50,19 +66,83 @@ export abstract class Collection<
     });
   }
 
+  /**
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/keys Array.prototype.keys}
+   * @returns Iterator with all keys in the collection
+   * @since 0.11.0
+   */
   abstract keys(): Iterable<KeyType>;
+
+  /**
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/keys Array.prototype.keys}
+   * @returns Iterator with all values in the collection
+   * @since 0.11.0
+   */
   abstract values(): Iterable<ValueType>;
+
+  /**
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries Array.prototype.keys}
+   * @returns Iterator with all key/value pairs in the collection
+   * @since 0.11.0
+   */
   abstract entries(): Iterable<EntryType>;
+
+  /**
+   * This is the same method as the {@link Collection.values} method.
+   * Its presence makes collections _iterable_, thus able to be used with ES6
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of `for-of`}
+   * loops,
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator `...`}
+   * spread operators, and more.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator Symbol.iterator}
+   *   and the {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable iterable protocol}
+   * @returns Iterable of each value in the collection
+   * @since 0.11.0
+   * @example
+   * for (let object of collection) {
+   *   // do something with each object
+   * }
+   */
   abstract [Symbol.iterator](): Iterator<T>;
 
+  /**
+   * Add a listener `callback` which will be called when a **live** collection instance changes.
+   * @param callback A function to be called when changes occur.
+   *   The callback function is called with two arguments:
+   *   - `collection`: the collection instance that changed,
+   *   - `changes`: a dictionary with keys `insertions`, `newModifications`, `oldModifications`
+   *      and `deletions`, each containing a list of indices in the collection that were
+   *      inserted, updated or deleted respectively. `deletions` and `oldModifications` are
+   *      indices into the collection before the change happened, while `insertions` and
+   *      `newModifications` are indices into the new version of the collection.
+   * @throws {Error} If `callback` is not a function.
+   * @example
+   * wines.addListener((collection, changes) => {
+   *  // collection === wines
+   *  console.log(`${changes.insertions.length} insertions`);
+   *  console.log(`${changes.oldModifications.length} oldModifications`);
+   *  console.log(`${changes.newModifications.length} newModifications`);
+   *  console.log(`${changes.deletions.length} deletions`);
+   *  console.log(`new size of collection: ${collection.length}`);
+   * });
+   */
   addListener(callback: ChangeCallbackType): void {
     this.listeners.add(callback);
   }
 
+  /**
+   * Remove the listener `callback` from the collection instance.
+   * @param callback Callback function that was previously
+   *   added as a listener through the **addListener** method.
+   * @throws {Error} If `callback` is not a function.
+   */
   removeListener(callback: ChangeCallbackType): void {
     this.listeners.remove(callback);
   }
 
+  /**
+   * Remove all `callback` listeners from the collection instance.
+   */
   removeAllListeners(): void {
     this.listeners.removeAll();
   }

--- a/packages/realm/src/Collection.ts
+++ b/packages/realm/src/Collection.ts
@@ -97,11 +97,11 @@ export abstract class Collection<
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator Symbol.iterator}
    *   and the {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable iterable protocol}
    * @returns Iterable of each value in the collection
-   * @since 0.11.0
    * @example
    * for (let object of collection) {
    *   // do something with each object
    * }
+   * @since 0.11.0
    */
   abstract [Symbol.iterator](): Iterator<T>;
 

--- a/packages/realm/src/Collection.ts
+++ b/packages/realm/src/Collection.ts
@@ -88,7 +88,7 @@ export abstract class Collection<
   abstract entries(): Iterable<EntryType>;
 
   /**
-   * This is the same method as the {@link Collection.values} method.
+   * This is the same method as the ***Collection.values*** method.
    * Its presence makes collections _iterable_, thus able to be used with ES6
    * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of `for-of`}
    * loops,

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -116,7 +116,7 @@ export enum ClientResetMode {
 //   /**
 //    * Optional object to configure the setup of an initial set of flexible
 //    * sync subscriptions to be used when opening the Realm. If this is specified,
-//    * {@link Realm.open} will not resolve until this set of subscriptions has been
+//    * ***open*** will not resolve until this set of subscriptions has been
 //    * fully synchronized with the server.
 //    *
 //    * Example:

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -29,8 +29,6 @@ import {
 const INTERNAL = Symbol("Dictionary#internal");
 const HELPERS = Symbol("Dictionary#helpers");
 
-// TODO: Implement this
-
 type DictionaryChangeSet = {
   deletions: string[];
   modifications: string[];
@@ -98,7 +96,12 @@ const PROXY_HANDLER: ProxyHandler<Dictionary> = {
 };
 
 /**
- * TODO: Make this extends Collection<T> (once that doesn't have a nummeric index accessor)
+ * Instances of this class are returned when accessing object properties whose type is `"Dictionary"`
+ *
+ * Dictionaries behave mostly like a JavaScript object i.e., as a key/value pair
+ * where the key is a string.
+ *
+ * @memberof Realm
  */
 export class Dictionary<T = unknown> extends Collection<string, T, [string, T], [string, T], DictionaryChangeCallback> {
   /**
@@ -213,8 +216,11 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
   }
 
   /**
-   * Adds given element to the dictionary
+ /**
+   * Add a key with a value or update value if key exists.
+   * @throws {Error} If not inside a write transaction or if value violates type constraints
    * @returns The dictionary
+   * @since 10.6.0
    */
   // @ts-expect-error We're exposing methods in the end-users namespace of keys
   set(element: { [key: string]: T }): this {
@@ -228,7 +234,10 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
   /**
    * Removes elements from the dictionary, with the keys provided.
    * This does not throw if the keys are already missing from the dictionary.
+   * @param key The key to be removed.
+   * @throws {Error} If not inside a write transaction
    * @returns The dictionary
+   * @since 10.6.0
    */
   // @ts-expect-error We're exposing methods in the end-users namespace of keys
   remove(key: string | string[]): this {
@@ -240,8 +249,11 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
   }
 
   /**
-   * @returns A plain object for JSON serialization.
-   */
+   * The plain object representation of the Dictionary for JSON serialization.
+   * Use circular JSON serialization libraries such as {@link https://www.npmjs.com/package/@ungap/structured-clone @ungap/structured-clone}
+   * and {@link https://www.npmjs.com/package/flatted flatted} for stringifying Realm entities that have circular structures.
+   * @returns A plain object.
+   **/
   // @ts-expect-error We're exposing methods in the users value namespace
   toJSON(_?: string, cache?: unknown): DefaultObject;
   /** @internal */

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -104,7 +104,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
   /**
    * Remove the **last** value from the list and return it.
    * @throws {Error} If not inside a write transaction.
-   * @returns the last value or undefined if the list is empty.
+   * @returns The last value or undefined if the list is empty.
    */
   pop(): T | undefined {
     assert.inTransaction(this.realm);
@@ -129,7 +129,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
    *   ***Realm.ObjectSchema*** for the list.
    *
    * @throws {Error} If not inside a write transaction.
-   * @returns {number} equal to the new length of
+   * @returns A number equal to the new length of
    *          the list after adding the values.
    */
   push(...items: T[]): number {
@@ -178,7 +178,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
    *   the list, or if an object being added to the list does not match the
    *   ***ObjectSchema*** for the list.
    * @throws {Error} If not inside a write transaction.
-   * @returns {number} equal to the new ***length*** of
+   * @returns The new ***length*** of
    *          the list after adding the values.
    */
   unshift(...items: T[]): number {

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -27,6 +27,16 @@ import {
 
 type PartiallyWriteableArray<T> = Pick<Array<T>, "pop" | "push" | "shift" | "unshift" | "splice">;
 
+/**
+ * Instances of this class will be returned when accessing object properties whose type is `"list"`.
+ *
+ * Lists mostly behave like normal Javascript Arrays, except for that they can
+ * only store values of a single type (indicated by the `type` and `optional`
+ * properties of the List), and can only be modified inside a ***write*** transaction.
+ *
+ * @extends Realm.Collection
+ * @memberof Realm
+ */
 export class List<T = unknown> extends OrderedCollection<T> implements PartiallyWriteableArray<T> {
   /**
    * The representation in the binding.
@@ -91,6 +101,11 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     return this.internal.size;
   }
 
+  /**
+   * Remove the **last** value from the list and return it.
+   * @throws {Error} If not inside a write transaction.
+   * @returns the last value or undefined if the list is empty.
+   */
   pop(): T | undefined {
     assert.inTransaction(this.realm);
     const {
@@ -106,8 +121,16 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
   }
 
   /**
-   * @param  {T} object
-   * @returns number
+   * Add one or more values to the _end_ of the list.
+   *
+   * @param items Values to add to the list.
+   * @throws {TypeError} If a `value` is not of a type which can be stored in
+   *   the list, or if an object being added to the list does not match the
+   *   ***Realm.ObjectSchema*** for the list.
+   *
+   * @throws {Error} If not inside a write transaction.
+   * @returns {number} equal to the new length of
+   *          the list after adding the values.
    */
   push(...items: T[]): number {
     assert.inTransaction(this.realm);
@@ -130,7 +153,9 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
   }
 
   /**
-   * @returns T
+   * Remove the **first** value from the list and return it.
+   * @throws {Error} If not inside a write transaction.
+   * @returns The first value or undefined if the list is empty.
    */
   shift(): T | undefined {
     assert.inTransaction(this.realm);
@@ -145,6 +170,17 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     }
   }
 
+  /**
+   * Add one or more values to the _beginning_ of the list.
+   *
+   * @param items Values to add to the list.
+   * @throws {TypeError} If a `value` is not of a type which can be stored in
+   *   the list, or if an object being added to the list does not match the
+   *   ***ObjectSchema*** for the list.
+   * @throws {Error} If not inside a write transaction.
+   * @returns {number} equal to the new ***length*** of
+   *          the list after adding the values.
+   */
   unshift(...items: T[]): number {
     assert.inTransaction(this.realm);
     const {
@@ -163,8 +199,49 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     return internal.size;
   }
 
+  /** TODO
+   * Changes the contents of the list by removing value and/or inserting new value.
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice Array.prototype.splice}
+   * @param start The start index. If greater than the length of the list,
+   *   the start index will be set to the length instead. If negative, then the start index
+   *   will be counted from the end of the list (e.g. `list.length - index`).
+   * @param deleteCount The number of values to remove from the list.
+   *   If not provided, then all values from the start index through the end of
+   *   the list will be removed.
+   * @returns An array containing the value that were removed from the list. The
+   *   array is empty if no value were removed.
+   */
   splice(start: number, deleteCount?: number): T[];
+  /**
+   * Changes the contents of the list by removing value and/or inserting new value.
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice Array.prototype.splice}
+   * @param start The start index. If greater than the length of the list,
+   *   the start index will be set to the length instead. If negative, then the start index
+   *   will be counted from the end of the list (e.g. `list.length - index`).
+   * @param deleteCount The number of values to remove from the list.
+   *   If not provided, then all values from the start index through the end of
+   *   the list will be removed.
+   * @param items Values to insert into the list starting at `index`.
+   * @returns An array containing the value that were removed from the list. The
+   *   array is empty if no value were removed.
+   */
   splice(start: number, deleteCount: number, ...items: T[]): T[];
+  /**
+   * Changes the contents of the list by removing value and/or inserting new value.
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice Array.prototype.splice}
+   * @param start The start index. If greater than the length of the list,
+   *   the start index will be set to the length instead. If negative, then the start index
+   *   will be counted from the end of the list (e.g. `list.length - index`).
+   * @param deleteCount The number of values to remove from the list.
+   *   If not provided, then all values from the start index through the end of
+   *   the list will be removed.
+   * @param items Values to insert into the list starting at `index`.
+   * @returns An array containing the value that were removed from the list. The
+   *   array is empty if no value were removed.
+   */
   splice(start: number, deleteCount?: number, ...items: T[]): T[] {
     // Comments in the code below is copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
     assert.inTransaction(this.realm);

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -264,7 +264,7 @@ export class RealmObject<T = DefaultObject> {
    * The plain object representation of this object for JSON serialization.
    * Use circular JSON serialization libraries such as {@link https://www.npmjs.com/package/@ungap/structured-clone @ungap/structured-clone}
    * and {@link https://www.npmjs.com/package/flatted flatted} for stringifying Realm entities that have circular structures.
-   * @returns An plain object.
+   * @returns A plain object.
    **/
   toJSON(_?: string, cache?: unknown): DefaultObject;
   /** @internal */
@@ -301,7 +301,7 @@ export class RealmObject<T = DefaultObject> {
 
   /**
    * Checks if this object has not been deleted and is part of a valid Realm.
-   * @returns True if the object can be safely accessed, false otherwise.
+   * @returns `true` if the object can be safely accessed, `false` if not.
    * @since 0.12.0
    */
   isValid(): boolean {
@@ -376,7 +376,6 @@ export class RealmObject<T = DefaultObject> {
    *       if the object has been deleted. `changesProperties` is an array of properties that have changed
    *       their value.
    * @throws {Error} If `callback` is not a function.
-   * @since 2.23.0
    * @example
    * wine.addListener((obj, changes) => {
    *  // obj === wine
@@ -386,6 +385,7 @@ export class RealmObject<T = DefaultObject> {
    *      console.log(` ${prop}`);
    *   });
    * })
+   * @since 2.23.0
    */
   addListener(callback: ObjectChangeCallback<T>): void {
     this[INTERNAL_LISTENERS].addListener(callback);
@@ -411,8 +411,8 @@ export class RealmObject<T = DefaultObject> {
   /**
    * Get underlying type of a property value.
    * @param propertyName The name of the property to retrieve the type of.
-   * @returns Underlying type of the property value.
    * @throws {Error} If property does not exist.
+   * @returns Underlying type of the property value.
    * @since 10.8.0
    */
   getPropertyType(propertyName: string): string {

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -261,7 +261,10 @@ export class RealmObject<T = DefaultObject> {
   }
 
   /**
-   * @returns A plain object for JSON serialization.
+   * The plain object representation of this object for JSON serialization.
+   * Use circular JSON serialization libraries such as {@link https://www.npmjs.com/package/@ungap/structured-clone @ungap/structured-clone}
+   * and {@link https://www.npmjs.com/package/flatted flatted} for stringifying Realm entities that have circular structures.
+   * @returns An plain object.
    **/
   toJSON(_?: string, cache?: unknown): DefaultObject;
   /** @internal */

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -228,8 +228,7 @@ export class RealmObject<T = DefaultObject> {
   /**
    * Create a `RealmObject` wrapping an `Obj` from the binding.
    * @param realm The Realm managing the object.
-   * @param constructor The constructor of the object.
-   * @param internal The internal Obj from the binding.
+   * @param values The values of the object's properties at creation.
    */
   public constructor(realm: Realm, values: RealmInsertionModel<T>) {
     return realm.create(this.constructor as RealmObjectConstructor, values) as unknown as this;
@@ -297,13 +296,32 @@ export class RealmObject<T = DefaultObject> {
     return result;
   }
 
+  /**
+   * Checks if this object has not been deleted and is part of a valid Realm.
+   * @returns True if the object can be safely accessed, false otherwise.
+   * @since 0.12.0
+   */
   isValid(): boolean {
     return this[INTERNAL] && this[INTERNAL].isValid;
   }
+
+  /**
+   * The schema for the type this object belongs to.
+   * @returns The schema that describes this object.
+   * @since 1.8.1
+   */
   objectSchema(): CanonicalObjectSchema<T> {
     return this.realm.getClassHelpers(this).canonicalObjectSchema as CanonicalObjectSchema<T>;
   }
 
+  /**
+   * Returns all the objects that link to this object in the specified relationship.
+   * @param objectType The type of the objects that link to this object's type.
+   * @param propertyName The name of the property that references objects of this object's type.
+   * @throws {Error} If the relationship is not valid.
+   * @returns The objects that link to this object.
+   * @since 1.9.0
+   */
   linkingObjects<T>(objectType: string, propertyName: string): Results<T> {
     const {
       objectSchema: { tableKey },
@@ -322,6 +340,11 @@ export class RealmObject<T = DefaultObject> {
     return new Realm.Results(this.realm, results, collectionHelpers);
   }
 
+  /**
+   * Returns the total count of incoming links to this object
+   * @returns The number of links to this object.
+   * @since 2.6.0
+   */
   linkingObjectsCount(): number {
     return this[INTERNAL].getBacklinkCount();
   }
@@ -341,15 +364,54 @@ export class RealmObject<T = DefaultObject> {
     return this[INTERNAL].key.toString();
   }
 
+  /**
+   * Add a listener `callback` which will be called when a **live** object instance changes.
+   * @param callback A function to be called when changes occur.
+   *   The callback function is called with two arguments:
+   *   - `obj`: the object that changed,
+   *   - `changes`: a dictionary with keys `deleted`, and `changedProperties`. `deleted` is true
+   *       if the object has been deleted. `changesProperties` is an array of properties that have changed
+   *       their value.
+   * @throws {Error} If `callback` is not a function.
+   * @since 2.23.0
+   * @example
+   * wine.addListener((obj, changes) => {
+   *  // obj === wine
+   *  console.log(`object is deleted: ${changes.deleted}`);
+   *  console.log(`${changes.changedProperties.length} properties have been changed:`);
+   *  changes.changedProperties.forEach(prop => {
+   *      console.log(` ${prop}`);
+   *   });
+   * })
+   */
   addListener(callback: ObjectChangeCallback<T>): void {
     this[INTERNAL_LISTENERS].addListener(callback);
   }
+
+  /**
+   * Remove the listener `callback`
+   * @param callback A function previously added as listener
+   * @since 2.23.0
+   */
   removeListener(callback: ObjectChangeCallback<T>): void {
     this[INTERNAL_LISTENERS].removeListener(callback);
   }
+
+  /**
+   * Remove all listeners.
+   * @since 2.23.0
+   */
   removeAllListeners(): void {
     this[INTERNAL_LISTENERS].removeAllListeners();
   }
+
+  /**
+   * Get underlying type of a property value.
+   * @param propertyName The name of the property to retrieve the type of.
+   * @returns Underlying type of the property value.
+   * @throws {Error} If property does not exist.
+   * @since 10.8.0
+   */
   getPropertyType(propertyName: string): string {
     const { properties } = this.realm.getClassHelpers(this);
     const { type, objectType, columnKey } = properties.get(propertyName);

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -196,7 +196,10 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   }
 
   /**
-   * @returns An array of plain objects for JSON serialization.
+   * The plain array representation of the collection for JSON serialization.
+   * Use circular JSON serialization libraries such as {@link https://www.npmjs.com/package/@ungap/structured-clone @ungap/structured-clone}
+   * and {@link https://www.npmjs.com/package/flatted flatted} for stringifying Realm entities that have circular structures.
+   * @returns An array of plain objects.
    **/
   toJSON(_?: string, cache?: unknown): Array<DefaultObject>;
   /**
@@ -245,6 +248,12 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   get type(): PropertyType {
     return getTypeName(this.results.type & ~binding.PropertyType.Flags, undefined);
   }
+
+  /**
+   * Whether `null` is a valid value for the collection.
+   * @readonly
+   * @since 2.0.0
+   */
   get optional(): boolean {
     return !!(this.results.type & binding.PropertyType.Nullable);
   }
@@ -364,14 +373,37 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     throw new Error("Method not implemented.");
   }
 
+  /**
+   * Checks if this collection has not been deleted and is part of a valid Realm.
+   * @returns True if the collection can be safely accessed, false otherwise.
+   * @since 0.14.0
+   */
   isValid(): boolean {
     throw new Error(`Calling isValid on a ${this.constructor.name} is not support`);
   }
 
+  /**
+   * Checks if this collection is empty.
+   * @returns True if the collection is empty, false otherwise
+   * @since 2.7.0
+   */
   isEmpty(): boolean {
     return this.results.size() === 0;
   }
 
+  /**
+   * Returns the minimum value of the values in the collection or of the
+   * given property among all the objects in the collection, or `undefined`
+   * if the collection is empty.
+   *
+   * Only supported for int, float, double and date properties. `null` values
+   * are ignored entirely by this method and will not be returned.
+   *
+   * @param property For a collection of objects, the property to take the minimum of.
+   * @throws {Error} If no property with the name exists or if property is not numeric/date.
+   * @returns The minimum value.
+   * @since 1.12.1
+   */
   min(property?: string): number | Date | undefined {
     const columnKey = this.getPropertyColumnKey(property);
     const result = this.results.min(columnKey);
@@ -387,6 +419,20 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       throw new TypeAssertionError("Timestamp, number, bigint, Float or null", result, "result");
     }
   }
+
+  /**
+   * Returns the maximum value of the values in the collection or of the
+   * given property among all the objects in the collection, or `undefined`
+   * if the collection is empty.
+   *
+   * Only supported for int, float, double and date properties. `null` values
+   * are ignored entirely by this method and will not be returned.
+   *
+   * @param property For a collection of objects, the property to take the maximum of.
+   * @throws {Error} If no property with the name exists or if property is not numeric/date.
+   * @returns The maximum value.
+   * @since 1.12.1
+   */
   max(property?: string): number | Date | undefined {
     const columnKey = this.getPropertyColumnKey(property);
     const result = this.results.max(columnKey);
@@ -402,6 +448,19 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       throw new TypeAssertionError("Timestamp, number, bigint, Float or undefined", result, "result");
     }
   }
+
+  /**
+   * Computes the sum of the values in the collection or of the given
+   * property among all the objects in the collection, or 0 if the collection
+   * is empty.
+   *
+   * Only supported for int, float and double properties. `null` values are
+   * ignored entirely by this method.
+   * @param property For a collection of objects, the property to take the sum of.
+   * @throws {Error} If no property with the name exists or if property is not numeric.
+   * @returns The sum.
+   * @since 1.12.1
+   */
   sum(property?: string): number {
     const columnKey = this.getPropertyColumnKey(property);
     const result = this.results.sum(columnKey);
@@ -415,6 +474,19 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       throw new TypeAssertionError("number, bigint or Float", result, "result");
     }
   }
+
+  /**
+   * Computes the average of the values in the collection or of the given
+   * property among all the objects in the collection, or `undefined` if the collection
+   * is empty.
+   *
+   * Only supported for int, float and double properties. `null` values are
+   * ignored entirely by this method and will not be factored into the average.
+   * @param property For a collection of objects, the property to take the average of.
+   * @throws {Error} If no property with the name exists or if property is not numeric.
+   * @returns The sum.
+   * @since 1.12.1
+   */
   avg(property?: string): number | undefined {
     const columnKey = this.getPropertyColumnKey(property);
     const result = this.results.average(columnKey);
@@ -430,9 +502,18 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   }
 
   /**
-   * @param  {string} query
-   * @param  {any[]} ...arg
-   * @returns Results
+   * Returns new _Results_ that represent this collection being filtered by the provided query.
+   *
+   * @param query Query used to filter objects from the collection.
+   * @param arg Each subsequent argument is used by the placeholders
+   *   (e.g. `$0`, `$1`, `$2`, …) in the query.
+   * @throws {Error} If the query or any other argument passed into this method is invalid.
+   * @returns Results filtered according to the provided query.
+   *
+   * This is currently only supported for collections of Realm Objects.
+   *
+   * @example
+   * let merlots = wines.filtered('variety == "Merlot" && vintage <= $0', maxYear);
    */
   filtered(queryString: string, ...args: any[]): Results<T> {
     const { results: parent, realm, helpers } = this;
@@ -443,8 +524,63 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     return new Results(realm, results, helpers);
   }
 
+  /**
+   * Returns new _Results_ that represent a sorted view of this collection.
+   *
+   * A collection of Realm Objects can be sorted on one or more properties of
+   * those objects, or of properties of objects linked to by those objects.
+   * To sort by a single property, simply pass the name of that property to
+   * `sorted()`, optionally followed by a boolean indicating if the sort should be reversed.
+   * For more than one property, you must pass an array of
+   * **sort descriptors** which list
+   * which properties to sort on.
+   *
+   * Collections of other types sort on the values themselves rather than
+   * properties of the values, and so no property name or sort descriptors
+   * should be supplied.
+   * @param reverse Sort in descending order rather than ascended.
+   *   May not be supplied if `descriptor` is an array of sort descriptors.
+   * @throws {Error} If a specified property does not exist.
+   * @returns Results sorted according to the arguments passed in.
+   */
   sorted(reverse?: boolean): Results<T>;
+  /**
+   * Returns new _Results_ that represent a sorted view of this collection.
+   *
+   * A collection of Realm Objects can be sorted on one or more properties of
+   * those objects, or of properties of objects linked to by those objects.
+   * To sort by a single property, simply pass the name of that property to
+   * `sorted()`, optionally followed by a boolean indicating if the sort should be reversed.
+   * For more than one property, you must pass an array of
+   * **sort descriptors** which list
+   * which properties to sort on.
+   *
+   * Collections of other types sort on the values themselves rather than
+   * properties of the values, and so no property name or sort descriptors
+   * should be supplied.
+   * @param descriptor The property name(s) to sort the collection on.
+   * @throws {Error} If a specified property does not exist.
+   * @returns Results sorted according to the arguments passed in.
+   */
   sorted(descriptor: SortDescriptor[]): Results<T>;
+  /**
+   * Returns new _Results_ that represent a sorted view of this collection.
+   *
+   * A collection of Realm Objects can be sorted on one or more properties of
+   * those objects, or of properties of objects linked to by those objects.
+   * To sort by a single property, simply pass the name of that property to
+   * `sorted()`, optionally followed by a boolean indicating if the sort should be reversed.
+   * For more than one property, you must pass an array of
+   * **sort descriptors** which list
+   * which properties to sort on.
+   *
+   * Collections of other types sort on the values themselves rather than
+   * properties of the values, and so no property name or sort descriptors
+   * should be supplied.
+   * @param descriptor The property name(s) to sort the collection on.
+   * @throws {Error} If a specified property does not exist.
+   * @returns Results sorted according to the arguments passed in.
+   */
   sorted(descriptor: string, reverse?: boolean): Results<T>;
   sorted(arg0: boolean | SortDescriptor[] | string = "self", arg1?: boolean): Results<T> {
     if (Array.isArray(arg0)) {
@@ -467,7 +603,19 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   }
 
   /**
-   * @returns Results
+   * Create a frozen snapshot of the collection.
+   *
+   * Values added to and removed from the original collection will not be
+   * reflected in the _Results_ returned by this method, including if the
+   * values of properties are changed to make them match or not match any
+   * filters applied.
+   *
+   * This is **not** a _deep_ snapshot. Realm objects contained in this
+   * snapshot will continue to update as changes are made to them, and if
+   * they are deleted from the Realm they will be replaced by `null` at the
+   * respective indices.
+   *
+   * @returns Results which will **not** live update.
    */
   snapshot(): Results<T> {
     return new Results(this.realm, this.results.snapshot(), this.helpers);

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -375,7 +375,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
 
   /**
    * Checks if this collection has not been deleted and is part of a valid Realm.
-   * @returns True if the collection can be safely accessed, false otherwise.
+   * @returns `true` if the collection can be safely accessed, `false` if not.
    * @since 0.14.0
    */
   isValid(): boolean {
@@ -384,7 +384,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
 
   /**
    * Checks if this collection is empty.
-   * @returns True if the collection is empty, false otherwise
+   * @returns `true` if the collection is empty, `false` if not.
    * @since 2.7.0
    */
   isEmpty(): boolean {

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -400,7 +400,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * are ignored entirely by this method and will not be returned.
    *
    * @param property For a collection of objects, the property to take the minimum of.
-   * @throws {Error} If no property with the name exists or if property is not numeric/date.
+   * @throws {TypeAssertionError} If no property with the name exists or if property is not numeric/date.
    * @returns The minimum value.
    * @since 1.12.1
    */

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -92,6 +92,10 @@ export class Realm {
 
   public static defaultPath = Realm.normalizePath("default.realm");
 
+  /**
+   * Clears the state by closing and deleting any Realm in the default directory and logout all users.
+   * @private Not a part of the public API: It's primarily used from the library's tests.
+   */
   public static clearTestState(): void {
     // Close any realms not already closed
     for (const weakRealm of RETURNED_REALMS) {
@@ -118,6 +122,11 @@ export class Realm {
     }
   }
 
+  /**
+   * Delete the Realm file for the given configuration.
+   * @param config The configuration for the Realm
+   * @throws If anything in the provided `config` is invalid.
+   */
   public static deleteFile(config: Configuration): void {
     const path = Realm.determinePath(config);
     fs.removeFile(path);
@@ -126,6 +135,12 @@ export class Realm {
     fs.removeDirectory(path + ".management");
   }
 
+  /**
+   * Checks if the Realm already exists on disk.
+   * @param arg The configuration for the Realm or the path to it.
+   * @throws If anything in the provided `config` is invalid.
+   * @returns `true` if the Realm exists on the device, `false` if not.
+   */
   public static exists(arg: Configuration | string = {}): boolean {
     const config = typeof arg === "string" ? { path: arg } : arg;
     validateConfiguration(config);
@@ -133,6 +148,15 @@ export class Realm {
     return fs.exists(path);
   }
 
+  /**
+   * Open a Realm asynchronously with a promise. If the Realm is synced, it will be fully
+   * synchronized before it is available.
+   * In the case of query-based sync, `config.schema` is required. An exception will be
+   * thrown if `config.schema` is not defined.
+   * @param arg The configuration for the Realm or the path to it.
+   * @returns A promise that will be resolved with the Realm instance when it's available.
+   * @throws If anything in the provided `config` is invalid.
+   */
   public static open(arg: Configuration | string = {}): ProgressRealmPromise {
     const config = typeof arg === "string" ? { path: arg } : arg;
     return new ProgressRealmPromise(config);
@@ -140,9 +164,12 @@ export class Realm {
 
   /**
    * Get the current schema version of the Realm at the given path.
-   * @param  {string} path
-   * @param  {any} encryptionKey?
-   * @returns number
+   * @param path - The path to the file where the
+   *   Realm database is stored.
+   * @param encryptionKey - Required only when
+   *   accessing encrypted Realms.
+   * @throws If passing an invalid or non-matching encryption key.
+   * @returns version of the schema, or `-1` if no Realm exists at `path`.
    */
   public static schemaVersion(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): number {
     const config: Configuration = { path };
@@ -211,6 +238,31 @@ export class Realm {
     return result as T;
   }
 
+  /**
+   * Copy any Realm files  (i.e. `*.realm`) bundled with the application from the application
+   * directory into the application's documents directory, so that they can be opened and used
+   * by Realm. If the file already exists in the documents directory, it will not be
+   * overwritten, so this can safely be called multiple times.
+   *
+   * This should be called before opening the Realm, in order to move the bundled Realm
+   * files into a place where they can be written to, for example:
+   *
+   * ```
+   * // Given a bundled file, example.realm, this will copy example.realm (and any other .realm files)
+   * // from the app bundle into the app's documents directory. If the file already exists, it will
+   * // not be overwritten, so it is safe to call this every time the app starts.
+   * Realm.copyBundledRealmFiles();
+   *
+   * const realm = await Realm.open({
+   *   // This will open example.realm from the documents directory, with the bundled data in.
+   *   path: "example.realm"
+   * });
+   * ```
+   *
+   * This is only implemented for React Native.
+   *
+   * @throws If an I/O error occured or method is not implemented.
+   */
   public static copyBundledRealmFiles() {
     fs.copyBundledRealmFiles();
   }
@@ -347,7 +399,27 @@ export class Realm {
   private schemaListeners = new RealmListeners(this, "schema");
 
   constructor();
+  /**
+   * Create a new `Realm` instance from the provided `path`.
+   * @param path - Required when first creating the Realm.
+   * @throws If anything in the provided `config` is invalid.
+   * @throws When an incompatible synced Realm is opened
+   */
   constructor(path: string);
+  /**
+   * Create a new `Realm` instance using the provided `config`. If a Realm does not yet exist
+   * at `config.path` (or {@link Realm.defaultPath} if not provided), then this constructor
+   * will create it with the provided `config.schema` (which is _required_ in this case).
+   * Otherwise, the instance will access the existing Realm from the file at that path.
+   * In this case, `config.schema` is _optional_ or not have changed, unless
+   * `config.schemaVersion` is incremented, in which case the Realm will be automatically
+   * migrated to use the new schema.
+   * In the case of query-based sync, `config.schema` is required. An exception will be
+   * thrown if `config.schema` is not defined.
+   * @param config - Required when first creating the Realm.
+   * @throws If anything in the provided `config` is invalid.
+   * @throws When an incompatible synced Realm is opened
+   */
   constructor(config: Configuration);
   /** @internal */
   constructor(internal: binding.Realm, schemaExtras?: RealmSchemaExtra);
@@ -396,22 +468,47 @@ export class Realm {
     this.classes = new ClassMap(this, this.internal.schema, this.schema);
   }
 
+  /**
+   * Indicates if this Realm contains any objects.
+   * @readonly
+   * @since 1.10.0
+   */
   get isEmpty(): boolean {
     return binding.Helpers.isEmptyRealm(this.internal);
   }
 
+  /**
+   * The path to the file where this Realm is stored.
+   * @readonly
+   * @since 0.12.0
+   */
   get path(): string {
     return this.internal.config.path;
   }
 
+  /**
+   * Indicates if this Realm was opened as read-only.
+   * @readonly
+   * @since 0.12.0
+   */
   get isReadOnly(): boolean {
     return this.internal.config.schemaMode === binding.SchemaMode.Immutable;
   }
 
+  /**
+   * Indicates if this Realm was opened in-memory.
+   * @readonly
+   */
   get isInMemory(): boolean {
     return this.internal.config.inMemory;
   }
 
+  /**
+   * A normalized representation of the schema provided in the
+   * {@link Configuration Configuration} when this Realm was constructed.
+   * @readonly
+   * @since 0.12.0
+   */
   get schema(): CanonicalObjectSchema[] {
     const schemas = fromBindingRealmSchema(this.internal.schema);
     // Stitch in the constructors and defaults stored in this.schemaExtras
@@ -427,20 +524,39 @@ export class Realm {
     return schemas;
   }
 
+  /**
+   * The current schema version of the Realm.
+   * @readonly
+   * @since 0.12.0
+   */
   get schemaVersion(): number {
     return Number(this.internal.schemaVersion);
   }
 
+  /**
+   * Indicates if this Realm is in a write transaction.
+   * @readonly
+   * @since 1.10.3
+   */
   get isInTransaction(): boolean {
     // TODO: Consider keeping a local state in JS for this
     return this.internal.isInTransaction;
   }
 
+  /**
+   * Indicates if this Realm has been closed.
+   * @readonly
+   * @since 2.1.0
+   */
   get isClosed(): boolean {
     // TODO: Consider keeping a local state in JS for this
     return this.internal.isClosed;
   }
 
+  /**
+   * The sync session if this is a synced Realm
+   * @readonly
+   */
   get syncSession(): SyncSession | null {
     const { syncConfig, path } = this.internal.config;
     if (syncConfig) {
@@ -452,10 +568,19 @@ export class Realm {
     return null;
   }
 
+  /**
+   * The latest set of flexible sync subscriptions.
+   * @throws If flexible sync is not enabled for this app
+   */
   get subscriptions(): any {
     throw new Error("Not yet implemented");
   }
 
+  /**
+   * Closes this Realm so it may be re-opened with a newer schema version.
+   * All objects and collections from this Realm are no longer valid after calling this method.
+   * The method is idempotent.
+   */
   close(): void {
     this.internal.close();
     // this.syncSession?.internal.close(); // Won't be good if session multiplexing is enabled
@@ -464,6 +589,23 @@ export class Realm {
 
   // TODO: Support embedded objects and asymmetric sync
   // TODO: Rollback by deleting the object if any property assignment fails (fixing #2638)
+  /**
+   * Create a new Realm object of the given type and with the specified properties. For object schemas annotated
+   * as asymmetric, no object is returned. The API for asymmetric object schema is subject to changes in the future.
+   * @param type - The type of Realm object to create.
+   * @param values - Property values for all required properties without a
+   *   default value.
+   * @param mode - Optional update mode. It can be one of the following values
+   *     - UpdateMode.Never: Objects are only created. If an existing object exists, an exception is thrown. This is the
+   *       default value.
+   *     - UpdateMode.All: If an existing object is found, all properties provided will be updated, any other properties will
+   *       remain unchanged.
+   *     - UpdateMode.Modified: If an existing object exists, only properties where the value has actually changed will be
+   *       updated. This improves notifications and server side performance but also have implications for how changes
+   *       across devices are merged. For most use cases, the behaviour will match the intuitive behaviour of how
+   *       changes should be merged, but if updating an entire object is considered an atomic operation, this mode
+   *       should not be used.
+   */
   create<T = DefaultObject>(type: string, values: RealmInsertionModel<T>, mode?: UpdateMode.Never): RealmObject<T> & T;
   create<T = DefaultObject>(
     type: string,
@@ -499,6 +641,9 @@ export class Realm {
     return RealmObject.create(this, values, mode, { helpers });
   }
 
+  /**
+   * Deletes the provided Realm object, or each one inside the provided collection.
+   */
   delete(subject: RealmObject | RealmObject[] | List | Results): void {
     assert.inTransaction(this, "Can only delete objects within a transaction.");
     assert.object(subject, "subject");
@@ -524,6 +669,11 @@ export class Realm {
     }
   }
 
+  /**
+   * Deletes a Realm model, including all of its objects.
+   * If called outside a migration function, {@link Realm.schema schema} and {@link Realm.schemaVersion schemaVersion} are updated.
+   * @param name - The model name
+   */
   deleteModel(name: string): void {
     assert.inTransaction(this, "Can only delete objects within a transaction.");
     binding.Helpers.deleteDataForObject(this.internal, name);
@@ -533,6 +683,9 @@ export class Realm {
     }
   }
 
+  /**
+   * **WARNING:** This will delete **all** objects in the Realm!
+   */
   deleteAll(): void {
     assert.inTransaction(this, "Can only delete objects within a transaction.");
     for (const objectSchema of this.internal.schema) {
@@ -541,6 +694,15 @@ export class Realm {
     }
   }
 
+  /**
+   * Searches for a Realm object by its primary key.
+   * @param type - The type of Realm object to search for.
+   * @param primaryKey - The primary key value of the object to search for.
+   * @throws If type passed into this method is invalid or if the object type did
+   *   not have a `primaryKey` specified in its {@link ObjectSchema}.
+   * @returns A Realm.Object or undefined if no object is found.
+   * @since 0.14.0
+   */
   objectForPrimaryKey<T = DefaultObject>(type: string, primaryKey: T[keyof T]): (RealmObject<T> & T) | null;
   objectForPrimaryKey<T extends RealmObject>(type: Constructor<T>, primaryKey: T[keyof T]): T | null;
   objectForPrimaryKey<T extends RealmObject>(type: string | Constructor<T>, primaryKey: unknown): T | null {
@@ -570,6 +732,12 @@ export class Realm {
     }
   }
 
+  /**
+   * Returns all objects of the given `type` in the Realm.
+   * @param type - The type of Realm objects to retrieve.
+   * @throws If type passed into this method is invalid or if the type is marked embedded or asymmetric.
+   * @returns Realm.Results that will live-update as objects are created and destroyed.
+   */
   /**
    * @internal
    */
@@ -616,6 +784,15 @@ export class Realm {
     });
   }
 
+  /**
+   * Add a listener `callback` for the specified event `name`.
+   * @param eventName - The name of event that should cause the callback to be called.
+   *   DISCUSS: why does it say _Currently, only the "change" and "schema" events are supported_.
+   * @param callback - Function to be called when a change event occurs.
+   *   Each callback will only be called once per event, regardless of the number of times
+   *   it was added.
+   * @throws If an invalid event `name` is supplied, or if `callback` is not a function.
+   */
   addListener(eventName: RealmEventName, callback: RealmListenerCallback): void {
     assert.open(this);
     if (eventName === "change") {
@@ -628,6 +805,14 @@ export class Realm {
       throw new Error(`Unknown event name '${eventName}': only 'change', 'schema' and 'beforenotify' are supported.`);
     }
   }
+
+  /**
+   * Remove the listener `callback` for the specfied event `name`.
+   * @param eventName - The event name.
+   * @param callback - Function that was previously added as a
+   *   listener for this event through the {@link Realm.addListener} method.
+   * @throws If an invalid event `name` is supplied, or if `callback` is not a function.
+   */
   removeListener(eventName: RealmEventName, callback: RealmListenerCallback): void {
     assert.open(this);
     if (eventName === "change") {
@@ -641,6 +826,11 @@ export class Realm {
     }
   }
 
+  /**
+   * Remove all event listeners (restricted to the event `name`, if provided).
+   * @param eventName - The name of the event whose listeners should be removed.
+   * @throws When invalid event `name` is supplied
+   */
   removeAllListeners(eventName?: RealmEventName): void {
     assert.open(this);
     if (eventName === "change") {
@@ -656,6 +846,16 @@ export class Realm {
     }
   }
 
+  /**
+   * Synchronously call the provided `callback` inside a write transaction. If an exception happens inside a transaction,
+   * you’ll lose the changes in that transaction, but the Realm itself won’t be affected (or corrupted).
+   * More precisely, {@link Realm.beginTransaction} and {@link Realm.commitTransaction} will be called
+   * automatically. If any exception is thrown during the transaction {@link Realm.cancelTransaction} will
+   * be called instead of {@link Realm.commitTransaction} and the exception will be re-thrown to the caller of `write()`.
+   *
+   * Nested transactions (calling `write()` within `write()`) is not possible.
+   * @returns Returned value from the callback.
+   */
   write<T>(callback: () => T): T {
     let result = undefined;
     this.internal.beginTransaction();
@@ -669,18 +869,65 @@ export class Realm {
     return result;
   }
 
+  /**
+   * Initiate a write transaction.
+   *
+   * When doing a transaction, it is highly recommended to do error handling.
+   * If you don't handle errors, your data might become inconsistent. Error handling
+   * will often involve canceling the transaction.
+   *
+   * @example
+   * realm.beginTransaction();
+   * try {
+   *   realm.create('Person', { name: 'Arthur Dent',  origin: 'Earth' });
+   *   realm.create('Person', { name: 'Ford Prefect', origin: 'Betelgeuse Five' });
+   *   realm.commitTransaction();
+   * } catch (e) {
+   *   realm.cancelTransaction();
+   *   throw e;
+   * }
+   * @throws {Error} When already in write transaction
+   * @see {@link Realm.cancelTransaction}
+   * @see {@link Realm.commitTransaction}
+   */
   beginTransaction(): void {
     this.internal.beginTransaction();
   }
 
+  /**
+   * Commit a write transaction.
+   *
+   * @see {@link Realm.beginTransaction}
+   */
   commitTransaction(): void {
     this.internal.commitTransaction();
   }
 
+  /**
+   * Cancel a write transaction.
+   *
+   * @see {@link Realm.beginTransaction}
+   */
   cancelTransaction(): void {
     this.internal.cancelTransaction();
   }
 
+  /**
+   * Replaces all string columns in this Realm with a string enumeration column and compacts the
+   * database file.
+   *
+   * Cannot be called from a write transaction.
+   *
+   * Compaction will not occur if other `Realm` instances exist.
+   *
+   * While compaction is in progress, attempts by other threads or processes to open the database will
+   * wait.
+   *
+   * Be warned that resource requirements for compaction is proportional to the amount of live data in
+   * the database. Compaction works by writing the database contents to a temporary database file and
+   * then replacing the database with the temporary one.
+   * @returns true if compaction succeeds.
+   */
   compact(): boolean {
     assert.outTransaction(this, "Cannot compact a Realm within a transaction.");
     return this.internal.compact();
@@ -704,6 +951,12 @@ export class Realm {
     this.internal.convert(bindingConfig);
   }
 
+  /**
+   * Update the schema of the Realm.
+   *
+   * @param schema The schema which the Realm should be updated to use.
+   * @private Not a part of the public API: Consider passing a `schema` when constructing the `Realm` instead.
+   */
   _updateSchema(schema: Realm.ObjectSchema[]): void {
     validateRealmSchema(schema);
     const normalizedSchema = normalizeRealmSchema(schema);

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -787,7 +787,6 @@ export class Realm {
   /**
    * Add a listener `callback` for the specified event `name`.
    * @param eventName The name of event that should cause the callback to be called.
-   *   DISCUSS: why does it say _Currently, only the "change" and "schema" events are supported_.
    * @param callback Function to be called when a change event occurs.
    *   Each callback will only be called once per event, regardless of the number of times
    *   it was added.

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -125,7 +125,7 @@ export class Realm {
   /**
    * Delete the Realm file for the given configuration.
    * @param config The configuration for the Realm
-   * @throws If anything in the provided `config` is invalid.
+   * @throws {Error} If anything in the provided `config` is invalid.
    */
   public static deleteFile(config: Configuration): void {
     const path = Realm.determinePath(config);
@@ -138,7 +138,7 @@ export class Realm {
   /**
    * Checks if the Realm already exists on disk.
    * @param arg The configuration for the Realm or the path to it.
-   * @throws If anything in the provided `config` is invalid.
+   * @throws {Error} If anything in the provided `config` is invalid.
    * @returns `true` if the Realm exists on the device, `false` if not.
    */
   public static exists(arg: Configuration | string = {}): boolean {
@@ -155,7 +155,7 @@ export class Realm {
    * thrown if `config.schema` is not defined.
    * @param arg The configuration for the Realm or the path to it.
    * @returns A promise that will be resolved with the Realm instance when it's available.
-   * @throws If anything in the provided `config` is invalid.
+   * @throws {Error} If anything in the provided `config` is invalid.
    */
   public static open(arg: Configuration | string = {}): ProgressRealmPromise {
     const config = typeof arg === "string" ? { path: arg } : arg;
@@ -164,11 +164,11 @@ export class Realm {
 
   /**
    * Get the current schema version of the Realm at the given path.
-   * @param path - The path to the file where the
+   * @param path The path to the file where the
    *   Realm database is stored.
-   * @param encryptionKey - Required only when
+   * @param encryptionKey Required only when
    *   accessing encrypted Realms.
-   * @throws If passing an invalid or non-matching encryption key.
+   * @throws {Error} If passing an invalid or non-matching encryption key.
    * @returns version of the schema, or `-1` if no Realm exists at `path`.
    */
   public static schemaVersion(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): number {
@@ -191,7 +191,7 @@ export class Realm {
    * set by the default property in the schema or the default value for the datatype if the schema
    * doesn't specify one, i.e. 0, false and "".
    *
-   * @param {Realm.ObjectSchema} objectSchema Schema describing the object that should be created.
+   * @param objectSchema Schema describing the object that should be created.
    */
   public static createTemplateObject<T extends Record<string, unknown>>(objectSchema: Realm.ObjectSchema): T {
     validateObjectSchema(objectSchema);
@@ -261,7 +261,7 @@ export class Realm {
    *
    * This is only implemented for React Native.
    *
-   * @throws If an I/O error occured or method is not implemented.
+   * @throws {Error} If an I/O error occured or method is not implemented.
    */
   public static copyBundledRealmFiles() {
     fs.copyBundledRealmFiles();
@@ -401,14 +401,14 @@ export class Realm {
   constructor();
   /**
    * Create a new `Realm` instance from the provided `path`.
-   * @param path - Required when first creating the Realm.
-   * @throws If anything in the provided `config` is invalid.
-   * @throws When an incompatible synced Realm is opened
+   * @param path Required when first creating the Realm.
+   * @throws {Error} If anything in the provided `config` is invalid.
+   * @throws {Error} When an incompatible synced Realm is opened
    */
   constructor(path: string);
   /**
    * Create a new `Realm` instance using the provided `config`. If a Realm does not yet exist
-   * at `config.path` (or {@link Realm.defaultPath} if not provided), then this constructor
+   * at `config.path` (or ***defaultPath*** if not provided), then this constructor
    * will create it with the provided `config.schema` (which is _required_ in this case).
    * Otherwise, the instance will access the existing Realm from the file at that path.
    * In this case, `config.schema` is _optional_ or not have changed, unless
@@ -416,9 +416,9 @@ export class Realm {
    * migrated to use the new schema.
    * In the case of query-based sync, `config.schema` is required. An exception will be
    * thrown if `config.schema` is not defined.
-   * @param config - Required when first creating the Realm.
-   * @throws If anything in the provided `config` is invalid.
-   * @throws When an incompatible synced Realm is opened
+   * @param config Required when first creating the Realm.
+   * @throws {Error} If anything in the provided `config` is invalid.
+   * @throws {Error} When an incompatible synced Realm is opened
    */
   constructor(config: Configuration);
   /** @internal */
@@ -505,7 +505,7 @@ export class Realm {
 
   /**
    * A normalized representation of the schema provided in the
-   * {@link Configuration Configuration} when this Realm was constructed.
+   * ***Configuration*** when this Realm was constructed.
    * @readonly
    * @since 0.12.0
    */
@@ -570,7 +570,7 @@ export class Realm {
 
   /**
    * The latest set of flexible sync subscriptions.
-   * @throws If flexible sync is not enabled for this app
+   * @throws {Error} If flexible sync is not enabled for this app
    */
   get subscriptions(): any {
     throw new Error("Not yet implemented");
@@ -592,10 +592,10 @@ export class Realm {
   /**
    * Create a new Realm object of the given type and with the specified properties. For object schemas annotated
    * as asymmetric, no object is returned. The API for asymmetric object schema is subject to changes in the future.
-   * @param type - The type of Realm object to create.
-   * @param values - Property values for all required properties without a
+   * @param type The type of Realm object to create.
+   * @param values Property values for all required properties without a
    *   default value.
-   * @param mode - Optional update mode. It can be one of the following values
+   * @param mode Optional update mode. It can be one of the following values
    *     - UpdateMode.Never: Objects are only created. If an existing object exists, an exception is thrown. This is the
    *       default value.
    *     - UpdateMode.All: If an existing object is found, all properties provided will be updated, any other properties will
@@ -671,8 +671,8 @@ export class Realm {
 
   /**
    * Deletes a Realm model, including all of its objects.
-   * If called outside a migration function, {@link Realm.schema schema} and {@link Realm.schemaVersion schemaVersion} are updated.
-   * @param name - The model name
+   * If called outside a migration function, ***schema*** and ***schemaVersion*** are updated.
+   * @param name The model name
    */
   deleteModel(name: string): void {
     assert.inTransaction(this, "Can only delete objects within a transaction.");
@@ -696,9 +696,9 @@ export class Realm {
 
   /**
    * Searches for a Realm object by its primary key.
-   * @param type - The type of Realm object to search for.
-   * @param primaryKey - The primary key value of the object to search for.
-   * @throws If type passed into this method is invalid or if the object type did
+   * @param type The type of Realm object to search for.
+   * @param primaryKey The primary key value of the object to search for.
+   * @throws {Error} If type passed into this method is invalid or if the object type did
    *   not have a `primaryKey` specified in its {@link ObjectSchema}.
    * @returns A Realm.Object or undefined if no object is found.
    * @since 0.14.0
@@ -734,8 +734,8 @@ export class Realm {
 
   /**
    * Returns all objects of the given `type` in the Realm.
-   * @param type - The type of Realm objects to retrieve.
-   * @throws If type passed into this method is invalid or if the type is marked embedded or asymmetric.
+   * @param type The type of Realm objects to retrieve.
+   * @throws {Error} If type passed into this method is invalid or if the type is marked embedded or asymmetric.
    * @returns Realm.Results that will live-update as objects are created and destroyed.
    */
   /**
@@ -786,12 +786,12 @@ export class Realm {
 
   /**
    * Add a listener `callback` for the specified event `name`.
-   * @param eventName - The name of event that should cause the callback to be called.
+   * @param eventName The name of event that should cause the callback to be called.
    *   DISCUSS: why does it say _Currently, only the "change" and "schema" events are supported_.
-   * @param callback - Function to be called when a change event occurs.
+   * @param callback Function to be called when a change event occurs.
    *   Each callback will only be called once per event, regardless of the number of times
    *   it was added.
-   * @throws If an invalid event `name` is supplied, or if `callback` is not a function.
+   * @throws {Error} If an invalid event `name` is supplied, or if `callback` is not a function.
    */
   addListener(eventName: RealmEventName, callback: RealmListenerCallback): void {
     assert.open(this);
@@ -808,10 +808,10 @@ export class Realm {
 
   /**
    * Remove the listener `callback` for the specfied event `name`.
-   * @param eventName - The event name.
-   * @param callback - Function that was previously added as a
-   *   listener for this event through the {@link Realm.addListener} method.
-   * @throws If an invalid event `name` is supplied, or if `callback` is not a function.
+   * @param eventName The event name.
+   * @param callback Function that was previously added as a
+   *   listener for this event through the ***addListener*** method.
+   * @throws {Error} If an invalid event `name` is supplied, or if `callback` is not a function.
    */
   removeListener(eventName: RealmEventName, callback: RealmListenerCallback): void {
     assert.open(this);
@@ -828,8 +828,8 @@ export class Realm {
 
   /**
    * Remove all event listeners (restricted to the event `name`, if provided).
-   * @param eventName - The name of the event whose listeners should be removed.
-   * @throws When invalid event `name` is supplied
+   * @param eventName The name of the event whose listeners should be removed.
+   * @throws {Error} When invalid event `name` is supplied
    */
   removeAllListeners(eventName?: RealmEventName): void {
     assert.open(this);
@@ -849,9 +849,9 @@ export class Realm {
   /**
    * Synchronously call the provided `callback` inside a write transaction. If an exception happens inside a transaction,
    * you’ll lose the changes in that transaction, but the Realm itself won’t be affected (or corrupted).
-   * More precisely, {@link Realm.beginTransaction} and {@link Realm.commitTransaction} will be called
-   * automatically. If any exception is thrown during the transaction {@link Realm.cancelTransaction} will
-   * be called instead of {@link Realm.commitTransaction} and the exception will be re-thrown to the caller of `write()`.
+   * More precisely, ***beginTransaction*** and ***commitTransaction*** will be called
+   * automatically. If any exception is thrown during the transaction ***cancelTransaction*** will
+   * be called instead of ***commitTransaction*** and the exception will be re-thrown to the caller of `write()`.
    *
    * Nested transactions (calling `write()` within `write()`) is not possible.
    * @returns Returned value from the callback.
@@ -886,7 +886,7 @@ export class Realm {
    *   realm.cancelTransaction();
    *   throw e;
    * }
-   * @throws {Error} When already in write transaction
+   * @throws {Error} If already in write transaction
    * @see {@link Realm.cancelTransaction}
    * @see {@link Realm.commitTransaction}
    */

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -169,7 +169,7 @@ export class Realm {
    * @param encryptionKey Required only when
    *   accessing encrypted Realms.
    * @throws {Error} If passing an invalid or non-matching encryption key.
-   * @returns version of the schema, or `-1` if no Realm exists at `path`.
+   * @returns Version of the schema, or `-1` if no Realm exists at `path`.
    */
   public static schemaVersion(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): number {
     const config: Configuration = { path };
@@ -876,6 +876,9 @@ export class Realm {
    * If you don't handle errors, your data might become inconsistent. Error handling
    * will often involve canceling the transaction.
    *
+   * @throws {Error} If already in write transaction
+   * @see ***cancelTransaction()***
+   * @see ***commitTransaction()***
    * @example
    * realm.beginTransaction();
    * try {
@@ -886,9 +889,6 @@ export class Realm {
    *   realm.cancelTransaction();
    *   throw e;
    * }
-   * @throws {Error} If already in write transaction
-   * @see ***cancelTransaction()***
-   * @see ***commitTransaction()***
    */
   beginTransaction(): void {
     this.internal.beginTransaction();
@@ -926,7 +926,7 @@ export class Realm {
    * Be warned that resource requirements for compaction is proportional to the amount of live data in
    * the database. Compaction works by writing the database contents to a temporary database file and
    * then replacing the database with the temporary one.
-   * @returns true if compaction succeeds.
+   * @returns `true` if compaction succeeds, `false` if not.
    */
   compact(): boolean {
     assert.outTransaction(this, "Cannot compact a Realm within a transaction.");

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -699,7 +699,7 @@ export class Realm {
    * @param type The type of Realm object to search for.
    * @param primaryKey The primary key value of the object to search for.
    * @throws {Error} If type passed into this method is invalid or if the object type did
-   *   not have a `primaryKey` specified in its {@link ObjectSchema}.
+   *   not have a `primaryKey` specified in its ***ObjectSchema***.
    * @returns A Realm.Object or undefined if no object is found.
    * @since 0.14.0
    */
@@ -887,8 +887,8 @@ export class Realm {
    *   throw e;
    * }
    * @throws {Error} If already in write transaction
-   * @see {@link Realm.cancelTransaction}
-   * @see {@link Realm.commitTransaction}
+   * @see ***cancelTransaction()***
+   * @see ***commitTransaction()***
    */
   beginTransaction(): void {
     this.internal.beginTransaction();
@@ -897,7 +897,7 @@ export class Realm {
   /**
    * Commit a write transaction.
    *
-   * @see {@link Realm.beginTransaction}
+   * @see ***beginTransaction()***
    */
   commitTransaction(): void {
     this.internal.commitTransaction();
@@ -906,7 +906,7 @@ export class Realm {
   /**
    * Cancel a write transaction.
    *
-   * @see {@link Realm.beginTransaction}
+   * @see ***beginTransaction()***
    */
   cancelTransaction(): void {
     this.internal.cancelTransaction();

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -25,6 +25,17 @@ import {
   binding,
 } from "./internal";
 
+/**
+ * Instances of this class are typically **live** collections returned by
+ * objects() that will update as new objects are either
+ * added to or deleted from the Realm that match the underlying query. Results returned by
+ * snapshot()}, however, will **not** live update
+ * (and listener callbacks added through addListener()
+ * will thus never be called).
+ *
+ * @extends Realm.Collection
+ * @memberof Realm
+ */
 export class Results<T = unknown> extends OrderedCollection<T> {
   /**
    * The representation in the binding.
@@ -66,9 +77,10 @@ export class Results<T = unknown> extends OrderedCollection<T> {
 
   /**
    * Bulk update objects in the collection.
-   * @param  {string} property
-   * @param  {any} value
-   * @returns void
+   * @param propertyName The name of the property.
+   * @param value The updated property value.
+   * @throws {Error} If no property with the name exists.
+   * @since 2.0.0-rc20
    */
   update(propertyName: keyof T, value: T[typeof propertyName]): void {
     const {

--- a/packages/realm/src/Set.ts
+++ b/packages/realm/src/Set.ts
@@ -60,7 +60,7 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
 
   /**
    * Checks if this set has not been deleted and is part of a valid Realm.
-   * @returns True if the set can be safely accessed, false otherwise.
+   * @returns `true` if the set can be safely accessed, `false` if not.
    */
   isValid() {
     return this.internal.isValid;
@@ -70,7 +70,7 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
    * Delete a value from the Set
    * @param value Value to delete from the Set
    * @throws {Error} If not inside a write transaction.
-   * @returns True if the value existed in the Set prior to deletion, false otherwise
+   * @returns `true` if the value existed in the Set prior to deletion, `false` if not.
    */
   delete(value: T): boolean {
     const [, success] = this.internal.removeAny(this.helpers.toBinding(value, undefined));
@@ -104,7 +104,7 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
    * @throws {TypeError} If a `value` is not of a type which can be stored in
    *   the Set, or if an object being added to the Set does not match the
    *   **object schema** for the Set.
-   * @returns True if the value exists in the Set, false otherwise
+   * @returns `true` if the value exists in the Set, `false` if not.
    */
   has(value: T): boolean {
     return this.includes(value);

--- a/packages/realm/src/Set.ts
+++ b/packages/realm/src/Set.ts
@@ -18,6 +18,22 @@
 
 import { IllegalConstructorError, OrderedCollection, OrderedCollectionHelpers, Realm, binding } from "./internal";
 
+/**
+ * Instances of this class will be returned when accessing object properties whose type is `"Set"`
+ *
+ * Sets mostly behave like normal JavaScript Sets, with a few exceptions:
+ * They can only store values of a single type (indicated by the `type`
+ * and `optional` properties of the Set).
+ * They can only be modified inside a **write** transaction.
+ * Unlike JavaScript's Set, Realm~Set does NOT make any guarantees about the
+ * traversal order of `values()`, `entries()`, `keys()`, or `forEach` iterations.
+ * If values in a Set are required to have some order, it must be implemented
+ * by the developer by, for example, wrapping values in an object that holds
+ * a user-supplied insertion order.
+ *
+ * @extends Realm.OrderedCollection
+ * @memberof Realm
+ */
 export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
   /** @internal */
   private internal!: binding.Set;
@@ -35,19 +51,26 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
       value: internal,
     });
   }
-
+  /**
+   * Number of items in the set
+   */
   get size(): number {
     return this.length;
   }
 
+  /**
+   * Checks if this set has not been deleted and is part of a valid Realm.
+   * @returns True if the set can be safely accessed, false otherwise.
+   */
   isValid() {
     return this.internal.isValid;
   }
 
   /**
    * Delete a value from the Set
-   * @param {T} object Value to delete from the Set
-   * @returns Boolean:  true if the value existed in the Set prior to deletion, false otherwise
+   * @param value Value to delete from the Set
+   * @throws {Error} If not inside a write transaction.
+   * @returns True if the value existed in the Set prior to deletion, false otherwise
    */
   delete(value: T): boolean {
     const [, success] = this.internal.removeAny(this.helpers.toBinding(value, undefined));
@@ -56,7 +79,10 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
 
   /**
    * Add a new value to the Set
-   * @param  {T} object Value to add to the Set
+   * @param value Value to add to the Set
+   * @throws {TypeError} If a `value` is not of a type which can be stored in
+   *   the Set, or if an object being added to the Set does not match the for the Set.
+   * @throws {Error} If not inside a write transaction.
    * @returns The Realm.Set<T> itself, after adding the new value
    */
   add(value: T): this {
@@ -65,7 +91,8 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
   }
 
   /**
-   * Clear all values from the Set
+   * Remove all values from the Set
+   * @throws {Error} If not inside a write transaction.
    */
   clear(): void {
     this.internal.deleteAll();
@@ -73,8 +100,11 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
 
   /**
    * Check for existence of a value in the Set
-   * @param  {T} object Value to search for in the Set
-   * @returns Boolean: true if the value exists in the Set, false otherwise
+   * @param value Value to search for in the Set
+   * @throws {TypeError} If a `value` is not of a type which can be stored in
+   *   the Set, or if an object being added to the Set does not match the
+   *   **object schema** for the Set.
+   * @returns True if the value exists in the Set, false otherwise
    */
   has(value: T): boolean {
     return this.includes(value);

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -28,6 +28,11 @@ import {
   fs,
 } from "../internal";
 
+/**
+ * This describes the options used to create a Realm.App instance.
+ * @prop id - The id of the Atlas App Services application.
+ * @prop baseUrl - The base URL of the Atlas App Services server.
+ */
 export type AppConfiguration = {
   id: string;
   baseUrl?: string;
@@ -38,6 +43,15 @@ export type AppChangeCallback = () => void;
 // TODO: Ensure this doesn't leak
 const appByUserId = new Map<string, App>();
 
+/**
+ * The class represents an Atlas App Services Application.
+ *
+ * ```js
+ * let app = new Realm.App(config);
+ * ```
+ *
+ * @memberof Realm
+ */
 export class App {
   // TODO: Ensure these are injected by the platform
   /** @internal */
@@ -74,8 +88,28 @@ export class App {
     },
   });
 
+  /**
+   * Creates a new app and connects to an Atlas App Services instance.
+   *
+   * @param id A string app id.
+   * @throws {Error} If no app id is provided.
+   */
   constructor(id: string);
+
+  /**
+   * Creates a new app and connects to an Atlas App Services instance.
+   *
+   * @param config The configuration of the app.
+   * @throws {Error} If no app id is provided.
+   */
   constructor(config: AppConfiguration);
+
+  /**
+   * Creates a new app and connects to an Atlas App Services instance.
+   *
+   * @param configOrId The configuration of the app or a string app id.
+   * @throws {Error} If no app id is provided.
+   */
   constructor(configOrId: AppConfiguration | string) {
     const config: AppConfiguration = typeof configOrId === "string" ? { id: configOrId } : configOrId;
     assert.object(config, "config");
@@ -98,6 +132,9 @@ export class App {
     );
   }
 
+  /**
+   * @return The app id.
+   */
   public get id(): string {
     return this.internal.config.appId;
   }

--- a/packages/realm/src/bson.ts
+++ b/packages/realm/src/bson.ts
@@ -19,6 +19,12 @@
 // export { ObjectId, Decimal128, UUID } from "bson";
 import * as bson from "bson";
 
+/**
+ * A re-export of the "bson" package, enabling access to the BSON types without requiring an explict dependency on the "bson" package.
+ *
+ * @see {@link https://www.npmjs.com/package/bson#documentation|the BSON documentation} for more information.
+ * @memberof Realm
+ */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace BSON {
   export const ObjectId = bson.ObjectId;


### PR DESCRIPTION
## What, How & Why?
Adds better documentation for methods and fields of Realm instance classes. I came up with some principles that decisions were made when I was not sure how to organize, prioritising consistency with legacy documentation as well as clear formatting from language server when viewed from VSCode.

- General prioritisation order of comments: `@params > @throws > @returns > @example > @since`. 
- All tags start with uppercase i.e. `@returns The sum`. The only exception is if it is referring to boolean / other references that happen to lowercase, i.e. @returns `true` if...
- No tags are followed by a dash (this was in legacy docs and is actually ignored by JSDoc but for sake of consistency this is removed).
- No tags other than `@throws` should specify types since this is TypeScript.
- `@throws` is followed by Error type (i.e. `{Error}`) then either If or When.
- `@returns` is followed by The / A if applicable. If it returns a boolean it follows the format: @returns `true` if X, `false` if not.
- `@since` is kept since it would be easier to remove it then add it back.
- I tried to replace links with italicised bold text i.e.` {@link Realm.Bold bold} => ***bold***`. This is because the links in i.e. VSCode were not useful and just led to the source code when clicked which did not seem appropriate in this context. In my opinion best developer experience would be for the links to link to the documentation website for the specific function. I did not see italicised bold text used before, so adding this specific styling to some words will hopefully make it easier to go through them and consider re-adding links in the future. I do think there are other instances where a link to doc would be useful so this is not exhaustive.
- All methods that override built-in JS parent class methods (i.e. `forEach`, `map`) have not been commented as they already have built-in documentation that is inherited.

Let me know if any of these "rules" seem unreasonable and I could change it, they are mostly following the old docs.

<!This closes # ??? -- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
* [ ] Chrome debug API is updated if API is available on React Native
