### PR TITLE
Workflow to build and publish Linux containers for realm-js builds

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,47 @@
+name: Create and publish container images
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**Dockerfile'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile
+            image: ghcr.io/${{ github.repository }}/linux-x64
+          - dockerfile: ./armhf.Dockerfile
+            image: ghcr.io/${{ github.repository }}/linux-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for container
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ matrix.image }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 RUN yum install -y centos-release-scl \
  && yum-config-manager --enable rhel-server-rhscl-7-rpms \
- && yum install -y yum install devtoolset-9 python27 rh-git218
+ && yum install -y yum install devtoolset-9 python27 rh-git218 epel-release
 
 ENV NPM_CONFIG_UNSAFE_PERM true
 ENV NVM_DIR /tmp/.nvm
@@ -16,12 +16,14 @@ RUN yum -y install \
     libXScrnSaver \
     gtk3 \
     alsa-lib \
+    ccache \
+    ninja-build \
  && yum clean all
 
 RUN mkdir -p $NVM_DIR \
  && curl -s https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
  && . $NVM_DIR/nvm.sh \
- && nvm install 12 \
+ && nvm install 16 \
  && chmod a+rwX -R $NVM_DIR
 
 ENV PATH /opt/rh/rh-git218/root/usr/bin:/opt/rh/python27/root/usr/bin:/opt/rh/devtoolset-9/root/usr/bin:$PATH

--- a/armhf.Dockerfile
+++ b/armhf.Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get install -y \
         nodejs \
         libnode-dev:armhf \
         npm \
+        ccache \
         qemu-user
 
 
@@ -22,15 +23,11 @@ ENV NVM_DIR /tmp/.nvm
 RUN mkdir -p $NVM_DIR \
  && curl -s https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
  && . $NVM_DIR/nvm.sh \
- && nvm install 10 \
- && nvm install 12 \
- && nvm install 13 \
- && nvm install 14 \
+ && nvm install 16 \
  && chmod a+rwX -R $NVM_DIR
 
 # Ensure a new enough version of CMake is available.
 RUN cd /opt \
-    && curl -O -J https://cmake.org/files/v3.15/cmake-3.15.2-Linux-x86_64.tar.gz \
-    && tar zxf cmake-3.15.2-Linux-x86_64.tar.gz
-
-ENV PATH "/opt/cmake-3.15.2-Linux-x86_64/bin:$PATH"
+    && curl -O -J https://cmake.org/files/v3.21/cmake-3.21.3-linux-x86_64.tar.gz \
+    && tar zxf cmake-3.21.3-linux-x86_64.tar.gz
+ENV PATH "/opt/cmake-3.21.3-linux-x86_64/bin/:$PATH"


### PR DESCRIPTION
A manually triggered github actions workflow is used to build and publish
2 different container images:
* CentOS 7 based container to build binaries that don't depend on recent Glibc.
* Debian 10 based container to cross compile ARMHF binaries