### PR TITLE
Fix legacy debugger for bindgen

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "program": "node",
             "args": [
                 "--expose_gc",
-                "${workspaceRoot}/tests/node_modules/jasmine/bin/jasmine.js",
+                "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
                 "spec/unit_tests.js",
                 "--filter=."
             ],
@@ -45,7 +45,7 @@
             "preLaunchTask": "Build Node Tests",
             "cwd": "${workspaceRoot}/tests",
             "console": "integratedTerminal",
-            "program": "${workspaceRoot}/tests/node_modules/jasmine/bin/jasmine.js",
+            "program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
             "runtimeArgs": [
                 "--expose_gc"
             ],
@@ -60,7 +60,7 @@
             "name": "Debug Node Unit Tests",
             "cwd": "${workspaceRoot}/tests",
             "console": "integratedTerminal",
-            "program": "${workspaceRoot}/tests/node_modules/jasmine/bin/jasmine.js",
+            "program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
             "runtimeArgs": [
                 "--expose_gc"
             ],
@@ -108,7 +108,7 @@
             "program": "node",
             "args": [
                 "--expose_gc",
-                "${workspaceFolder}/tests/node_modules/jasmine/bin/jasmine.js",
+                "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js",
                 "spec/unit_tests.js",
                 "--filter=${input:testFilter}"
             ],


### PR DESCRIPTION
## What, How & Why?
The location of `jasmine.js` changed with the migration to npm workspaces.  This fixes the debug launch commands to point to the new location

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
