### PR TITLE
Immediately bind Realm in RealmProvider

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,3 +1,23 @@
+## vNext (TBD)
+
+### Enhancements
+* Immediately bind local Realm in the RealmProvider ([#5074](https://github.com/realm/realm-js/issues/5074))
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* None
+
+### Compatibility
+* React Native >= v0.70.0
+* Atlas App Services.
+* Realm Studio v12.0.0.
+* File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+
+### Internal
+<!-- * Either mention core version or upgrade -->
+<!-- * Using Realm Core vX.Y.Z -->
+<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+
 ## 0.4.1 (2022-11-3)
 
 ### Fixed

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -68,7 +68,11 @@ export function createRealmProvider(
    * e.g. `path="newPath.realm"`
    */
   return ({ children, fallback: Fallback, realmRef, ...restProps }) => {
-    const [realm, setRealm] = useState<Realm | null>(null);
+    const [realm, setRealm] = useState<Realm | null>(() =>
+      realmConfig.sync === undefined && restProps.sync === undefined
+        ? new Realm(mergeRealmConfiguration(realmConfig, restProps))
+        : null,
+    );
 
     // Automatically set the user in the configuration if its been set.
     const user = useUser();

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -214,7 +214,9 @@ describe("RealmProvider", () => {
 
     expect(realmRefPathText).toHaveTextContent("testPath.realm");
   });
-  describe("initially renders a fallback, until realm exists", () => {
+  // TODO: Now that local realm is immediately set, the fallback never renders.
+  // We need to test synced realm in order to produce the fallback
+  describe.skip("initially renders a fallback, until realm exists", () => {
     it("as a component", async () => {
       const App = () => {
         return (


### PR DESCRIPTION
## What, How & Why?
There was a possible optimisation pointed out by issue #5011 For local realm, we could just immediately open a new realm instance if the sync configuration is not set.  This would skip the fallback procedure.  It also fixes the jest warning the user was seeing.

As a side effect, I had to disable the `fallback` tests for the `RealmProvider`.  We will have to start testing `@realm/react` with sync enabled in order to see this.  I wrote an issue to get this done, so that we can also test authentication (#5073).

This closes #5011

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
