### PR TITLE
Halfbaked implementation of access to deleted object keys

### DIFF
--- a/packages/realm-react/src/cachedCollection.ts
+++ b/packages/realm-react/src/cachedCollection.ts
@@ -133,6 +133,7 @@ export function createCachedCollection<T extends Realm.Object>({
   const listenerCallback: Realm.CollectionChangeCallback<(T & Realm.Object) | (unknown & Realm.Object)> = (
     listenerCollection,
     changes,
+    deletedObjects
   ) => {
     if (changes.deletions.length > 0 || changes.insertions.length > 0 || changes.newModifications.length > 0) {
       // TODO: There is currently no way to rebuild the cache key from the changes array for deleted object.
@@ -153,6 +154,14 @@ export function createCachedCollection<T extends Realm.Object>({
         const objectId = listenerCollection[index]._objectKey();
         if (objectId) {
           const cacheKey = getCacheKey(objectId);
+          if (objectCache.has(cacheKey)) {
+            objectCache.delete(cacheKey);
+          }
+        }
+      });
+      deletedObjects.forEach((key) => {
+        if (key) {
+          const cacheKey = getCacheKey(key);
           if (objectCache.has(cacheKey)) {
             objectCache.delete(cacheKey);
           }


### PR DESCRIPTION
## What, How & Why?
This is an attempt to show how the issue explained in [realm-core#5220](https://github.com/realm/realm-core/issues/5220) could be solved. My knowledge on how things are handled in `cachedCollectio.ts` is zero, so please bare with me.

To be used as a basis for further discussion.

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
