### PR TITLE
Add remaining user-methods for bindgen

### DIFF
--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -1001,16 +1001,17 @@ classes:
 
   UserProfile:
     cppName: SyncUserProfile
-    properties:
-      name: util::Optional<std::string>
-      email: util::Optional<std::string>
-      picture_url: util::Optional<std::string>
-      first_name: util::Optional<std::string>
-      last_name: util::Optional<std::string>
-      gender: util::Optional<std::string>
-      birthday: util::Optional<std::string>
-      min_age: util::Optional<std::string>
-      max_age: util::Optional<std::string>
+    methods:
+      name: '() -> util::Optional<std::string>'
+      email: '() -> util::Optional<std::string>'
+      picture_url: '() -> util::Optional<std::string>'
+      first_name: '() -> util::Optional<std::string>'
+      last_name: '() -> util::Optional<std::string>'
+      gender: '() -> util::Optional<std::string>'
+      birthday: '() -> util::Optional<std::string>'
+      min_age: '() -> util::Optional<std::string>'
+      max_age: '() -> util::Optional<std::string>'
+      data: '() -> bson::BsonDocument'  
 
   AppSubscriptionToken:
     cppName: app::App::Token

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -986,8 +986,8 @@ classes:
       refresh_token: std::string
       device_id: std::string
       has_device_id: bool
-      user_profile: UserProfile # TODO
-      identities: std::vector<UserIdentity> # TODO
+      user_profile: UserProfile 
+      identities: std::vector<UserIdentity>
       custom_data: util::Optional<bson::BsonDocument>
       sync_manager: SharedSyncManager
       state: SyncUserState

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -1070,6 +1070,7 @@ classes:
       resend_confirmation_email: '(email: const std::string&, completion: AsyncCallback<(err: util::Optional<AppError>)>&&)'
       reset_password: '(password: const std::string&, token: const std::string&, token_id: const std::string&, completion: AsyncCallback<(err: util::Optional<AppError>)>&&)'
       send_reset_password_email: '(email: const std::string&, completion: AsyncCallback<(err: util::Optional<AppError>)>&&)'
+      call_reset_password_function: '(email: const std::string&, password: const std::string&, args: const bson::BsonArray&, completion: AsyncCallback<(err: util::Optional<AppError>)>&&)'
 
   UserAPIKeyProviderClient:
     cppName: app::App::UserAPIKeyProviderClient

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -986,7 +986,7 @@ classes:
       refresh_token: std::string
       device_id: std::string
       has_device_id: bool
-      # user_profile: UserProfile # TODO
+      user_profile: UserProfile # TODO
       identities: std::vector<UserIdentity> # TODO
       custom_data: util::Optional<bson::BsonDocument>
       sync_manager: SharedSyncManager
@@ -998,6 +998,19 @@ classes:
       subscribe: '(observer: (user: IgnoreArgument<const SyncUser&>)) -> SyncUserSubscriptionToken'
       unsubscribe: '(token: SyncUserSubscriptionToken)'
       # TODO update methods?
+
+  UserProfile:
+    cppName: SyncUserProfile
+    properties:
+      name: util::Optional<std::string>
+      email: util::Optional<std::string>
+      picture_url: util::Optional<std::string>
+      first_name: util::Optional<std::string>
+      last_name: util::Optional<std::string>
+      gender: util::Optional<std::string>
+      birthday: util::Optional<std::string>
+      min_age: util::Optional<std::string>
+      max_age: util::Optional<std::string>
 
   AppSubscriptionToken:
     cppName: app::App::Token

--- a/packages/realm/src/app-services/EmailPasswordAuthClient.ts
+++ b/packages/realm/src/app-services/EmailPasswordAuthClient.ts
@@ -107,6 +107,6 @@ export class EmailPasswordAuthClient {
   }
 
   public async callResetPasswordFunction(credentials: { email: string; password: string }, ...args: unknown[]) {
-    throw new Error("Not yet implemented, need BSONArray");
+    await this.internal.callResetPasswordFunction(credentials.email, credentials.password, args as binding.EJson[]);
   }
 }

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -184,7 +184,11 @@ export class User<
    * If this value has not been configured, it will be empty.
    */
   get customData(): CustomDataType {
-    throw new Error("Not yet implemented");
+    const result = this.internal.customData;
+    if (result === undefined) {
+      return {} as CustomDataType;
+    }
+    return result as CustomDataType;
   }
 
   /**

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -195,7 +195,7 @@ export class User<
    * A profile containing additional information about the user.
    */
   get profile(): UserProfileDataType {
-    throw new Error("Not yet implemented");
+    return this.internal.userProfile as UserProfileDataType;
   }
 
   /**

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -91,6 +91,9 @@ export class User<
   /** @internal */
   public internal: binding.SyncUser;
 
+  // cached version of profile
+  private _profile: UserProfileDataType | undefined;
+
   private listeners = new Listeners<UserChangeCallback, UserListenerToken>({
     register: (callback: () => void): UserListenerToken => {
       return this.internal.subscribe(callback);
@@ -110,6 +113,7 @@ export class User<
   constructor(internal: binding.SyncUser, app: App) {
     this.internal = internal;
     this.app = app;
+    this._profile = undefined;
   }
 
   /**
@@ -195,7 +199,10 @@ export class User<
    * A profile containing additional information about the user.
    */
   get profile(): UserProfileDataType {
-    return this.internal.userProfile as UserProfileDataType;
+    if (!this._profile) {
+      this._profile = this.internal.userProfile.data() as UserProfileDataType;
+    }
+    return this._profile;
   }
 
   /**
@@ -265,7 +272,8 @@ export class User<
    * @returns The newly fetched custom data.
    */
   async refreshCustomData(): Promise<CustomDataType> {
-    throw new Error("Not yet implemented");
+    await this.app.internal.refreshCustomData(this.internal);
+    return this.customData;
   }
 
   /**

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -92,7 +92,7 @@ export class User<
   public internal: binding.SyncUser;
 
   // cached version of profile
-  private _profile: UserProfileDataType | undefined;
+  private cachedProfile: UserProfileDataType | undefined;
 
   private listeners = new Listeners<UserChangeCallback, UserListenerToken>({
     register: (callback: () => void): UserListenerToken => {
@@ -113,7 +113,7 @@ export class User<
   constructor(internal: binding.SyncUser, app: App) {
     this.internal = internal;
     this.app = app;
-    this._profile = undefined;
+    this.cachedProfile = undefined;
   }
 
   /**
@@ -199,10 +199,10 @@ export class User<
    * A profile containing additional information about the user.
    */
   get profile(): UserProfileDataType {
-    if (!this._profile) {
-      this._profile = this.internal.userProfile.data() as UserProfileDataType;
+    if (!this.cachedProfile) {
+      this.cachedProfile = this.internal.userProfile.data() as UserProfileDataType;
     }
-    return this._profile;
+    return this.cachedProfile;
   }
 
   /**


### PR DESCRIPTION
Standalone PR which complements #4808 and #4805 now that support for Bson is provided through the bindgen.

implements the following methods:

- `User.customData()`
- `User.refreshCustomData()`
- `User.profile()`
- `EmailPasswordAuthClient.callResetPassWordFunction()`