### PR TITLE
Fix SessionTests.testNonAcceptedPartitionValueTypes

### DIFF
--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -103,6 +103,7 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
   }
   const { user, onError, _sessionStopPolicy } = config;
   assert.instanceOf(user, User, "user");
+  validatePartitionValue(config.partitionValue);
   const partitionValue = EJSON.stringify(config.partitionValue as EJSON.SerializableTypes);
   return {
     user: config.user.internal,
@@ -112,4 +113,28 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
       ? toBindingStopPolicy(_sessionStopPolicy)
       : binding.SyncSessionStopPolicy.AfterChangesUploaded,
   };
+}
+
+/** @internal */
+function validatePartitionValue(partitionValue: unknown) {
+  if (partitionValue === undefined) {
+    throw new Error(partitionValue + " is not an allowed PartitionValue");
+  }
+  const numberValue = Number(partitionValue);
+  if (!isNaN(numberValue)) {
+    validateNumberValue(numberValue);
+  }
+}
+
+/** @internal */
+function validateNumberValue(numberValue: number) {
+  if (!Number.isInteger(numberValue)) {
+    throw new Error("PartitionValue " + numberValue + " must be of type integer");
+  }
+  if (numberValue > Number.MAX_SAFE_INTEGER) {
+    throw new Error("PartitionValue " + numberValue + " is greater than Number.MAX_SAFE_INTEGER");
+  }
+  if (numberValue < Number.MIN_SAFE_INTEGER) {
+    throw new Error("PartitionValue " + numberValue + " is lesser than Number.MIN_SAFE_INTEGER");
+  }
 }

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { EJSON } from "bson";
+import { EJSON, ObjectId, UUID } from "bson";
 
 import {
   BSON,
@@ -116,12 +116,13 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
 }
 
 /** @internal */
-function validatePartitionValue(partitionValue: unknown) {
-  if (partitionValue === undefined) {
-    throw new Error(partitionValue + " is not an allowed PartitionValue");
+function validatePartitionValue(pv: unknown) {
+  if (typeof pv === "number") {
+    validateNumberValue(pv);
+    return;
   }
-  if (typeof partitionValue == "number") {
-    validateNumberValue(partitionValue);
+  if (!(pv instanceof ObjectId || pv instanceof UUID || typeof pv === "string" || pv === null)) {
+    throw new Error(pv + " is not an allowed PartitionValue");
   }
 }
 

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -120,9 +120,8 @@ function validatePartitionValue(partitionValue: unknown) {
   if (partitionValue === undefined) {
     throw new Error(partitionValue + " is not an allowed PartitionValue");
   }
-  const numberValue = Number(partitionValue);
-  if (!isNaN(numberValue)) {
-    validateNumberValue(numberValue);
+  if (typeof partitionValue == "number") {
+    validateNumberValue(partitionValue);
   }
 }
 

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -1046,6 +1046,9 @@ module.exports = {
 
   async testNonAcceptedPartitionValueTypes() {
     const testPartitionValues = [
+      true,
+      {},
+      [],
       undefined,
       Number.MAX_SAFE_INTEGER + 1,
       1.2,


### PR DESCRIPTION
Added validation for the `PartitionValue` provided when opening a `Realm`
This closes #5064