### PR TITLE
consume the provided ThreadSafeReference in Realm.open async callback

### DIFF
--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -559,6 +559,7 @@ classes:
       base64_decode: '(input: StringData) -> BinaryData'
       make_logger_factory: '(log: (level: LoggerLevel, message: const std::string&) off_thread) -> LoggerFactory'
       simulate_sync_error: '(session: SyncSession&, code: int, message: StringData, type: StringData, is_fatal: bool)'
+      consume_thread_safe_reference_to_shared_realm: '(tsr: ThreadSafeReference) -> SharedRealm'
 
   ConstTableRef:
     needsDeref: true

--- a/packages/bindgen/src/realm_js_helpers.h
+++ b/packages/bindgen/src/realm_js_helpers.h
@@ -216,6 +216,12 @@ struct Helpers {
         error.server_requests_action = code == 211 ? sync::ProtocolErrorInfo::Action::ClientReset : sync::ProtocolErrorInfo::Action::Warning;
         SyncSession::OnlyForTesting::handle_error(session, error);
     }
+
+    // This is entirely because ThreadSafeReference is a move-only type, and those are hard to expose to JS.
+    // Instead, we are exposing a function that takes a mutable lvalue reference and moves from it.
+    static SharedRealm consume_thread_safe_reference_to_shared_realm(ThreadSafeReference& tsr) {
+        return Realm::get_shared_realm(std::move(tsr));
+    }
 };
 
 struct ObjectChangeSet {

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { Helpers } from "./binding";
 import {
   Configuration,
   OpenRealmBehaviorType,
@@ -78,11 +79,11 @@ export class ProgressRealmPromise implements Promise<Realm> {
         this.task = binding.Realm.getSynchronizedRealm(bindingConfig);
         this.task
           .start()
-          .then(async () => {
+          .then(async (tsr) => {
             // This callback is passed a `ThreadSafeReference` which can (except not easily) be resolved to a Realm
             // We could consider comparing that to the Realm we create below,
             // since the coordinator should ensure they're pointing to the same underlying Realm.
-            const realm = new Realm(config);
+            const realm = new Realm(config, binding.Helpers.consumeThreadSafeReferenceToSharedRealm(tsr));
 
             const initialSubscriptions = config.sync && config.sync.flexible ? config.sync.initialSubscriptions : false;
             const realmExists = Realm.exists(config);

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -446,10 +446,12 @@ export class Realm {
    */
   constructor(config: Configuration);
   /** @internal */
+  constructor(config: Configuration, internal: binding.Realm);
+  /** @internal */
   constructor(internal: binding.Realm, schemaExtras?: RealmSchemaExtra);
-  constructor(arg: Configuration | binding.Realm | string = {}, schemaExtras = {}) {
+  constructor(arg: Configuration | binding.Realm | string = {}, secondArg?: object) {
     if (arg instanceof binding.Realm) {
-      this.schemaExtras = schemaExtras;
+      this.schemaExtras = (secondArg ?? {}) as RealmSchemaExtra;
       this.internal = arg;
     } else {
       const config = typeof arg === "string" ? { path: arg } : arg;
@@ -457,7 +459,8 @@ export class Realm {
       const { bindingConfig, schemaExtras } = Realm.transformConfig(config);
       debug("open", bindingConfig);
       this.schemaExtras = schemaExtras;
-      this.internal = binding.Realm.getSharedRealm(bindingConfig);
+      assert(!secondArg || secondArg instanceof binding.Realm, "The realm constructor only takes a single argument");
+      this.internal = secondArg ?? binding.Realm.getSharedRealm(bindingConfig);
 
       binding.Helpers.setBindingContext(this.internal, {
         didChange: (r) => {


### PR DESCRIPTION
I confirmed that this solves the hanging issue that we were seeing in `testAddConnectionNotification` when combined with https://github.com/realm/realm-js/commit/abf636b52a833671456c336a31d3190e8aefdf1d. I'm making a PR since we had previously discussed that you didn't want to consume the TSR here. Since this matches the [existing SDK behavior](https://github.com/realm/realm-js/blob/8a63052553554e1634fbb7fa04f26f32709b472f/src/js_realm.hpp#L1228), and it ended up not being too gross, I think it is worth reconsidering. Let me know if you are happy with this direction.

There is also an issue where a forgotten `realm.close()` in one of our [legacy tests](https://github.com/realm/realm-js/blob/f2d7e1862f087c42a55a263348a88a1c3ef6da3e/tests/js/set-sync-tests.js#L63-L70) now crashes with the following error. Adding the `realm.close()` fixes this. I need to look into whether this is a real problem that could affect users or just an artifact of our testing with `clearTestState()` and `_sessionStopPolicy: "immediately"`.

```
terminate called after throwing an instance of 'realm::MultipleSyncAgents'
  what():  Multiple sync agents attempted to join the same session
```