### PR TITLE
Jg/sync config

### DIFF
--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -398,7 +398,9 @@ records:
         type: bool
         default: false
       error_handler: 'Nullable<std::function<(session: SharedSyncSession, error: SyncError) -> void>>'
-      custom_http_headers: 'std::map<std::string, std::string>'
+      custom_http_headers: 
+        type: 'std::map<std::string, std::string>'
+        default: {}
 
   ObjectChangeSet:
     fields:

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -398,6 +398,7 @@ records:
         type: bool
         default: false
       error_handler: 'Nullable<std::function<(session: SharedSyncSession, error: SyncError) -> void>>'
+      custom_http_headers: 'std::map<std::string, std::string>'
 
   ObjectChangeSet:
     fields:

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -18,6 +18,7 @@
 
 import {
   DefaultObject,
+  ErrorCallback,
   ObjectSchema,
   Realm,
   RealmObject,

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -18,7 +18,6 @@
 
 import {
   DefaultObject,
-  ErrorCallback,
   ObjectSchema,
   Realm,
   RealmObject,

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -62,6 +62,7 @@ export type BaseSyncConfiguration = {
   newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   onError?: ErrorCallback;
+  customHttpHeaders?: Record<string, string>;
   /** @internal */
   _sessionStopPolicy?: SessionStopPolicy; // TODO: Why is this _ prefixed?
 };
@@ -112,6 +113,7 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
     stopPolicy: _sessionStopPolicy
       ? toBindingStopPolicy(_sessionStopPolicy)
       : binding.SyncSessionStopPolicy.AfterChangesUploaded,
+    customHttpHeaders: config.customHttpHeaders ? (config.customHttpHeaders as Record<string, string>) : {},
   };
 }
 

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -102,7 +102,7 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
   if (config.flexible) {
     throw new Error("Flexible sync has not been implemented yet");
   }
-  const { user, onError, _sessionStopPolicy } = config;
+  const { user, onError, _sessionStopPolicy, customHttpHeaders } = config;
   assert.instanceOf(user, User, "user");
   validatePartitionValue(config.partitionValue);
   const partitionValue = EJSON.stringify(config.partitionValue as EJSON.SerializableTypes);
@@ -113,7 +113,7 @@ export function toBindingSyncConfig(config: SyncConfiguration): binding.SyncConf
     stopPolicy: _sessionStopPolicy
       ? toBindingStopPolicy(_sessionStopPolicy)
       : binding.SyncSessionStopPolicy.AfterChangesUploaded,
-    customHttpHeaders: config.customHttpHeaders ? (config.customHttpHeaders as Record<string, string>) : {},
+    customHttpHeaders: customHttpHeaders,
   };
 }
 

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -182,11 +182,11 @@ export class SyncSession {
   // TODO: Return the `error_handler` and `custom_http_headers`
   get config(): SyncConfiguration {
     const user = new User(this.internal.user, {} as unknown as App);
-    const { partitionValue, flxSyncRequested } = this.internal.config;
+    const { partitionValue, flxSyncRequested, customHttpHeaders } = this.internal.config;
     if (flxSyncRequested) {
-      return { user, flexible: true };
+      return { user, flexible: true, customHttpHeaders };
     } else {
-      return { user, partitionValue: EJSON.parse(partitionValue) as PartitionValue };
+      return { user, partitionValue: EJSON.parse(partitionValue) as PartitionValue, customHttpHeaders };
     }
   }
 

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -154,7 +154,6 @@ module.exports = {
     config.sync.customHttpHeaders = { language: "English" };
     const realm = new Realm(config);
     const session = realm.syncSession;
-    console.log(session.config);
     TestCase.assertEqual(
       "English",
       session.config.customHttpHeaders.language,

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -145,6 +145,14 @@ function unexpectedError(e) {
 }
 
 module.exports = {
+  testHttpHeaders() {
+    const config = {
+      ...getSyncConfiguration(),
+      customHttpHeaders: { langue: "English" },
+      onError: (err, syncSession) => {},
+    };
+  },
+
   testLocalRealmHasNoSession() {
     let realm = new Realm();
     TestCase.assertNull(realm.syncSession);

--- a/tests/js/session-tests.js
+++ b/tests/js/session-tests.js
@@ -145,12 +145,21 @@ function unexpectedError(e) {
 }
 
 module.exports = {
-  testHttpHeaders() {
-    const config = {
-      ...getSyncConfiguration(),
-      customHttpHeaders: { langue: "English" },
-      onError: (err, syncSession) => {},
-    };
+  async testHttpHeaders() {
+    const partition = Utils.genPartition();
+    let credentials = Realm.Credentials.anonymous();
+    let app = new Realm.App(appConfig);
+    const user = await app.logIn(credentials);
+    const config = getSyncConfiguration(user, partition);
+    config.sync.customHttpHeaders = { language: "English" };
+    const realm = new Realm(config);
+    const session = realm.syncSession;
+    console.log(session.config);
+    TestCase.assertEqual(
+      "English",
+      session.config.customHttpHeaders.language,
+      "Synced realm does not contain the expected customHttpHeader",
+    );
   },
 
   testLocalRealmHasNoSession() {


### PR DESCRIPTION
This closes #5063 

Allows a user to get `customHttpHeaders` from a `syncSession.config`.
it was decided that the onError field should not be exposed.