### PR TITLE
Optimize Realm.Object accessor creation

### DIFF
--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -67,7 +67,7 @@ const PROXY_HANDLER: ProxyHandler<RealmObject<any>> = {
     if (typeof prop === "string" && target[KEY_SET].has(prop)) {
       return DEFAULT_PROPERTY_DESCRIPTOR;
     }
-    const res = Reflect.getOwnPropertyDescriptor(target, prop);
+    const result = Reflect.getOwnPropertyDescriptor(target, prop);
     if (res && typeof prop === "symbol") {
       if (prop == INTERNAL) {
         res.enumerable = false;

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -396,9 +396,11 @@ export class RealmObject<T = DefaultObject> {
    * })
    * @since 2.23.0
    */
-  addListener(this: RealmObject<T> & T, callback: ObjectChangeCallback<T>): void {
+  addListener(callback: ObjectChangeCallback<T>): void {
     assert.function(callback);
-    if (!this[INTERNAL_LISTENERS]) this[INTERNAL_LISTENERS] = new ObjectListeners<T>(this[REALM].internal, this);
+    if (!this[INTERNAL_LISTENERS]) {
+      this[INTERNAL_LISTENERS] = new ObjectListeners<T>(this[REALM].internal, this as unknown as RealmObject<T> & T);
+    }
     this[INTERNAL_LISTENERS].addListener(callback);
   }
 

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -68,15 +68,15 @@ const PROXY_HANDLER: ProxyHandler<RealmObject<any>> = {
       return DEFAULT_PROPERTY_DESCRIPTOR;
     }
     const result = Reflect.getOwnPropertyDescriptor(target, prop);
-    if (res && typeof prop === "symbol") {
+    if (result && typeof prop === "symbol") {
       if (prop == INTERNAL) {
-        res.enumerable = false;
-        res.writable = false;
+        result.enumerable = false;
+        result.writable = false;
       } else if (prop == INTERNAL_LISTENERS) {
-        res.enumerable = false;
+        result.enumerable = false;
       }
     }
-    return res;
+    return result;
   },
 };
 

--- a/packages/realm/src/ObjectListeners.ts
+++ b/packages/realm/src/ObjectListeners.ts
@@ -28,7 +28,7 @@ export class ObjectListeners<T> {
    */
   private internal!: binding.ObjectNotifier | null;
 
-  constructor(private realm: binding.Realm, private object: RealmObject<T> & T) {
+  constructor(private realm: binding.Realm, private object: RealmObject<T>) {
     this.properties = getClassHelpers(this.object.constructor as typeof RealmObject).properties;
   }
 
@@ -38,7 +38,7 @@ export class ObjectListeners<T> {
     register: (callback) => {
       const token = this.notifier.addCallback((changes) => {
         try {
-          callback(this.object, {
+          callback(this.object as RealmObject<T> & T, {
             deleted: changes.isDeleted,
             changedProperties: changes.changedColumns.map(this.properties.getName),
           });

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -23,6 +23,7 @@ import {
   INTERNAL,
   List,
   ObjCreator,
+  REALM,
   Realm,
   RealmObject,
   TypeAssertionError,
@@ -83,7 +84,7 @@ export function mixedToBinding(realm: binding.Realm, value: unknown): binding.Mi
   } else if (value instanceof Date) {
     return binding.Timestamp.fromDate(value);
   } else if (value instanceof RealmObject) {
-    const otherRealm = value.realm.internal;
+    const otherRealm = value[REALM].internal;
     assert.isSameRealm(realm, otherRealm, "Realm object is from another Realm");
     return value[INTERNAL];
   } else if (value instanceof Collection) {


### PR DESCRIPTION
This contains a handful of changes primarily focused on optimizing the creation of instances derived from Realm.Object. Note that this is the binding of a JS object to an existing DB object, not just the DB insert path. There are also a handful of correctness changes in related areas in order to avoid the potential for conflicts with users' field names.

This improves our link traversal integration test ("Car") by 3.5x over status quo and makes us now 2.5x faster than v11. This test has some noise, but on my machine I was seeing around {before: 200k ops/s, after: 700k, v11: 350k}.

Changes:
* The `realm` instance member is now a unique REALM symbol field bound into the synthetic prototype[1].
* `keys()` method changes:
  * Internal consumers now use symbol properties `this[KEY_ARRAY]` or `this[KEY_SET]` depending on whether they need O(1) membership checking.
  * Both new properties live on the synthetic prototype.
  * `keys()` is now a normal method on Realm.Object rather than being on the synthetic constructor.
  * `keys()` now returns a copy of the array to prevent caller mutation of the "true" list of keys.
* We no longer use `Object.createProperty()` to mark our internal properties as not writable or enumerable. It is a very slow method at least on V8. Since we are already using a Proxy, we just modify the result returned by `getOwnPropertyDescriptor()` from the proxy handler instead.
* We now lazily create the `ObjectListeners` for each object when the first listener is added. This avoids a rather expensive operation for objects that never have any listeners registered.
* Use `declare` for internal properties we synthetically inject. This tells tsc not to generate a class field declaration when using a new enough target and has weird interactions with some of the techniques we are using.

[1] This is for the synthetic constructor which we create in ClassMap to be the most-derived class for all instances of Realm.Object that we create. This is also where the get/set properties for user fields live. We create a unique synthetic constructor for each combination of user type + `Realm` instance.
