### PR TITLE
Fix blank screen on user provider if fallback not passed

### DIFF
--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -62,10 +62,13 @@ export const UserProvider: React.FC<UserProviderProps> = ({ fallback: Fallback, 
   }, [user, app]);
 
   if (!user) {
-    if (typeof Fallback === "function") {
-      return <Fallback />;
+    if (Fallback) {
+      if (typeof Fallback === "function") {
+        return <Fallback />;
+      }
+      return <>{Fallback}</>;
     }
-    return <>{Fallback}</>;
+    return children
   }
 
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;


### PR DESCRIPTION
## What, How & Why?
While implementing user authentication with `UserProvider` using the last one with no `fallback` provided gave me blank screen with no user. I digged into the code and noticed that `UserProvider` always expects `fallback` and doesn't return children if it's absent
