### PR TITLE
Assert NDK version #2

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -13,7 +13,7 @@ jobs:
     container: ${{ matrix.variant.container }}
     env:
       REALM_DISABLE_ANALYTICS: 1
-      NDK_VERSION: 23.2.8568313
+      NDK_VERSION: 23.1.7779620
     strategy:
       fail-fast: false
       matrix:
@@ -146,8 +146,6 @@ jobs:
       - name: Build Android
         if: ${{ (matrix.variant.os == 'android') }}
         run: npm run prebuild:android -- --arch=${{matrix.variant.arch}}
-        env:
-          ANDROID_NDK: ${{ env.ANDROID_SDK_ROOT }}/ndk/${{ env.NDK_VERSION }}
 
       - name: Upload prebuild artifact
         uses: actions/upload-artifact@v2

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -103,10 +103,6 @@ Next you need to define some environment variables. The best way to do this is i
 # Location of your Android SDK
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
 
-# Location of your Android NDK
-export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/23.2.8568313
-export ANDROID_NDK=$ANDROID_NDK_HOME
-
 # Other required locations
 export ANDROID_SDK_HOME=$HOME/.android
 export ANDROID_EMULATOR_HOME=$HOME/.android
@@ -122,7 +118,7 @@ Then you can install the SDK and NDK by running: (you can alternatively do this 
 
 ```sh
 sdkmanager --install "platforms;android-31"
-sdkmanager --install "ndk;23.2.8568313"
+sdkmanager --install "ndk;23.1.7779620"
 ```
 
 #### Optional extras

--- a/scripts/build-android.js
+++ b/scripts/build-android.js
@@ -21,10 +21,26 @@ const fs = require("fs-extra");
 const path = require("path");
 const exec = require("child_process").execFileSync;
 
+const NDK_VERSION = "23.1.7779620";
+
+const { ANDROID_SDK_ROOT } = process.env;
+if (!fs.existsSync(ANDROID_SDK_ROOT)) {
+  console.error(`Missing the Android SDK ${ANDROID_SDK_ROOT}`);
+  process.exit(1);
+}
+
+const ndkPath = path.resolve(ANDROID_SDK_ROOT, "ndk", NDK_VERSION);
+if (!fs.existsSync(ndkPath)) {
+  const cmd = `sdkmanager --install "ndk;${NDK_VERSION}"`;
+  console.error(`Missing Android NDK v${NDK_VERSION} (${ndkPath}) - run: ${cmd}`);
+  process.exit(1);
+}
+
 //simple validation of current directory.
 const rnDir = path.resolve(process.cwd(), "react-native");
 if (!fs.existsSync(rnDir)) {
-  throw new Error("This script needs to be run at the root dir of the project");
+  console.error("This script needs to be run at the root dir of the project");
+  process.exit(1);
 }
 
 const buildTypes = ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"];
@@ -47,12 +63,6 @@ if (options.arch) {
 }
 
 const buildType = options.buildType;
-
-const ndkPath = process.env["ANDROID_NDK"] || process.env["ANDROID_NDK_HOME"];
-if (!ndkPath) {
-  throw Error("ANDROID_NDK / ANDROID_NDK_HOME environment variable not set");
-}
-
 const cmakePath = process.platform === "win32" ? "cmake.exe" : "cmake";
 
 const buildPath = path.resolve(process.cwd(), "build-android");


### PR DESCRIPTION
## What, How & Why?

As per @takameyer's suggestion, we could simply expect that the SDK manager is used to download the NDK and infer and assert the path of the NDK relative to that. The only place the ANDROID_NDK is explicitly set is in the Dockerfile.android which isn't used by the new GHA.

This PR also updates the NDK version used on CI to explicitly match [that used by the RN template](https://github.com/facebook/react-native/blob/v0.71.0-rc.5/template/android/build.gradle#L11).

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
