### PR TITLE
Make integration tests conform to new parser

### DIFF
--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -40,7 +40,7 @@ describe("Class models", () => {
       }
       expect(() => {
         new Realm({ schema: [Person as any] });
-      }).throws("Expected 'Person.properties' to be an object, got undefined");
+      }).throws("Expected 'properties' on 'Person' to be an object, got undefined");
     });
 
     it("fails if it doesn't extend Realm.Object", () => {

--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -40,7 +40,7 @@ describe("Class models", () => {
       }
       expect(() => {
         new Realm({ schema: [Person as any] });
-      }).throws("Expected 'properties' to be an object, got undefined");
+      }).throws("Expected 'Person.properties' to be an object, got undefined");
     });
 
     it("fails if it doesn't extend Realm.Object", () => {

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -33,7 +33,7 @@ describe("Dictionary", () => {
       schema: [
         {
           name: "Item",
-          properties: { dict: "{}" },
+          properties: { dict: "mixed{}" },
         },
         {
           name: "Person",
@@ -236,7 +236,7 @@ describe("Dictionary", () => {
       schema: [
         {
           name: "Item",
-          properties: { dict: "{}" },
+          properties: { dict: "mixed{}" },
         },
       ],
     });

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -172,7 +172,7 @@ describe("realm._updateSchema", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.realm as any)._updateSchema();
       });
-    }).to.throw("Expected 'schema' to be an array, got undefined");
+    }).to.throw("Expected 'schema (the realm schema)' to be an array, got undefined");
   });
 
   it("throws if called with an unexpected type", function (this: RealmContext) {
@@ -181,6 +181,6 @@ describe("realm._updateSchema", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.realm as any)._updateSchema("w00t");
       });
-    }).to.throw("Expected 'schema' to be an array, got a string");
+    }).to.throw("Expected 'schema (the realm schema)' to be an array, got a string");
   });
 });

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -53,7 +53,7 @@ describe("realm._updateSchema", () => {
     const MyClassSchema = this.realm.schema.find((s) => s.name === "MyClass");
     expect(MyClassSchema).deep.equals({
       name: "MyClass",
-      constructor: undefined,
+      ctor: undefined,
       asymmetric: false,
       embedded: false,
       properties: {
@@ -86,7 +86,7 @@ describe("realm._updateSchema", () => {
     const ModifiedDogSchema = this.realm.schema.find((s) => s.name === "Dog");
     expect(ModifiedDogSchema).deep.equals({
       name: "Dog",
-      constructor: undefined,
+      ctor: undefined,
       asymmetric: false,
       embedded: false,
       properties: {

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -172,7 +172,7 @@ describe("realm._updateSchema", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.realm as any)._updateSchema();
       });
-    }).to.throw("Expected 'schema (the realm schema)' to be an array, got undefined");
+    }).to.throw("Expected 'realm schema' to be an array, got undefined");
   });
 
   it("throws if called with an unexpected type", function (this: RealmContext) {
@@ -181,6 +181,6 @@ describe("realm._updateSchema", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.realm as any)._updateSchema("w00t");
       });
-    }).to.throw("Expected 'schema (the realm schema)' to be an array, got a string");
+    }).to.throw("Expected 'realm schema' to be an array, got a string");
   });
 });

--- a/integration-tests/tests/src/tests/realm-constructor.ts
+++ b/integration-tests/tests/src/tests/realm-constructor.ts
@@ -159,7 +159,7 @@ describe("Realm#constructor", () => {
     it("fails when passed an object", () => {
       expect(() => {
         new RealmAsAny({ schema: {} });
-      }).throws("Expected 'schema (the realm schema)' to be an array, got an object");
+      }).throws("Expected 'realm schema' to be an array, got an object");
     });
 
     it("fails when passed an array with non-objects", () => {
@@ -171,19 +171,19 @@ describe("Realm#constructor", () => {
     it("fails when passed an array with empty object", () => {
       expect(() => {
         new RealmAsAny({ schema: [{}] });
-      }).throws("Expected 'name (the object schema name)' to be a string, got undefined");
+      }).throws("Expected 'name' on object schema to be a string, got undefined");
     });
 
     it("fails when passed an array with an object without 'properties'", () => {
       expect(() => {
         new RealmAsAny({ schema: [{ name: "SomeObject" }] });
-      }).throws("Expected 'SomeObject.properties' to be an object, got undefined");
+      }).throws("Expected 'properties' on 'SomeObject' to be an object, got undefined");
     });
 
     it("fails when passed an array with an object without 'name'", () => {
       expect(() => {
         new RealmAsAny({ schema: [{ properties: {} }] });
-      }).throws("Expected 'name (the object schema name)' to be a string, got undefined");
+      }).throws("Expected 'name' on object schema to be a string, got undefined");
     });
 
     function expectInvalidProperty(
@@ -192,7 +192,7 @@ describe("Realm#constructor", () => {
       addMessagePrefix = true,
     ) {
       if (addMessagePrefix) {
-        message = `Invalid type declaration for property 'InvalidObject.bad': ${message}`;
+        message = `Invalid type declaration for property 'bad' on 'InvalidObject': ${message}`;
       }
       expect(() => {
         new Realm({
@@ -211,23 +211,10 @@ describe("Realm#constructor", () => {
       }).throws(message);
     }
 
-    // Old test: The new schema parser no longer allows combining shorthand and object notation.
-    it.skip("fails when asking for a list of lists", () => {
-      expectInvalidProperty({ type: "list[]" }, "List property 'InvalidObject#bad' cannot have list elements");
-    });
-
     it("fails when asking for a list of lists", () => {
       expectInvalidProperty(
         { type: "list", objectType: "list" },
         "A list must contain only primitive or user-defined types specified through 'objectType'",
-      );
-    });
-
-    // Old test: The new schema parser no longer allows combining shorthand and object notation.
-    it.skip("fails when asking for an optional list", () => {
-      expectInvalidProperty(
-        { type: "list?", objectType: "InvalidObject" },
-        "List property 'InvalidObject#bad' of 'InvalidObject' elements, cannot be optional",
       );
     });
 
@@ -276,25 +263,6 @@ describe("Realm#constructor", () => {
         "Property 'InvalidObject.another' declared as origin of linking objects property 'InvalidObject.bad' links to type 'AnotherObject'",
         false,
       );
-    });
-
-    // Old test: The new schema parser no longer allows combining shorthand and object notation.
-    it.skip("doesn't allow list of objects with objectType defined", () => {
-      expect(() => {
-        new Realm({
-          schema: [
-            {
-              name: "SomeObject",
-              properties: {
-                myObjects: {
-                  objectType: "SomeObject",
-                  type: "object[]",
-                },
-              },
-            },
-          ],
-        });
-      }).throws("Expected no 'objectType' in property schema, when using '[]' shorthand");
     });
   });
 

--- a/integration-tests/tests/src/tests/realm-constructor.ts
+++ b/integration-tests/tests/src/tests/realm-constructor.ts
@@ -159,7 +159,7 @@ describe("Realm#constructor", () => {
     it("fails when passed an object", () => {
       expect(() => {
         new RealmAsAny({ schema: {} });
-      }).throws("Expected 'schema' to be an array, got an object");
+      }).throws("Expected 'schema (the realm schema)' to be an array, got an object");
     });
 
     it("fails when passed an array with non-objects", () => {
@@ -171,22 +171,29 @@ describe("Realm#constructor", () => {
     it("fails when passed an array with empty object", () => {
       expect(() => {
         new RealmAsAny({ schema: [{}] });
-      }).throws("Expected 'name' to be a string, got undefined");
+      }).throws("Expected 'name (the object schema name)' to be a string, got undefined");
     });
 
     it("fails when passed an array with an object without 'properties'", () => {
       expect(() => {
         new RealmAsAny({ schema: [{ name: "SomeObject" }] });
-      }).throws("Expected 'properties' to be an object, got undefined");
+      }).throws("Expected 'SomeObject.properties' to be an object, got undefined");
     });
 
     it("fails when passed an array with an object without 'name'", () => {
       expect(() => {
         new RealmAsAny({ schema: [{ properties: {} }] });
-      }).throws("Expected 'name' to be a string, got undefined");
+      }).throws("Expected 'name (the object schema name)' to be a string, got undefined");
     });
 
-    function expectInvalidProperty(badProperty: Realm.PropertyType | Realm.ObjectSchemaProperty, message: string) {
+    function expectInvalidProperty(
+      badProperty: Realm.PropertyType | Realm.ObjectSchemaProperty,
+      message: string,
+      addMessagePrefix = true,
+    ) {
+      if (addMessagePrefix) {
+        message = `Invalid type declaration for property 'InvalidObject.bad': ${message}`;
+      }
       expect(() => {
         new Realm({
           schema: [
@@ -204,19 +211,35 @@ describe("Realm#constructor", () => {
       }).throws(message);
     }
 
-    it("fails when asking for a list of lists", () => {
+    // Old test: The new schema parser no longer allows combining shorthand and object notation.
+    it.skip("fails when asking for a list of lists", () => {
       expectInvalidProperty({ type: "list[]" }, "List property 'InvalidObject#bad' cannot have list elements");
     });
 
-    it("fails when asking for an optional list", () => {
+    it("fails when asking for a list of lists", () => {
+      expectInvalidProperty(
+        { type: "list", objectType: "list" },
+        "A list must contain only primitive or user-defined types specified through 'objectType'",
+      );
+    });
+
+    // Old test: The new schema parser no longer allows combining shorthand and object notation.
+    it.skip("fails when asking for an optional list", () => {
       expectInvalidProperty(
         { type: "list?", objectType: "InvalidObject" },
         "List property 'InvalidObject#bad' of 'InvalidObject' elements, cannot be optional",
       );
     });
 
+    it("fails when asking for an optional list of objects", () => {
+      expectInvalidProperty(
+        { type: "list", objectType: "InvalidObject", optional: true },
+        "User-defined types in lists and sets are always non-optional and cannot be made optional",
+      );
+    });
+
     it("fails when asking for an empty type string", () => {
-      expectInvalidProperty("", "Property 'InvalidObject#bad' cannot have an empty object type");
+      expectInvalidProperty("", "The type must be specified.");
     });
 
     it("fails when asking for linkingObjects to a non-existing property", () => {
@@ -227,6 +250,7 @@ describe("Realm#constructor", () => {
           type: "linkingObjects",
         },
         "Property 'InvalidObject.nosuchproperty' declared as origin of linking objects property 'InvalidObject.bad' does not exist",
+        false,
       );
     });
 
@@ -238,6 +262,7 @@ describe("Realm#constructor", () => {
           type: "linkingObjects",
         },
         "Property 'InvalidObject.nummeric' declared as origin of linking objects property 'InvalidObject.bad' is not a link",
+        false,
       );
     });
 
@@ -249,10 +274,12 @@ describe("Realm#constructor", () => {
           type: "linkingObjects",
         },
         "Property 'InvalidObject.another' declared as origin of linking objects property 'InvalidObject.bad' links to type 'AnotherObject'",
+        false,
       );
     });
 
-    it("doesn't allow list of objects with objectType defined", () => {
+    // Old test: The new schema parser no longer allows combining shorthand and object notation.
+    it.skip("doesn't allow list of objects with objectType defined", () => {
       expect(() => {
         new Realm({
           schema: [

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -54,7 +54,7 @@ interface IPlaylist {
 const BirthdaysSchema: Realm.ObjectSchema = {
   name: "Birthdays",
   properties: {
-    dict: "{}",
+    dict: "mixed{}",
   },
 };
 

--- a/integration-tests/tests/src/tests/set.ts
+++ b/integration-tests/tests/src/tests/set.ts
@@ -30,7 +30,7 @@ describe("Set", () => {
       schema: [
         {
           name: "Item",
-          properties: { set: { type: "set" } },
+          properties: { set: { type: "set", objectType: "mixed" } },
         },
         {
           name: "Person",

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -231,7 +231,7 @@ export function validateConfiguration(config: unknown): asserts config is Config
  * Validate the data types of the fields of a user-provided realm schema.
  */
 export function validateRealmSchema(realmSchema: unknown): asserts realmSchema is Configuration["schema"][] {
-  assert.array(realmSchema, "the realm schema");
+  assert.array(realmSchema, "schema (the realm schema)");
   for (const objectSchema of realmSchema) {
     validateObjectSchema(objectSchema);
   }
@@ -260,9 +260,9 @@ export function validateObjectSchema(
     validateObjectSchema(clazz.schema);
   } else {
     // Schema is passed as an object
-    assert.object(objectSchema, "the object schema", false);
+    assert.object(objectSchema, "object schema", false);
     const { name: objectName, properties, primaryKey, asymmetric, embedded } = objectSchema;
-    assert.string(objectName, "the object schema name");
+    assert.string(objectName, "name (the object schema name)");
     assert.object(properties, `${objectName}.properties`, false);
     if (primaryKey !== undefined) {
       assert.string(primaryKey, `${objectName}.primaryKey`);

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -249,7 +249,7 @@ export function validateConfiguration(config: unknown): asserts config is Config
  * Validate the data types of the fields of a user-provided realm schema.
  */
 export function validateRealmSchema(realmSchema: unknown): asserts realmSchema is Configuration["schema"][] {
-  assert.array(realmSchema, "schema (the realm schema)");
+  assert.array(realmSchema, "realm schema");
   for (const objectSchema of realmSchema) {
     validateObjectSchema(objectSchema);
   }
@@ -279,18 +279,18 @@ export function validateObjectSchema(
   }
   // Schema is passed as an object (ObjectSchema)
   else {
-    assert.object(objectSchema, "object schema", false);
+    assert.object(objectSchema, "object schema", { allowArrays: false });
     const { name: objectName, properties, primaryKey, asymmetric, embedded } = objectSchema;
-    assert.string(objectName, "name (the object schema name)");
-    assert.object(properties, `${objectName}.properties`, false);
+    assert.string(objectName, "'name' on object schema");
+    assert.object(properties, `'properties' on '${objectName}'`, { allowArrays: false });
     if (primaryKey !== undefined) {
-      assert.string(primaryKey, `${objectName}.primaryKey`);
+      assert.string(primaryKey, `'primaryKey' on '${objectName}'`);
     }
     if (embedded !== undefined) {
-      assert.boolean(embedded, `${objectName}.embedded`);
+      assert.boolean(embedded, `'embedded' on '${objectName}'`);
     }
     if (asymmetric !== undefined) {
-      assert.boolean(asymmetric, `${objectName}.asymmetric`);
+      assert.boolean(asymmetric, `'asymmetric' on '${objectName}'`);
     }
 
     const invalidKeysUsed = filterInvalidKeys(objectSchema, OBJECT_SCHEMA_KEYS);
@@ -318,29 +318,28 @@ export function validatePropertySchema(
   propertyName: string,
   propertySchema: unknown,
 ): asserts propertySchema is ObjectSchemaProperty {
-  const displayedName = `${objectName}.${propertyName}`;
-  assert.object(propertySchema, displayedName, false);
+  assert.object(propertySchema, `'${propertyName}' on '${objectName}'`, { allowArrays: false });
   const { type, objectType, optional, property, indexed, mapTo } = propertySchema;
-  assert.string(type, `${displayedName}.type`);
+  assert.string(type, `'${propertyName}.type' on '${objectName}'`);
   if (objectType !== undefined) {
-    assert.string(objectType, `${displayedName}.objectType`);
+    assert.string(objectType, `'${propertyName}.objectType' on '${objectName}'`);
   }
   if (optional !== undefined) {
-    assert.boolean(optional, `${displayedName}.optional`);
+    assert.boolean(optional, `'${propertyName}.optional' on '${objectName}'`);
   }
   if (property !== undefined) {
-    assert.string(property, `${displayedName}.property`);
+    assert.string(property, `'${propertyName}.property' on '${objectName}'`);
   }
   if (indexed !== undefined) {
-    assert.boolean(indexed, `${displayedName}.indexed`);
+    assert.boolean(indexed, `'${propertyName}.indexed' on '${objectName}'`);
   }
   if (mapTo !== undefined) {
-    assert.string(mapTo, `${displayedName}.mapTo`);
+    assert.string(mapTo, `'${propertyName}.mapTo' on '${objectName}'`);
   }
   const invalidKeysUsed = filterInvalidKeys(propertySchema, PROPERTY_SCHEMA_KEYS);
   assert(
     !invalidKeysUsed.length,
-    `Unexpected field(s) found on the schema for property '${displayedName}': '${invalidKeysUsed.join("', '")}'.`,
+    `Unexpected field(s) found on the schema for property '${propertyName}' on '${objectName}': '${invalidKeysUsed.join("', '")}'.`,
   );
 }
 

--- a/packages/realm/src/assert.ts
+++ b/packages/realm/src/assert.ts
@@ -45,81 +45,81 @@ export function assert(
 assert.instanceOf = <T extends Function>(
   value: unknown,
   constructor: T,
-  name?: string,
+  target?: string,
 ): asserts value is T["prototype"] => {
   if (!(value instanceof constructor)) {
-    throw new TypeAssertionError(`an instance of ${constructor.name}`, value, name);
+    throw new TypeAssertionError(`an instance of ${constructor.name}`, value, target);
   }
 };
 
-assert.string = (value: unknown, name?: string): asserts value is string => {
+assert.string = (value: unknown, target?: string): asserts value is string => {
   if (typeof value !== "string") {
-    throw new TypeAssertionError("a string", value, name);
+    throw new TypeAssertionError("a string", value, target);
   }
 };
 
-assert.number = (value: unknown, name?: string): asserts value is number => {
+assert.number = (value: unknown, target?: string): asserts value is number => {
   if (typeof value !== "number") {
-    throw new TypeAssertionError("a number", value, name);
+    throw new TypeAssertionError("a number", value, target);
   }
 };
 
-assert.boolean = (value: unknown, name?: string): asserts value is boolean => {
+assert.boolean = (value: unknown, target?: string): asserts value is boolean => {
   if (typeof value !== "boolean") {
-    throw new TypeAssertionError("a boolean", value, name);
+    throw new TypeAssertionError("a boolean", value, target);
   }
 };
 
-assert.bigInt = (value: unknown, name?: string): asserts value is bigint => {
+assert.bigInt = (value: unknown, target?: string): asserts value is bigint => {
   if (typeof value !== "bigint") {
-    throw new TypeAssertionError("a bigint", value, name);
+    throw new TypeAssertionError("a bigint", value, target);
   }
 };
 
-assert.numberOrBigInt = (value: unknown, name?: string): asserts value is number => {
+assert.numberOrBigInt = (value: unknown, target?: string): asserts value is number => {
   if (typeof value !== "number" && typeof value !== "bigint") {
-    throw new TypeAssertionError("a number or bigint", value, name);
+    throw new TypeAssertionError("a number or bigint", value, target);
   }
 };
 
 /* eslint-disable-next-line @typescript-eslint/ban-types */
-assert.function = (value: unknown, name?: string): asserts value is (...args: unknown[]) => unknown => {
+assert.function = (value: unknown, target?: string): asserts value is (...args: unknown[]) => unknown => {
   if (typeof value !== "function") {
-    throw new TypeAssertionError("a function", value, name);
+    throw new TypeAssertionError("a function", value, target);
   }
 };
 
-assert.symbol = (value: unknown, name?: string): asserts value is symbol => {
+assert.symbol = (value: unknown, target?: string): asserts value is symbol => {
   if (typeof value !== "symbol") {
-    throw new TypeAssertionError("a symbol", value, name);
+    throw new TypeAssertionError("a symbol", value, target);
   }
 };
 
 assert.object = <K extends string | number | symbol = string, V = unknown>(
   value: unknown,
-  name?: string,
-  allowArrays = true,
+  target?: string,
+  { allowArrays } = { allowArrays: true },
 ): asserts value is Record<K, V> => {
   if (typeof value !== "object" || value === null || (!allowArrays && Array.isArray(value))) {
-    throw new TypeAssertionError("an object", value, name);
+    throw new TypeAssertionError("an object", value, target);
   }
 };
 
-assert.undefined = (value: unknown, name?: string): asserts value is undefined => {
+assert.undefined = (value: unknown, target?: string): asserts value is undefined => {
   if (typeof value !== "undefined") {
-    throw new TypeAssertionError("undefined", value, name);
+    throw new TypeAssertionError("undefined", value, target);
   }
 };
 
-assert.null = (value: unknown, name?: string): asserts value is null => {
+assert.null = (value: unknown, target?: string): asserts value is null => {
   if (value !== null) {
-    throw new TypeAssertionError("null", value, name);
+    throw new TypeAssertionError("null", value, target);
   }
 };
 
-assert.array = (value: unknown, name?: string): asserts value is Array<unknown> => {
+assert.array = (value: unknown, target?: string): asserts value is Array<unknown> => {
   if (!Array.isArray(value)) {
-    throw new TypeAssertionError("an array", value, name);
+    throw new TypeAssertionError("an array", value, target);
   }
 };
 
@@ -127,23 +127,23 @@ assert.array = (value: unknown, name?: string): asserts value is Array<unknown> 
 assert.extends = <T extends Function>(
   value: unknown,
   constructor: T,
-  name?: string,
+  target?: string,
 ): asserts value is T & DefaultObject => {
-  assert.function(value, name);
+  assert.function(value, target);
   if (!(value.prototype instanceof constructor)) {
-    throw new TypeAssertionError(`a class extending ${constructor.name}`, value, name);
+    throw new TypeAssertionError(`a class extending ${constructor.name}`, value, target);
   }
 };
 
-assert.iterable = (value: unknown, name?: string): asserts value is Iterable<unknown> => {
-  assert.object(value, name);
+assert.iterable = (value: unknown, target?: string): asserts value is Iterable<unknown> => {
+  assert.object(value, target);
   if (!(Symbol.iterator in value)) {
-    throw new TypeAssertionError("iterable", value, name);
+    throw new TypeAssertionError("iterable", value, target);
   }
 };
 
-assert.never = (value: never, name?: string): asserts value is never => {
-  throw new TypeAssertionError("never", value, name);
+assert.never = (value: never, target?: string): asserts value is never => {
+  throw new TypeAssertionError("never", value, target);
 };
 
 // SDK specific

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -49,13 +49,23 @@ export class TypeAssertionError extends AssertionError {
     }
   }
 
-  private static message(expected: string, value: unknown, name?: string) {
+  /**
+   * Get an error message for when the target's value is of
+   * the wrong type. Single quotes are added around the target
+   * string if it does not already contain one.
+   */
+  private static message(expected: string, value: unknown, target?: string) {
     const actual = TypeAssertionError.deriveType(value);
-    return `Expected ${name ? "'" + name + "'" : "value"} to be ${expected}, got ${actual}`;
+    if (target) {
+      target = target.includes("'") ? target : `'${target}'`;
+    } else {
+      target = "value";
+    }
+    return `Expected ${target} to be ${expected}, got ${actual}`;
   }
 
-  constructor(private expected: string, private value: unknown, name?: string) {
-    super(TypeAssertionError.message(expected, value, name));
+  constructor(private expected: string, private value: unknown, target?: string) {
+    super(TypeAssertionError.message(expected, value, target));
   }
 
   public rename(name: string) {

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -392,7 +392,7 @@ function assertNotUsingShorthand(input: string | undefined, info: PropertyInfo):
  * Get an error message for an invalid property schema.
  */
 function errMessage({ objectName, propertyName }: PropertyInfo, message: string): string {
-  return `Invalid type declaration for property '${objectName}.${propertyName}': ${message}`;
+  return `Invalid type declaration for property '${propertyName}' on '${objectName}': ${message}`;
 }
 
 /**

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -36,6 +36,7 @@ type PropertyInfo = {
   readonly objectName: string;
   readonly propertyName: string;
   readonly propertySchema: PropertySchema | PropertySchemaShorthand;
+  readonly isPrimaryKey?: boolean;
 };
 
 interface PropertyInfoUsingObject extends PropertyInfo {
@@ -141,10 +142,12 @@ function normalizePropertySchemas(
 ): Record<string, CanonicalObjectSchemaProperty> {
   const normalizedSchemas: Record<string, CanonicalObjectSchemaProperty> = {};
   for (const propertyName in propertiesSchemas) {
-    normalizedSchemas[propertyName] = normalizePropertySchema(
-      { objectName, propertyName, propertySchema: propertiesSchemas[propertyName] },
-      primaryKey === propertyName,
-    );
+    normalizedSchemas[propertyName] = normalizePropertySchema({
+      objectName,
+      propertyName,
+      propertySchema: propertiesSchemas[propertyName],
+      isPrimaryKey: primaryKey === propertyName,
+    });
   }
 
   return normalizedSchemas;
@@ -153,17 +156,11 @@ function normalizePropertySchemas(
 /**
  * Transform a user-provided property schema into its canonical form.
  */
-export function normalizePropertySchema(info: PropertyInfo, isPrimaryKey = false): CanonicalObjectSchemaProperty {
-  const normalizedSchema =
-    typeof info.propertySchema === "string"
-      ? normalizePropertySchemaShorthand(info as PropertyInfoUsingShorthand)
-      : normalizePropertySchemaObject(info as PropertyInfoUsingObject);
-
-  if (isPrimaryKey) {
-    assert(!normalizedSchema.optional, errMessage(info, "Optional properties cannot be used as a primary key."));
-    assert(normalizedSchema.indexed !== false, errMessage(info, "Primary keys must always be indexed."));
-    normalizedSchema.indexed = true;
-  }
+export function normalizePropertySchema(info: PropertyInfo): CanonicalObjectSchemaProperty {
+  const isUsingShorthand = typeof info.propertySchema === "string";
+  const normalizedSchema = isUsingShorthand
+    ? normalizePropertySchemaShorthand(info as PropertyInfoUsingShorthand)
+    : normalizePropertySchemaObject(info as PropertyInfoUsingObject);
 
   return normalizedSchema;
 }
@@ -178,7 +175,7 @@ function normalizePropertySchemaShorthand(info: PropertyInfoUsingShorthand): Can
 
   let type = "";
   let objectType: string | undefined;
-  let optional = false;
+  let optional: boolean | undefined;
 
   if (hasCollectionSuffix(propertySchema)) {
     const suffixLength = 2;
@@ -250,11 +247,15 @@ function normalizePropertySchemaShorthand(info: PropertyInfoUsingShorthand): Can
     optional = false;
   }
 
+  if (info.isPrimaryKey) {
+    assert(!optional, errMessage(info, "Optional properties cannot be used as a primary key."));
+  }
+
   const normalizedSchema: CanonicalObjectSchemaProperty = {
     name: info.propertyName,
     type: type as PropertyTypeName,
-    optional,
-    indexed: false,
+    optional: !!optional,
+    indexed: !!info.isPrimaryKey,
     mapTo: info.propertyName,
   };
   // Add optional properties only if defined (tests expect no 'undefined' properties)
@@ -270,7 +271,7 @@ function normalizePropertySchemaShorthand(info: PropertyInfoUsingShorthand): Can
 function normalizePropertySchemaObject(info: PropertyInfoUsingObject): CanonicalObjectSchemaProperty {
   const { propertySchema } = info;
   const { type, objectType, property, default: defaultValue } = propertySchema;
-  let { optional } = propertySchema;
+  let { optional, indexed } = propertySchema;
 
   assert(type.length > 0, errMessage(info, "'type' must be specified."));
   assertNotUsingShorthand(type, info);
@@ -315,11 +316,17 @@ function normalizePropertySchemaObject(info: PropertyInfoUsingObject): Canonical
     optional = false;
   }
 
+  if (info.isPrimaryKey) {
+    assert(!optional, errMessage(info, "Optional properties cannot be used as a primary key."));
+    assert(indexed !== false, errMessage(info, "Primary keys must always be indexed."));
+    indexed = true;
+  }
+
   const normalizedSchema: CanonicalObjectSchemaProperty = {
     name: info.propertyName,
     type: type as PropertyTypeName,
     optional: !!optional,
-    indexed: !!propertySchema.indexed,
+    indexed: !!indexed,
     mapTo: propertySchema.mapTo || info.propertyName,
   };
   // Add optional properties only if defined (tests expect no 'undefined' properties)

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -182,7 +182,7 @@ describe("normalizePropertySchema", () => {
         indexed: true,
         optional: false,
       },
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
   });
 
@@ -253,17 +253,9 @@ describe("normalizePropertySchema", () => {
     // Indexed & Primary Keys
     // -------------------------
 
-    itThrowsWhenNormalizing(
-      "string?",
-      "Optional properties cannot be used as a primary key.",
-      true, // Declare that it is a primary key.
-    );
+    itThrowsWhenNormalizing("string?", "Optional properties cannot be used as a primary key.", { isPrimaryKey: true });
 
-    itThrowsWhenNormalizing(
-      "mixed",
-      "Optional properties cannot be used as a primary key.",
-      true, // Declare that it is a primary key.
-    );
+    itThrowsWhenNormalizing("mixed", "Optional properties cannot be used as a primary key.", { isPrimaryKey: true });
   });
 
   // ------------------------------------------------------------------------
@@ -667,7 +659,7 @@ describe("normalizePropertySchema", () => {
         indexed: true,
         optional: false,
       },
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
 
     itNormalizes(
@@ -680,7 +672,7 @@ describe("normalizePropertySchema", () => {
         indexed: true,
         optional: false,
       },
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
 
     itNormalizes(
@@ -693,7 +685,7 @@ describe("normalizePropertySchema", () => {
         indexed: true,
         optional: false,
       },
-      false, // Declare that it is not a primary key (default).
+      { isPrimaryKey: false },
     );
   });
 
@@ -916,7 +908,7 @@ describe("normalizePropertySchema", () => {
         optional: true,
       },
       "Optional properties cannot be used as a primary key.",
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
 
     itThrowsWhenNormalizing(
@@ -924,7 +916,7 @@ describe("normalizePropertySchema", () => {
         type: "mixed",
       },
       "Optional properties cannot be used as a primary key.",
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
 
     itThrowsWhenNormalizing(
@@ -934,7 +926,7 @@ describe("normalizePropertySchema", () => {
         optional: false,
       },
       "Primary keys must always be indexed.",
-      true, // Declare that it is a primary key.
+      { isPrimaryKey: true },
     );
   });
 });
@@ -956,7 +948,7 @@ describe("extractGeneric", () => {
 function itNormalizes(
   input: string | ObjectSchemaProperty,
   expected: Partial<CanonicalObjectSchemaProperty>,
-  isPrimaryKey = false,
+  { isPrimaryKey } = { isPrimaryKey: false },
 ): void {
   it(`normalizes ${inspect(input, { compact: true, breakLength: Number.MAX_SAFE_INTEGER })} ${isPrimaryKey ? "(primary key)" : ""}`, () => {
     const result = normalizePropertySchema({
@@ -982,7 +974,11 @@ function itNormalizes(
   });
 }
 
-function itThrowsWhenNormalizing(input: string | ObjectSchemaProperty, errMessage: string, isPrimaryKey = false): void {
+function itThrowsWhenNormalizing(
+  input: string | ObjectSchemaProperty,
+  errMessage: string,
+  { isPrimaryKey } = { isPrimaryKey: false },
+): void {
   it(`throws when normalizing ${inspect(input, { compact: true, breakLength: Number.MAX_SAFE_INTEGER })} ${isPrimaryKey ? "(primary key)" : ""}`, () => {
     const normalizeFn = () =>
       normalizePropertySchema({
@@ -992,7 +988,7 @@ function itThrowsWhenNormalizing(input: string | ObjectSchemaProperty, errMessag
         isPrimaryKey,
       });
     expect(normalizeFn).to.throw(
-      `Invalid type declaration for property '${OBJECT_NAME}.${PROPERTY_NAME}': ${errMessage}`,
+      `Invalid type declaration for property '${PROPERTY_NAME}' on '${OBJECT_NAME}': ${errMessage}`,
     );
   });
 }

--- a/packages/realm/src/tests/schema-validation.test.ts
+++ b/packages/realm/src/tests/schema-validation.test.ts
@@ -59,18 +59,22 @@ describe("validateObjectSchema", () => {
   // ------------------------------------------------------------------------
 
   describe("using invalid shape of input", () => {
-    itThrowsWhenValidating("an array", [], "Expected 'the object schema' to be an object, got an array");
+    itThrowsWhenValidating("an array", [], "Expected 'object schema' to be an object, got an array");
 
-    itThrowsWhenValidating("'null'", null, "Expected 'the object schema' to be an object, got null");
+    itThrowsWhenValidating("'null'", null, "Expected 'object schema' to be an object, got null");
 
-    itThrowsWhenValidating("an empty object", {}, "Expected 'the object schema name' to be a string, got undefined");
+    itThrowsWhenValidating(
+      "an empty object",
+      {},
+      "Expected 'name (the object schema name)' to be a string, got undefined",
+    );
 
     itThrowsWhenValidating(
       "an object with invalid type for property 'name'",
       {
         name: NOT_A_STRING,
       },
-      "Expected 'the object schema name' to be a string, got a number",
+      "Expected 'name (the object schema name)' to be a string, got a number",
     );
 
     itThrowsWhenValidating(

--- a/packages/realm/src/tests/schema-validation.test.ts
+++ b/packages/realm/src/tests/schema-validation.test.ts
@@ -63,18 +63,14 @@ describe("validateObjectSchema", () => {
 
     itThrowsWhenValidating("'null'", null, "Expected 'object schema' to be an object, got null");
 
-    itThrowsWhenValidating(
-      "an empty object",
-      {},
-      "Expected 'name (the object schema name)' to be a string, got undefined",
-    );
+    itThrowsWhenValidating("an empty object", {}, "Expected 'name' on object schema to be a string, got undefined");
 
     itThrowsWhenValidating(
       "an object with invalid type for property 'name'",
       {
         name: NOT_A_STRING,
       },
-      "Expected 'name (the object schema name)' to be a string, got a number",
+      "Expected 'name' on object schema to be a string, got a number",
     );
 
     itThrowsWhenValidating(
@@ -83,7 +79,7 @@ describe("validateObjectSchema", () => {
         name: OBJECT_NAME,
         properties: NOT_AN_OBJECT,
       },
-      `Expected '${OBJECT_NAME}.properties' to be an object, got a number`,
+      `Expected 'properties' on '${OBJECT_NAME}' to be an object, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -93,7 +89,7 @@ describe("validateObjectSchema", () => {
         properties: {},
         primaryKey: NOT_A_STRING,
       },
-      `Expected '${OBJECT_NAME}.primaryKey' to be a string, got a number`,
+      `Expected 'primaryKey' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -103,7 +99,7 @@ describe("validateObjectSchema", () => {
         properties: {},
         embedded: NOT_A_BOOLEAN,
       },
-      `Expected '${OBJECT_NAME}.embedded' to be a boolean, got a number`,
+      `Expected 'embedded' on '${OBJECT_NAME}' to be a boolean, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -113,7 +109,7 @@ describe("validateObjectSchema", () => {
         properties: {},
         asymmetric: NOT_A_BOOLEAN,
       },
-      `Expected '${OBJECT_NAME}.asymmetric' to be a boolean, got a number`,
+      `Expected 'asymmetric' on '${OBJECT_NAME}' to be a boolean, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -144,7 +140,7 @@ describe("validateObjectSchema", () => {
   }
 });
 
-describe("validatePropertySchemaObject", () => {
+describe("validatePropertySchema", () => {
   // ------------------------------------------------------------------------
   // Valid shape of input
   // ------------------------------------------------------------------------
@@ -180,20 +176,26 @@ describe("validatePropertySchemaObject", () => {
   // ------------------------------------------------------------------------
 
   describe("using invalid shape of input", () => {
-    const DISPLAYED_NAME = `${OBJECT_NAME}.${PROPERTY_NAME}`;
+    itThrowsWhenValidating(
+      "an array",
+      [],
+      `Expected '${PROPERTY_NAME}' on '${OBJECT_NAME}' to be an object, got an array`,
+    );
 
-    itThrowsWhenValidating("an array", [], `Expected '${DISPLAYED_NAME}' to be an object, got an array`);
+    itThrowsWhenValidating("'null'", null, `Expected '${PROPERTY_NAME}' on '${OBJECT_NAME}' to be an object, got null`);
 
-    itThrowsWhenValidating("'null'", null, `Expected '${DISPLAYED_NAME}' to be an object, got null`);
-
-    itThrowsWhenValidating("an empty object", {}, `Expected '${DISPLAYED_NAME}.type' to be a string, got undefined`);
+    itThrowsWhenValidating(
+      "an empty object",
+      {},
+      `Expected '${PROPERTY_NAME}.type' on '${OBJECT_NAME}' to be a string, got undefined`,
+    );
 
     itThrowsWhenValidating(
       "an object with invalid type for property 'type'",
       {
         type: NOT_A_STRING,
       },
-      `Expected '${DISPLAYED_NAME}.type' to be a string, got a number`,
+      `Expected '${PROPERTY_NAME}.type' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -202,7 +204,7 @@ describe("validatePropertySchemaObject", () => {
         type: "",
         objectType: NOT_A_STRING,
       },
-      `Expected '${DISPLAYED_NAME}.objectType' to be a string, got a number`,
+      `Expected '${PROPERTY_NAME}.objectType' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -211,7 +213,7 @@ describe("validatePropertySchemaObject", () => {
         type: "",
         optional: NOT_A_BOOLEAN,
       },
-      `Expected '${DISPLAYED_NAME}.optional' to be a boolean, got a number`,
+      `Expected '${PROPERTY_NAME}.optional' on '${OBJECT_NAME}' to be a boolean, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -220,7 +222,7 @@ describe("validatePropertySchemaObject", () => {
         type: "",
         property: NOT_A_STRING,
       },
-      `Expected '${DISPLAYED_NAME}.property' to be a string, got a number`,
+      `Expected '${PROPERTY_NAME}.property' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -229,7 +231,7 @@ describe("validatePropertySchemaObject", () => {
         type: "",
         indexed: NOT_A_BOOLEAN,
       },
-      `Expected '${DISPLAYED_NAME}.indexed' to be a boolean, got a number`,
+      `Expected '${PROPERTY_NAME}.indexed' on '${OBJECT_NAME}' to be a boolean, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -238,7 +240,7 @@ describe("validatePropertySchemaObject", () => {
         type: "",
         mapTo: NOT_A_STRING,
       },
-      `Expected '${DISPLAYED_NAME}.mapTo' to be a string, got a number`,
+      `Expected '${PROPERTY_NAME}.mapTo' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(
@@ -249,7 +251,7 @@ describe("validatePropertySchemaObject", () => {
         invalidName2: "",
         invalidName3: "",
       },
-      `Unexpected field(s) found on the schema for property '${DISPLAYED_NAME}': 'invalidName1', 'invalidName2', 'invalidName3'`,
+      `Unexpected field(s) found on the schema for property '${PROPERTY_NAME}' on '${OBJECT_NAME}': 'invalidName1', 'invalidName2', 'invalidName3'`,
     );
   });
 


### PR DESCRIPTION
## What, How & Why?

This makes the integration tests conform to the new parser:
* Expected error messages have been updated.
* Tests that were using now-invalid schemas have been updated.
* The canonical object schema key `ctor` (previously `constructor`) and the canonical property schema key `name` which do not exist on the relaxed representations are no longer treated as invalid keys (even though we expect the relaxed representations). This is due to some integrations tests passing canonical objects.
* A bug with indexed properties was fixed.

Errors not fixed in this PR:
* Flexible-sync related errors.

## ☑️ ToDos
* [x] 🚦 Tests
