### PR TITLE
Revisiting bindgen Metro config (+ re-enabling performance tests)

### DIFF
--- a/integration-tests/environments/react-native/metro.config.js
+++ b/integration-tests/environments/react-native/metro.config.js
@@ -16,13 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-const path = require("path");
 module.exports = require("@realm/metro-config")({
   projectRoot: __dirname,
-  watchFolders: [
-    path.resolve(__dirname, "../../../packages/realm"),
-    path.resolve(__dirname, "../../../node_modules"),
-    path.resolve(__dirname, "../../tests"),
-    path.resolve(__dirname, "../../../packages/realm-app-importer"),
-  ],
 });

--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -31,6 +31,7 @@
     "@realm/app-importer": "*"
   },
   "dependencies": {
+    "@thi.ng/bench": "^3.1.16",
     "@realm/network-transport": "^0.7.2",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -31,4 +31,4 @@ import "./utils/import-app.test";
 import "./utils/chai-plugin.test";
 
 import "./tests";
-//import "./performance-tests";
+import "./performance-tests";

--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -16,104 +16,104 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-// import { Realm } from "realm";
+import { Realm } from "realm";
 
-// import { describePerformance } from "../utils/benchmark";
+import { describePerformance } from "../utils/benchmark";
 
-// type Value = ((realm: Realm) => unknown) | unknown;
+type Value = ((realm: Realm) => unknown) | unknown;
 
-// function getTypeName(type: Realm.PropertyType | Realm.ObjectSchemaProperty) {
-//   if (typeof type === "object") {
-//     if (type.objectType) {
-//       return `${type.type}<${type.objectType}>`;
-//     } else {
-//       return type.type;
-//     }
-//   } else {
-//     return type;
-//   }
-// }
+function getTypeName(type: Realm.PropertyType | Realm.ObjectSchemaProperty) {
+  if (typeof type === "object") {
+    if (type.objectType) {
+      return `${type.type}<${type.objectType}>`;
+    } else {
+      return type.type;
+    }
+  } else {
+    return type;
+  }
+}
 
-// type TestParameters = {
-//   name?: string;
-//   type: Realm.PropertyType | Realm.ObjectSchemaProperty;
-//   value: Value;
-//   schema?: Realm.ObjectSchema[];
-// };
+type TestParameters = {
+  name?: string;
+  type: Realm.PropertyType | Realm.ObjectSchemaProperty;
+  value: Value;
+  schema?: Realm.ObjectSchema[];
+};
 
-// function describeTypeRead({ type, value, schema = [] }: TestParameters) {
-//   const typeName = getTypeName(type);
-//   const objectSchemaName = type + "Class";
-//   const propertyName = type + "Prop";
+function describeTypeRead({ type, value, schema = [] }: TestParameters) {
+  const typeName = getTypeName(type);
+  const objectSchemaName = type + "Class";
+  const propertyName = type + "Prop";
 
-//   const defaultSchema = {
-//     name: objectSchemaName,
-//     properties: {
-//       [propertyName]:
-//         typeof type === "object"
-//           ? type
-//           : {
-//               type,
-//               optional: true,
-//             },
-//     },
-//   };
+  const defaultSchema = {
+    name: objectSchemaName,
+    properties: {
+      [propertyName]:
+        typeof type === "object"
+          ? type
+          : {
+              type,
+              optional: true,
+            },
+    },
+  };
 
-//   describePerformance(`reading property of type '${typeName}'`, {
-//     schema: [defaultSchema, ...schema],
-//     benchmarkTitle: `reads ${type}`,
-//     before(this: Partial<RealmObjectContext> & RealmContext & Mocha.Context) {
-//       this.realm.write(() => {
-//         this.object = this.realm.create(objectSchemaName, {
-//           [propertyName]: typeof value === "function" ? value(this.realm) : value,
-//         });
-//         // Override toJSON to prevent this being serialized by Mocha Remote
-//         Object.defineProperty(this.object, "toJSON", { value: () => ({}) });
-//       });
-//       // Override toJSON to prevent this being serialized by Mocha Remote
-//       Object.defineProperty(this.realm, "toJSON", { value: () => ({}) });
-//     },
-//     test(this: RealmObjectContext) {
-//       const value = this.object[propertyName];
-//       if (typeof value === "undefined") {
-//         // Performing a check to avoid the get of the property to be optimized away
-//         throw new Error("Expected a value");
-//       }
-//     },
-//   });
-// }
+  describePerformance(`reading property of type '${typeName}'`, {
+    schema: [defaultSchema, ...schema],
+    benchmarkTitle: `reads ${type}`,
+    before(this: Partial<RealmObjectContext> & RealmContext & Mocha.Context) {
+      this.realm.write(() => {
+        this.object = this.realm.create(objectSchemaName, {
+          [propertyName]: typeof value === "function" ? value(this.realm) : value,
+        });
+        // Override toJSON to prevent this being serialized by Mocha Remote
+        Object.defineProperty(this.object, "toJSON", { value: () => ({}) });
+      });
+      // Override toJSON to prevent this being serialized by Mocha Remote
+      Object.defineProperty(this.realm, "toJSON", { value: () => ({}) });
+    },
+    test(this: RealmObjectContext) {
+      const value = this.object[propertyName];
+      if (typeof value === "undefined") {
+        // Performing a check to avoid the get of the property to be optimized away
+        throw new Error("Expected a value");
+      }
+    },
+  });
+}
 
-// const cases: Array<TestParameters | [Realm.PropertyType | Realm.ObjectSchemaProperty, Value]> = [
-//   ["bool", true],
-//   ["int", 123],
-//   ["float", 123.456],
-//   ["double", 123.456],
-//   ["string", "Hello!"],
-//   ["decimal128", new Realm.BSON.Decimal128("123")],
-//   ["objectId", new Realm.BSON.ObjectId("0000002a9a7969d24bea4cf4")],
-//   ["uuid", new Realm.BSON.UUID()],
-//   ["date", new Date("2000-01-01")],
-//   ["data", new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])],
-//   {
-//     type: "Car",
-//     schema: [{ name: "Car", properties: { model: "string" } }],
-//     value: (realm: Realm) => realm.create("Car", { model: "VW Touran" }),
-//   },
-//   // List of bool
-//   ["bool[]", []],
-//   // Set of bool
-//   ["bool<>", []],
-//   // Dictionary of bool
-//   ["bool{}", {}],
-// ];
+const cases: Array<TestParameters | [Realm.PropertyType | Realm.ObjectSchemaProperty, Value]> = [
+  ["bool", true],
+  ["int", 123],
+  ["float", 123.456],
+  ["double", 123.456],
+  ["string", "Hello!"],
+  ["decimal128", new Realm.BSON.Decimal128("123")],
+  ["objectId", new Realm.BSON.ObjectId("0000002a9a7969d24bea4cf4")],
+  ["uuid", new Realm.BSON.UUID()],
+  ["date", new Date("2000-01-01")],
+  ["data", new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])],
+  {
+    type: "Car",
+    schema: [{ name: "Car", properties: { model: "string" } }],
+    value: (realm: Realm) => realm.create("Car", { model: "VW Touran" }),
+  },
+  // List of bool
+  ["bool[]", []],
+  // Set of bool
+  ["bool<>", []],
+  // Dictionary of bool
+  ["bool{}", {}],
+];
 
-// describe.skipIf(environment.performance !== true, "Property read performance", () => {
-//   for (const c of cases) {
-//     if (Array.isArray(c)) {
-//       const [type, value] = c;
-//       describeTypeRead({ type, value });
-//     } else {
-//       describeTypeRead(c);
-//     }
-//   }
-// });
+describe.skipIf(environment.performance !== true, "Property read performance", () => {
+  for (const c of cases) {
+    if (Array.isArray(c)) {
+      const [type, value] = c;
+      describeTypeRead({ type, value });
+    } else {
+      describeTypeRead(c);
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@realm/network-transport": "^0.7.2",
+        "@thi.ng/bench": "^3.1.16",
         "chai": "4.3.6",
         "chai-as-promised": "^7.1.1",
         "concurrently": "^6.0.2",
@@ -5851,6 +5852,45 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@thi.ng/api": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@thi.ng/api/-/api-8.6.2.tgz",
+      "integrity": "sha512-+pquJSv0vND7Q9pMHwOjIT+r9sH95vRp0GVggiNtB75bwFxMbJmvCy3iNeZ3XJsVdZYmfdSxUlyA0irmk4EE2A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "engines": {
+        "node": ">=12.7"
+      }
+    },
+    "node_modules/@thi.ng/bench": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@thi.ng/bench/-/bench-3.1.22.tgz",
+      "integrity": "sha512-LmLPLv7fwBDyOMUYrNmErsLrEX/E78TcHv/tuZj0pDGMbuBIrNXH5oWlD5otSNfeF2cXztgPuPMOOvBFo8aSjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/postspectacular"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/thing_umbrella"
+        }
+      ],
+      "dependencies": {
+        "@thi.ng/api": "^8.6.2"
+      },
+      "engines": {
+        "node": ">=12.7"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -19,24 +19,14 @@
 const path = require("path");
 const exclusionList = require("metro-config/src/defaults/exclusionList");
 
-function build({ projectRoot, watchFolders }) {
-  const extraNodeModules = new Proxy(
-    {},
-    {
-      get(target, name) {
-        // We want to resolve to the directory of the package, to let Metro choose the correct "main" field.
-        const resolvedPackage = require.resolve(name + "/package.json");
-        return path.dirname(resolvedPackage);
-      },
-    },
-  );
+const rootDir = path.resolve(__dirname, "../..");
 
+function build({ projectRoot, watchFolders = [] }) {
   return {
     projectRoot,
-    watchFolders,
+    watchFolders: [rootDir, ...watchFolders],
     resolver: {
       blockList: exclusionList(),
-      extraNodeModules,
     },
     transformer: {
       getTransformOptions: async () => ({


### PR DESCRIPTION
## What, How & Why?

This PR reverts part of https://github.com/realm/realm-js/pull/5194 in favour of a simpler Metro config which successfully runs the tests (including the performance tests). We might need to add additional directories to the watch folders or use [the `nodeModulesPaths` option](https://facebook.github.io/metro/docs/configuration/#nodemodulespaths) in the future.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests (manually in combination with other changes on a different branch)
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
