### PR TITLE
Moving platform specific tsconfigs back

### DIFF
--- a/packages/realm/rollup.config.mjs
+++ b/packages/realm/rollup.config.mjs
@@ -39,10 +39,10 @@ export default [
         },
       }),
       typescript({
-        tsconfig: "tsconfig.node.json",
+        tsconfig: "src/node/tsconfig.json",
       }),
     ],
-    external: ["node:module", "node:fs", "undici", "bson", "debug"],
+    external: ["bson", "debug", "node:module", "node:fs", "undici"],
   },
   {
     input: "src/react-native/index.ts",
@@ -53,7 +53,7 @@ export default [
     },
     plugins: [
       typescript({
-        tsconfig: "tsconfig.react-native.json",
+        tsconfig: "src/react-native/tsconfig.json",
       }),
     ],
     external: ["bson", "debug"],

--- a/packages/realm/src/node/tsconfig.json
+++ b/packages/realm/src/node/tsconfig.json
@@ -1,13 +1,13 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
     "noResolve": false,
     "incremental": true
   },
   "exclude": [
-    "src/tests/",
-    "type-tests/",
-    "src/react-native/"
+    "../tests/",
+    "../react-native/",
+    "../../type-tests/"
   ],
 }

--- a/packages/realm/src/react-native/tsconfig.json
+++ b/packages/realm/src/react-native/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noResolve": false,
     "incremental": true
   },
   "exclude": [
-    "src/tests/",
-    "type-tests/",
-    "src/node/"
+    "../tests/",
+    "../node/",
+    "../../type-tests/"
   ],
 }

--- a/packages/realm/src/tests/tsconfig.json
+++ b/packages/realm/src/tests/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noResolve": false,
-    "hhehhe": "fkjdf",
     "strictFunctionTypes": false,
     "types": [
       "mocha",


### PR DESCRIPTION
## What, How & Why?

This reverts part of https://github.com/realm/realm-js/commit/1da003797eab048767d9c35a9e5199c165456b9c, moving the platform specific tsconfigs into their respective sub-directories. 

As discussed in-person: In general I agree that configs should be top-level, but having them here will help us signal to VSCode which runtime APIs are available for use by the source files in the platform specific directories.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
