### PR TITLE
Bindgen RN fetch implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7048,42 +7048,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
-      "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.70.8",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.8.tgz",
-      "integrity": "sha512-jvs5QMOrlyi0ScfT5Brha2roDoOWtbIOadNkp0jsueVen5+pH4SQAYtzL6xu0+dIcx3J/5LtZ/JYby2C1/zUug==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -9099,12 +9067,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
@@ -21394,9 +21356,9 @@
         "@types/chai": "^4.3.3",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.9",
-        "@types/react-native": "^0.70.8",
         "chai": "^4.3.6",
         "mocha": "^10.1.0",
+        "react-native": "^0.71.0-rc.5",
         "rollup-plugin-dts": "^5.0.0",
         "tsm": "^2.2.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7048,10 +7048,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
+      "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-native": {
+      "version": "0.70.8",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.8.tgz",
+      "integrity": "sha512-jvs5QMOrlyi0ScfT5Brha2roDoOWtbIOadNkp0jsueVen5+pH4SQAYtzL6xu0+dIcx3J/5LtZ/JYby2C1/zUug==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -9067,6 +9099,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
@@ -21356,6 +21394,7 @@
         "@types/chai": "^4.3.3",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.9",
+        "@types/react-native": "^0.70.8",
         "chai": "^4.3.6",
         "mocha": "^10.1.0",
         "rollup-plugin-dts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21363,7 +21363,13 @@
         "tsm": "^2.2.2"
       },
       "peerDependencies": {
-        "bson": "^4"
+        "bson": "^4",
+        "react-native": "^0.70.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "packages/realm-app-importer": {

--- a/packages/bindgen/CMakeLists.txt
+++ b/packages/bindgen/CMakeLists.txt
@@ -158,7 +158,7 @@ set(GENERATED_JS_FILES
 
 add_custom_command(
     OUTPUT ${SCHEMA_FILE}
-    COMMAND ${NODE_FORCE_COLOR} npx typescript-json-schema ${CMAKE_CURRENT_SOURCE_DIR}/src/spec/relaxed-model.ts RelaxedSpec --out ${SCHEMA_FILE} --required --noExtraProps --aliasRefs
+    COMMAND ${NODE_FORCE_COLOR} npx typescript-json-schema ${CMAKE_CURRENT_SOURCE_DIR}/tsconfig.json RelaxedSpec --include ${CMAKE_CURRENT_SOURCE_DIR}/src/spec/relaxed-model.ts --out ${SCHEMA_FILE} --required --noExtraProps --aliasRefs
     VERBATIM
     MAIN_DEPENDENCY src/spec/relaxed-model.ts
     DEPENDS

--- a/packages/bindgen/package.json
+++ b/packages/bindgen/package.json
@@ -11,8 +11,9 @@
   "scripts": {
     "start": "./realm-bindgen.ts",
     "test": "mocha",
-    "generate:spec-schema": "typescript-json-schema src/spec/relaxed-model.ts RelaxedSpec --out generated/spec.schema.json --required",
-    "build": "cmake-js compile --debug"
+    "generate:spec-schema": "typescript-json-schema tsconfig.json RelaxedSpec --include src/spec/relaxed-model.ts --out generated/spec.schema.json --required",
+    "build": "cmake-js build --debug",
+    "rebuild": "cmake-js rebuild --debug"
   },
   "dependencies": {
     "@types/node": "^18.11.9",

--- a/packages/bindgen/src/templates/typescript.ts
+++ b/packages/bindgen/src/templates/typescript.ts
@@ -22,6 +22,21 @@ import { strict as assert } from "assert";
 
 import { doJsPasses } from "../js-passes";
 
+import { addFormatter } from "../formatter";
+
+// Ideally, this would be codified in a tsconfig.json, but tsc doesn't support
+// configs mixed with filenames when invoked via the CLI.
+addFormatter("typescript-checker", [
+  "npx",
+  "tsc",
+  "--noEmit",
+  "--noResolve",
+  "--lib",
+  "es2022",
+  "--types",
+  "buffer,bson",
+]);
+
 const PRIMITIVES_MAPPING: Record<string, string> = {
   void: "void",
   bool: "boolean",
@@ -43,7 +58,7 @@ const PRIMITIVES_MAPPING: Record<string, string> = {
   AppError: "AppError",
   "std::exception_ptr": "Error",
   "std::error_code": "CppErrorCode",
-  "Status": "Error", // We don't currently expose the code.
+  Status: "Error", // We don't currently expose the code.
   EJson: "EJson",
   EJsonArray: "EJson[]",
   EJsonObj: "Record<string, EJson>",

--- a/packages/bindgen/tsconfig.json
+++ b/packages/bindgen/tsconfig.json
@@ -6,5 +6,8 @@
     "moduleResolution": "node",
     "noEmit": true,
     "esModuleInterop": true
-  }
+  },
+  "include": [
+    "src/"
+  ]
 }

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -31,9 +31,9 @@
     "@types/chai": "^4.3.3",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
-    "@types/react-native": "^0.70.8",
     "chai": "^4.3.6",
     "mocha": "^10.1.0",
+    "react-native": "^0.71.0-rc.5",
     "rollup-plugin-dts": "^5.0.0",
     "tsm": "^2.2.2"
   },

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -20,7 +20,13 @@
     "debug": "^4.3.4"
   },
   "peerDependencies": {
-    "bson": "^4"
+    "bson": "^4",
+    "react-native": "^0.70.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@realm/bindgen": "^0.1.0",

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -31,6 +31,7 @@
     "@types/chai": "^4.3.3",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
+    "@types/react-native": "^0.70.8",
     "chai": "^4.3.6",
     "mocha": "^10.1.0",
     "rollup-plugin-dts": "^5.0.0",

--- a/packages/realm/src/react-native/tsconfig.json
+++ b/packages/realm/src/react-native/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noResolve": false,
-    "incremental": true
+    "incremental": true,
+    "types": [
+      "react-native"
+    ]
   },
   "exclude": [
     "../tests/",


### PR DESCRIPTION
## What, How & Why?

This adds the network implementation on top of `fetch` provided by `react-native` at runtime.

I had to refactor the bindgen's typescript template, because its TS formatter was freaking out about duplicate globals (due to `react-native/types` conflicting with `@types/react-native` which pointed to the fact that we were not compiling in proper isolation).

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
