### PR TITLE
Fixing creation of named constuctors

### DIFF
--- a/packages/realm/src/ClassMap.ts
+++ b/packages/realm/src/ClassMap.ts
@@ -44,12 +44,12 @@ export class ClassMap {
   private nameByTableKey: Record<binding.TableKey, string>;
 
   private static createNamedConstructor<T extends Constructor>(name: string): T {
-    const obj = {
-      [name]: function () {
-        /* no-op */
-      },
+    const result = function () {
+      /* no-op */
     };
-    return obj[name] as unknown as T;
+    // Need to use `defineProperty` since it isn't writable
+    Object.defineProperty(result, "name", { value: name });
+    return result as unknown as T;
   }
 
   private static createClass<T extends RealmObjectConstructor = RealmObjectConstructor>(


### PR DESCRIPTION
## What, How & Why?

This fixes a "Hermes only" issue, where the name of a function implemented on a computed property of an object, got the empty string as `name`.

Note: I want to upstream an issue and patch for this, but found this workaround which honestly feels more clean than the original code did to me.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
