### PR TITLE
Stabilized References for Collections, Lists and Objects

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -4,8 +4,7 @@
 * Improve AppProvider and UserProvider rendering performance ([#5215](https://github.com/realm/realm-js/pull/5215))
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Stabilized references for Collections, Lists and Objects ([#5269](https://github.com/realm/realm-js/issues/5269))
 
 ### Compatibility
 * React Native >= v0.70.0

--- a/packages/realm-react/src/cachedCollection.ts
+++ b/packages/realm-react/src/cachedCollection.ts
@@ -39,6 +39,14 @@ type CachedCollectionArgs<T> = {
    * Callback which is called whenever an object in the collection changes
    */
   updateCallback: () => void;
+
+  /**
+   * Reference boolean which is set to true whenever an object in the collection changes
+   * It is used to determine if the collection's object reference should be updated
+   * The implementing component should reset this to false when updating its object reference
+   */
+  updatedRef: React.MutableRefObject<boolean>;
+
   /**
    * Optional Map to be used as the cache. This is used to allow a `sorted` or `filtered`
    * (derived) version of the collection to reuse the same cache, preventing excess new object
@@ -69,6 +77,7 @@ export function createCachedCollection<T extends Realm.Object>({
   collection,
   realm,
   updateCallback,
+  updatedRef,
   objectCache = new Map(),
   isDerived = false,
 }: CachedCollectionArgs<T>): { collection: Realm.Collection<T>; tearDown: () => void } {
@@ -84,6 +93,7 @@ export function createCachedCollection<T extends Realm.Object>({
               collection: col,
               realm,
               updateCallback,
+              updatedRef,
               objectCache,
               isDerived: true,
             });
@@ -158,7 +168,7 @@ export function createCachedCollection<T extends Realm.Object>({
           }
         }
       });
-
+      updatedRef.current = true;
       updateCallback();
     }
   };


### PR DESCRIPTION
* Only update the returned references if a relevant changes occurs
* This fix will work for:
  * Collections returned from `useQuery`
  * Collections returned from object.list
  * Object references returned from `useObject`

This closes #5264

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
