### PR TITLE
Update Build Xcode to 13.4.1

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -27,9 +27,9 @@ jobs:
           - { os: android, runner: ubuntu-latest, arch: armeabi-v7a, artifact-path: react-native/android/src/main/jniLibs }
           - { os: android, runner: ubuntu-latest, arch: arm64-v8a, artifact-path: react-native/android/src/main/jniLibs }
           - { os: android, runner: ubuntu-latest, arch: x86, artifact-path: react-native/android/src/main/jniLibs }
-          - { os: darwin, runner: macos-11, arch: x64, artifact-path: prebuilds, test-node: true, test-electron: true }
-          - { os: darwin, runner: macos-11, arch: arm64, artifact-path: prebuilds, test-node: true, test-electron: true }
-          - { os: ios, runner: macos-11, arch: apple, artifact-path: react-native/ios/realm-js-ios.xcframework }
+          - { os: darwin, runner: macos-latest, arch: x64, artifact-path: prebuilds, test-node: true, test-electron: true }
+          - { os: darwin, runner: macos-latest, arch: arm64, artifact-path: prebuilds, test-node: true, test-electron: true }
+          - { os: ios, runner: macos-latest, arch: apple, artifact-path: react-native/ios/realm-js-ios.xcframework }
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -196,7 +196,7 @@ jobs:
       MOCHA_REMOTE_EXIT_ON_ERROR: true
       SPAWN_LOGCAT: true
       # Pin the Xcode version
-      DEVELOPER_DIR: /Applications/Xcode_13.1.app
+      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
     runs-on: ${{ matrix.variant.runner }}
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * File format: generates Realms with format v23 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
+* Unpin Xcode version when building locally and upgrade the Xcode version used by GHA.
 * Enable tests for notifications on dictionary.
 <!-- * Either mention core version or upgrade -->
 <!-- * Using Realm Core vX.Y.Z -->

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -42,8 +42,8 @@
 
 The following dependencies are required. All except Xcode can be installed by following the [setup instructions for MacOS section](#setup-instructions-for-macos).
 
-- [Xcode](https://developer.apple.com/xcode/) 13+ with Xcode command line tools installed
-  - Newer versions may work, but 13.1 is the current recommended version, which can be downloaded from [Apple](https://developer.apple.com/download/all/?q=xcode%2013.1). To install older Xcode versions, [Xcodes.app](https://github.com/RobotsAndPencils/XcodesApp) is highly recommended
+- [Xcode](https://developer.apple.com/xcode/) latest Xcode with command line tools installed
+  - The latest Xcode should work, which can be downloaded from [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12). To install older Xcode versions, [Xcodes.app](https://github.com/RobotsAndPencils/XcodesApp) is highly recommended
 - [Node.js](https://nodejs.org/en/) version 13 or later
   - Consider [using NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to enable fast switching between Node.js & NPM versions
 - [CMake](https://cmake.org/) 3.21.4 or later

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -87,12 +87,16 @@ pushd react-native/ios
 mkdir -p build
 pushd build
 
+# If the developer directory is not set, use the default Xcode path
+SELECTED_DEVELOPER_DIR="$(xcode-select -p)"
+DEVELOPER_DIR="${DEVELOPER_DIR:-${SELECTED_DEVELOPER_DIR}}"
+
 # Configure CMake project
-SDKROOT="${SDK_ROOT_OVERRIDE:-/Applications/Xcode_13.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/}" cmake "$PROJECT_ROOT" -GXcode \
+SDKROOT="$DEVELOPER_DIR/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/" cmake "$PROJECT_ROOT" -GXcode \
     -DCMAKE_TOOLCHAIN_FILE="$PROJECT_ROOT/vendor/realm-core/tools/cmake/xcode.toolchain.cmake" \
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="$(pwd)/out/$<CONFIG>\$EFFECTIVE_PLATFORM_NAME" \
 
-DEVELOPER_DIR="${DEVELOPER_DIR_OVERRIDE:-/Applications/Xcode_13.1.app}" xcodebuild build \
+DEVELOPER_DIR="$DEVELOPER_DIR" xcodebuild build \
     -scheme realm-js-ios \
     "${DESTINATIONS[@]}" \
     -configuration $CONFIGURATION \


### PR DESCRIPTION
## What, How & Why?
The core minimum version has update to 13.4.1 and GHA was pinned to an older version.  This will pin Xcode to this version for GHA.
I have also set the build script to just point to the Xcode that is installed on the developers machine.  This can be overriden with the "DEVELOPER_DIR" env, which CI is currently using.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
