### PR TITLE
Run pod-install in the PR workflow for IOS only

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -311,6 +311,11 @@ jobs:
       - name: Bootstrap lerna sub-packages
         run: npx lerna bootstrap --scope @realm/${{ matrix.variant.environment }}-tests --include-dependencies
 
+      - name: Install pods
+        if: ${{ matrix.variant.environment == 'react-native' && matrix.variant.os == 'ios'}}
+        working-directory: integration-tests/environments/${{ matrix.variant.environment }}
+        run: npx pod-install
+
       - name: Build tests
         run: npm run build --prefix integration-tests/tests
 

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -21,8 +21,7 @@
     "common": "mocha-remote --template @realm/mocha-reporter --context mode=$MODE,appImporterIsRemote,$MOCHA_REMOTE_CONTEXT --watch $WATCH -- concurrently --kill-others-on-fail npm:metro npm:runner npm:app-importer",
     "app-importer": "realm-app-importer serve ../../realm-apps",
     "metro": "react-native start --reset-cache",
-    "runner": "node harness/runner.js",
-    "prepare": "pod-install"
+    "runner": "node harness/runner.js"
   },
   "dependencies": {
     "@react-native-community/art": "^1.2.0",


### PR DESCRIPTION
lerna was calling the prepare script on both IOS and Android which then wasted time installing pods on Android.