### PR TITLE
New Cluster Deployment Strategy

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -182,10 +182,48 @@ jobs:
           path: |
             dependencies.list
             ${{ matrix.variant.artifact-path }}
+  cluster-prep:
+    name: Prepare Clusters for Integration Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { key: linux-node }
+          - { key: linux-electron-main }
+          - { key: linux-electron-render }
+          #- { key: windows-node }
+          #- { key: windows-electron-main }
+          #- { key: windows-electron-render }
+          - { key: darwin-electron-main }
+          - { key: darwin-electron-render }
+          - { key: darwin-node }
+          - { key: android-rn }
+          - { key: ios-rn }
+          #- { key: ios-rn-catalyst }
+    steps:
+    - name: Deploy Cluster for ${{ matrix.variant.key }}
+      uses: realm/ci-actions/mdb-realm/deployApps@fac1d6958f03d71de743305ce3ab27594efbe7b7
+      id: deploy-mdb-apps
+      with:
+        realmUrl: ${{ secrets.REALM_QA_BASE_URL }}
+        projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
+        atlasUrl: ${{ secrets.ATLAS_QA_BASE_URL}}
+        apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+        privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
+        differentiator: ${{ matrix.variant.key }}-${{ github.run_id }}
+    - name: Save Cluster Name to File
+      run: |
+          echo ${{ steps.deploy-mdb-apps.outputs.clusterName }} > cluster-name.txt
+    - name: Save Cluster Name
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{matrix.variant.key}}-cluster-name
+        path: cluster-name.txt
 
   integration-tests:
     name: Integration tests (${{matrix.variant.target}}) for ${{ matrix.variant.environment }} on ${{ matrix.variant.os }}
-    needs: [build]
+    needs: [build, cluster-prep]
     env:
       REALM_DISABLE_ANALYTICS: 1
       MOCHA_REMOTE_TIMEOUT: 60000
@@ -202,33 +240,28 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - { os: linux, target: test, runner: ubuntu-latest, environment: node }
-          - { os: linux, target: "test:main", runner: ubuntu-latest, environment: electron }
-          - { os: linux, target: "test:renderer", runner: ubuntu-latest, environment: electron }
-          #- { os: windows, target: test, runner: windows-latest, environment: node}
-          #- { os: windows, target: "test:main", runner: windows-latest, environment: electron }
-          #- { os: windows, target: "test:renderer", runner: windows-latest, environment: electron }
-          - { os: darwin, target: "test:main", runner: macos-latest, environment: electron }
-          - { os: darwin, target: "test:renderer", runner: macos-latest, environment: electron }
-          - { os: darwin, target: test, runner: macos-latest, environment: node }
-          - { os: android, target: "test:android", runner: macos-latest, environment: react-native, arch: "armeabi-v7a" }
-          - { os: ios, target: "test:ios", runner: macos-latest, environment: react-native, arch: "apple" }
-          #- { os: ios, target: "test:catalyst", runner: macos-latest, environment: react-native, arch: "apple" }
+          - { key: linux-node, os: linux, target: test, runner: ubuntu-latest, environment: node }
+          - { key: linux-electron-main, os: linux, target: "test:main", runner: ubuntu-latest, environment: electron }
+          - { key: linux-electron-render, os: linux, target: "test:renderer", runner: ubuntu-latest, environment: electron }
+          #- { key: windows-node, os: windows, target: test, runner: windows-latest, environment: node}
+          #- { key: windows-electron-main, os: windows, target: "test:main", runner: windows-latest, environment: electron }
+          #- { key: windows-electron-render, os: windows, target: "test:renderer", runner: windows-latest, environment: electron }
+          - { key: darwin-electron-main, os: darwin, target: "test:main", runner: macos-latest, environment: electron }
+          - { key: darwin-electron-render, os: darwin, target: "test:renderer", runner: macos-latest, environment: electron }
+          - { key: darwin-node, os: darwin, target: test, runner: macos-latest, environment: node }
+          - { key: android-rn, os: android, target: "test:android", runner: macos-latest, environment: react-native, arch: "armeabi-v7a" }
+          - { key: ios-rn, os: ios, target: "test:ios", runner: macos-latest, environment: react-native, arch: "apple" }
+          #- { key: ios-rn-catalyst, os: ios, target: "test:catalyst", runner: macos-latest, environment: react-native, arch: "apple" }
     timeout-minutes: 60
     steps:
-      - name: Generate Cluster Differentiator
-        id: differentiator
-        run: echo "::set-output name=name::${{matrix.variant.os}}-${{matrix.variant.target}}-${{matrix.variant.environment}}-${{env.GITHUB_RUN_ATTEMPT}}"
-
-      - uses: realm/ci-actions/mdb-realm/deployApps@fac1d6958f03d71de743305ce3ab27594efbe7b7
-        id: deploy-mdb-apps
+      - name: Save Cluster Name to File
+        uses: actions/download-artifact@v3
         with:
-          realmUrl: ${{ secrets.REALM_QA_BASE_URL }}
-          projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
-          atlasUrl: ${{ secrets.ATLAS_QA_BASE_URL}}
-          apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
-          privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
-          differentiator: ${{ steps.differentiator.outputs.name }}
+          name: ${{matrix.variant.key}}-cluster-name
+
+      - name: Save Cluster Name to Environment Variable
+        run: |
+          echo "CLUSTER_NAME=$(cat cluster-name.txt)" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -325,7 +358,7 @@ jobs:
 
       - name: Create Mocha Env
         id: mocha-env
-        run: echo "::set-output name=name::syncLogLevel=warn,realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ steps.deploy-mdb-apps.outputs.clusterName }},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}"
+        run: echo "::set-output name=name::syncLogLevel=warn,realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ env.CLUSTER_NAME}},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}"
 
       - name: Run ${{matrix.variant.target}} (${{ matrix.variant.os}} / ${{ matrix.variant.environment }})
         if: ${{ (matrix.variant.os != 'android') && (matrix.variant.os != 'ios') }}
@@ -385,12 +418,34 @@ jobs:
           cmake: 3.22.1
           script: npm run ${{ matrix.variant.target}} --prefix integration-tests/environments/${{ matrix.variant.environment }}
 
-      - uses: realm/ci-actions/mdb-realm/cleanup@800a0234bcbe9073e7a07a66c864d54db3688e56
-        if: ${{always()}}
-        with:
-          realmUrl: ${{ secrets.REALM_QA_BASE_URL }}
-          atlasUrl: ${{ secrets.ATLAS_QA_BASE_URL}}
-          projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
-          apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
-          privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
-          differentiator: ${{ steps.differentiator.outputs.name }}
+
+  cluster-cleanup:
+    name: Cleanup Clusters
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { key: linux-node }
+          - { key: linux-electron-main }
+          - { key: linux-electron-render }
+          #- { key: windows-node }
+          #- { key: windows-electron-main }
+          #- { key: windows-electron-render }
+          - { key: darwin-electron-main }
+          - { key: darwin-electron-render }
+          - { key: darwin-node }
+          - { key: android-rn }
+          - { key: ios-rn }
+          #- { key: ios-rn-catalyst }
+    steps:
+    - uses: realm/ci-actions/mdb-realm/cleanup@800a0234bcbe9073e7a07a66c864d54db3688e56
+      if: ${{always()}}
+      with:
+        realmUrl: ${{ secrets.REALM_QA_BASE_URL }}
+        atlasUrl: ${{ secrets.ATLAS_QA_BASE_URL}}
+        projectId: ${{ secrets.ATLAS_QA_PROJECT_ID }}
+        apiKey: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+        privateApiKey: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
+        differentiator: ${{ matrix.variant.key }}-${{ github.run_id }}


### PR DESCRIPTION
## What, How & Why?
We suspect that the amount of time a cluster deployment needs to settle is greater than the time it takes to setup an integration tests.  This change prepares the cluster deployments ahead of time for each integration tests during the build phase.  

If this works, it may not be the solution we want to merge, but it could be an insight into how reliable clusters are after deployment.  If we do merge this, we should refactor to share the matrix between the three jobs (cluster-prep, integration-tests, cluster-cleanup) in order to keep the workflow maintainable.


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
