### PR TITLE
Cleanup Clusters and Apps every night

### DIFF
--- a/.github/workflows/cleanup-clusters.yml
+++ b/.github/workflows/cleanup-clusters.yml
@@ -1,6 +1,8 @@
-name: Wipe all clusters and apps on dev
+name: Wipe all clusters and apps
 
 on:
+  schedule:
+    - cron: "0 6 * * *"
   workflow_dispatch:
 jobs:
   main:

--- a/.github/workflows/cleanup-clusters.yml
+++ b/.github/workflows/cleanup-clusters.yml
@@ -2,14 +2,14 @@ name: Wipe all clusters and apps
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
 jobs:
   main:
     runs-on: ubuntu-latest
     name: Wipe all clusters and apps on dev
     steps:
-    - uses: realm/ci-actions/mdb-realm/deleteAllClusters@3d95b9f473d06ef0f56e1a5d8c5981743dc4fed9
+    - uses: realm/ci-actions/mdb-realm/deleteAllClusters@e7b65d7d587e1abc358968d7ff816cc0163906d2
       name: "on realm.dev"
       with:
         realmUrl: ${{ secrets.REALM_BASE_URL }}
@@ -17,7 +17,7 @@ jobs:
         projectId: ${{ secrets.ATLAS_PROJECT_ID }}
         apiKey: ${{ secrets.ATLAS_PUBLIC_API_KEY }}
         privateApiKey: ${{ secrets.ATLAS_PRIVATE_API_KEY }}
-    - uses: realm/ci-actions/mdb-realm/deleteAllClusters@3d95b9f473d06ef0f56e1a5d8c5981743dc4fed9
+    - uses: realm/ci-actions/mdb-realm/deleteAllClusters@e7b65d7d587e1abc358968d7ff816cc0163906d2
       name: "on realm.qa"
       with:
         realmUrl: ${{ secrets.REALM_QA_BASE_URL }}


### PR DESCRIPTION
## What, How & Why?
Currently this was only a manual workflow.  We should just run this every night.  Alternatively, we should find out why we end up having so many apps deployed that never get cleaned up after their tests. (Probably due to test failures)

I also updated the cleanup task.  This was very outdated and slow, since it was using the realm-cli to delete apps rather than fetch.  This should now be much faster.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
