### PR TITLE
use correct baseurl for tests

### DIFF
--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -20,6 +20,7 @@ import { ObjectId } from "bson";
 import { expect } from "chai";
 import { importAppBefore } from "../../hooks";
 import { generatePartition } from "../../utils/generators";
+import { getUrls } from "../../utils/import-app";
 
 const TestObjectSchema: Realm.ObjectSchema = {
   name: "TestObject",
@@ -73,7 +74,8 @@ describe("App", () => {
     afterEach(async () => {
       Realm.clearTestState();
     });
-    const conf = { id: "smurf", baseUrl: "http://localhost:9090" };
+    const urls = getUrls();
+    const conf = { id: "smurf", baseUrl: urls.baseUrl };
 
     it("from config", () => {
       const app = new Realm.App(conf);
@@ -97,8 +99,8 @@ describe("App", () => {
     });
 
     it("throws on invalid baseURL", async function () {
-      const invalid_url_conf = { id: "smurf", baseUrl: "http://localhost:9999" };
-      const app = new Realm.App(invalid_url_conf);
+      const invalidUrlConf = { id: conf.id, baseUrl: "http://localhost:9999" };
+      const app = new Realm.App(invalidUrlConf);
 
       const credentials = Realm.Credentials.anonymous();
       await expect(app.logIn(credentials)).to.be.rejectedWith(

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -74,18 +74,20 @@ describe("App", () => {
     afterEach(async () => {
       Realm.clearTestState();
     });
-    const urls = getUrls();
-    const conf = { id: "smurf", baseUrl: urls.baseUrl };
+    const { baseUrl } = getUrls();
+    const missingAppConfig = { id: "smurf", baseUrl: baseUrl };
 
     it("from config", () => {
-      const app = new Realm.App(conf);
+      //even if "id" is not an existing app we can still instantiate a new Realm.
+      const app = new Realm.App(missingAppConfig);
       expect(app).instanceOf(Realm.App);
     });
 
     it("from string", () => {
-      const app = new Realm.App(conf.id);
+      //even if "id" is not an existing app we can still instantiate a new Realm.
+      const app = new Realm.App(missingAppConfig.id);
       expect(app).instanceOf(Realm.App);
-      expect(app.id).equals(conf.id);
+      expect(app.id).equals(missingAppConfig.id);
     });
 
     it("throws on undefined app", function () {
@@ -98,8 +100,8 @@ describe("App", () => {
       expect(() => new Realm.App(1234)).throws(Error, "Expected either a configuration object or an app id string.");
     });
 
-    it("throws on invalid baseURL", async function () {
-      const invalidUrlConf = { id: conf.id, baseUrl: "http://localhost:9999" };
+    it("logging in throws on invalid baseURL", async function () {
+      const invalidUrlConf = { id: missingAppConfig.id, baseUrl: "http://localhost:9999" };
       const app = new Realm.App(invalidUrlConf);
 
       const credentials = Realm.Credentials.anonymous();
@@ -108,8 +110,8 @@ describe("App", () => {
       );
     });
 
-    it("throws on non existing app", async function () {
-      const app = new Realm.App(conf);
+    it("logging in throws on non existing app", async function () {
+      const app = new Realm.App(missingAppConfig);
       const credentials = Realm.Credentials.anonymous();
       await expect(app.logIn(credentials)).to.be.rejectedWith("cannot find app using Client App ID 'smurf'");
     });

--- a/integration-tests/tests/src/utils/import-app.ts
+++ b/integration-tests/tests/src/utils/import-app.ts
@@ -25,7 +25,7 @@ export type ErrorResponse = { message: string; appId: never };
 export type ImportResponse = { appId: string; message: never };
 export type Response = ImportResponse | ErrorResponse;
 
-function getUrls() {
+export function getUrls() {
   // Try reading the app importer URL out of the environment, it might not be accessiable via localhost
   const { appImporterUrl, realmBaseUrl } = environment;
   return {

--- a/integration-tests/tests/src/utils/import-app.ts
+++ b/integration-tests/tests/src/utils/import-app.ts
@@ -25,6 +25,7 @@ export type ErrorResponse = { message: string; appId: never };
 export type ImportResponse = { appId: string; message: never };
 export type Response = ImportResponse | ErrorResponse;
 
+//TODO should be moved to a separate file as it doesn't directly have anything to do with importing an app.
 export function getUrls() {
   // Try reading the app importer URL out of the environment, it might not be accessiable via localhost
   const { appImporterUrl, realmBaseUrl } = environment;

--- a/tests/js/object-tests.js
+++ b/tests/js/object-tests.js
@@ -421,7 +421,7 @@ module.exports = {
   },
 
   testObjectIsValid: function () {
-    const realm = new Realm({ schema: [schemas.TestObject] });
+    const realm = new realm({ schema: [schemas.testobject] });
     var obj;
     realm.write(function () {
       obj = realm.create("TestObject", { doubleCol: 1 });


### PR DESCRIPTION
test `throws on non existing app` failed because I used a hardcoded url in the config which worked locally but not in the CI