### PR TITLE
Create Default Provider and Hooks for `@realm/react`

### DIFF
--- a/example/app/AppNonSync.tsx
+++ b/example/app/AppNonSync.tsx
@@ -1,10 +1,9 @@
 import React, {useMemo} from 'react';
 
 import {Task} from './models/Task';
-import {TaskRealmContext} from './models';
 import {TaskManager} from './components/TaskManager';
 
-const {useQuery} = TaskRealmContext;
+import {useQuery} from '@realm/react';
 
 export const AppNonSync = () => {
   const result = useQuery(Task);

--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -3,14 +3,13 @@ import {useApp, useUser} from '@realm/react';
 import {Pressable, StyleSheet, Text} from 'react-native';
 
 import {Task} from './models/Task';
-import {TaskRealmContext} from './models';
 import {TaskManager} from './components/TaskManager';
 import {buttonStyles} from './styles/button';
 import {shadows} from './styles/shadows';
 import colors from './styles/colors';
 import {OfflineModeButton} from './components/OfflineModeButton';
 
-const {useRealm, useQuery} = TaskRealmContext;
+import {useRealm, useQuery} from '@realm/react';
 
 export const AppSync: React.FC = () => {
   const realm = useRealm();

--- a/example/app/AppWrapperNonSync.tsx
+++ b/example/app/AppWrapperNonSync.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import {SafeAreaView, StyleSheet} from 'react-native';
 
-import {TaskRealmContext} from './models';
 import colors from './styles/colors';
 import {AppNonSync} from './AppNonSync';
 
-export const AppWrapperNonSync = () => {
-  const {RealmProvider} = TaskRealmContext;
+import {RealmProvider} from '@realm/react';
+import {schemas} from './models';
 
+export const AppWrapperNonSync = () => {
   // If sync is disabled, setup the app without any sync functionality and return early
   return (
     <SafeAreaView style={styles.screen}>
-      <RealmProvider>
+      <RealmProvider schema={schemas}>
         <AppNonSync />
       </RealmProvider>
     </SafeAreaView>

--- a/example/app/AppWrapperSync.tsx
+++ b/example/app/AppWrapperSync.tsx
@@ -2,26 +2,24 @@ import React from 'react';
 import {AppProvider, UserProvider} from '@realm/react';
 import {SafeAreaView, StyleSheet} from 'react-native';
 
-import {TaskRealmContext} from './models';
+import {schemas} from './models';
 import {LoginScreen} from './components/LoginScreen';
 import colors from './styles/colors';
 import {AppSync} from './AppSync';
 
+import {RealmProvider} from '@realm/react';
+
 export const AppWrapperSync: React.FC<{
   appId: string;
 }> = ({appId}) => {
-  const {RealmProvider} = TaskRealmContext;
-
   // If we are logged in, add the sync configuration the the RealmProvider and render the app
   return (
     <SafeAreaView style={styles.screen}>
       <AppProvider id={appId}>
         <UserProvider fallback={<LoginScreen />}>
           <RealmProvider
-            sync={{
-              flexible: true,
-              onError: error => console.error(error),
-            }}>
+            schema={schemas}
+            sync={{flexible: true, onError: error => console.error(error)}}>
             <AppSync />
           </RealmProvider>
         </UserProvider>

--- a/example/app/components/OfflineModeButton.tsx
+++ b/example/app/components/OfflineModeButton.tsx
@@ -1,8 +1,6 @@
 import React, {useState} from 'react';
 import {StyleSheet, Switch, Text, View} from 'react-native';
-import {TaskRealmContext} from '../models';
-
-const {useRealm} = TaskRealmContext;
+import {useRealm} from '@realm/react';
 
 export function OfflineModeButton() {
   const realm = useRealm();

--- a/example/app/components/TaskManager.tsx
+++ b/example/app/components/TaskManager.tsx
@@ -2,12 +2,11 @@ import React, {useCallback} from 'react';
 import {View, StyleSheet} from 'react-native';
 
 import {Task} from '../models/Task';
-import {TaskRealmContext} from '../models';
 import {IntroText} from './IntroText';
 import {AddTaskForm} from './AddTaskForm';
 import TaskList from './TaskList';
 
-const {useRealm} = TaskRealmContext;
+import {useRealm} from '@realm/react';
 
 export const TaskManager: React.FC<{
   tasks: Realm.Results<Task & Realm.Object>;

--- a/example/app/models/index.ts
+++ b/example/app/models/index.ts
@@ -1,6 +1,3 @@
-import {createRealmContext} from '@realm/react';
 import {Task} from './Task';
 
-export const TaskRealmContext = createRealmContext({
-  schema: [Task],
-});
+export const schemas = [Task];

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,7 +1,24 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Create a default context so the `RealmProvider`, `useQuery`, `useRealm`, and `useObject` can be directly imported from `@realm/react` ([#5292](https://github.com/realm/realm-js/issue/5292))
+  Usage example:
+```tsx
+// These imports are now available without calling `createRealmContext`
+import {RealmProvider, useQuery} from '@realm/react'
+//...
+// Provider your schema models directly to the realm provider
+<RealmProvider schema={[Item]}>
+	<SomeComponent/>
+</RealmProvider>
+
+const SomeComponent = () => {
+	const items = useQuery(Item)
+
+	//...
+}
+```
+>NOTE: If your app is using multiple Realms, then you should continue using `createRealmContext`
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
@@ -89,7 +106,7 @@
 
 ### Enhancements
 
-- Add UserProvider and useUser hook ([#4557](https://github.com/realm/realm-js/pull/4557)). Usage example:
+* Add UserProvider and useUser hook ([#4557](https://github.com/realm/realm-js/pull/4557)). Usage example:
 
 ```
 import {AppProvider, UserProvider} from '@realm/react'
@@ -114,7 +131,7 @@ const SomeComponent = () => {
 }
 ```
 
-- Add AppProvider and useApp hook ([#4470](https://github.com/realm/realm-js/pull/4470)). Usage example:
+* Add AppProvider and useApp hook ([#4470](https://github.com/realm/realm-js/pull/4470)). Usage example:
 
 ```
 import {AppProvider} from '@realm/react'
@@ -138,50 +155,50 @@ const SomeComponent = () => {
 
 ### Fixed
 
-- Implicit children [was removed from `React.FC`](https://solverfox.dev/writing/no-implicit-children/). Children has now been explicitly added to provider props. ([#4565](https://github.com/realm/realm-js/issues/4565))
-- Fixed potential "Cannot create asynchronous query while in a write transaction" error with `useObject` due to adding event listeners while in a write transaction ([#4375](https://github.com/realm/realm-js/issues/4375), since v0.1.0)
+* Implicit children [was removed from `React.FC`](https://solverfox.dev/writing/no-implicit-children/). Children has now been explicitly added to provider props. ([#4565](https://github.com/realm/realm-js/issues/4565))
+* Fixed potential "Cannot create asynchronous query while in a write transaction" error with `useObject` due to adding event listeners while in a write transaction ([#4375](https://github.com/realm/realm-js/issues/4375), since v0.1.0)
 
 ### Compatibility
 
-- None.
+* None.
 
 ### Internal
 
-- Tests run with `--forceExit` to prevent them hanging ([#4531](https://github.com/realm/realm-js/pull/4531))
+* Tests run with `--forceExit` to prevent them hanging ([#4531](https://github.com/realm/realm-js/pull/4531))
 
 ## 0.2.1 (2022-03-24)
 
 ### Enhancements
 
-- Allow `createRealmContext` to be called without an initial configuration
-- Add a `fallback` property to `RealmProvider` that is shown while realm is opening
+* Allow `createRealmContext` to be called without an initial configuration
+* Add a `fallback` property to `RealmProvider` that is shown while realm is opening
 
 ### Fixed
 
-- Fixed bug when trying to access a collection result with an out of bounds index.([#4416](https://github.com/realm/realm-js/pull/4416), since v0.2.0)
+* Fixed bug when trying to access a collection result with an out of bounds index.([#4416](https://github.com/realm/realm-js/pull/4416), since v0.2.0)
 
 ### Compatibility
 
-- None
+* None
 
 ### Internal
 
-- None
+* None
 
 ## 0.2.0 (2022-03-07)
 
 ### Enhancements
 
-- Add ability to import `Realm` directly from `@realm/react`
-- Add cachedObject and cachedCollection
-  - Ensures that React.Memo that have Realm.Object/Collection as a property only rerender on actual changes
-  - Increased compatability with VirtualizedList/FlatList
-- Added more comprehensive documentation in the source code
-- List properties of a Realm.Object now rerender on change
-- Broadened test coverage for collections, lists and linked objects
+* Add ability to import `Realm` directly from `@realm/react`
+* Add cachedObject and cachedCollection
+  * Ensures that React.Memo that have Realm.Object/Collection as a property only rerender on actual changes
+  * Increased compatability with VirtualizedList/FlatList
+* Added more comprehensive documentation in the source code
+* List properties of a Realm.Object now rerender on change
+* Broadened test coverage for collections, lists and linked objects
 
 ## 0.1.0 (2021-11-10)
 
 ### Enhancements
 
-- Initial release
+* Initial release

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -25,7 +25,7 @@ import { createRealmProvider } from "./RealmProvider";
 
 type RealmContext = {
   /**
-   * Returns a Context Provider component that is required to wrap any component using
+   * The Provider component that is required to wrap any component using
    * the Realm hooks.
    *
    * @example
@@ -37,7 +37,7 @@ type RealmContext = {
    *   };
    *
    *   return (
-   *     <RealmProvider path={"data.realm"} sync={syncConfig}>
+   *     <RealmProvider schema={[Task, User]} path={"data.realm"} sync={syncConfig}>
    *       <App/>
    *     </RealmProvider>
    *   )
@@ -52,9 +52,20 @@ type RealmContext = {
    */
   RealmProvider: ReturnType<typeof createRealmProvider>;
   /**
+   * Returns the instance of the {@link Realm} opened by the `RealmProvider`.
+   *
+   * @example
+   * ```
+   * const realm = useRealm();
+   * ```
+   *
+   * @returns a realm instance
+   */
+  useRealm: ReturnType<typeof createUseRealm>;
+  /**
    * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
    * The hook will update on any changes to any object in the collection
-   * and return an empty array if the colleciton is empty.
+   * and return an empty array if the collection is empty.
    *
    * The result of this can be consumed directly by the `data` argument of any React Native
    * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
@@ -87,17 +98,6 @@ type RealmContext = {
    * @returns either the desired {@link Realm.Object} or `null` in the case of it being deleted or not existing.
    */
   useObject: ReturnType<typeof createUseObject>;
-  /**
-   * Returns the instance of the {@link Realm} configured by `createRealmContext`
-   *
-   * @example
-   * ```
-   * const realm = useRealm();
-   * ```
-   *
-   * @returns a realm instance
-   */
-  useRealm: ReturnType<typeof createUseRealm>;
 };
 
 /**
@@ -117,7 +117,7 @@ type RealmContext = {
  *  };
  *}
  *
- *const {userRealm, useQuery, useObject, RealmProvider} = createRealmContext({schema: [Task]});
+ *const {useRealm, useQuery, useObject, RealmProvider} = createRealmContext({schema: [Task]});
  * ```
  *
  * @param realmConfig - {@link Realm.Configuration} used to open the Realm
@@ -140,6 +140,82 @@ export const createRealmContext: (realmConfig?: Realm.Configuration) => RealmCon
     useObject,
   };
 };
+
+const defaultContext = createRealmContext();
+
+/**
+ * The Provider component that is required to wrap any component using
+ * the Realm hooks.
+ *
+ * @example
+ * ```
+ * const AppRoot = () => {
+ *   const syncConfig = {
+ *     flexible: true,
+ *     user: currentUser
+ *   };
+ *
+ *   return (
+ *     <RealmProvider schema={[Task, User]} path={"data.realm"} sync={syncConfig}>
+ *       <App/>
+ *     </RealmProvider>
+ *   )
+ * }
+ * ```
+ * @param props - The {@link Realm.Configuration} for this Realm, passed as props.
+ * By default, this is the main configuration for the Realm.
+ */
+export const RealmProvider = defaultContext.RealmProvider;
+
+/**
+ * Returns the instance of the {@link Realm} opened by the `RealmProvider`.
+ *
+ * @example
+ * ```
+ * const realm = useRealm();
+ * ```
+ *
+ * @returns a realm instance
+ */
+export const useRealm = defaultContext.useRealm;
+
+/**
+ * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
+ * The hook will update on any changes to any object in the collection
+ * and return an empty array if the collection is empty.
+ *
+ * The result of this can be consumed directly by the `data` argument of any React Native
+ * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
+ * then only the modified object will re-render.
+ *
+ * @example
+ * ```
+ * const collection = useQuery(Object);
+ *
+ * // The methods `sorted` and `filtered` should be wrapped in a useMemo.
+ * const sortedCollection = useMemo(collection.sorted(), [collection]);
+ * ```
+ *
+ * @param type - The object type, depicted by a string or a class extending Realm.Object
+ * @returns a collection of realm objects or an empty array
+ */
+export const useQuery = defaultContext.useQuery;
+
+/**
+ * Returns a {@link Realm.Object} from a given type and value of primary key.
+ * The hook will update on any changes to the properties on the returned object
+ * and return null if it either doesn't exists or has been deleted.
+ *
+ * @example
+ * ```
+ * const object = useObject(ObjectClass, objectId);
+ * ```
+ *
+ * @param type - The object type, depicted by a string or a class extending {@link Realm.Object}
+ * @param primaryKey - The primary key of the desired object which will be retrieved using {@link Realm.objectForPrimaryKey}
+ * @returns either the desired {@link Realm.Object} or `null` in the case of it being deleted or not existing.
+ */
+export const useObject = defaultContext.useObject;
 
 export { Realm };
 export * from "./AppProvider";

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -31,20 +31,6 @@ type PrimaryKey = Parameters<typeof Realm.prototype.objectForPrimaryKey>[1];
  * @returns useObject - Hook that is used to gain access to a single Realm object from a primary key
  */
 export function createUseObject(useRealm: () => Realm) {
-  /**
-   * Returns a {@link Realm.Object} from a given type and primary key.
-   * The hook will update on any changes to the properties on the returned object
-   * and return null if it either doesn't exist or has been deleted.
-   *
-   * @example
-   * ```
-   * const object = useObject(ObjectClass, objectId);
-   * ```
-   *
-   * @param type - The object type, depicted by a string or a class extending {@link Realm.Object}
-   * @param primaryKey - The primary key of the desired object which will be retrieved using {@link Realm.objectForPrimaryKey}
-   * @returns either the desired {@link Realm.Object} or `null` in the case of it being deleted or not existing.
-   */
   return function useObject<T>(
     type: string | { new (...args: any): T },
     primaryKey: PrimaryKey,

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -28,26 +28,6 @@ import { symbols } from "@realm/common";
  * @returns useObject - Hook that is used to gain access to a {@link Realm.Collection}
  */
 export function createUseQuery(useRealm: () => Realm) {
-  /**
-   * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
-   * The hook will update on any changes to any object in the collection
-   * and return an empty array if the colleciton is empty.
-   *
-   * The result of this can be consumed directly by the `data` argument of any React Native
-   * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
-   * then only the modified object will re-render.
-   *
-   * @example
-   * ```
-   * const collection = useQuery(Object);
-   *
-   * // The methods `sorted` and `filtered` should be wrapped in a useMemo.
-   * const sortedCollection = useMemo(collection.sorted(), [collection]);
-   * ```
-   *
-   * @param type - The object type, depicted by a string or a class extending Realm.Object
-   * @returns a collection of realm objects or an empty array
-   */
   return function useQuery<T>(
     type: string | ({ new (...args: any): T } & Realm.ObjectClass),
   ): Realm.Results<T & Realm.Object> {

--- a/packages/realm-react/src/useRealm.tsx
+++ b/packages/realm-react/src/useRealm.tsx
@@ -26,16 +26,6 @@ import { useContext } from "react";
  * @returns useRealm - Hook that is used to gain access to the {@link Realm} instance
  */
 export const createUseRealm = (RealmContext: React.Context<Realm | null>) => {
-  /**
-   * Returns the instance of the {@link Realm} configured by `createRealmContext`
-   *
-   * @example
-   * ```
-   * const realm = useRealm();
-   * ```
-   *
-   * @returns a realm instance
-   */
   return function useRealm(): Realm {
     // This is the context setup by `createRealmContext`
     const context = useContext(RealmContext);


### PR DESCRIPTION
## What, How & Why?
* Creates a default context and exports the results.
* Provide the tsdoc directly on the function exports.
* This makes the single realm use case much simpler to start with.  For multi realm usage, the `createRealmContext` is still available.

This closes #5292

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
