### PR TITLE
Allow `path` to be used to specify path for synced Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* You can now specify the path for synced Realms. The absolute path will contain some user related information in order to avoid collisions. The property `Realm#path` will still give you the full absolute path.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -121,6 +121,7 @@ async function addSubscriptionAndSync<T>(
 }
 
 describe.skipIf(environment.missingServer, "Flexible sync", function () {
+  this.timeout(20 * 1000);
   importAppBefore("with-db-flx");
   authenticateUserBefore();
   openRealmBeforeEach({
@@ -138,6 +139,26 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             sync: { _sessionStopPolicy: SessionStopPolicy.Immediately, flexible: true, user: this.user },
           });
         }).to.not.throw();
+      });
+
+      it("possible to set file name when { flexible: true }", async function () {
+        const config = {
+          path: "foobar.realm",
+          schema: [FlexiblePersonSchema, DogSchema],
+          sync: {
+            _sessionStopPolicy: SessionStopPolicy.Immediately,
+            flexible: true,
+            user: this.user,
+          },
+        } as Realm.Configuration;
+        const realm = await Realm.open(config);
+        // Expect file name to be the same as `config.path`
+        expect(realm.path.endsWith("foobar.realm")).to.be.true;
+        // Expect the file to be created
+        const fileExists = await fs.exists(realm.path);
+        expect(fileExists).to.equal(true);
+
+        realm.close();
       });
 
       it("can be constructed asynchronously", async function () {

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -628,8 +628,8 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 config.encryption_key.assign(encryption_key.data(), encryption_key.data() + encryption_key.size());
             }
 
-            // Parsing the `path` option must be done before parsing `sync` in order to 
-            // be able to control the path for synced Realms. 
+            // Parsing the `path` option must be done before parsing `sync` in order to
+            // be able to control the path for synced Realms.
             static const String path_string = "path";
             ValueType path_value = Object::get_property(ctx, object, path_string);
             if (!Value::is_undefined(ctx, path_value)) {

--- a/src/js_sync.hpp
+++ b/src/js_sync.hpp
@@ -47,6 +47,7 @@
 #include <realm/util/uri.hpp>
 #include <realm/util/network.hpp>
 #include <stdexcept>
+#include <string>
 
 #if REALM_PLATFORM_NODE
 #include <realm/object-store/impl/realm_coordinator.hpp>
@@ -1426,7 +1427,17 @@ void SyncClass<T>::populate_sync_config(ContextType ctx, ObjectType realm_constr
         }
 
         config.schema_mode = SchemaMode::AdditiveExplicit;
-        config.path = user->m_user->sync_manager()->path_for_realm(*(config.sync_config));
+        if (config.path.empty()) {
+            config.path = user->m_user->sync_manager()->path_for_realm(*(config.sync_config));
+        }
+        else {
+            // remove .realm if it exists
+            std::size_t found = config.path.rfind(".realm");
+            if (found != std::string::npos) {
+                config.path = config.path.erase(found, std::string::npos);
+            }
+            config.path = user->m_user->sync_manager()->path_for_realm(*(config.sync_config), config.path);
+        }
     }
 }
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 📝 Update `COMPATIBILITY.md`~
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* ~[ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
