### PR TITLE
Adding a `longTimeout` method to `Suite` and `Context`

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -189,6 +189,7 @@ jobs:
     env:
       REALM_DISABLE_ANALYTICS: 1
       MOCHA_REMOTE_TIMEOUT: 60000
+      LONG_TIMEOUT: 300000 # 5 minutes
       REALM_BASE_URL: ${{ secrets.REALM_QA_BASE_URL }}
       REALM_PUBLIC_KEY: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
       REALM_PRIVATE_KEY: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}
@@ -320,7 +321,7 @@ jobs:
 
       - name: Create Mocha Env
         id: mocha-env
-        run: echo "::set-output name=name::syncLogLevel=warn,realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ steps.deploy-mdb-apps.outputs.clusterName }},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}"
+        run: echo "::set-output name=name::syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ steps.deploy-mdb-apps.outputs.clusterName }},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}"
 
       - name: Run ${{matrix.variant.target}} (${{ matrix.variant.os}} / ${{ matrix.variant.environment }})
         if: ${{ (matrix.variant.os != 'android') && (matrix.variant.os != 'ios') }}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -71,6 +71,8 @@ This is controlled via an environment variable:
 
 To set context variables, simply set the environment variable (seperate multiple values with comma `,` and keys from values with equal-sign `=`). You can skip the `=` and value to indicate a `true` boolean value. As an example: To set the value `key1` to `value1` and `key2` to `true`, run with the context environment variable set to `key1=value1,key2`.
 
+See all valid context variables in the `Environment` type declared in [typings.d.ts](./tests/src/typings.d.ts).
+
 Examples of context variables used:
 - `missingServer`: Skip tests that require a running BaaS server.
 - `performance`: Disabled skipping of the "Performance tests" suite.

--- a/integration-tests/tests/src/hooks/authenticate-user-before.ts
+++ b/integration-tests/tests/src/hooks/authenticate-user-before.ts
@@ -18,7 +18,7 @@
 import { Credentials } from "realm";
 
 export function authenticateUserBefore(): void {
-  before(async function (this: AppContext & Partial<UserContext>) {
+  before("authenticateUserBefore", async function (this: AppContext & Partial<UserContext>) {
     if (this.app) {
       this.user = this.app.currentUser || (await this.app.logIn(Credentials.anonymous()));
     } else {

--- a/integration-tests/tests/src/hooks/authenticate-user-before.ts
+++ b/integration-tests/tests/src/hooks/authenticate-user-before.ts
@@ -18,7 +18,7 @@
 import { Credentials } from "realm";
 
 export function authenticateUserBefore(): void {
-  before("authenticateUserBefore", async function (this: AppContext & Partial<UserContext>) {
+  before(authenticateUserBefore.name, async function (this: AppContext & Partial<UserContext>) {
     if (this.app) {
       this.user = this.app.currentUser || (await this.app.logIn(Credentials.anonymous()));
     } else {

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -24,7 +24,7 @@ export function importAppBefore(
   replacements?: TemplateReplacements,
   logLevel: Realm.App.Sync.LogLevel = (environment.syncLogLevel as Realm.App.Sync.LogLevel) || "warn",
 ): void {
-  before("importAppBefore", async function (this: Partial<AppContext> & Mocha.Context) {
+  before(importAppBefore.name, async function (this: Partial<AppContext> & Mocha.Context) {
     // Importing an app might take up to 5 minutes when the app has a MongoDB Atlas service enabled.
     this.longTimeout();
     if (this.app) {

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -26,7 +26,7 @@ export function importAppBefore(
 ): void {
   before("importAppBefore", async function (this: Partial<AppContext> & Mocha.Context) {
     // Importing an app might take up to 5 minutes when the app has a MongoDB Atlas service enabled.
-    this.timeout(5 * 60 * 1000);
+    this.longTimeout();
     if (this.app) {
       throw new Error("Unexpected app on context, use only one importAppBefore per test");
     } else {

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -24,7 +24,7 @@ export function importAppBefore(
   replacements?: TemplateReplacements,
   logLevel: Realm.App.Sync.LogLevel = (environment.syncLogLevel as Realm.App.Sync.LogLevel) || "warn",
 ): void {
-  before(async function (this: Partial<AppContext> & Mocha.Context) {
+  before("importAppBefore", async function (this: Partial<AppContext> & Mocha.Context) {
     // Importing an app might take up to 5 minutes when the app has a MongoDB Atlas service enabled.
     this.timeout(5 * 60 * 1000);
     if (this.app) {
@@ -48,7 +48,7 @@ export function importAppBefore(
 
   // Delete our app after we have finished, otherwise the server can slow down
   // (in the case of flexible sync, with lots of apps with subscriptions created)
-  after(async function (this: Partial<AppContext> & Mocha.Context) {
+  after("deleteAppAfter", async function (this: Partial<AppContext> & Mocha.Context) {
     if (environment.preserveAppAfterRun) return;
     if (this.app) {
       await deleteApp(this.app.id);

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -31,6 +31,7 @@ export function openRealmHook(config: OpenRealmConfiguration = {}) {
   return async function openRealmHandler(
     this: Partial<RealmContext> & Partial<UserContext> & Mocha.Context,
   ): Promise<void> {
+    this.longTimeout();
     if (this.realm) {
       throw new Error("Unexpected realm on context, use only one openRealmBefore per test");
     } else {

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -43,11 +43,11 @@ export function openRealmHook(config: OpenRealmConfiguration = {}) {
 }
 
 export function openRealmBeforeEach(config: OpenRealmConfiguration = {}): void {
-  beforeEach("openRealmBeforeEach", openRealmHook(config));
+  beforeEach(openRealmBeforeEach.name, openRealmHook(config));
   afterEach("closeRealmAfterEach", closeThisRealm);
 }
 
 export function openRealmBefore(config: OpenRealmConfiguration = {}): void {
-  before("openRealmBefore", openRealmHook(config));
+  before(openRealmBefore.name, openRealmHook(config));
   after("closeRealmAfter", closeThisRealm);
 }

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -42,11 +42,11 @@ export function openRealmHook(config: OpenRealmConfiguration = {}) {
 }
 
 export function openRealmBeforeEach(config: OpenRealmConfiguration = {}): void {
-  beforeEach(openRealmHook(config));
-  afterEach(closeThisRealm);
+  beforeEach("openRealmBeforeEach", openRealmHook(config));
+  afterEach("closeRealmAfterEach", closeThisRealm);
 }
 
 export function openRealmBefore(config: OpenRealmConfiguration = {}): void {
-  before(openRealmHook(config));
-  after(closeThisRealm);
+  before("openRealmBefore", openRealmHook(config));
+  after("closeRealmAfter", closeThisRealm);
 }

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -18,6 +18,11 @@
 
 console.log("Loading Realm Integration Tests");
 
+/**
+ * Use the `longTimeout` context variable to override this.
+ */
+const DEFAULT_LONG_TIMEOUT = 10 * 1000; // 10s
+
 if (!global.fs) {
   throw new Error("Expected 'fs' to be available as a global");
 }
@@ -49,7 +54,7 @@ describe("Test Harness", function (this: Mocha.Suite) {
    * @see [typings.d.ts](./typings.d.ts) for documentation.
    */
   function longTimeout(this: Mocha.Context | Mocha.Suite) {
-    this.timeout(environment.longTimeout || 5 * 60 * 1000); // 5 minutes
+    this.timeout(environment.longTimeout || DEFAULT_LONG_TIMEOUT); // 5 minutes
   }
   // Patching the Suite and Context with a longTimeout method
   // We cannot simply `import { Suite, Context } from "mocha"` here,

--- a/integration-tests/tests/src/index.ts
+++ b/integration-tests/tests/src/index.ts
@@ -32,8 +32,8 @@ if (!global.environment || typeof global.environment !== "object") {
 
 // Patch in a function that can skip running tests in specific environments
 import { testSkipIf, suiteSkipIf } from "./utils/skip-if";
-global.describe.skipIf = suiteSkipIf;
-global.it.skipIf = testSkipIf;
+describe.skipIf = suiteSkipIf;
+it.skipIf = testSkipIf;
 
 afterEach(() => {
   // Trigger garbage collection after every test, if exposed by the environment.
@@ -44,7 +44,22 @@ afterEach(() => {
 
 // Using `require` instead of `import` here to ensure the Mocha globals (including `skipIf`) are set
 
-describe("Test Harness", () => {
+describe("Test Harness", function (this: Mocha.Suite) {
+  /**
+   * @see [typings.d.ts](./typings.d.ts) for documentation.
+   */
+  function longTimeout(this: Mocha.Context | Mocha.Suite) {
+    this.timeout(environment.longTimeout || 5 * 60 * 1000); // 5 minutes
+  }
+  // Patching the Suite and Context with a longTimeout method
+  // We cannot simply `import { Suite, Context } from "mocha"` here,
+  // since Mocha Remote client brings its own classes
+  const Suite = this.constructor as typeof Mocha.Suite;
+  const Context = this.ctx.constructor as typeof Mocha.Context;
+  Suite.prototype.longTimeout = longTimeout;
+  Context.prototype.longTimeout = longTimeout;
+
+  // Test importing an app
   require("./utils/import-app.test");
 });
 

--- a/integration-tests/tests/src/tests/sync/asymmetric.ts
+++ b/integration-tests/tests/src/tests/sync/asymmetric.ts
@@ -23,7 +23,7 @@ import { authenticateUserBefore, importAppBefore, openRealmBeforeEach } from "..
 
 describe.skipIf(environment.missingServer, "Asymmetric sync", function () {
   describe("Configuration and schema", function () {
-    this.timeout(20 * 1000);
+    this.longTimeout();
     const PersonSchema: Realm.ObjectSchema = {
       name: "Person",
       asymmetric: true,

--- a/integration-tests/tests/src/tests/sync/client-reset.ts
+++ b/integration-tests/tests/src/tests/sync/client-reset.ts
@@ -274,7 +274,7 @@ function getSchema(useFlexibleSync: boolean) {
     environment.missingServer,
     `client reset handling (${getPartialTestTitle(useFlexibleSync)} sync)`,
     function () {
-      this.timeout(100 * 1000); // client reset with flexible sync can take quite some time
+      this.longTimeout(); // client reset with flexible sync can take quite some time
       importAppBefore(useFlexibleSync ? "with-db-flx" : "with-db");
       authenticateUserBefore();
 
@@ -511,7 +511,7 @@ function getSchema(useFlexibleSync: boolean) {
         //       of the Realm will be downloaded (resync)
         // (ii)  two callback will be called, while the sync error handler is not
         // (iii) after the reset, the Realm can be used as before
-        this.timeout(900 * 1000);
+        this.longTimeout();
         const clientResetBefore = (realm: Realm) => {
           expect(realm.schema.length).to.equal(2);
         };

--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -230,13 +230,13 @@ function describeTypes(flexibleSync: boolean) {
 
 describe.skipIf(environment.missingServer, "mixed", () => {
   describe("partition-based sync roundtrip", function () {
-    this.timeout(25 * 1000);
+    this.longTimeout();
     importAppBefore("with-db");
     describeTypes(false);
   });
 
   describe.skipIf(environment.skipFlexibleSync, "flexible sync roundtrip", function () {
-    this.timeout(25 * 1000);
+    this.longTimeout();
     importAppBefore("with-db-flx");
     describeTypes(true);
   });

--- a/integration-tests/tests/src/tests/sync/sync-as-local.ts
+++ b/integration-tests/tests/src/tests/sync/sync-as-local.ts
@@ -33,7 +33,7 @@ describe.skipIf(environment.missingServer, "Synced Realm as local", () => {
   });
 
   before(async function (this: RealmContext) {
-    this.timeout(5000);
+    this.longTimeout();
     // Add a subscription
     await this.realm.subscriptions.update((subs) => {
       subs.add(this.realm.objects("Person"));

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -103,6 +103,20 @@ declare namespace Mocha {
   interface TestFunction {
     skipIf: (condition: unknown, title: string, callback: Mocha.AsyncFunc | Mocha.Func) => void;
   }
+  interface Context {
+    /**
+     * Sets a "long timeout" for the test or hook.
+     * It will use the timeout provided via `environment.longTimeout` or default to 1 min.
+     */
+    longTimeout(): void;
+  }
+  interface Suite {
+    /**
+     * Sets a "long timeout" for the suite.
+     * It will use the timeout provided via `environment.longTimeout` or default to 1 min.
+     */
+    longTimeout(): void;
+  }
 }
 
 // Mocha contexts made available by hooks

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -29,7 +29,53 @@ interface path {
 
 type Require = (id: string) => unknown;
 
-type Environment = Record<string, unknown>;
+type Environment = Record<string, unknown> & {
+  longTimeout?: number;
+  /** Are the tests running without a server? In which case all sync tests should be skipped. */
+  missingServer?: true;
+  /** The URL of the Realm server to run tests against. */
+  realmBaseUrl?: string;
+  /** Set the name of the cluster, used when setting up the "mongodb-atlas" service on imported apps. */
+  mongodbClusterName?: string;
+  /** Run the performance tests (skipped by default) */
+  performance?: true;
+  /** Disable deletion of the Realm app after the test run. */
+  preserveAppAfterRun?: true;
+  /** Set the sync client log level to help debugging sync client issues */
+  syncLogLevel?: Realm.App.Sync.LogLevel;
+
+  // Platform specific variables below
+
+  /**
+   * Node specific variable injected by the runner, to signal if we're running on Node.
+   */
+  node?: true;
+  /**
+   * Electron specific variable injected by the runner, to signal if we're running on Electron (and what process mode).
+   */
+  electron?: "main" | "renderer";
+  /**
+   * React native specific variable injected by the runner, to signal if we're running on React Native (and what platform OS we're running on).
+   */
+  reactNative?: "ios" | "android" | "web" | "macos" | "windows";
+  /**
+   * React native specific variable to control if tests are ran natively (default) or via the legacy chrome-debugger.
+   * @deprecated Since we no longer support the legacy chrome debugger.
+   */
+  mode?: "native" | "chrome-debugging";
+  /**
+   * React native specific variable injected by the runner, to signal if we're running on Android.
+   */
+  android?: true;
+  /**
+   * React native specific variable injected by the runner, to signal if we're running on iOS.
+   */
+  ios?: true;
+  /**
+   * React native specific variable injected by the runner, to signal if the tests are ran by the legacy chrome debugger (i.e. in a browser).
+   * @deprecated Since we no longer support the legacy chrome debugger. */
+  chromeDebugging?: true;
+};
 
 interface Global extends NodeJS.Global {
   title: string;

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -30,6 +30,7 @@ interface path {
 type Require = (id: string) => unknown;
 
 type Environment = Record<string, unknown> & {
+  /** Set the number of milliseconds to use for tests that require a long timeout. */
   longTimeout?: number;
   /** Set the name of the cluster, used when setting up the "mongodb-atlas" service on imported apps. */
   mongodbClusterName?: string;

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -31,10 +31,6 @@ type Require = (id: string) => unknown;
 
 type Environment = Record<string, unknown> & {
   longTimeout?: number;
-  /** Are the tests running without a server? In which case all sync tests should be skipped. */
-  missingServer?: true;
-  /** The URL of the Realm server to run tests against. */
-  realmBaseUrl?: string;
   /** Set the name of the cluster, used when setting up the "mongodb-atlas" service on imported apps. */
   mongodbClusterName?: string;
   /** Run the performance tests (skipped by default) */
@@ -43,6 +39,37 @@ type Environment = Record<string, unknown> & {
   preserveAppAfterRun?: true;
   /** Set the sync client log level to help debugging sync client issues */
   syncLogLevel?: Realm.App.Sync.LogLevel;
+
+  // BaaS server and Realm App Importer specific variables below
+
+  /** Are the tests running without a server? In which case all sync tests should be skipped. */
+  missingServer?: true;
+  /** The URL of the Realm server to run tests against. */
+  realmBaseUrl?: string;
+  /**
+   * Public key part used when authenticating towards BaaS during import of an app.
+   * Note: This is only used when the app importer is ran from within the test suite.
+   * Note: Either (publicKey and privateKey) or (username and password) needs to be set.
+   */
+  publicKey?: string;
+  /**
+   * Private key part used when authenticating towards BaaS during import of an app.
+   * Note: This is only used when the app importer is ran from within the test suite.
+   * Note: Either (publicKey and privateKey) or (username and password) needs to be set.
+   */
+  privateKey?: string;
+  /**
+   * Username used when authenticating towards BaaS during import of an app.
+   * Note: This is only used when the app importer is ran from within the test suite.
+   * Note: Either (publicKey and privateKey) or (username and password) needs to be set.
+   */
+  username?: string;
+  /**
+   * Password used when authenticating towards BaaS during import of an app.
+   * Note: This is only used when the app importer is ran from within the test suite.
+   * Note: Either (publicKey and privateKey) or (username and password) needs to be set.
+   */
+  password?: string;
 
   // Platform specific variables below
 


### PR DESCRIPTION
## What, How & Why?

This PR adds:
- A `longTimeout` method to `Suite` and `Context` which expose a timeout configurable by the harness, to specify what "long" is. It defaults to 10s when running locally, but 5 minutes when ran on CI.
- Names to the hooks, making it easier to determine what hook is timing out from the error logged to console.
- Types and documentation for the context variables currently available / in-use by the test suite.