### PR TITLE
Remove ability to use index operator on `BaseSubscriptionSet`

### DIFF
--- a/packages/realm/src/app-services/BaseSubscriptionSet.ts
+++ b/packages/realm/src/app-services/BaseSubscriptionSet.ts
@@ -81,9 +81,9 @@ const PROXY_HANDLER: ProxyHandler<BaseSubscriptionSet> = {
  *
  * SubscriptionSets can only be modified inside a {@link SubscriptionSet.update} callback.
  *
- * The SubscriptionSet is an iterable; thus, if absolutely needed, the contained
- * {@link Subscription}s can be accessed in `for-of` loops or spread into an `Array`
- * for access to the ECMAScript Array API, e.g. `[...realm.subscriptions][0]`.
+ * The SubscriptionSet is an iterable; thus, the contained {@link Subscription}s can be
+ * accessed in `for-of` loops or spread into an `Array` for access to the ECMAScript
+ * Array API, e.g. `[...realm.subscriptions][0]`.
  */
 export abstract class BaseSubscriptionSet {
   /**@internal */

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -49,7 +49,7 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
   // (`this.internal = internal` cannot be used in the constructor due to the proxy
   // handler in BaseSubscriptionSet making it non-writable.)
   /**@internal */
-  declare internal: binding.MutableSyncSubscriptionSet;
+  protected declare internal: binding.MutableSyncSubscriptionSet;
 
   /**@internal */
   constructor(/**@internal */ internal: binding.MutableSyncSubscriptionSet) {


### PR DESCRIPTION
## What, How & Why?
Removes the ability to do `realm.subscriptions[0]`. If users need this functionality, they will need to do `[...realm.subcriptions][0]`.

Note:
* This aligns with the [deprecation](https://github.com/realm/realm-js/pull/5353) of `ReadonlyArray`.
* In the merged Flexible Sync PR, this functionality was still possible. What was not possible was accessing JS array methods.

## ☑️ ToDos
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
