### PR TITLE
Improve install tests (setting `newArchEnabled` and `hermesEnabled` correctly on Android)

### DIFF
--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   install:
-    name: Install Test on React Native ${{ toJSON(matrix) }}
+    name: Install Test on React Native
     runs-on: macos-12
     timeout-minutes: 120
     strategy:
@@ -53,6 +53,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+      - id: set-summary
+        run: |
+          node -p "Object.entries(${{ toJSON(matrix) }}).map(([k,v]) => k + ': ' + v).join(', ')" >> $GITHUB_STEP_SUMMARY
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -18,6 +18,7 @@ defaults:
 
 jobs:
   install:
+    name: Install Test on React Native ${{ toJSON(matrix) }}
     runs-on: macos-12
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   install:
-    name: Install Test on React Native
+    name: Install Test on React Native ${{ matrix.platform == 'ios' && 'iOS' || 'Android' }} realm@${{ matrix.realm-version }}, react-native@${{ matrix.react-native-version }} new architecture ${{ matrix.new-architecture && 'enabled' || 'disabled' }} running ${{ matrix.engine }}
     runs-on: macos-12
     timeout-minutes: 120
     strategy:
@@ -53,9 +53,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - id: set-summary
-        run: |
-          node -p "Object.entries(${{ toJSON(matrix) }}).map(([k,v]) => k + ': ' + v).join(', ')" >> $GITHUB_STEP_SUMMARY
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -119,6 +119,7 @@ jobs:
         uses: Gamesight/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_webhook_url: ${{ secrets.SLACK_TEAM_WEBHOOK }}
+          # Post only to the #realm-js-team Slack channel in case of a scheduled run (realm-js-bot-tests otherwise)
+          slack_webhook_url: ${{ github.event.schedule && secrets.SLACK_TEAM_WEBHOOK || secrets.SLACK_TEST_WEBHOOK }}
           include_jobs: true
           include_commit_message: false

--- a/install-tests/react-native/cli.ts
+++ b/install-tests/react-native/cli.ts
@@ -182,18 +182,20 @@ yargs(hideBin(process.argv))
         console.log("Skipping patch of Podfile to use JSC, relying on USE_HERMES env variable instead");
       }
 
-      // Store local Gradle properties for RN >=0.71.0
-      const localPropertiesPath = path.resolve(appPath, "android/local.properties");
+      // Store Gradle properties for RN >=0.71.0
+      const localPropertiesPath = path.resolve(appPath, "android/gradle.properties");
       const localProperties = {
         newArchEnabled: newArchitecture,
         hermesEnabled: engine === "hermes",
       };
-      const localPropertiesContent = Object.entries(localProperties)
-        .map(([k, v]) => `${k}=${v}`)
-        .join("\n");
+      const localPropertiesContent =
+        "\n# Install test overwrites below\n\n" +
+        Object.entries(localProperties)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("\n");
 
-      console.log(`Writing local.properties to ${localPropertiesPath}`);
-      fs.writeFileSync(localPropertiesPath, localPropertiesContent);
+      console.log(`Appending gradle properties to ${localPropertiesPath}`);
+      fs.appendFileSync(localPropertiesPath, localPropertiesContent);
 
       if (!skipBundleInstall) {
         console.log(`Installing gem bundle (needed to pod-install for iOS)`);

--- a/install-tests/react-native/cli.ts
+++ b/install-tests/react-native/cli.ts
@@ -288,7 +288,7 @@ yargs(hideBin(process.argv))
         // Await the response from the server or a timeout
         const actualMessage = await Promise.race([message, timeout]);
         console.log(`App sent "${actualMessage}"!`);
-        const expectedMessage = "Persons are Alice, Bob, Charlie";
+        const expectedMessage = "Persons are Alice, Bob, Charlie!";
         if (actualMessage === expectedMessage) {
           console.log("... which was expected ✅");
         } else {


### PR DESCRIPTION
## What, How & Why?

We had a bug in the way the install tests configured the Android test to run with Hermes disabled.
Also, we now test throwing in code called from C++, because that has historically been (and is currently) broken (because of https://github.com/facebook/react-native/issues/36052).

This also makes it so PRs updating the install test workflow won't post and spam the team channel anymore.
