### PR TITLE
[bindgen] Bundle `path-browserify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6706,8 +6706,9 @@
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+      "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "@types/resolve": "1.20.2",
@@ -21405,6 +21406,7 @@
     },
     "packages/realm": {
       "version": "12.0.0-rc.0",
+      "license": "apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
         "path-browserify": "^1.0.1"

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -37,8 +37,7 @@
     "build:watch": "rollup -c --watch"
   },
   "dependencies": {
-    "debug": "^4.3.4",
-    "path-browserify": "^1.0.1"
+    "debug": "^4.3.4"
   },
   "peerDependencies": {
     "bson": "^4",
@@ -61,6 +60,7 @@
     "@types/path-browserify": "^1.0.0",
     "chai": "^4.3.6",
     "mocha": "^10.1.0",
+    "path-browserify": "^1.0.1",
     "react-native": "^0.71.0-rc.5",
     "rollup-plugin-dts": "^5.0.0",
     "tsm": "^2.2.2"

--- a/packages/realm/rollup.config.mjs
+++ b/packages/realm/rollup.config.mjs
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import replace from "@rollup/plugin-replace";
 import dts from "rollup-plugin-dts";
@@ -30,11 +32,13 @@ export default [
         file: pkg.main,
         format: "cjs",
         sourcemap: true,
+        exports: "named",
       },
       {
         file: pkg.module,
         format: "esm",
         sourcemap: true,
+        exports: "named",
       },
     ],
     plugins: [
@@ -59,6 +63,11 @@ export default [
       sourcemap: true,
     },
     plugins: [
+      nodeResolve({
+        resolveOnly: ["path-browserify"],
+      }),
+      // We need to use `commonjs` because of "path-browserify"
+      commonjs(),
       replace({
         preventAssignment: true,
         delimiters: ["", ""],
@@ -70,7 +79,7 @@ export default [
         tsconfig: "src/react-native/tsconfig.json",
       }),
     ],
-    external: ["bson", "debug", "react-native", "path-browserify"],
+    external: ["bson", "debug", "react-native"],
   },
   {
     input: "src/index.ts",

--- a/packages/realm/src/react-native/fs.ts
+++ b/packages/realm/src/react-native/fs.ts
@@ -15,10 +15,11 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
+import { isAbsolute, join } from "path-browserify";
+
 import { inject } from "../platform/file-system";
 import { extendDebug } from "../debug";
 import { Helpers, JsPlatformHelpers } from "../binding";
-import { isAbsolute, join } from "path-browserify";
 
 const debug = extendDebug("fs");
 

--- a/packages/realm/src/react-native/tsconfig.json
+++ b/packages/realm/src/react-native/tsconfig.json
@@ -4,7 +4,8 @@
     "noResolve": false,
     "incremental": true,
     "types": [
-      "react-native"
+      "react-native",
+      "path-browserify"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## What, How & Why?

Instead of having a dependency on `path-browserify` I think we should include the code in our React Native bundle.
It's very small, only used on React Native and we're not reexporting any of its APIs to end-users.
