### PR TITLE
[bindgen] Global `Realm`

### DIFF
--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -122,6 +122,7 @@ import {
   fs,
   normalizeObjectSchema,
   normalizeRealmSchema,
+  safeGlobalThis,
   toArrayBuffer,
   toBindingSchema,
   toBindingSyncConfig,
@@ -1236,6 +1237,7 @@ type ApiKeyAuthType = ApiKeyAuth;
 
 type GlobalDate = Date;
 
+// IMPORTANT: This needs to match the namespace below!
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export declare namespace Realm {
   // TODO: Decide if we want to deprecate this as well
@@ -1510,3 +1512,304 @@ export declare namespace Realm {
     export type LinkingObjects<ObjectTypeT, LinkingPropertyName> = Realm.Results<ObjectTypeT>;
   }
 }
+
+// Exporting a deprecated global for backwards compatibility
+const RealmConstructor = Realm;
+declare global {
+  /** @deprecated Will be removed in v13.0.0. Please use named imports */
+  export class Realm extends RealmConstructor {}
+  // IMPORTANT: This needs to match the namespace above!
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace Realm {
+    // TODO: Decide if we want to deprecate this as well
+    export type Object<T = DefaultObject> = RealmObject<T>;
+    export {
+      // Pure type exports below
+      /** @deprecated Please use named imports */
+      AppType as App,
+      /** @deprecated Please use named imports */
+      AppChangeCallback,
+      /** @deprecated Please use named imports */
+      AppConfiguration,
+      /** @deprecated Please use named imports */
+      BaseConfiguration,
+      /** @deprecated Please use named imports */
+      BaseObjectSchema,
+      /** @deprecated Please use named imports */
+      BaseSyncConfiguration,
+      /** @deprecated Please use named imports */
+      BSONType as BSON,
+      /** @deprecated Please use named imports */
+      CanonicalObjectSchema,
+      /** @deprecated Will be removed in v13.0.0. Please use {@link CanonicalPropertySchema} as a named import */
+      CanonicalObjectSchemaProperty,
+      /** @deprecated Please use named imports */
+      CanonicalPropertySchema,
+      /** @deprecated Please use named imports */
+      CanonicalPropertiesTypes,
+      /** @deprecated Please use named imports */
+      ClientResetModeType as ClientResetMode,
+      /** @deprecated Please use named imports */
+      ClientResetFallbackCallback,
+      /** @deprecated Please use named imports */
+      ClientResetBeforeCallback,
+      /** @deprecated Please use named imports */
+      ClientResetAfterCallback,
+      /** @deprecated Please use named imports */
+      ClientResetManualConfiguration,
+      /** @deprecated Please use named imports */
+      ClientResetDiscardUnsyncedChangesConfiguration,
+      /** @deprecated Please use named imports */
+      ClientResetRecoverUnsyncedChangesConfiguration,
+      /**
+       * This type got renamed to {@link ClientResetRecoverUnsyncedChangesConfiguration}
+       * @deprecated Please use named imports
+       */
+      ClientResetRecoverUnsyncedChangesConfiguration as ClientResetRecoveryConfiguration,
+      /** @deprecated Please use named imports */
+      ClientResetRecoverOrDiscardUnsyncedChangesConfiguration,
+      /** @deprecated Please use named imports */
+      ClientResetConfig,
+      /** @deprecated Please use named imports */
+      CollectionChangeCallback,
+      /** @deprecated Please use named imports */
+      CollectionChangeSet,
+      /** @deprecated Please use named imports */
+      CollectionType as Collection,
+      /** @deprecated Please use named imports */
+      ConfigurationWithoutSync,
+      /** @deprecated Please use named imports */
+      ConfigurationWithSync,
+      /** @deprecated Please use named imports */
+      Configuration,
+      /** @deprecated Please use named imports */
+      ConnectionNotificationCallback,
+      /** @deprecated Please use named imports */
+      ConnectionStateType as ConnectionState,
+      /** @deprecated Please use named imports */
+      CredentialsType as Credentials,
+      /** @deprecated Please use named imports */
+      DefaultFunctionsFactory,
+      /** @deprecated Please use named imports */
+      DefaultUserProfileData,
+      /** @deprecated Please use named imports */
+      DictionaryType as Dictionary,
+      /** @deprecated Please use named imports */
+      DictionaryChangeCallback,
+      /** @deprecated Please use named imports */
+      DictionaryChangeSet,
+      /** @deprecated Please use named imports */
+      ErrorCallback,
+      /** @deprecated Please use named imports */
+      FlexibleSyncConfiguration,
+      /** @deprecated Please use named imports */
+      ListType as List,
+      /** @deprecated Please use named imports */
+      LocalAppConfiguration,
+      /** @deprecated Please use named imports */
+      MigrationCallback,
+      /** @deprecated Please use named imports */
+      Mixed,
+      /** @deprecated Please use named imports */
+      ObjectChangeCallback,
+      /** @deprecated Please use named imports */
+      ObjectChangeSet,
+      /** @deprecated Please use named imports */
+      ObjectSchema,
+      /**
+       * @deprecated Will be removed in v13.0.0. Please use {@link PropertySchema}.
+       */
+      ObjectSchemaProperty,
+      /** @deprecated Please use named imports */
+      ObjectType,
+      /** @deprecated Please use named imports */
+      OpenRealmBehaviorConfiguration,
+      /** @deprecated Please use named imports */
+      OpenRealmBehaviorTypeType as OpenRealmBehaviorType,
+      /** @deprecated Please use named imports */
+      OpenRealmTimeOutBehaviorType as OpenRealmTimeOutBehavior,
+
+      /** @deprecated Please use named imports */
+      PartitionSyncConfiguration,
+      /** @deprecated Please use named imports */
+      PrimaryKey,
+      /** @deprecated Please use named imports */
+      ProgressDirectionType as ProgressDirection,
+      /** @deprecated Please use named imports */
+      ProgressModeType as ProgressMode,
+      /** @deprecated Please use named imports */
+      ProgressNotificationCallback,
+      /** @deprecated Please use named imports */
+      PropertiesTypes,
+      /** @deprecated Please use named imports */
+      PropertySchema,
+      /** @deprecated Please use named imports */
+      PropertySchemaShorthand,
+      /** @deprecated Please use named imports */
+      ProviderTypeType as ProviderType,
+      /** @deprecated Please use named imports */
+      RealmFunction,
+      /** @deprecated Please use named imports */
+      RealmObjectConstructor,
+      /**
+       * This type got renamed to RealmObjectConstructor
+       * @deprecated Please use named imports
+       */
+      RealmObjectConstructor as ObjectClass,
+      /** @deprecated Please use named imports */
+      ResultsType as Results,
+      /** @deprecated Please use named imports */
+      SessionStateType as SessionState,
+      /** @deprecated Please use named imports */
+      SessionStopPolicyType as SessionStopPolicy,
+      /** @deprecated Please use named imports */
+      SetType as Set,
+      // TODO: Add these once we've implemented the SSL config for the sync client
+      // SSLVerifyObject,
+      // SSLVerifyCallback,
+      // SSLConfiguration,
+      /** @deprecated Please use named imports */
+      SortDescriptor,
+      /** @deprecated Please use named imports */
+      SyncConfiguration,
+      /** @deprecated Please use named imports */
+      SyncErrorType as SyncError,
+      /** @deprecated Please use named imports */
+      TypesType as Types,
+      /** @deprecated Please use named imports */
+      UpdateModeType as UpdateMode,
+      /** @deprecated Please use named imports */
+      UserType as User,
+      /** @deprecated Please use named imports */
+      UserChangeCallback,
+      /** @deprecated Please use named imports */
+      UserStateType as UserState,
+    };
+
+    /** @deprecated Please use named imports */
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    export namespace App {
+      /** @deprecated Please use named imports */
+      export type Credentials = CredentialsType;
+      /** @deprecated Please use named imports */
+      // eslint-disable-next-line @typescript-eslint/no-namespace
+      export namespace Sync {
+        /** @deprecated Please use named imports */
+        export type BaseSubscriptionSet = BaseSubscriptionSetType;
+        /** @deprecated Please use named imports */
+        export type LogLevel = LogLevelType;
+        /** @deprecated Please use named imports */
+        export type NumericLogLevel = NumericLogLevelType;
+        /** @deprecated Please use named imports */
+        export type MutableSubscriptionSet = MutableSubscriptionSetType;
+        /** @deprecated Please use named imports */
+        export type PartitionValue = PartitionValueType;
+        /** @deprecated Please use named imports */
+        export type SubscriptionOptions = SubscriptionOptionsType;
+        /** @deprecated Please use named imports */
+        export type SubscriptionSet = SubscriptionSetType;
+        /** @deprecated Please use named imports */
+        export type SubscriptionsState = SubscriptionsStateType;
+        /** @deprecated Please use named imports */
+        export type Subscription = SubscriptionType;
+        /** @deprecated Please use named imports */
+        export type SyncSession = SyncSessionType;
+        /**
+         * @deprecated Got renamed to {@SyncSession} and please use named imports
+         */
+        export type Session = SyncSessionType;
+      }
+    }
+
+    /** @deprecated Please use named imports */
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    export namespace BSON {
+      /** @deprecated Please use named imports */
+      export type ObjectId = ObjectIdType;
+      /** @deprecated Please use named imports */
+      export type Decimal128 = Decimal128Type;
+      /** @deprecated Please use named imports */
+      export type UUID = UUIDType;
+    }
+
+    /** @deprecated Please use named imports */
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    export namespace Auth {
+      /**
+       * @deprecated Got renamed to {@link EmailPasswordAuth} and please use named imports
+       */
+      export type EmailPasswordAuth = EmailPasswordAuthType;
+      /** @deprecated Please use named imports */
+      export type ApiKey = ApiKeyType;
+      /**
+       * @deprecated Got renamed to {@link ApiKeyAuth} and please use named imports
+       */
+      export type ApiKeyAuth = ApiKeyAuthType;
+    }
+
+    /** @deprecated Please use named imports */
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    export namespace Services {
+      // TODO: Fill in once the MongoDB client has stabilized
+
+      /**
+       * @deprecated Got renamed to {@link PushClient} and please use named imports
+       */
+      export type Push = PushClient;
+    }
+
+    /** @deprecated Please use named imports */
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    export namespace Types {
+      /** @deprecated Please use named imports */
+      export type Bool = boolean;
+      /** @deprecated Please use named imports */
+      export type String = string;
+      /** @deprecated Please use named imports */
+      export type Int = number;
+      /** @deprecated Please use named imports */
+      export type Float = number;
+      /** @deprecated Please use named imports */
+      export type Double = number;
+      /** @deprecated Please use named imports */
+      export type Decimal128 = Realm.BSON.Decimal128;
+      /** @deprecated Please use named imports */
+      export type ObjectId = Realm.BSON.ObjectId;
+      /** @deprecated Please use named imports */
+      export type UUID = Realm.BSON.UUID;
+      /** @deprecated Please use named imports */
+      export type Date = GlobalDate;
+      /** @deprecated Please use named imports */
+      export type Data = ArrayBuffer;
+      /** @deprecated Please use named imports */
+      export type List<T> = Realm.List<T>;
+      /** @deprecated Please use named imports */
+      export type Set<T> = Realm.Set<T>;
+      /** @deprecated Please use named imports */
+      export type Dictionary<T> = Realm.Dictionary<T>;
+      /** @deprecated Please use named imports */
+      export type Mixed = unknown;
+      /** @deprecated Please use named imports */
+      export type LinkingObjects<ObjectTypeT, LinkingPropertyName> = Realm.Results<ObjectTypeT>;
+    }
+  }
+}
+
+// Patch the global at runtime
+let warnedAboutGlobalRealmUse = false;
+Object.defineProperty(safeGlobalThis, "Realm", {
+  get() {
+    if (!warnedAboutGlobalRealmUse) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Your app is relying on a Realm global, which will be removed in realm-js v13,\n",
+        "please update your code to ensure you import Realm via a named import:\n\n",
+        'import { Realm } from "realm"; // For ES Modules\n',
+        'const { Realm } = require("realm"); // For CommonJS\n',
+      );
+      warnedAboutGlobalRealmUse = true;
+    }
+    return RealmConstructor;
+  },
+  configurable: false,
+});

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -119,7 +119,7 @@ export {
   UserTypeName,
 } from "./internal";
 
-import { Realm, RealmObjectConstructor, safeGlobalThis } from "./internal";
+import { Constructor, Realm, RealmObjectConstructor, safeGlobalThis } from "./internal";
 
 export type Mixed = unknown;
 export type ObjectType = string | RealmObjectConstructor;
@@ -128,10 +128,11 @@ export type ObjectType = string | RealmObjectConstructor;
 export default Realm;
 
 // Exporting a deprecated global for backwards compatibility
-const RealmConstructor = Realm;
+type RealmType = Realm;
 declare global {
   /** @deprecated Will be removed in v13.0.0. Please use named imports */
-  export type Realm = typeof RealmConstructor;
+  export type Realm = RealmType;
+  export const Realm: Constructor<RealmType>;
 }
 
 // Patch the global at runtime
@@ -142,12 +143,13 @@ Object.defineProperty(safeGlobalThis, "Realm", {
       // eslint-disable-next-line no-console
       console.warn(
         "Your app is relying on a Realm global, which will be removed in realm-js v13,\n",
-        "please update your code to ensure you import Realm via a named ESM-style import:\n\n",
-        'import { Realm } from "realm";\n',
+        "please update your code to ensure you import Realm via a named import:\n\n",
+        'import { Realm } from "realm"; // For ES Modules\n',
+        'const { Realm } = require("realm"); // For CommonJS\n',
       );
       warnedAboutGlobalRealmUse = true;
     }
-    return RealmConstructor;
+    return Realm;
   },
   configurable: false,
 });

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -119,37 +119,10 @@ export {
   UserTypeName,
 } from "./internal";
 
-import { Constructor, Realm, RealmObjectConstructor, safeGlobalThis } from "./internal";
+import { Realm, RealmObjectConstructor } from "./internal";
 
 export type Mixed = unknown;
 export type ObjectType = string | RealmObjectConstructor;
 
 // Exporting default for backwards compatibility
 export default Realm;
-
-// Exporting a deprecated global for backwards compatibility
-type RealmType = Realm;
-declare global {
-  /** @deprecated Will be removed in v13.0.0. Please use named imports */
-  export type Realm = RealmType;
-  export const Realm: Constructor<RealmType>;
-}
-
-// Patch the global at runtime
-let warnedAboutGlobalRealmUse = false;
-Object.defineProperty(safeGlobalThis, "Realm", {
-  get() {
-    if (!warnedAboutGlobalRealmUse) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "Your app is relying on a Realm global, which will be removed in realm-js v13,\n",
-        "please update your code to ensure you import Realm via a named import:\n\n",
-        'import { Realm } from "realm"; // For ES Modules\n',
-        'const { Realm } = require("realm"); // For CommonJS\n',
-      );
-      warnedAboutGlobalRealmUse = true;
-    }
-    return Realm;
-  },
-  configurable: false,
-});

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -23,6 +23,7 @@
 
 /** @internal */
 export * from "./debug";
+export * from "./safeGlobalThis";
 
 /** @internal */
 export * from "./platform";

--- a/packages/realm/src/runtime.d.ts
+++ b/packages/realm/src/runtime.d.ts
@@ -29,6 +29,8 @@ declare function clearTimeout(timer: Timer): void;
 
 declare interface Console {
   log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
 }
 
 declare const console: Console;

--- a/packages/realm/src/safeGlobalThis.ts
+++ b/packages/realm/src/safeGlobalThis.ts
@@ -28,7 +28,7 @@ const check = function (it: any) {
 // eslint-disable-next-line no-restricted-globals
 export const safeGlobalThis: typeof globalThis & Record<string, unknown> =
   // eslint-disable-next-line no-restricted-globals
-  check(typeof globalThis == "object" && globalThis) ||
+  check(typeof globalThis === "object" && globalThis) ||
   // @ts-expect-error We're relying on an identifier that might not be there
   check(typeof window == "object" && window) ||
   // eslint-disable-next-line no-restricted-globals -- safe

--- a/packages/realm/src/safeGlobalThis.ts
+++ b/packages/realm/src/safeGlobalThis.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 // Exports a globalThis which is polyfilled for iOS 11/12
-// From https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/global.js
+// From https://github.com/zloirock/core-js/blob/v3.27.2/packages/core-js/internals/global.js
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const check = function (it: any) {

--- a/packages/realm/src/safeGlobalThis.ts
+++ b/packages/realm/src/safeGlobalThis.ts
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+// Exports a globalThis which is polyfilled for iOS 11/12
+// From https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/global.js
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const check = function (it: any) {
+  return it && it.Math == Math && it;
+};
+
+/** @internal */
+// eslint-disable-next-line no-restricted-globals
+export const safeGlobalThis: typeof globalThis & Record<string, unknown> =
+  // eslint-disable-next-line no-restricted-globals
+  check(typeof globalThis == "object" && globalThis) ||
+  // @ts-expect-error We're relying on an identifier that might not be there
+  check(typeof window == "object" && window) ||
+  // eslint-disable-next-line no-restricted-globals -- safe
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore allow `self`
+  check(typeof self == "object" && self) ||
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore allow `global`
+  check(typeof global == "object" && global) ||
+  // eslint-disable-next-line no-new-func -- fallback
+  (function () {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore allow `this`
+    return this;
+  })() ||
+  Function("return this")();

--- a/packages/realm/src/safeGlobalThis.ts
+++ b/packages/realm/src/safeGlobalThis.ts
@@ -21,7 +21,7 @@
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const check = function (it: any) {
-  return it && it.Math == Math && it;
+  return it && it.Math === Math && it;
 };
 
 /** @internal */
@@ -30,14 +30,14 @@ export const safeGlobalThis: typeof globalThis & Record<string, unknown> =
   // eslint-disable-next-line no-restricted-globals
   check(typeof globalThis === "object" && globalThis) ||
   // @ts-expect-error We're relying on an identifier that might not be there
-  check(typeof window == "object" && window) ||
+  check(typeof window === "object" && window) ||
   // eslint-disable-next-line no-restricted-globals -- safe
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore allow `self`
-  check(typeof self == "object" && self) ||
+  check(typeof self === "object" && self) ||
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore allow `global`
-  check(typeof global == "object" && global) ||
+  check(typeof global === "object" && global) ||
   // eslint-disable-next-line no-new-func -- fallback
   (function () {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/realm/type-tests/tsconfig.json
+++ b/packages/realm/type-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "noResolve": false,
+    "noResolve": true,
     "esModuleInterop": true,
     "lib": [
       "ES2022",
@@ -15,8 +15,7 @@
   },
   "exclude": [],
   "include": [
-    "../..",
-    "../src/types.d.ts",
+    "../src/**/*.ts",
     "type-tests.ts"
   ]
 }

--- a/packages/realm/type-tests/type-tests.ts
+++ b/packages/realm/type-tests/type-tests.ts
@@ -16,77 +16,20 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as Realm from "realm";
-import * as next from "next-realm";
+import { Realm as Realm2 } from "../src/index";
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+const realm = new Realm();
+const realm2: Realm = new Realm();
+const realm3 = new Realm2();
+const app = new Realm.App("");
+const app2 = new Realm2.App("");
+const realm4: Realm2 = new Realm2();
+declare const options: Realm2.App.Sync.SubscriptionOptions;
+declare const options2: Realm.App.Sync.SubscriptionOptions;
 
-declare class Person {
-  name: string;
-  age: number;
-}
+// Calling statics is supported
+Realm.deleteFile({});
 
-// Realm constructor
-
-{
-  // const realm: lib.Realm = new Realm();
-}
-{
-  type IncompatibleProps =
-    // This is now @internal
-    | "_updateSchema"
-    // The syncSession.config.initialSubscriptions.update takes a Realm (which doesn't exactly match yet)
-    | "syncSession"
-    // The callback takes a Realm (which doesn't exactly match yet)
-    | "addListener"
-    | "removeListener"
-    // This method takes a config, which are slightly different - which will be tested in another test
-    | "writeCopyTo";
-  /*
-   */
-  type OldRealm = Omit<Realm, IncompatibleProps>;
-  type NextRealm = Omit<next.Realm, IncompatibleProps>;
-  const nextRealm = {} as NextRealm;
-  const oldRealm: OldRealm = nextRealm;
-}
-{
-  type OldRealmConfiguration = Realm.Configuration;
-  type NextRealmConfiguration = next.Realm.Configuration;
-  const nextConfig = {} as NextRealmConfiguration;
-  const oldConfig: OldRealmConfiguration = nextConfig;
-}
-
-/*
-{
-  const config: Realm.Configuration = {} as lib.Configuration;
-}
-{
-  const realm = new lib.Realm();
-  const object: lib.Object = realm.objectForPrimaryKey("Person", "alice");
-}
-
-{
-  const object: Realm.Object<Person> = null as unknown as lib.Object<Person>;
-}
-
-{
-  const results: Realm.Results<Person> = null as unknown as lib.Results<Person>;
-}
-
-{
-  const list: Realm.List<Person> = null as unknown as lib.List<Person>;
-}
-
-{
-  type T = { foo: string; bar: number };
-  const dict: Realm.Dictionary<Person> = null as unknown as lib.Dictionary<Person>;
-}
-
-{
-  const app: Realm.App = null as unknown as lib.App;
-}
-
-{
-  const user: Realm.User = null as unknown as lib.User;
-}
-*/
+// Mixing enums is supported
+declare const state1: Realm.App.Sync.SubscriptionsState;
+const state2: Realm2.App.Sync.SubscriptionsState = state1;


### PR DESCRIPTION
## What, How & Why?

This will export the `Realm` constructor on the global, as [we do with our old SDK](https://github.com/realm/realm-js/blob/v11/src/js_realm.hpp#L598). This is completely against our goal of eventually [stop polluting the global object](https://github.com/realm/realm-js/issues/2126), but it'll make it easier for existing users to migrate.

I've added a `console.warn` that happens the first time a user access the `Realm` off the global, in hopes that this will help them migrate sooner.
