### PR TITLE
[bindgen] Temporarily disable tests relying on non-queryable fields to throw

### DIFF
--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -494,7 +494,22 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
         });
 
-        it("is rejected if there is an error synchronising subscriptions", async function (this: RealmContext) {
+        // Should only pass if `"development_mode_enabled": true`
+        it("does not throw if querying a not explicitly queryable field (ONLY VALID IN DEV MODE)", async function (this: RealmContext) {
+          const { subs } = addSubscription(
+            this.realm,
+            this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
+          );
+          expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+
+          await subs.waitForSynchronization();
+
+          expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+        });
+
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is rejected if there is an error synchronising subscriptions", async function (this: RealmContext) {
           const { subs } = addSubscription(
             this.realm,
             this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
@@ -508,7 +523,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
         });
 
-        it("is rejected if subscriptions are already in an error state", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is rejected if subscriptions are already in an error state", async function (this: RealmContext) {
           const { subs } = addSubscription(
             this.realm,
             this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
@@ -726,7 +743,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
         });
 
-        it("is Error if there is an error during synchronisation", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is Error if there is an error during synchronisation", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -739,7 +758,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
         });
 
-        it("is Error if there are two errors in a row", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is Error if there are two errors in a row", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -798,7 +819,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.error).to.be.null;
         });
 
-        it("contains the error message if there was an error synchronising subscriptions", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("contains the error message if there was an error synchronising subscriptions", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -811,7 +834,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           );
         });
 
-        it("is null if there was an error but it was subsequently corrected", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is null if there was an error but it was subsequently corrected", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -833,7 +858,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.error).to.be.null;
         });
 
-        it("still contains the erroring subscription in the set if there was an error synchronising", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("still contains the erroring subscription in the set if there was an error synchronising", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -955,7 +982,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
           });
 
-          it("returns a promise which is rejected if there is an error synchronising", async function (this: RealmContext) {
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+          it.skip("returns a promise which is rejected if there is an error synchronising", async function (this: RealmContext) {
             const subs = this.realm.subscriptions;
 
             await expect(
@@ -1029,7 +1058,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subsCopy[2].objectType).to.equal(DogSchema.name);
         });
 
-        it("still applies all updates in a batch if one errors", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("still applies all updates in a batch if one errors", async function (this: RealmContext) {
           const { subs } = await addSubscriptionForPersonAndSync(this.realm);
 
           await expect(


### PR DESCRIPTION
## What, How & Why?

BaaS was recently updated to now allow fields not explicitly listed as queryable to be queryable when development mode is enabled (the fields are automatically added to the queryable fields list).

Our tests were using non-queryable fields as a way to trigger a `SubscriptionsState.Error`, but until we have a solution for triggering such errors in our tests, they are now disabled in order to make the CI green.

This will be reenabled when #5402 is done.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
