### PR TITLE
Temporarily disable tests relying on non-queryable fields to throw

### DIFF
--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -491,7 +491,22 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
         });
 
-        it("is rejected if there is an error synchronising subscriptions", async function (this: RealmContext) {
+        // Should only pass if `"development_mode_enabled": true`
+        it("does not throw if querying a not explicitly queryable field (ONLY VALID IN DEV MODE)", async function (this: RealmContext) {
+          const { subs } = addSubscription(
+            this.realm,
+            this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
+          );
+          expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+
+          await subs.waitForSynchronization();
+
+          expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+        });
+
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is rejected if there is an error synchronising subscriptions", async function (this: RealmContext) {
           const { subs } = addSubscription(
             this.realm,
             this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
@@ -505,7 +520,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
         });
 
-        it("is rejected if subscriptions are already in an error state", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is rejected if subscriptions are already in an error state", async function (this: RealmContext) {
           const { subs } = addSubscription(
             this.realm,
             this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
@@ -678,7 +695,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
         });
 
-        it("is Error if there is an error during synchronisation", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is Error if there is an error during synchronisation", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -691,7 +710,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
         });
 
-        it("is Error if there are two errors in a row", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is Error if there are two errors in a row", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -750,7 +771,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.error).to.be.null;
         });
 
-        it("contains the error message if there was an error synchronising subscriptions", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("contains the error message if there was an error synchronising subscriptions", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -763,7 +786,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           );
         });
 
-        it("is null if there was an error but it was subsequently corrected", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("is null if there was an error but it was subsequently corrected", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -785,7 +810,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions.error).to.be.null;
         });
 
-        it("still contains the erroring subscription in the set if there was an error synchronising", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("still contains the erroring subscription in the set if there was an error synchronising", async function (this: RealmContext) {
           await expect(
             addSubscriptionAndSync(
               this.realm,
@@ -907,7 +934,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
           });
 
-          it("returns a promise which is rejected if there is an error synchronising", async function (this: RealmContext) {
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+          it.skip("returns a promise which is rejected if there is an error synchronising", async function (this: RealmContext) {
             const subs = this.realm.subscriptions;
 
             await expect(
@@ -979,7 +1008,9 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(subs[2].objectType).to.equal(DogSchema.name);
         });
 
-        it("still applies all updates in a batch if one errors", async function (this: RealmContext) {
+        // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+        //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
+        it.skip("still applies all updates in a batch if one errors", async function (this: RealmContext) {
           const { subs } = await addSubscriptionForPersonAndSync(this.realm);
 
           await expect(

--- a/packages/realm-app-importer/src/AppImporter.ts
+++ b/packages/realm-app-importer/src/AppImporter.ts
@@ -38,9 +38,14 @@ type LoginResponse = {
 
 type AppConfig = {
   name: string;
+  sync?: SyncConfig;
   security?: {
     allowed_request_origins?: string[];
   };
+};
+
+type SyncConfig = {
+  development_mode_enabled?: boolean;
 };
 
 type ErrorResponse = {
@@ -168,7 +173,7 @@ export class AppImporter {
    * @returns A promise of an object containing the app id.
    */
   public async importApp(appTemplatePath: string, replacements: TemplateReplacements = {}): Promise<{ appId: string }> {
-    const { name: appName, security } = this.loadAppConfigJson(appTemplatePath);
+    const { name: appName, sync, security } = this.loadAppConfigJson(appTemplatePath);
 
     await this.logIn();
 
@@ -191,7 +196,7 @@ export class AppImporter {
     }
 
     // Create the app service
-    await this.applyAppConfiguration(appPath, app._id, groupId);
+    await this.applyAppConfiguration(appPath, app._id, groupId, sync);
 
     if (appId) {
       console.log(`The application ${appId} was successfully deployed...`);
@@ -286,9 +291,8 @@ export class AppImporter {
     }
   }
 
-  private async enableDevelopmentMode(groupId: string, appId: string) {
+  private async applySyncConfig(groupId: string, appId: string, config: SyncConfig) {
     const configUrl = `${this.apiUrl}/groups/${groupId}/apps/${appId}/sync/config`;
-    const config = { development_mode_enabled: true };
     const response = await fetch(configUrl, {
       method: "PUT",
       headers: {
@@ -298,7 +302,7 @@ export class AppImporter {
       body: JSON.stringify(config),
     });
     if (!response.ok) {
-      console.error("Could not apply development mode: ", config, configUrl, response.status, response.statusText);
+      console.error("Could not apply sync configuration: ", config, configUrl, response.status, response.statusText);
     }
   }
 
@@ -331,7 +335,7 @@ export class AppImporter {
     }
   }
 
-  private async configureServiceFromAppPath(appPath: string, appId: string, groupId: string) {
+  private async configureServiceFromAppPath(appPath: string, appId: string, groupId: string, syncConfig?: SyncConfig) {
     const servicesDir = path.join(appPath, "services");
     if (fs.existsSync(servicesDir)) {
       console.log("Applying services... ");
@@ -362,7 +366,9 @@ export class AppImporter {
           if (!response.ok) {
             console.warn("Could not create service: ", tmpConfig, serviceUrl, response.statusText);
           } else {
-            await this.enableDevelopmentMode(groupId, appId);
+            if (syncConfig) {
+              await this.applySyncConfig(groupId, appId, syncConfig);
+            }
             const rulesDir = path.join(servicesDir, serviceDir, "rules");
             const responseJson = await response.json();
             const serviceId = responseJson._id;
@@ -550,7 +556,7 @@ export class AppImporter {
     return result;
   }
 
-  private async applyAppConfiguration(appPath: string, appId: string, groupId: string) {
+  private async applyAppConfiguration(appPath: string, appId: string, groupId: string, syncConfig?: SyncConfig) {
     // Create all secrets in parallel
     const secrets = this.loadSecretsJson(appPath);
     await Promise.all(
@@ -564,7 +570,7 @@ export class AppImporter {
 
     await this.configureValuesFromAppPath(appPath, appId, groupId);
 
-    await this.configureServiceFromAppPath(appPath, appId, groupId);
+    await this.configureServiceFromAppPath(appPath, appId, groupId, syncConfig);
 
     await this.configureFunctionsFromAppPath(appPath, appId, groupId);
 


### PR DESCRIPTION
## What, How & Why?

BaaS was recently updated to now allow fields not explicitly listed as queryable to be queryable when development mode is enabled (the fields are automatically added to the queryable fields list).

Our tests were using non-queryable fields as a way to trigger a `SubscriptionsState.Error`, but until we have a solution for triggering such errors in our tests, they are now disabled in order to make the CI green.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
