### PR TITLE
support JSC versions without BigInt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,9 @@
       },
       "devDependencies": {
         "react-native": "0.71.0-rc.5"
+      },
+      "peerDependencies": {
+        "jsc-android": "250231.0.0"
       }
     },
     "integration-tests/baas-test-server": {
@@ -15276,8 +15279,10 @@
       }
     },
     "node_modules/jsc-android": {
-      "version": "250230.2.1",
-      "license": "BSD-2-Clause"
+      "version": "250231.0.0",
+      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250231.0.0.tgz",
+      "integrity": "sha512-rS46PvsjYmdmuz1OAWXY/1kCYG7pnf1TBqeTiOJr1iDz7s5DLxxC9n/ZMknLDxzYzNVfI7R95MH10emSSG1Wuw==",
+      "peer": true
     },
     "node_modules/jscodeshift": {
       "version": "0.13.1",
@@ -18525,7 +18530,6 @@
         "event-target-shim": "^5.0.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.2.1",
-        "jsc-android": "^250230.2.1",
         "memoize-one": "^5.0.0",
         "metro-react-native-babel-transformer": "0.73.5",
         "metro-runtime": "0.73.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
     "turbo": "^1.6.3",
     "typescript": "^4.9.3"
   },
+  "peerDependencies": {
+      "jsc-android": "250231.0.0"
+  },
+  "overrides": {
+      "react-native": {
+          "jsc-android": "250231.0.0"
+      }
+  },
   "devDependencies": {
     "react-native": "0.71.0-rc.5"
   }

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -64,6 +64,7 @@ typeAliases:
   IndexRange: std::pair<count_t, count_t>
   AppCredentialsToken: std::string
   Email: std::string
+  SchemaVersion: int64_t # is uint64_t in C++ but -1 is used as a sentinel.
 
 templates: # value tells you how many arguments it takes ('*' means any number)
   util::Optional: 1
@@ -372,7 +373,7 @@ records:
         default: false
       schema: util::Optional<std::vector<ObjectSchema>>
       schema_version:
-        type: uint64_t
+        type: SchemaVersion
         default: -1
       schema_mode:
         type: SchemaMode
@@ -680,8 +681,8 @@ classes:
 
   ObjectStore:
     staticMethods:
-      get_schema_version: '(group: Group) -> uint64_t'
-      set_schema_version: '(group: Group, version: uint64_t)'
+      get_schema_version: '(group: Group) -> SchemaVersion'
+      set_schema_version: '(group: Group, version: SchemaVersion)'
       #    verify_no_migration_required: '(changes: std::vector<SchemaChange>)'
       #needs_migration: '(changes: std::vector<SchemaChange>) -> bool'
       #verify_valid_additive_changes:
@@ -692,7 +693,7 @@ classes:
       #verify_compatible_for_immutable_and_readonly: '(changes: std::vector<SchemaChange>)'
       #verify_no_changes_required: '(changes: std::vector<SchemaChange>)'
 
-      # apply_schema_changes: '(group: Transaction&, uint64_t: schema_version, target_schema: Schema&, target_schema_version: uint64_t, mode: SchemaMode, changes: std::vector<SchemaChange>, migration_function: () -> void)'
+      # apply_schema_changes: '(group: Transaction&, schema_version: SchemaVersion, target_schema: Schema&, target_schema_version: SchemaVersion, mode: SchemaMode, changes: std::vector<SchemaChange>, migration_function: () -> void)'
       # apply_additive_changes: '(group: Group&, changes: std::vector<SchemaChanges>, update_indexes: bool)'
       # table_for_object_type
       # table_for_Schema_type
@@ -790,12 +791,12 @@ classes:
         #   sig: '(thread: ThreadSafeReference, scheduler: std::shared_ptr<Scheduler>) -> SharedRealm'
       get_synchronized_realm: '(config: RealmConfig) -> SharedAsyncOpenTask'
       #make_shared_realm: '(config: Realm::Config, version: util::Optional<VersionID>, coordinator: std::shared_ptr<_impl::RealmCoordinator>) -> SharedRealm'
-      get_schema_version: '(config: const RealmConfig&) const -> uint64_t'
+      get_schema_version: '(config: const RealmConfig&) const -> SchemaVersion'
 
     properties:
       config: const RealmConfig&
       schema: const std::vector<ObjectSchema>&
-      schema_version: uint64_t
+      schema_version: SchemaVersion
       is_in_transaction: bool
       is_frozen: bool
       is_in_migration: bool
@@ -826,7 +827,7 @@ classes:
       read_group: () -> Group&
       duplicate: () -> TransactionRef
 
-      update_schema: '(schema: std::vector<ObjectSchema>, version: uint64_t, migration_function: Nullable<std::function<(old_realm: SharedRealm, new_realm: SharedRealm, new_schema_handle: IgnoreArgument<Schema&>) -> void>>, initialization_function: Nullable<std::function<(realm: SharedRealm) -> void>>, in_transaction: bool) -> void'
+      update_schema: '(schema: std::vector<ObjectSchema>, version: SchemaVersion, migration_function: Nullable<std::function<(old_realm: SharedRealm, new_realm: SharedRealm, new_schema_handle: IgnoreArgument<Schema&>) -> void>>, initialization_function: Nullable<std::function<(realm: SharedRealm) -> void>>, in_transaction: bool) -> void'
       enable_wait_for_change: ()
       wait_for_change: () -> bool
       wait_for_change_release: ()

--- a/packages/bindgen/src/js-passes.ts
+++ b/packages/bindgen/src/js-passes.ts
@@ -39,12 +39,17 @@ export function doJsPasses(spec: BoundSpec) {
 function addSharedPtrMethods(spec: BoundSpec) {
   for (const cls of spec.classes) {
     if (cls.sharedPtrWrapped && !cls.base) {
+      // Note: using double rather than int64 because bigint can't polyfill == operations.
+      // Also all JS engines rely on there being <= 52 bits of virtual address because they
+      // stuff pointers into nan-boxed doubles anyway for performance. By the time we can't
+      // rely on the 52 bit limit (if that ever happens), I'm sure we will have good bigint
+      // support across all engines.
       cls.methods.push(
         new CustomProperty( //
           cls,
           "$addr",
-          spec.types.int64_t,
-          ({ self }) => `reinterpret_cast<int64_t>(&${self})`,
+          spec.types.double,
+          ({ self }) => `double(reinterpret_cast<intptr_t>(&${self}))`,
         ),
       );
 

--- a/packages/bindgen/src/templates/typescript.ts
+++ b/packages/bindgen/src/templates/typescript.ts
@@ -42,10 +42,10 @@ const PRIMITIVES_MAPPING: Record<string, string> = {
   bool: "boolean",
   double: "number",
   float: "Float",
-  int64_t: "bigint",
+  int64_t: "Int64",
   int32_t: "number",
   count_t: "number",
-  uint64_t: "bigint",
+  uint64_t: "Int64",
   "std::string": "string",
   "std::string_view": "string",
   StringData: "string",
@@ -197,6 +197,17 @@ export function generate({ spec: rawSpec, file }: TemplateContext): void {
     export class WeakRef<T extends object> {
       constructor(obj: T);
       deref(): T | undefined;
+    }
+
+    export declare const enum Int64Type {} // This shouldn't need to be exported, but rollup complains if it isn't.
+    export type Int64 = Int64Type;
+    export const Int64: {
+      add(a: Int64, b: Int64): Int64;
+      equals(a: Int64, b: Int64 | number | string): boolean;
+      isInt(a: unknown): a is Int64;
+      numToInt(a: number): Int64;
+      strToInt(a: string): Int64;
+      intToNum(a: Int64): number;
     }
   `);
 

--- a/packages/bindgen/tests/test.ts
+++ b/packages/bindgen/tests/test.ts
@@ -21,7 +21,16 @@
 /* eslint-disable header/header */
 
 import { Decimal128 } from "bson";
-import { Realm, Float, PropertyType, Helpers, Results, SortDescriptor, List } from "../../realm/src/binding";
+import {
+  Int64,
+  Realm,
+  Float,
+  PropertyType,
+  Helpers,
+  Results,
+  SortDescriptor,
+  List,
+} from "../../realm/src/binding";
 
 import { strict as assert } from "assert";
 import * as util from "util";
@@ -31,7 +40,7 @@ util; // mark as used since it is useful for debugging.
 const realm = Realm.getSharedRealm({
   path: "/tmp/realm2.realm",
   inMemory: true,
-  schemaVersion: 1n,
+  schemaVersion: Int64.numToInt(1),
   schema: [
     {
       name: "Foo",
@@ -82,13 +91,13 @@ console.log(table.getColumnType(numCol));
 realm.beginTransaction();
 
 const obj1 = table.createObject();
-obj1.setAny(numCol, 1234n);
+obj1.setAny(numCol, Int64.numToInt(1234));
 obj1.setAny(strCol, "hello");
 obj1.setAny(fltCol, new Float(0.1234));
 obj1.setAny(decCol, new Decimal128("0.9876"));
 
 const obj2 = table.createObject();
-obj2.setAny(numCol, 9876n);
+obj2.setAny(numCol, Int64.numToInt(9876));
 obj2.setAny(strCol, "world");
 
 const obj3 = table.createObject();
@@ -109,11 +118,11 @@ const token = notifier.addCallback(
 );
 
 realm.beginTransaction();
-obj1.setAny(numCol, 12345n);
+obj1.setAny(numCol, Int64.numToInt(12345));
 realm.commitTransaction();
 
 realm.beginTransaction();
-obj1.setAny(numCol, 123456n);
+obj1.setAny(numCol, Int64.numToInt(123456));
 realm.commitTransaction();
 
 notifier.removeCallback(token);
@@ -157,7 +166,7 @@ for (const obj of table) {
 
 console.log("---");
 const kpMapping = Helpers.getKeypathMapping(realm);
-const query = table.query("num = $0", [[9876n]], kpMapping);
+const query = table.query("num = $0", [[Int64.numToInt(9876)]], kpMapping);
 console.log(query.count());
 const results = Helpers.resultsFromQuery(realm, query);
 {

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -441,7 +441,7 @@ export class RealmObject<T = DefaultObject> {
       const value = this[INTERNAL].getAny(columnKey);
       if (value === null) {
         return "null";
-      } else if (typeof value === "bigint") {
+      } else if (binding.Int64.isInt(value)) {
         return "int";
       } else if (value instanceof binding.Float) {
         return "float";

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -35,7 +35,7 @@ import {
   unwind,
 } from "./internal";
 
-const DEFAULT_COLUMN_KEY = 0n as unknown as binding.ColKey;
+const DEFAULT_COLUMN_KEY = binding.Int64.numToInt(0) as unknown as binding.ColKey;
 
 type PropertyType = string;
 export type SortDescriptor = string | [string, boolean];
@@ -410,8 +410,8 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     const result = this.results.min(columnKey);
     if (result instanceof Date || typeof result === "number" || typeof result === "undefined") {
       return result;
-    } else if (typeof result === "bigint") {
-      return Number(result);
+    } else if (binding.Int64.isInt(result)) {
+      return binding.Int64.intToNum(result);
     } else if (result instanceof binding.Float) {
       return result.value;
     } else if (result instanceof binding.Timestamp) {
@@ -439,8 +439,8 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     const result = this.results.max(columnKey);
     if (result instanceof Date || typeof result === "number" || typeof result === "undefined") {
       return result;
-    } else if (typeof result === "bigint") {
-      return Number(result);
+    } else if (binding.Int64.isInt(result)) {
+      return binding.Int64.intToNum(result);
     } else if (result instanceof binding.Float) {
       return result.value;
     } else if (result instanceof binding.Timestamp) {
@@ -467,8 +467,8 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     const result = this.results.sum(columnKey);
     if (typeof result === "number") {
       return result;
-    } else if (typeof result === "bigint") {
-      return Number(result);
+    } else if (binding.Int64.isInt(result)) {
+      return binding.Int64.intToNum(result);
     } else if (result instanceof binding.Float) {
       return result.value;
     } else {
@@ -493,8 +493,8 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     const result = this.results.average(columnKey);
     if (typeof result === "number" || typeof result === "undefined") {
       return result;
-    } else if (typeof result === "bigint") {
-      return Number(result);
+    } else if (binding.Int64.isInt(result)) {
+      return binding.Int64.intToNum(result);
     } else if (result instanceof binding.Float) {
       return result.value;
     } else {

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -150,9 +150,9 @@ export class ProgressRealmPromise implements Promise<Realm> {
   catch = this.handle.promise.catch.bind(this.handle.promise);
   finally = this.handle.promise.finally.bind(this.handle.promise);
 
-  private emitProgress = (transferredArg: bigint, transferableArg: bigint) => {
-    const transferred = Number(transferredArg);
-    const transferable = Number(transferableArg);
+  private emitProgress = (transferredArg: binding.Int64, transferableArg: binding.Int64) => {
+    const transferred = binding.Int64.intToNum(transferredArg);
+    const transferable = binding.Int64.intToNum(transferableArg);
     for (const listener of this.listeners) {
       listener(transferred, transferable);
     }

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -30,22 +30,26 @@ import {
   UpdateMode,
   assert,
   binding,
+  safeGlobalThis,
 } from "./internal";
 
-const TYPED_ARRAY_CONSTRUCTORS = new Set([
-  DataView,
-  Int8Array,
-  Uint8Array,
-  Uint8ClampedArray,
-  Int16Array,
-  Uint16Array,
-  Int32Array,
-  Uint32Array,
-  Float32Array,
-  Float64Array,
-  BigInt64Array,
-  BigUint64Array,
-]);
+const TYPED_ARRAY_CONSTRUCTORS = new Set(
+  [
+    DataView,
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    // These will not be present on old versions of JSC without BigInt support.
+    safeGlobalThis.BigInt64Array,
+    safeGlobalThis.BigUint64Array,
+  ].filter((ctor) => ctor !== undefined),
+);
 
 export function toArrayBuffer(value: unknown, stringToBase64 = true) {
   if (typeof value === "string" && stringToBase64) {
@@ -125,8 +129,8 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
     return {
       toBinding: nullPassthrough((value) => {
         if (typeof value === "number") {
-          return BigInt(value);
-        } else if (typeof value === "bigint") {
+          return binding.Int64.numToInt(value);
+        } else if (binding.Int64.isInt(value)) {
           return value;
         } else {
           throw new TypeAssertionError("a number or bigint", value);
@@ -246,8 +250,8 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
     return {
       toBinding: mixedToBinding.bind(null, realm.internal),
       fromBinding(value) {
-        if (typeof value === "bigint") {
-          return Number(value);
+        if (binding.Int64.isInt(value)) {
+          return binding.Int64.intToNum(value);
         } else if (value instanceof binding.Timestamp) {
           return value.toDate();
         } else if (value instanceof binding.Float) {

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -208,7 +208,7 @@ export function toBindingClientResetMode(resetMode: ClientResetMode): binding.Cl
 
 type ListenerToken = {
   internal: binding.SyncSession;
-  token: bigint;
+  token: binding.Int64;
 };
 
 /**

--- a/packages/realm/src/assert.ts
+++ b/packages/realm/src/assert.ts
@@ -71,18 +71,6 @@ assert.boolean = (value: unknown, target?: string): asserts value is boolean => 
   }
 };
 
-assert.bigInt = (value: unknown, target?: string): asserts value is bigint => {
-  if (typeof value !== "bigint") {
-    throw new TypeAssertionError("a bigint", value, target);
-  }
-};
-
-assert.numberOrBigInt = (value: unknown, target?: string): asserts value is number => {
-  if (typeof value !== "number" && typeof value !== "bigint") {
-    throw new TypeAssertionError("a number or bigint", value, target);
-  }
-};
-
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 assert.function = (value: unknown, target?: string): asserts value is (...args: unknown[]) => unknown => {
   if (typeof value !== "function") {

--- a/packages/realm/src/binding.ts
+++ b/packages/realm/src/binding.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { IndexSet, ObjKey, Timestamp } from "../generated/ts/native.mjs";
+import { Int64, IndexSet, ObjKey, Timestamp } from "../generated/ts/native.mjs";
 
 /** @internal */
 export * from "../generated/ts/native.mjs"; // core types are transitively exported.
@@ -46,7 +46,7 @@ IndexSet.prototype.asIndexes = function* (this: IndexSet) {
 };
 
 Timestamp.fromDate = (d: Date) =>
-  Timestamp.make(BigInt(Math.floor(d.valueOf() / 1000)), (d.valueOf() % 1000) * 1000_000);
+  Timestamp.make(Int64.numToInt(Math.floor(d.valueOf() / 1000)), (d.valueOf() % 1000) * 1000_000);
 
 Timestamp.prototype.toDate = function () {
   return new Date(Number(this.seconds) * 1000 + this.nanoseconds / 1000_000);
@@ -62,7 +62,7 @@ export class InvalidObjKey extends TypeError {
 /** @internal */
 export function stringToObjKey(input: string): ObjKey {
   try {
-    return BigInt(input) as unknown as ObjKey;
+    return Int64.strToInt(input) as unknown as ObjKey;
   } catch {
     throw new InvalidObjKey(input);
   }
@@ -71,5 +71,5 @@ export function stringToObjKey(input: string): ObjKey {
 /** @internal */
 export function isEmptyObjKey(objKey: ObjKey) {
   // This relies on the JS representation of an ObjKey being a bigint
-  return (objKey as unknown as bigint) === -1n;
+  return Int64.equals(objKey as unknown as Int64, -1);
 }

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -116,7 +116,7 @@ export function normalizeObjectSchema(arg: RealmObjectConstructor | ObjectSchema
 
   const { name, primaryKey, asymmetric, embedded, properties } = arg;
   assert(name.length > 0, "Invalid schema for unnamed object: 'name' must be specified.");
-  const primaryKeyFieldIsMissing = primaryKey && !Object.hasOwn(properties, primaryKey);
+  const primaryKeyFieldIsMissing = primaryKey && !Object.prototype.hasOwnProperty.call(properties, primaryKey);
   assert(
     !primaryKeyFieldIsMissing,
     `Invalid schema for object '${name}': '${primaryKey}' is set as the primary key field but was not found in 'properties'.`,


### PR DESCRIPTION
Mostly looking for review of the `Int64` API exposed in typescript.ts and implemented in node-wrapper.ts, along with the changes to the SDK to use that in place of direct operations on `bigint`s. Feel free to review the implementation in jsi.ts of course.