### PR TITLE
Enforce PascalCase for generated enum constants

### DIFF
--- a/packages/bindgen/src/bound-model.ts
+++ b/packages/bindgen/src/bound-model.ts
@@ -621,8 +621,7 @@ export function bindModel(spec: Spec): BoundSpec {
     struct.fields = Object.entries(fields).map(([name, field]) => {
       const type = resolveTypes(field.type);
       // Optional and Nullable fields are never required.
-      const required =
-        field.default === undefined && !(type.isNullable() || type.isOptional());
+      const required = field.default === undefined && !(type.isNullable() || type.isOptional());
       return new Field(name, field.cppName ?? name, type, required, field.default);
     });
   }

--- a/packages/bindgen/src/js-passes.ts
+++ b/packages/bindgen/src/js-passes.ts
@@ -18,6 +18,7 @@
 import {
   BoundSpec,
   Class,
+  Enumerator,
   Field,
   InstanceMethod,
   Method,
@@ -99,6 +100,9 @@ declare module "./bound-model" {
   interface Field {
     readonly jsName: string;
   }
+  interface Enumerator {
+    readonly jsName: string;
+  }
   interface Class {
     iteratorMethodId(): string;
   }
@@ -121,6 +125,12 @@ Object.defineProperty(Method.prototype, "jsName", {
 Object.defineProperty(Field.prototype, "jsName", {
   get(this: Field) {
     return camelCase(this.name);
+  },
+});
+
+Object.defineProperty(Enumerator.prototype, "jsName", {
+  get(this: Enumerator) {
+    return pascalCase(this.name);
   },
 });
 

--- a/packages/bindgen/src/templates/typescript.ts
+++ b/packages/bindgen/src/templates/typescript.ts
@@ -170,7 +170,7 @@ export function generate({ spec: rawSpec, file }: TemplateContext): void {
   for (const e of spec.enums) {
     // Using const enum to avoid having to emit JS backing these
     coreOut(`export const enum ${e.jsName} {`);
-    coreOut(...e.enumerators.map(({ name, value }) => `${name} = ${value},\n`));
+    coreOut(...e.enumerators.map(({ jsName, value }) => `${jsName} = ${value},\n`));
     coreOut("};");
   }
   coreOut(`

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -281,7 +281,7 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
       fromBinding: defaultFromBinding,
     };
   },
-  [binding.PropertyType.UUID]({ optional }) {
+  [binding.PropertyType.Uuid]({ optional }) {
     return {
       toBinding: nullPassthrough((value) => {
         assert.instanceOf(value, BSON.UUID);

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -65,9 +65,9 @@ export enum SessionState {
 
 function toBindingDirection(direction: ProgressDirection) {
   if (direction === ProgressDirection.Download) {
-    return binding.ProgressDirection.download;
+    return binding.ProgressDirection.Download;
   } else if (direction === ProgressDirection.Upload) {
-    return binding.ProgressDirection.upload;
+    return binding.ProgressDirection.Upload;
   } else {
     throw new Error(`Unexpected direction: ${direction}`);
   }

--- a/packages/realm/src/platform/network.ts
+++ b/packages/realm/src/platform/network.ts
@@ -32,11 +32,11 @@ type NetworkType = {
 };
 
 const HTTP_METHOD: Record<binding.HttpMethod, Method> = {
-  [binding.HttpMethod.get]: "GET",
-  [binding.HttpMethod.post]: "POST",
-  [binding.HttpMethod.put]: "PUT",
-  [binding.HttpMethod.patch]: "PATCH",
-  [binding.HttpMethod.del]: "DELETE",
+  [binding.HttpMethod.Get]: "GET",
+  [binding.HttpMethod.Post]: "POST",
+  [binding.HttpMethod.Put]: "PUT",
+  [binding.HttpMethod.Patch]: "PATCH",
+  [binding.HttpMethod.Del]: "DELETE",
 };
 
 function toFetchRequest({ method, timeoutMs, body, headers, url }: binding.Request_Relaxed) {

--- a/packages/realm/src/schema/from-binding.ts
+++ b/packages/realm/src/schema/from-binding.ts
@@ -36,7 +36,7 @@ const TYPE_MAPPINGS: Record<binding.PropertyType, PropertyTypeName | null> = {
   [PropertyType.Mixed]: "mixed",
   [PropertyType.ObjectId]: "objectId",
   [PropertyType.Decimal]: "decimal128",
-  [PropertyType.UUID]: "uuid",
+  [PropertyType.Uuid]: "uuid",
   [PropertyType.Array]: "list",
   [PropertyType.Set]: "set",
   [PropertyType.Dictionary]: "dictionary",

--- a/packages/realm/src/schema/to-binding.ts
+++ b/packages/realm/src/schema/to-binding.ts
@@ -36,7 +36,7 @@ export const TYPE_MAPPINGS: Record<PropertyTypeName, BindingPropertyType> = {
   mixed: BindingPropertyType.Mixed,
   objectId: BindingPropertyType.ObjectId,
   decimal128: BindingPropertyType.Decimal,
-  uuid: BindingPropertyType.UUID,
+  uuid: BindingPropertyType.Uuid,
   list: BindingPropertyType.Array,
   set: BindingPropertyType.Set,
   dictionary: BindingPropertyType.Dictionary,


### PR DESCRIPTION
## What, How & Why?

Enforces enum constants generated by the Binding Generator to use PascalCase naming convention.

This is only an internal change (types available on our `binding` export).

This closes #5373.

## ☑️ ToDos
* [x] 🚦 Run tests
