### PR TITLE
Fix "Invalid Realm passed to bind_to_context()" when clearing test state

### DIFF
--- a/integration-tests/tests/src/tests/index.ts
+++ b/integration-tests/tests/src/tests/index.ts
@@ -31,6 +31,7 @@ import "./dynamic-schema-updates";
 import "./bson";
 import "./dictionary";
 import "./credentials/anonymous";
+import "./sync/open";
 import "./sync/mixed";
 import "./sync/flexible";
 import "./sync/asymmetric";

--- a/integration-tests/tests/src/tests/sync/open.ts
+++ b/integration-tests/tests/src/tests/sync/open.ts
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import { authenticateUserBefore, importAppBefore } from "../../hooks";
+
+describe("Realm.open on a sync Realm", () => {
+  importAppBefore("with-db-flx");
+  authenticateUserBefore();
+
+  it("fails gracefully when canceled while opening", async function (this: UserContext) {
+    const result = Realm.open({ sync: { flexible: true, user: this.user } });
+    result.cancel();
+    await expect(result).to.be.rejectedWith("Async open canceled");
+  });
+
+  it("fails gracefully when clearing test state while opening", async function (this: UserContext) {
+    const result = Realm.open({ sync: { flexible: true, user: this.user } });
+    Realm.clearTestState();
+    await expect(result).to.be.rejectedWith("Async open canceled");
+  });
+});

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -283,17 +283,14 @@ module.exports = function (realmConstructor) {
             asyncOpenTask = realmConstructor._asyncOpen(config, (realm, error) => {
               setTimeout(() => {
                 asyncOpenTask = null;
-                // The user may have cancelled the open between when
-                // the download completed and when we managed to
-                // actually invoke this, so recheck here.
-                if (cancelled) {
-                  return;
-                }
                 // Clear the fallback timeOut if it has been started
                 clearTimeout(timeoutId);
                 if (error) {
                   reject(error);
-                } else {
+                } else if (!cancelled) {
+                  // The user may have cancelled the open between when
+                  // the download completed and when we managed to
+                  // actually invoke this, so recheck here.
                   resolve(realm);
                 }
               }, 0);

--- a/src/js_realm.cpp
+++ b/src/js_realm.cpp
@@ -22,6 +22,7 @@
 #include <realm/object-store/impl/realm_coordinator.hpp>
 
 #if REALM_ENABLE_SYNC
+#include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_user.hpp>
 #endif
@@ -75,6 +76,7 @@ void clear_test_state()
     }
     s_test_files_path = util::make_temp_dir();
 #endif
+    realm::app::App::clear_cached_apps();
 #endif
 }
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -978,9 +978,6 @@ void RealmClass<T>::clear_test_state(ContextType ctx, ObjectType this_object, Ar
 {
     args.validate_maximum(0);
     js::clear_test_state();
-#if REALM_ENABLE_SYNC
-    realm::app::App::clear_cached_apps();
-#endif
 }
 
 template <typename T>

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1222,13 +1222,9 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
                 std::rethrow_exception(error);
             }
             catch (const std::exception& e) {
-                ObjectType object = Object::create_empty(protected_ctx);
-                Object::set_property(protected_ctx, object, "message", Value::from_string(protected_ctx, e.what()));
-                Object::set_property(protected_ctx, object, "errorCode", Value::from_number(protected_ctx, 1));
-
                 ValueType callback_arguments[2] = {
                     Value::from_undefined(protected_ctx),
-                    object,
+                    Object::create_error(protected_ctx, e.what()),
                 };
                 Function<T>::callback(protected_ctx, protected_callback, protected_this, 2, callback_arguments);
                 return;

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -980,6 +980,7 @@ void RealmClass<T>::clear_test_state(ContextType ctx, ObjectType this_object, Ar
                                      ReturnValue& return_value)
 {
     args.validate_maximum(0);
+    AsyncOpenTaskClass<T>::cancel_tasks();
     js::clear_test_state();
 }
 

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -1199,8 +1199,7 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
 
     std::shared_ptr<AsyncOpenTask> task = Realm::get_synchronized_realm(config);
 
-    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=,
-                                                                             args_count = args.count,
+    realm::util::EventLoopDispatcher<RealmCallbackHandler> callback_handler([=, args_count = args.count,
                                                                              defaults = std::move(defaults),
                                                                              constructors = std::move(constructors)](
                                                                                 ThreadSafeReference&& realm_ref,
@@ -1211,10 +1210,10 @@ void RealmClass<T>::async_open_realm(ContextType ctx, ObjectType this_object, Ar
             return;
         }
         // Remove once we are done do avoid destroying the lambda's state while still running.
-        auto guard = util::make_scope_exit([&] () noexcept {
+        auto guard = util::make_scope_exit([&]() noexcept {
             AsyncOpenTaskClass<T>::tasks.erase(task);
         });
-        
+
         HANDLESCOPE(protected_ctx)
 
         if (error) {
@@ -1819,7 +1818,9 @@ public:
         {"cancel", wrap<cancel>},
     };
 
-    static inline std::map<std::shared_ptr<AsyncOpenTask>, util::UniqueFunction<void(ThreadSafeReference&&, std::exception_ptr)>> tasks;
+    static inline std::map<std::shared_ptr<AsyncOpenTask>,
+                           util::UniqueFunction<void(ThreadSafeReference&&, std::exception_ptr)>>
+        tasks;
 
     static inline void cancel_tasks()
     {
@@ -1852,7 +1853,7 @@ void AsyncOpenTaskClass<T>::cancel(ContextType ctx, ObjectType this_object, Argu
     if (callback != tasks.end()) {
         callback->second({}, err); // Removes the task from tasks map.
     }
-    
+
     task->cancel();
 }
 


### PR DESCRIPTION
## What, How & Why?

This fix an issue provoked when an async open task resolved after `Realm.clearTestState` had been called, which would result in a termination of the process, yielding:

> Invalid Realm passed to bind_to_context()

This happened a lot in our integration tests, when a test awaiting a `Realm.open` call would timeout and `Realm.clearTestState` would be called from an after hook.