### PR TITLE
Moved `closeThisRealm` and simplified `closeRealm`

### DIFF
--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { closeThisRealm } from "../utils/close-realm";
+import { closeRealm } from "../utils/close-realm";
 import { openRealm, OpenRealmConfiguration } from "../utils/open-realm";
 
 /**
@@ -39,6 +39,21 @@ export function openRealmHook(config: OpenRealmConfiguration = {}) {
       this.config = result.config;
     }
   };
+}
+
+/**
+ * Close the Realm instance on the current `this` context
+ *
+ * @param this Mocha `this` context
+ */
+export function closeThisRealm(this: Partial<RealmContext> & Mocha.Context): void {
+  // If opening the Realm fails or times out
+  if (this.realm) {
+    closeRealm(this.realm);
+  }
+  // Get rid of the Realm in any case
+  delete this.realm;
+  delete this.config;
 }
 
 export function openRealmBeforeEach(config: OpenRealmConfiguration = {}): void {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -268,9 +268,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           async function openRealm(user: Realm.User, extraConfig: ExtraConfig = {}) {
             const config = getSuccessConfig(user, extraConfig);
-            const realm = await Realm.open(config);
-
-            return { realm, config };
+            return Realm.open(config);
           }
 
           async function testSuccess(
@@ -278,14 +276,14 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             extraConfig: Partial<FlexibleSyncConfiguration["initialSubscriptions"]> = {},
             closeRealmAfter = true,
           ) {
-            const { realm, config } = await openRealm(user, extraConfig);
+            const realm = await openRealm(user, extraConfig);
 
             try {
               expect(realm.subscriptions).to.have.length(1);
               expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
             } finally {
               if (closeRealmAfter) {
-                closeRealm(realm, config);
+                closeRealm(realm);
               }
             }
 
@@ -293,12 +291,11 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           }
 
           it("returns a promise", async function (this: RealmContext) {
-            const result = openRealm(this.user, {});
+            const result = openRealm(this.user);
             try {
               expect(result).to.be.instanceOf(Promise);
             } finally {
-              const { realm, config } = await result;
-              closeRealm(realm, config);
+              closeRealm(await result);
             }
           });
 
@@ -311,7 +308,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(realm.subscriptions).to.have.length(1);
             expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
 
-            closeRealm(realm, config);
+            closeRealm(realm);
           });
 
           it("updates the subscriptions on first open if rerunOnOpen is undefined", async function (this: RealmContext) {
@@ -333,10 +330,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await realm.subscriptions.update((subs) => subs.removeAll());
             realm.close();
 
-            const { realm: realm2, config } = await openRealm(this.user, {});
+            const realm2 = await openRealm(this.user);
             expect(realm2.subscriptions).to.have.length(0);
 
-            closeRealm(realm2, config);
+            closeRealm(realm2);
           });
 
           it("does not update the subscriptions on second open if rerunOnOpen is false", async function (this: RealmContext) {
@@ -346,10 +343,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await realm.subscriptions.update((subs) => subs.removeAll());
             realm.close();
 
-            const { realm: realm2, config } = await openRealm(this.user, {});
+            const realm2 = await openRealm(this.user);
             expect(realm2.subscriptions).to.have.length(0);
 
-            closeRealm(realm2, config);
+            closeRealm(realm2);
           });
 
           it("does update the subscriptions on second open if rerunOnOpen is true", async function (this: RealmContext) {

--- a/integration-tests/tests/src/utils/close-realm.ts
+++ b/integration-tests/tests/src/utils/close-realm.ts
@@ -24,41 +24,18 @@
  * @param deleteRealmFile If false, do not delete the Realm file before reopening.
  * @param clearTestState If false, do not clear test state before reopening.
  */
-export function closeRealm(
-  realm: Realm,
-  config: Realm.Configuration,
-  deleteRealmFile = true,
-  clearTestState = true,
-): void {
+export function closeRealm(realm: Realm, deleteRealmFile = true, clearTestState = true): void {
+  const path = realm.path;
   realm.close();
 
   if (deleteRealmFile) {
-    Realm.deleteFile(config);
+    Realm.deleteFile({ path });
   }
 
   if (clearTestState) {
     // Clearing the test state to ensure the sync session gets completely reset and nothing is cached between tests
     Realm.clearTestState();
   }
-}
-
-/**
- * Close the Realm instance on the current `this` context
- *
- * @param this Mocha `this` context
- */
-export function closeThisRealm(this: Partial<RealmContext> & Mocha.Context): void {
-  if (!this.realm) {
-    throw new Error("Expected a 'realm' to close");
-  }
-  if (!this.config) {
-    throw new Error("Expected a 'config' to close");
-  }
-
-  closeRealm(this.realm, this.config);
-
-  delete this.realm;
-  delete this.config;
 }
 
 /**
@@ -73,6 +50,6 @@ export function closeThisRealm(this: Partial<RealmContext> & Mocha.Context): voi
  * @returns New re-opened Realm instance
  */
 export function closeAndReopenRealm(realm: Realm, config: Realm.Configuration, clearRealm = true): Promise<Realm> {
-  closeRealm(realm, config, clearRealm, clearRealm);
+  closeRealm(realm, clearRealm, clearRealm);
   return Realm.open(config);
 }


### PR DESCRIPTION
## What, How & Why?

- When the opening of a Realm fails the after hook would also fail, which I think isn't ideal. Instead we should consider a `realm` missing from the context a way of signaling that the Realm was never opened or already closed.
- I don't think the utils were the right place for `closeThisRealm` as it required `this` being a Mocha context and was only used by the "open-realm-before.ts". So I simply moved it into the calling source file.
- I also changed the `closeRealm` to not have to take a config and instead use the path of the Realm to construct a mocked config pointing to the right file (even in the case of synced realms).