### PR TITLE
allow useQuery to apply filter before listener is added

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -19,6 +19,7 @@ const SomeComponent = () => {
 }
 ```
 >NOTE: If your app is using multiple Realms, then you should continue using `createRealmContext`
+* `useQuery` can now have a filter applied within the hook. Use this when your filter does not change across re-renders. Applying the filter within the hook means that only changes found on filtered objects will trigger a re-render.
 
 ### Fixed
 * `useUser` is now typed to never returned `null` [#4973](https://github.com/realm/realm-js/issues/4973)

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -30,6 +30,8 @@ import { symbols } from "@realm/common";
 export function createUseQuery(useRealm: () => Realm) {
   return function useQuery<T>(
     type: string | ({ new (...args: any): T } & Realm.ObjectClass),
+    filter?: string,
+    filterArgs: any[] = [],
   ): Realm.Results<T & Realm.Object> {
     const realm = useRealm();
 
@@ -42,7 +44,7 @@ export function createUseQuery(useRealm: () => Realm) {
     // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `primaryKey` or `type` change
     const { collection, tearDown } = useMemo(() => {
       return createCachedCollection({
-        collection: realm.objects(type),
+        collection: filter ? realm.objects(type).filtered(filter, ...filterArgs) : realm.objects(type),
         realm,
         updateCallback: forceRerender,
         updatedRef,
@@ -65,7 +67,7 @@ export function createUseQuery(useRealm: () => Realm) {
       // (see `lib/mutable-subscription-set.js` for more details)
       // TODO: We can remove this if `realm` becomes a peer dependency >= 12
       Object.defineProperty(collectionRef.current, symbols.PROXY_TARGET, {
-        value: realm.objects(type),
+        value: filter ? realm.objects(type).filtered(filter, ...filterArgs) : realm.objects(type),
         enumerable: false,
         configurable: false,
         writable: true,


### PR DESCRIPTION
## What, How & Why?
I am submitting this change for review because I would like to apply a filter before the listener for `useQuery` is applied. In some instances (ie: your filter doesn't change) it makes sense to apply a filter and have that be a requirements for a new render.

In the current implementation you can apply a filter in a `useMemo` call but even if your filter is constant you will still get re-renders even when objects outside the filter are changed or added.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
