### PR TITLE
allow useQuery to filter or sort a collection by using a callback

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -19,6 +19,7 @@ const SomeComponent = () => {
 }
 ```
 >NOTE: If your app is using multiple Realms, then you should continue using `createRealmContext`
+* Allow `useQuery` to be passed a `query` function where `sorted` and `filtered` methods can be called
 
 ### Fixed
 * `useUser` is now typed to never returned `null` [#4973](https://github.com/realm/realm-js/issues/4973)

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -155,10 +155,11 @@ import {useQuery} from '@realm/react';
 const Component = () => {
   // ObjectClass is a class extending Realm.Object, which should have been provided in the Realm Config.
   // It is also possible to use the model's name as a string ( ex. "Object" ) if you are not using class based models.
-  const collection = useQuery(ObjectClass);
-
-  // The methods `sorted` and `filtered` should be wrapped in a useMemo.
-  const sortedCollection = useMemo(() => collection.sorted(), [collection]);
+  const sortedCollection = useQuery(ObjectClass, (collection) => {
+    // The methods `sorted` and `filtered` should be passed as a `query` function
+    // any variables that are dependencies for this should be placed in the dependency array
+    return collection.sorted();
+  }, []);
 
   return (
     <FlatList data={sortedCollection} renderItem={({ item }) => <Object item={item}/>

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -41,6 +41,9 @@ export function createUseQuery(useRealm: () => Realm) {
     const realm = useRealm();
 
     const queryCallback = useMemo(() => {
+      // We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
+      // This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
+      // Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback`
       return query;
     }, deps);
 

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -55,7 +55,7 @@ export function createUseQuery(useRealm: () => Realm) {
     const collectionRef = useRef<RealmResults<T>>();
     const updatedRef = useRef(true);
 
-    // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `type` or `collectionCallbackMemo` change
+    // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `realm` or `queryResult` change
     const { collection, tearDown } = useMemo(() => {
       return createCachedCollection({
         collection: queryResult,

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
-import { useEffect, useReducer, useMemo, useRef } from "react";
+import { useEffect, useReducer, useMemo, useRef, useCallback } from "react";
 import { createCachedCollection } from "./cachedCollection";
 import { symbols } from "@realm/common";
 
@@ -40,12 +40,10 @@ export function createUseQuery(useRealm: () => Realm) {
   ): RealmResults<T> {
     const realm = useRealm();
 
-    const queryCallback = useMemo(() => {
-      // We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
-      // This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
-      // Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback`
-      return query;
-    }, deps);
+    // We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
+    // This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
+    // Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback`
+    const queryCallback = useCallback(query, deps);
 
     const queryResult = useMemo(() => {
       return queryCallback(realm.objects(type));


### PR DESCRIPTION
## What, How & Why?
allow useQuery to filter or sort a collection by using a callback mehod that gets momoized based on the dependency array

This fixes: #5471

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
