### PR TITLE
`realm-web` BaaS QA test server

### DIFF
--- a/.github/workflows/pr-realm-web.yml
+++ b/.github/workflows/pr-realm-web.yml
@@ -53,4 +53,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.BAAS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BAAS_AWS_SECRET_ACCESS_KEY }}
-          MONGODB_REALM_TEST_SERVER: "2022-06-15"
+          MDB_REALM_BASE_URL: ${{ secrets.REALM_QA_BASE_URL }}
+          MDB_REALM_PUBLIC_KEY: ${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+          MDB_REALM_PRIVATE_KEY: ${{ secrets.ATLAS_QA_PRIVATE_API_KEY }}

--- a/packages/realm-web-integration-tests/harness/github.ts
+++ b/packages/realm-web-integration-tests/harness/github.ts
@@ -15,92 +15,9 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
-import cp from "child_process";
-
 import { run } from "./index";
 
-const IMAGE_TAG = process.env.MONGODB_REALM_TEST_SERVER || "latest";
-const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = process.env;
-
-if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
-  console.error("Missing either AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY");
-  process.exit(1);
-}
-
-async function startServer() {
-  console.log("Starting Atlas App Services server");
-  const serverProcess = cp.spawn(
-    "docker",
-    [
-      "run",
-      "--rm",
-      "--name",
-      "mongodb-realm-test-server",
-      "--publish",
-      "9090:9090",
-      "--env",
-      `AWS_ACCESS_KEY_ID`,
-      "--env",
-      `AWS_SECRET_ACCESS_KEY`,
-      `ghcr.io/realm/ci/mongodb-realm-test-server:${IMAGE_TAG}`,
-    ],
-    { stdio: ["ignore", "pipe", "inherit"] },
-  );
-  // Kill the server when the process ends
-  function killServer() {
-    console.log("Killing the Atlas App Services server");
-    // Tell docker to kill the container
-    cp.execSync("docker kill mongodb-realm-test-server", {
-      encoding: "utf8",
-    });
-  }
-  process.once("exit", killServer);
-  process.on("SIGINT", () => {
-    // Stop listening on the exit event
-    process.off("exit", killServer);
-    // Kill the server
-    killServer();
-    // Exit
-    process.exit(1);
-  });
-  // Start reading the STDOUT to determine when the container is ready for connections
-  return new Promise<void>((resolve, reject) => {
-    let output = "";
-    /**
-     * Handle standard output by looking for a started "Stitch" service.
-     */
-    function handleOutput(chunk: Buffer) {
-      // Write to the regular STDOUT
-      process.stdout.write(chunk);
-      // Resolve the promise when the server gets ready
-      output += chunk.toString();
-      // If it contains the magic string
-      if (output.includes("Starting Stitch... Done")) {
-        // Stop listening for output
-        serverProcess.stdout.off("data", handleOutput);
-        resolve();
-      }
-    }
-    /**
-     * Handle an unexpected exit by rejecting the promise
-     */
-    function handleUnexpectedExit() {
-      const err = new Error("Atlas App Services server closed before it was ready");
-      reject(err);
-    }
-    // Start listening for output
-    serverProcess.stdout.on("data", handleOutput);
-    // Reject the promise if the process exits before it gets ready
-    serverProcess.once("exit", handleUnexpectedExit);
-  });
-}
-
-async function startRunAndStop() {
-  await startServer();
-  await run();
-}
-
-startRunAndStop().then(
+run().then(
   () => {
     process.exit();
   },

--- a/packages/realm-web-integration-tests/harness/import-realm-app.ts
+++ b/packages/realm-web-integration-tests/harness/import-realm-app.ts
@@ -18,15 +18,35 @@
 
 import path from "path";
 
-import { AppImporter } from "@realm/app-importer";
+import { AppImporter, Credentials } from "@realm/app-importer";
 
-const MDB_REALM_BASE_URL = process.env.MDB_REALM_BASE_URL || "http://localhost:9090";
-const MDB_REALM_USERNAME = process.env.MDB_REALM_USERNAME || "unique_user@domain.com";
-const MDB_REALM_PASSWORD = process.env.MDB_REALM_PASSWORD || "password";
+const {
+  MDB_REALM_BASE_URL = "http://localhost:9090",
+  MDB_REALM_USERNAME = "unique_user@domain.com",
+  MDB_REALM_PASSWORD = "password",
+  MDB_REALM_PUBLIC_KEY,
+  MDB_REALM_PRIVATE_KEY,
+} = process.env;
 
 const MDB_REALM_APP_ID = process.env.MDB_REALM_APP_ID;
 
 const MDB_REALM_SKIP_CLEANUP = process.env.MDB_REALM_SKIP_CLEANUP === "true";
+
+function buildCredentials(): Credentials {
+  if (MDB_REALM_PUBLIC_KEY && MDB_REALM_PRIVATE_KEY) {
+    return {
+      kind: "api-key",
+      publicKey: MDB_REALM_PUBLIC_KEY,
+      privateKey: MDB_REALM_PRIVATE_KEY,
+    };
+  } else {
+    return {
+      kind: "username-password",
+      username: MDB_REALM_USERNAME,
+      password: MDB_REALM_PASSWORD,
+    };
+  }
+}
 
 export async function importRealmApp() {
   // Create a new MongoDBRealmService
@@ -37,11 +57,7 @@ export async function importRealmApp() {
   } else {
     const importer = new AppImporter({
       baseUrl,
-      credentials: {
-        kind: "username-password",
-        username: MDB_REALM_USERNAME,
-        password: MDB_REALM_PASSWORD,
-      },
+      credentials: buildCredentials(),
       appsDirectoryPath: path.resolve(__dirname, "../imported-apps"),
       realmConfigPath: path.resolve(__dirname, "../realm-config"),
       cleanUp: !MDB_REALM_SKIP_CLEANUP,


### PR DESCRIPTION
## What, How & Why?

- Updates the `realm-web` integration tests to run against the shared QA test cluster, instead of spinning up it's own baas test server using docker. This aligns the way we run tests for our main integration tests of the root package.
