### PR TITLE
`realm-web` importing http service fixed

### DIFF
--- a/packages/realm-app-importer/src/AppImporter.ts
+++ b/packages/realm-app-importer/src/AppImporter.ts
@@ -390,7 +390,10 @@ export class AppImporter {
                   // Relationships is not valid in a rule request, but is included when exporting an app from realm
                   delete ruleConfig.relationships;
                 }
-                const rulesUrl = `${this.apiUrl}/groups/${groupId}/apps/${appId}/services/${serviceId}/default_rule`;
+                const rulesUrl =
+                  config.type === "mongodb" || config.type === "mongodb-atlas"
+                    ? `${this.apiUrl}/groups/${groupId}/apps/${appId}/services/${serviceId}/default_rule`
+                    : `${this.apiUrl}/groups/${groupId}/apps/${appId}/services/${serviceId}/rules`;
 
                 const response = await fetch(rulesUrl, {
                   method: "POST",

--- a/packages/realm-web-integration-tests/src/email-password-auth.test.ts
+++ b/packages/realm-web-integration-tests/src/email-password-auth.test.ts
@@ -129,7 +129,7 @@ describe("EmailPasswordAuth", () => {
     } catch (err) {
       // We expect this to throw, since password resets via functions fail with this app configuration
       expect(err).instanceOf(MongoDBRealmError);
-      expect((err as MongoDBRealmError).error).equals(`failed to reset password for user ${email}`);
+      expect((err as MongoDBRealmError).error).equals(`failed to reset password for user "${email}"`);
     }
   });
 });


### PR DESCRIPTION
## What, How & Why?

- Introduces a couple of changes I needed to make to the baas test server package to make the tests pass.
- Adds a conditional to the URL used when creating rules, to fall back to the old behaviour for the "HTTP" service.
