### PR TITLE
Set max-parallel in test strategy

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -163,8 +163,8 @@ jobs:
         env:
           ANDROID_NDK: ${{ env.ANDROID_SDK_ROOT }}/ndk/${{ env.NDK_VERSION }}
 
-      # Due to a limitation in upload-artifact a redundant file is needed to force 
-      # preserving paths (https://github.com/actions/upload-artifact/issues/174) 
+      # Due to a limitation in upload-artifact a redundant file is needed to force
+      # preserving paths (https://github.com/actions/upload-artifact/issues/174)
       - name: Upload prebuild artifact
         uses: actions/upload-artifact@v3
         with:
@@ -191,8 +191,8 @@ jobs:
       - name: Regenerate Info.plist
         run: scripts/regen-info-plist.sh react-native/ios/realm-js-ios.xcframework
 
-      # Due to a limitation in upload-artifact a redundant file is needed to force 
-      # preserving paths (https://github.com/actions/upload-artifact/issues/174) 
+      # Due to a limitation in upload-artifact a redundant file is needed to force
+      # preserving paths (https://github.com/actions/upload-artifact/issues/174)
       - name: Upload prebuild artifact
         uses: actions/upload-artifact@v3
         with:
@@ -219,6 +219,7 @@ jobs:
     runs-on: ${{ matrix.variant.runner }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         variant:
           - { os: linux, target: test, runner: ubuntu-latest, environment: node }


### PR DESCRIPTION

## What, How & Why?
In order to reduce connections on the cluster, I'm applying a temporary fix to set the max number of parallel tests to 3.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
