### PR TITLE
Implement getAllSyncSessions

### DIFF
--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -394,9 +394,9 @@ records:
   UserIdentity:
     cppName: SyncUserIdentity
     fields:
-      id: 
+      id:
         type: std::string
-      provider_type: 
+      provider_type:
         type: std::string
 
   UserAPIKey:
@@ -1037,6 +1037,7 @@ classes:
   SyncUser:
     sharedPtrWrapped: SharedSyncUser
     properties:
+      all_sessions: std::vector<SharedSyncSession>
       is_logged_in: bool
       identity: const std::string&
       provider_type: const std::string&

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -93,7 +93,7 @@ export class Sync {
     app.internal.syncManager.setLoggerFactory(factory);
   }
   static getAllSyncSessions(user: User): SyncSession[] {
-    throw new Error("Not yet implemented");
+    return user.internal.allSessions.map((session) => new SyncSession(session));
   }
   static getSyncSession(user: User, partitionValue: PartitionValue): SyncSession | null {
     validateSyncConfiguration({ user, partitionValue });


### PR DESCRIPTION
Add allSessions to SyncUser in bindgen. Transform result to JS SyncSession array.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
