### PR TITLE
fix call to Platform.isPad and isTV

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,9 +160,9 @@ module.exports = {
         let deviceName = "unknown";
         let deviceVersion = "unknown";
         if (Platform.OS === "ios") {
-          if (Platform.isPad()) {
+          if (Platform.isPad) {
             deviceName = "iPad";
-          } else if (Platform.isTV()) {
+          } else if (Platform.isTV) {
             deviceName = "AppleTV";
           } else {
             // RN doesn't support Apple Watch


### PR DESCRIPTION
## What, How & Why?
Fix error `TypeError: false is not a function, js engine: hermes`

Platform.isPad and isTV were being called as a function but both are booleans https://reactnative.dev/docs/platform#ispad-ios

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
