### PR TITLE
allow useQuery to filter or sort a collection by using a callback

### DIFF
--- a/example/app/AppNonSync.tsx
+++ b/example/app/AppNonSync.tsx
@@ -6,9 +6,17 @@ import {TaskManager} from './components/TaskManager';
 import {useQuery} from '@realm/react';
 
 export const AppNonSync = () => {
-  const result = useQuery(Task);
+  const [showDone, setShowDone] = React.useState(false);
+  const tasks = useQuery(
+    Task,
+    collection =>
+      showDone
+        ? collection.sorted('createdAt')
+        : collection.filtered('isComplete == false').sorted('createdAt'),
+    [showDone],
+  );
 
-  const tasks = useMemo(() => result.sorted('createdAt'), [result]);
-
-  return <TaskManager tasks={tasks} />;
+  return (
+    <TaskManager tasks={tasks} setShowDone={setShowDone} showDone={showDone} />
+  );
 };

--- a/example/app/AppNonSync.tsx
+++ b/example/app/AppNonSync.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 
 import {Task} from './models/Task';
 import {TaskManager} from './components/TaskManager';

--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -27,7 +27,7 @@ export const AppSync: React.FC = () => {
 
   useEffect(() => {
     realm.subscriptions.update(mutableSubs => {
-      mutableSubs.add(result);
+      mutableSubs.add(tasks);
     });
   }, [realm, tasks]);
 

--- a/example/app/AppSync.tsx
+++ b/example/app/AppSync.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {useApp, useUser} from '@realm/react';
 import {Pressable, StyleSheet, Text} from 'react-native';
 
@@ -15,7 +15,7 @@ export const AppSync: React.FC = () => {
   const realm = useRealm();
   const user = useUser();
   const app = useApp();
-  const [showDone, setShowDone] = React.useState(false);
+  const [showDone, setShowDone] = useState(false);
   const tasks = useQuery(
     Task,
     collection =>

--- a/example/app/components/TaskList.tsx
+++ b/example/app/components/TaskList.tsx
@@ -19,7 +19,7 @@ export const TaskList: React.FC<TaskListProps> = ({
   return (
     <View style={styles.listContainer}>
       <FlatList
-        data={tasks} // Spread the Realm results into an array until the 0.71.4 release
+        data={tasks}
         keyExtractor={task => task._id.toString()}
         renderItem={({item}) => (
           <TaskItem

--- a/example/app/components/TaskManager.tsx
+++ b/example/app/components/TaskManager.tsx
@@ -31,7 +31,10 @@ export const TaskManager: React.FC<{
       // of sync participants to successfully sync everything in the transaction, otherwise
       // no changes propagate and the transaction needs to start over when connectivity allows.
       realm.write(() => {
-        return new Task(realm, description, userId);
+        return realm.create(Task, {
+          description,
+          userId: userId ? userId : 'blah',
+        });
       });
     },
     [realm, userId],

--- a/example/app/components/TaskManager.tsx
+++ b/example/app/components/TaskManager.tsx
@@ -33,7 +33,7 @@ export const TaskManager: React.FC<{
       realm.write(() => {
         return realm.create(Task, {
           description,
-          userId: userId ? userId : 'blah',
+          userId: userId ?? 'SYNC_DISABLED',
         });
       });
     },

--- a/example/app/components/TaskManager.tsx
+++ b/example/app/components/TaskManager.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, Switch, Text} from 'react-native';
 
 import {Task} from '../models/Task';
 import {IntroText} from './IntroText';
@@ -7,11 +7,14 @@ import {AddTaskForm} from './AddTaskForm';
 import TaskList from './TaskList';
 
 import {useRealm} from '@realm/react';
+import {shadows} from '../styles/shadows';
 
 export const TaskManager: React.FC<{
   tasks: Realm.Results<Task & Realm.Object>;
   userId?: string;
-}> = ({tasks, userId}) => {
+  setShowDone: (showDone: boolean) => void;
+  showDone: boolean;
+}> = ({tasks, userId, setShowDone, showDone}) => {
   const realm = useRealm();
 
   const handleAddTask = useCallback(
@@ -71,18 +74,24 @@ export const TaskManager: React.FC<{
   );
 
   return (
-    <View style={styles.content}>
-      <AddTaskForm onSubmit={handleAddTask} />
-      {tasks.length === 0 ? (
-        <IntroText />
-      ) : (
-        <TaskList
-          tasks={tasks}
-          onToggleTaskStatus={handleToggleTaskStatus}
-          onDeleteTask={handleDeleteTask}
-        />
-      )}
-    </View>
+    <>
+      <View style={styles.content}>
+        <AddTaskForm onSubmit={handleAddTask} />
+        {tasks.length === 0 ? (
+          <IntroText />
+        ) : (
+          <TaskList
+            tasks={tasks}
+            onToggleTaskStatus={handleToggleTaskStatus}
+            onDeleteTask={handleDeleteTask}
+          />
+        )}
+      </View>
+      <View style={styles.switchPanel}>
+        <Text style={styles.switchPanelText}>Show Completed?</Text>
+        <Switch value={showDone} onValueChange={() => setShowDone(!showDone)} />
+      </View>
+    </>
   );
 };
 
@@ -91,5 +100,19 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: 20,
     paddingHorizontal: 20,
+  },
+  switchPanel: {
+    flexDirection: 'row',
+    backgroundColor: '#fff',
+    padding: 10,
+    borderRadius: 5,
+    marginHorizontal: 10,
+    marginBottom: 10,
+    ...shadows,
+  },
+  switchPanelText: {
+    flex: 1,
+    fontSize: 16,
+    padding: 5,
   },
 });

--- a/example/app/models/Task.ts
+++ b/example/app/models/Task.ts
@@ -11,7 +11,7 @@ import {Realm, BSON} from 'realm';
 // To use a class as a Realm object type in Typescript with the `@realm/babel-plugin` plugin,
 // simply define the properties on the class with the correct type and the plugin will convert
 // it to a Realm schema automatically.
-export class Task extends Realm.Object<Task> {
+export class Task extends Realm.Object {
   _id: BSON.ObjectId = new BSON.ObjectId();
   description!: string;
   isComplete: boolean = false;
@@ -19,8 +19,4 @@ export class Task extends Realm.Object<Task> {
   userId!: string;
 
   static primaryKey = '_id';
-
-  constructor(realm: Realm, description: string, userId?: string) {
-    super(realm, {description, userId: userId || '_SYNC_DISABLED_'});
-  }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -415,7 +415,7 @@ PODS:
     - React-jsi (= 0.71.4)
     - React-logger (= 0.71.4)
     - React-perflogger (= 0.71.4)
-  - RealmJS (12.0.0-rc.0):
+  - RealmJS (12.0.0-alpha.1):
     - React
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -625,7 +625,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: ad17efcfb2fa8f6bfd8ac0cf48d96668b8b28e0b
   React-runtimeexecutor: 8fa50b38df6b992c76537993a2b0553d3b088004
   ReactCommon: b49a4b00ca6d181ff74b17c12b2d59ac4add0bde
-  RealmJS: 8eee99b934b4baa64c19b13e9381a724d6182e9a
+  RealmJS: 258cdfc55fc10455cad414486b4b01f046a5a4d4
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 79dd7410de6f8ad73a77c868d3d368843f0c93e0
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/package-lock.json
+++ b/package-lock.json
@@ -29873,7 +29873,6 @@
       "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@realm/common": "^0.1.4",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -36071,7 +36070,6 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.15.0",
         "@babel/runtime": "^7.15.4",
-        "@realm/common": "^0.1.4",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^9.0.2",
         "@testing-library/jest-native": "^4.0.13",

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -7,24 +7,36 @@
 	// logger includes a default that prints level and message
 	<AppProvider id={appId} logLevel={'trace'} logger={(level, message) => console.log(`[${level}]: ${message}`)}>
 	```
+* Allow `useQuery` to be passed a `query` function where `sorted` and `filtered` methods can be called ([#5471](https://github.com/realm/realm-js/issues/4973)) Thanks for the contribution [@levipro](https://github.com/levipro)!
+
+  Example:
+	```tsx
+	const SomeComponent = () => {
+	  const user = useUser();
+		const items = useQuery(Item,
+			(res) => res.filtered(`owner_id == "${user?.id}"`).sorted('createdAt'),
+			 [user]
+		);
+	```
 * Create a default context so the `RealmProvider`, `useQuery`, `useRealm`, and `useObject` can be directly imported from `@realm/react` ([#5292](https://github.com/realm/realm-js/issue/5292))
-  Usage example:
-```tsx
-// These imports are now available without calling `createRealmContext`
-import {RealmProvider, useQuery} from '@realm/react'
-//...
-// Provider your schema models directly to the realm provider
-<RealmProvider schema={[Item]}>
-	<SomeComponent/>
-</RealmProvider>
 
-const SomeComponent = () => {
-	const items = useQuery(Item)
-
+  Example:
+	```tsx
+	// These imports are now available without calling `createRealmContext`
+	import {RealmProvider, useQuery} from '@realm/react'
 	//...
-}
-```
->NOTE: If your app is using multiple Realms, then you should continue using `createRealmContext`
+	// Provider your schema models directly to the realm provider
+	<RealmProvider schema={[Item]}>
+		<SomeComponent/>
+	</RealmProvider>
+
+	const SomeComponent = () => {
+		const items = useQuery(Item)
+
+		//...
+	}
+	```
+	>NOTE: If your app is using multiple Realms, then you should continue using `createRealmContext`
 
 ### Fixed
 * `useUser` is now typed to never returned `null` [#4973](https://github.com/realm/realm-js/issues/4973)

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -12,11 +12,12 @@
   Example:
 	```tsx
 	const SomeComponent = () => {
-	  const user = useUser();
-		const items = useQuery(Item,
-			(res) => res.filtered(`owner_id == "${user?.id}"`).sorted('createdAt'),
-			 [user]
-		);
+	    const user = useUser();
+	    const items = useQuery(Item,
+	        (res) => res.filtered(`owner_id == "${user?.id}"`).sorted('createdAt'),
+	        [user]
+	    );
+	};
 	```
 * Create a default context so the `RealmProvider`, `useQuery`, `useRealm`, and `useObject` can be directly imported from `@realm/react` ([#5292](https://github.com/realm/realm-js/issue/5292))
 

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -156,8 +156,8 @@ const Component = () => {
   // ObjectClass is a class extending Realm.Object, which should have been provided in the Realm Config.
   // It is also possible to use the model's name as a string ( ex. "Object" ) if you are not using class based models.
   const sortedCollection = useQuery(ObjectClass, (collection) => {
-    // The methods `sorted` and `filtered` should be passed as a `query` function
-    // any variables that are dependencies for this should be placed in the dependency array
+    // The methods `sorted` and `filtered` should be passed as a `query` function.
+    // Any variables that are dependencies of this should be placed in the dependency array.
     return collection.sorted();
   }, []);
 

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -155,10 +155,11 @@ import {useQuery} from '@realm/react';
 const Component = () => {
   // ObjectClass is a class extending Realm.Object, which should have been provided in the Realm Config.
   // It is also possible to use the model's name as a string ( ex. "Object" ) if you are not using class based models.
-  const collection = useQuery(ObjectClass);
-
-  // The methods `sorted` and `filtered` should be wrapped in a useMemo.
-  const sortedCollection = useMemo(() => collection.sorted(), [collection]);
+  const sortedCollection = useQuery(ObjectClass, (collection) => {
+    // The methods `sorted` and `filtered` should be passed as a `query` function
+    // any variables that are dependencies for this should be placed in the dependency array
+    return collection.sorted();
+  }, []);
 
   return (
     <FlatList data={sortedCollection} renderItem={({ item }) => <Object item={item}/>

--- a/packages/realm-react/src/__tests__/useQueryRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryRender.test.tsx
@@ -23,7 +23,7 @@ import { View, TextInput, TouchableHighlight, Text, FlatList, ListRenderItem } f
 import "@testing-library/jest-native/extend-expect";
 import { createRealmContext } from "..";
 
-class Item extends Realm.Object<Item> {
+class Item extends Realm.Object {
   id!: number;
   name!: string;
   tags!: Realm.List<Tag>;
@@ -39,7 +39,7 @@ class Item extends Realm.Object<Item> {
   };
 }
 
-class Tag extends Realm.Object<Tag> {
+class Tag extends Realm.Object {
   id!: number;
   name!: string;
 
@@ -349,9 +349,9 @@ describe.each`
 
     // Insert some tags into visible Items
     testRealm.write(() => {
-      const tag1 = new Tag(testRealm, { id: 1, name: "a123" });
-      const tag2 = new Tag(testRealm, { id: 2, name: "b234" });
-      const tag3 = new Tag(testRealm, { id: 3, name: "c567" });
+      const tag1 = testRealm.create(Tag, { id: 1, name: "a123" });
+      const tag2 = testRealm.create(Tag, { id: 2, name: "b234" });
+      const tag3 = testRealm.create(Tag, { id: 3, name: "c567" });
 
       collection[0].tags.push(tag1);
       collection[0].tags.push(tag2);

--- a/packages/realm-react/src/__tests__/useQueryRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryRender.test.tsx
@@ -23,7 +23,7 @@ import { View, TextInput, TouchableHighlight, Text, FlatList, ListRenderItem } f
 import "@testing-library/jest-native/extend-expect";
 import { createRealmContext } from "..";
 
-class Item extends Realm.Object {
+class Item extends Realm.Object<Item> {
   id!: number;
   name!: string;
   tags!: Realm.List<Tag>;
@@ -39,7 +39,7 @@ class Item extends Realm.Object {
   };
 }
 
-class Tag extends Realm.Object {
+class Tag extends Realm.Object<Tag> {
   id!: number;
   name!: string;
 
@@ -101,7 +101,7 @@ const SetupComponent = ({ children }: { children: JSX.Element }): JSX.Element | 
   useEffect(() => {
     realm.write(() => {
       realm.deleteAll();
-      testCollection.forEach((object) => realm.create(Item, object));
+      testCollection.forEach((object) => new Item(realm, object));
     });
     setSetupComplete(true);
   }, [realm]);
@@ -349,9 +349,9 @@ describe.each`
 
     // Insert some tags into visible Items
     testRealm.write(() => {
-      const tag1 = testRealm.create(Tag, { id: 1, name: "a123" });
-      const tag2 = testRealm.create(Tag, { id: 2, name: "b234" });
-      const tag3 = testRealm.create(Tag, { id: 3, name: "c567" });
+      const tag1 = new Tag(testRealm, { id: 1, name: "a123" });
+      const tag2 = new Tag(testRealm, { id: 2, name: "b234" });
+      const tag3 = new Tag(testRealm, { id: 3, name: "c567" });
 
       collection[0].tags.push(tag1);
       collection[0].tags.push(tag2);
@@ -405,7 +405,7 @@ describe.each`
         await new Promise((resolve) => setTimeout(resolve, 10));
         const id = i;
         testRealm.write(() => {
-          testRealm.create(Item, { id, name: `${id}` }, Realm.UpdateMode.Modified);
+          return new Item(testRealm, { id, name: `${id}` });
         });
         await new Promise((resolve) => setTimeout(resolve, 0));
         testRealm.write(() => {

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -72,14 +72,18 @@ type RealmContext = {
    * then only the modified object will re-render.
    *
    * @example
-   * ```
-   * const collection = useQuery(Object);
+   * ```tsx
+   * // Return all collection items
+   * const collection = useQuery(Object)
    *
-   * // The methods `sorted` and `filtered` should be wrapped in a useMemo.
-   * const sortedCollection = useMemo(collection.sorted(), [collection]);
+   * // Return all collection items sorted by name and filtered by category
+   * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
    * ```
    *
    * @param type - The object type, depicted by a string or a class extending Realm.Object
+   * @param query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
+   * This allows for filtering and sorting of the collection, before it is returned.
+   * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
    * @returns a collection of realm objects or an empty array
    */
   useQuery: ReturnType<typeof createUseQuery>;
@@ -189,14 +193,18 @@ export const useRealm = defaultContext.useRealm;
  * then only the modified object will re-render.
  *
  * @example
- * ```
- * const collection = useQuery(Object);
+ * ```tsx
+ * // Return all collection items
+ * const collection = useQuery(Object)
  *
- * // The methods `sorted` and `filtered` should be wrapped in a useMemo.
- * const sortedCollection = useMemo(collection.sorted(), [collection]);
+ * // Return all collection items sorted by name and filtered by category
+ * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
  * ```
  *
  * @param type - The object type, depicted by a string or a class extending Realm.Object
+ * @param query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
+ * This allows for filtering and sorting of the collection, before it is returned.
+ * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
  * @returns a collection of realm objects or an empty array
  */
 export const useQuery = defaultContext.useQuery;

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -17,9 +17,13 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
-import { useEffect, useReducer, useMemo, useRef } from "react";
+import { useEffect, useReducer, useMemo, useRef, useCallback } from "react";
 import { createCachedCollection } from "./cachedCollection";
 import { getObjects } from "./helpers";
+
+type RealmClassType<T> = { new (...args: any): T } & Realm.ObjectClass;
+type QueryCallback<T> = (collection: Realm.Results<T>) => Realm.Results<T>;
+type DependencyList = ReadonlyArray<unknown>;
 
 /**
  * Generates the `useQuery` hook from a given `useRealm` hook.
@@ -28,26 +32,54 @@ import { getObjects } from "./helpers";
  * @returns useObject - Hook that is used to gain access to a {@link Realm.Collection}
  */
 export function createUseQuery(useRealm: () => Realm) {
-  function useQuery<T>(type: string): Realm.Results<T & Realm.Object<T>>;
-  function useQuery<T extends Realm.Object<any>>(type: { new (...args: any): T }): Realm.Results<T>;
-  function useQuery<T extends Realm.Object>(type: string | { new (...args: any): T }): Realm.Results<T> {
+  function useQuery<T>(
+    type: string,
+    query?: QueryCallback<T>,
+    deps?: DependencyList,
+  ): Realm.Results<T & Realm.Object<T>>;
+  function useQuery<T extends Realm.Object<any>>(
+    type: RealmClassType<T>,
+    query?: QueryCallback<T>,
+    deps?: DependencyList,
+  ): Realm.Results<T>;
+  function useQuery<T extends Realm.Object>(
+    type: string | RealmClassType<T>,
+    query: QueryCallback<T> = (collection) => collection,
+    deps: DependencyList = [],
+  ): Realm.Results<T> {
     const realm = useRealm();
 
     // Create a forceRerender function for the cachedCollection to use as its updateCallback, so that
     // the cachedCollection can force the component using this hook to re-render when a change occurs.
     const [, forceRerender] = useReducer((x) => x + 1, 0);
-    const collectionRef = useRef<Realm.Results<T & Realm.Object>>();
+    const collectionRef = useRef<Realm.Results<T>>();
     const updatedRef = useRef(true);
+    const queryCallbackRef = useRef<QueryCallback<T> | null>(null);
 
-    // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `primaryKey` or `type` change
+    // We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
+    // This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
+    // Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback`
+    const queryCallback = useCallback(query, deps);
+
+    // If the query function changes, we need to update the cachedCollection
+    if (queryCallbackRef.current !== queryCallback) {
+      queryCallbackRef.current = queryCallback;
+      updatedRef.current = true;
+    }
+
+    const queryResult = useMemo(() => {
+      return queryCallback(getObjects(realm, type));
+    }, [type, realm, queryCallback]);
+
+    // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `realm` or `queryResult` change
     const { collection, tearDown } = useMemo(() => {
       return createCachedCollection<T>({
-        collection: getObjects(realm, type),
+        collection: queryResult,
         realm,
         updateCallback: forceRerender,
         updatedRef,
       });
-    }, [type, realm]);
+    }, [realm, queryResult]);
 
     // Invoke the tearDown of the cachedCollection when useQuery is unmounted
     useEffect(() => {

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -21,7 +21,7 @@ import { useEffect, useReducer, useMemo, useRef, useCallback } from "react";
 import { createCachedCollection } from "./cachedCollection";
 import { getObjects } from "./helpers";
 
-type RealmClassType<T> = { new (...args: any): T } & Realm.ObjectClass;
+type RealmClassType<T = any> = { new (...args: any): T };
 type QueryCallback<T> = (collection: Realm.Results<T>) => Realm.Results<T>;
 type DependencyList = ReadonlyArray<unknown>;
 
@@ -42,9 +42,9 @@ export function createUseQuery(useRealm: () => Realm) {
     query?: QueryCallback<T>,
     deps?: DependencyList,
   ): Realm.Results<T>;
-  function useQuery<T extends Realm.Object>(
+  function useQuery<T extends Realm.Object<any>>(
     type: string | RealmClassType<T>,
-    query: QueryCallback<T> = (collection) => collection,
+    query: QueryCallback<T> = (collection: Realm.Results<T>) => collection,
     deps: DependencyList = [],
   ): Realm.Results<T> {
     const realm = useRealm();


### PR DESCRIPTION
## What, How & Why?
This adds the ability to filter and sort the return value of `useQuery`, before it arrives in the component.  This ensures that `filtered` and `sorted` are not called again when `useQuery` triggers a re-render.

This closes #5471

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
