### PR TITLE
Add a sync log capability to the AppProvider

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## vNext (TBD)
 
 ### Enhancements
+* Add sync log configuration to AppProvider ([#5517](https://github.com/realm/realm-js/issue/5517))
+  Usage example:
+	```tsx
+	// logger includes a default that prints level and message
+	<AppProvider id={appId} logLevel={'trace'} logger={(level, message) => console.log(`[${level}]: ${message}`)}>
+	```
 * Create a default context so the `RealmProvider`, `useQuery`, `useRealm`, and `useObject` can be directly imported from `@realm/react` ([#5292](https://github.com/realm/realm-js/issue/5292))
   Usage example:
 ```tsx

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -347,3 +347,12 @@ const { RealmProvider: PrivateRealmProvider, useRealm: usePrivateRealm, useObjec
 ```
 
 It is also possible to call it without any Config; in the case that you want to do all your configuration through the `RealmProvider` props.
+
+
+#### Sync Debug Logs
+When running into issues with sync, it may be helpful to view logs in order to determine what the issue was or to provide more context when submitting an issue.  This can by done with the `AppProvider`.
+
+```
+// logger includes a default that prints level and message
+<AppProvider id={appId} logLevel={'trace'} logger={(level, message) => console.log(`[${level}]: ${message}`)}>
+```


### PR DESCRIPTION
## What, How & Why?
Make it easier to output sync logs in a `@realm/react` application
* Add a log level and logger arguments to the AppProvider
* Update Readme and tsdoc

This closes #5517

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
* [ ] jsdoc files updated
