### PR TITLE
Using `declare` in class-based models in the integration tests

### DIFF
--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -128,6 +128,8 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@babel/preset-env": "^7.14.0",
+    "@realm/babel-plugin": "*",
+    "@realm/babel-preset": "*",
     "@realm/metro-config": "*",
     "@react-native-community/eslint-config": "^3.0.0",
     "@tsconfig/react-native": "^2.0.2",

--- a/integration-tests/tests/src/schemas/contact.ts
+++ b/integration-tests/tests/src/schemas/contact.ts
@@ -35,8 +35,8 @@ export const ContactSchema: Realm.ObjectSchema = {
 };
 
 export class Contact extends Realm.Object implements IContact {
-  name!: string;
-  phones!: Realm.List<string>;
+  declare name: string;
+  declare phones: Realm.List<string>;
 
   static schema: Realm.ObjectSchema = ContactSchema;
 }

--- a/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
+++ b/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
@@ -40,11 +40,11 @@ export const PersonSchema: Realm.ObjectSchema = {
 };
 
 export class Person extends Realm.Object<Person> implements IPerson {
-  _id!: Realm.BSON.ObjectId;
-  name!: string;
-  age!: number;
-  friends!: Realm.List<Person>;
-  dogs!: Realm.Collection<Dog>;
+  declare _id: Realm.BSON.ObjectId;
+  declare name: string;
+  declare age: number;
+  declare friends: Realm.List<Person>;
+  declare dogs: Realm.Collection<Dog>;
 
   static schema: Realm.ObjectSchema = PersonSchema;
 }
@@ -68,10 +68,10 @@ export const DogSchema: Realm.ObjectSchema = {
 };
 
 export class Dog extends Realm.Object<Dog> implements IDog {
-  _id!: Realm.BSON.ObjectId;
-  name!: string;
-  age!: number;
-  owner!: Person;
+  declare _id: Realm.BSON.ObjectId;
+  declare name: string;
+  declare age: number;
+  declare owner: Person;
 
   static schema: Realm.ObjectSchema = DogSchema;
 }

--- a/integration-tests/tests/src/schemas/person-and-dogs.ts
+++ b/integration-tests/tests/src/schemas/person-and-dogs.ts
@@ -38,10 +38,10 @@ export const PersonSchema: Realm.ObjectSchema = {
 };
 
 export class Person extends Realm.Object<Person> {
-  name!: string;
-  age!: number;
-  friends!: Realm.List<Person>;
-  dogs!: Realm.Collection<Dog>;
+  declare name: string;
+  declare age: number;
+  declare friends: Realm.List<Person>;
+  declare dogs: Realm.Collection<Dog>;
 
   constructor(realm: Realm, name: string, age: number) {
     super(realm, { name, age });
@@ -66,9 +66,9 @@ export const DogSchema: Realm.ObjectSchema = {
 };
 
 export class Dog extends Realm.Object<Dog> {
-  name!: string;
-  age!: number;
-  owner!: Person;
+  declare name: string;
+  declare age: number;
+  declare owner: Person;
 
   constructor(realm: Realm, name: string, age: number, owner: Person) {
     super(realm, { name, age, owner });

--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -64,7 +64,7 @@ describe("Class models", () => {
 
     it("is allowed", () => {
       class Person extends Realm.Object<Person> {
-        name!: string;
+        declare name: string;
         static schema: Realm.ObjectSchema = {
           name: "Person",
           properties: { name: "string" },
@@ -77,10 +77,10 @@ describe("Class models", () => {
   describe("#constructor", () => {
     // The Pick and Partial is needed to correctly reflect the defaults
     class Person extends Realm.Object<Pick<Person, "name"> & Partial<Person>> {
-      id!: Realm.BSON.ObjectId;
-      name!: string;
-      age!: number;
-      friends!: Realm.List<Person>;
+      declare id: Realm.BSON.ObjectId;
+      declare name: string;
+      declare age: number;
+      declare friends: Realm.List<Person>;
 
       static schema: Realm.ObjectSchema = {
         name: "Person",

--- a/integration-tests/tests/src/tests/linking-objects.ts
+++ b/integration-tests/tests/src/tests/linking-objects.ts
@@ -107,18 +107,18 @@ interface ICountrySchema {
 }
 
 class Person extends Realm.Object implements IPersonSchema {
-  name!: string;
-  age!: number;
-  married!: boolean;
-  children!: Realm.List<IPersonSchema>;
-  parents!: Realm.Collection<IPersonSchema>;
+  declare name: string;
+  declare age: number;
+  declare married: boolean;
+  declare children: Realm.List<IPersonSchema>;
+  declare parents: Realm.Collection<IPersonSchema>;
 }
 
 class Name extends Realm.Object implements INameSchema {
-  _id!: BSON.ObjectId;
-  family!: string;
-  given!: string[];
-  prefix!: string[];
+  declare _id: BSON.ObjectId;
+  declare family: string;
+  declare given: string[];
+  declare prefix: string[];
 }
 
 describe("Linking objects", () => {

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -336,27 +336,27 @@ interface IMultiListObjectSchema {
 }
 
 class PrimitiveArrays extends Realm.Object implements IPrimitiveArraysSchema {
-  bool!: Realm.List<boolean>;
-  int!: Realm.List<number>;
-  float!: Realm.List<number>;
-  double!: Realm.List<number>;
-  string!: Realm.List<string>;
-  date!: Realm.List<Date>;
-  data!: Realm.List<ArrayBuffer>;
-  decimal128!: Realm.List<BSON.Decimal128>;
-  objectId!: Realm.List<BSON.ObjectId>;
-  uuid!: Realm.List<BSON.UUID>;
+  declare bool: Realm.List<boolean>;
+  declare int: Realm.List<number>;
+  declare float: Realm.List<number>;
+  declare double: Realm.List<number>;
+  declare string: Realm.List<string>;
+  declare date: Realm.List<Date>;
+  declare data: Realm.List<ArrayBuffer>;
+  declare decimal128: Realm.List<BSON.Decimal128>;
+  declare objectId: Realm.List<BSON.ObjectId>;
+  declare uuid: Realm.List<BSON.UUID>;
 
-  optBool!: Realm.List<boolean | null>;
-  optInt!: Realm.List<number | null>;
-  optFloat!: Realm.List<number | null>;
-  optDouble!: Realm.List<number | null>;
-  optString!: Realm.List<string | null>;
-  optDate!: Realm.List<Date | null>;
-  optData!: Realm.List<ArrayBuffer | null>;
-  optDecimal128!: Realm.List<BSON.Decimal128 | null>;
-  optObjectId!: Realm.List<BSON.ObjectId | null>;
-  optUuid!: Realm.List<BSON.UUID | null>;
+  declare optBool: Realm.List<boolean | null>;
+  declare optInt: Realm.List<number | null>;
+  declare optFloat: Realm.List<number | null>;
+  declare optDouble: Realm.List<number | null>;
+  declare optString: Realm.List<string | null>;
+  declare optDate: Realm.List<Date | null>;
+  declare optData: Realm.List<ArrayBuffer | null>;
+  declare optDecimal128: Realm.List<BSON.Decimal128 | null>;
+  declare optObjectId: Realm.List<BSON.ObjectId | null>;
+  declare optUuid: Realm.List<BSON.UUID | null>;
 }
 
 class TodoItem extends Realm.Object {

--- a/integration-tests/tests/src/tests/notifications.ts
+++ b/integration-tests/tests/src/tests/notifications.ts
@@ -21,7 +21,7 @@ import Realm from "realm";
 import { openRealmBeforeEach } from "../hooks";
 
 class ListObject extends Realm.Object {
-  list!: Realm.List<TestObject>;
+  declare list: Realm.List<TestObject>;
   static schema = {
     name: "ListObject",
     properties: {
@@ -31,7 +31,7 @@ class ListObject extends Realm.Object {
 }
 
 class TestObject extends Realm.Object {
-  doubleCol!: Realm.Types.Double;
+  declare doubleCol: Realm.Types.Double;
   static schema = {
     name: "TestObject",
     properties: {
@@ -41,7 +41,7 @@ class TestObject extends Realm.Object {
 }
 
 class StringOnlyObject extends Realm.Object {
-  stringCol!: Realm.Types.String;
+  declare stringCol: Realm.Types.String;
   static schema = {
     name: "StringOnlyObject",
     properties: {

--- a/integration-tests/tests/src/tests/queries.ts
+++ b/integration-tests/tests/src/tests/queries.ts
@@ -35,16 +35,16 @@ interface INullableTypesObject {
 }
 
 class NullableTypesObject extends Realm.Object implements INullableTypesObject {
-  boolCol?: boolean;
-  intCol?: Realm.Types.Int;
-  floatCol?: Realm.Types.Float;
-  doubleCol?: Realm.Types.Double;
-  stringCol?: Realm.Types.String;
-  dateCol?: Realm.Types.Date;
-  dataCol?: Realm.Types.Data;
-  decimal128Col?: Realm.Types.Decimal128;
-  objectIdCol?: Realm.Types.ObjectId;
-  uuidCol?: Realm.Types.UUID;
+  declare boolCol?: boolean;
+  declare intCol?: Realm.Types.Int;
+  declare floatCol?: Realm.Types.Float;
+  declare doubleCol?: Realm.Types.Double;
+  declare stringCol?: Realm.Types.String;
+  declare dateCol?: Realm.Types.Date;
+  declare dataCol?: Realm.Types.Data;
+  declare decimal128Col?: Realm.Types.Decimal128;
+  declare objectIdCol?: Realm.Types.ObjectId;
+  declare uuidCol?: Realm.Types.UUID;
 
   static schema = {
     name: "NullableTypesObject",
@@ -581,7 +581,7 @@ describe("Queries", () => {
   describe("Object and list types", () => {
     describe("querying objects with linked objects", () => {
       class LinkObject extends Realm.Object {
-        linkCol?: { intCol: number };
+        declare linkCol?: { intCol: number };
         static schema = { name: "LinkObject", properties: { linkCol: "IntObject" } };
       }
       let objects: LinkObject[];
@@ -1012,8 +1012,8 @@ describe("Queries", () => {
 
       it("should work with scientific notation numbers", () => {
         class DecimalNumbersObject extends Realm.Object {
-          f!: Realm.Types.Float;
-          d!: Realm.Types.Double;
+          declare f: Realm.Types.Float;
+          declare d: Realm.Types.Double;
 
           static schema = {
             name: "DecimalNumbersObject",

--- a/integration-tests/tests/src/tests/realm-constructor.ts
+++ b/integration-tests/tests/src/tests/realm-constructor.ts
@@ -22,7 +22,7 @@ import { Realm } from "realm";
 import { IPerson, PersonSchema, DogSchema } from "../schemas/person-and-dogs";
 
 class TestObject extends Realm.Object {
-  doubleCol!: number;
+  declare doubleCol: number;
   static schema: Realm.ObjectSchema = {
     name: "TestObject",
     properties: {

--- a/integration-tests/tests/src/tests/results.ts
+++ b/integration-tests/tests/src/tests/results.ts
@@ -23,7 +23,7 @@ import { select } from "../utils/select";
 const { Decimal128, ObjectId, UUID } = Realm.BSON;
 
 class TestObject extends Realm.Object {
-  doubleCol!: Realm.Types.Double;
+  declare doubleCol: Realm.Types.Double;
   static schema = {
     name: "TestObject",
     properties: {
@@ -391,11 +391,12 @@ describe("Results", () => {
 
   describe("Filtering and sorting", () => {
     class PersonObject extends Realm.Object {
-      name!: string;
-      age!: Realm.Types.Double;
-      married!: boolean;
-      children!: Realm.List<PersonObject>;
-      parents!: Realm.List<PersonObject>;
+      declare name: string;
+      declare age: Realm.Types.Double;
+      declare married: boolean;
+      declare children: Realm.List<PersonObject>;
+      declare parents: Realm.List<PersonObject>;
+
       static schema = {
         name: "PersonObject",
         properties: {

--- a/integration-tests/tests/src/tests/sync/dictionary.ts
+++ b/integration-tests/tests/src/tests/sync/dictionary.ts
@@ -26,10 +26,10 @@ describe.skipIf(environment.missingServer, "Type roundtrip of UUID object", () =
   authenticateUserBefore();
 
   class DictionaryObject extends Realm.Object {
-    _id!: Realm.Types.Int;
-    columnStringDictionary!: Realm.Dictionary<string>;
-    columnIntegerDictionary!: Realm.Dictionary<Realm.Types.Int>;
-    columnFloatDictionary!: Realm.Dictionary<Realm.Types.Float>;
+    declare _id: Realm.Types.Int;
+    declare columnStringDictionary: Realm.Dictionary<string>;
+    declare columnIntegerDictionary: Realm.Dictionary<Realm.Types.Int>;
+    declare columnFloatDictionary: Realm.Dictionary<Realm.Types.Float>;
 
     static schema = {
       name: "DictionaryObject",

--- a/integration-tests/tests/src/tests/sync/realm.ts
+++ b/integration-tests/tests/src/tests/sync/realm.ts
@@ -382,7 +382,7 @@ interface IDateObject {
 }
 
 class TestObject extends Realm.Object {
-  doubleCol!: number;
+  declare doubleCol: number;
   static schema: Realm.ObjectSchema = {
     name: "TestObject",
     properties: {
@@ -392,11 +392,11 @@ class TestObject extends Realm.Object {
 }
 
 class PersonObject extends Realm.Object {
-  name!: string;
-  age!: number;
-  married!: boolean;
-  children!: PersonObject[];
-  parents!: PersonObject[];
+  declare name: string;
+  declare age: number;
+  declare married: boolean;
+  declare children: PersonObject[];
+  declare parents: PersonObject[];
   static schema: Realm.ObjectSchema = {
     name: "PersonObject",
     properties: {

--- a/integration-tests/tests/src/tests/sync/set.ts
+++ b/integration-tests/tests/src/tests/sync/set.ts
@@ -25,8 +25,8 @@ describe.skipIf(environment.missingServer, "Type roundtrip of set object", () =>
   authenticateUserBefore();
 
   class SetObject extends Realm.Object {
-    _id!: Realm.Types.Int;
-    numbers!: Realm.Set<Realm.Types.Int>;
+    declare _id: Realm.Types.Int;
+    declare numbers: Realm.Set<Realm.Types.Int>;
 
     static schema = {
       name: "SyncedNumbers",

--- a/integration-tests/tests/src/tests/sync/uuid.ts
+++ b/integration-tests/tests/src/tests/sync/uuid.ts
@@ -26,10 +26,10 @@ describe.skipIf(environment.missingServer, "Type roundtrip of UUID object", () =
   const { UUID } = Realm.BSON;
 
   class UUIDObject extends Realm.Object {
-    _id!: Realm.Types.UUID;
-    mandatory!: Realm.Types.UUID;
-    optional?: Realm.Types.UUID;
-    list?: Realm.List<Realm.Types.UUID>;
+    declare _id: Realm.Types.UUID;
+    declare mandatory: Realm.Types.UUID;
+    declare optional?: Realm.Types.UUID;
+    declare list?: Realm.List<Realm.Types.UUID>;
 
     static schema = {
       name: "UUIDObject",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/realm-react",
         "packages/realm-common",
         "packages/realm-network-transport",
+        "packages/babel-preset",
         "packages/realm-app-importer",
         "packages/realm-tools",
         "packages/metro-config",
@@ -1428,6 +1429,8 @@
         "@babel/preset-env": "^7.14.0",
         "@babel/runtime": "^7.12.5",
         "@react-native-community/eslint-config": "^3.0.0",
+        "@realm/babel-plugin": "*",
+        "@realm/babel-preset": "*",
         "@realm/metro-config": "*",
         "@tsconfig/react-native": "^2.0.2",
         "concurrently": "^6.0.2",
@@ -6841,6 +6844,10 @@
     },
     "node_modules/@realm/babel-plugin": {
       "resolved": "packages/babel-plugin",
+      "link": true
+    },
+    "node_modules/@realm/babel-preset": {
+      "resolved": "packages/babel-preset",
       "link": true
     },
     "node_modules/@realm/bindgen": {
@@ -31676,12 +31683,13 @@
       }
     },
     "packages/babel-plugin": {
+      "name": "@realm/babel-plugin",
       "version": "0.1.1",
       "license": "apache-2.0",
       "devDependencies": {
         "@babel/plugin-proposal-decorators": "^7.17.9",
         "@babel/preset-typescript": "^7.16.7",
-        "@types/babel__core": "^7.1.19",
+        "@types/babel__core": "^7.20.0",
         "@types/jest": "^27.4.1",
         "babel": "^6.23.0",
         "jest": "^27.5.1",
@@ -31937,6 +31945,19 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "packages/babel-plugin/node_modules/@types/babel__core": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
+      "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
       }
     },
     "packages/babel-plugin/node_modules/@types/jest": {
@@ -32861,6 +32882,9 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "packages/babel-preset": {
+      "version": "0.1.0"
     },
     "packages/bindgen": {
       "name": "@realm/bindgen",
@@ -39733,7 +39757,7 @@
       "requires": {
         "@babel/plugin-proposal-decorators": "^7.17.9",
         "@babel/preset-typescript": "^7.16.7",
-        "@types/babel__core": "^7.1.19",
+        "@types/babel__core": "^7.20.0",
         "@types/jest": "^27.4.1",
         "babel": "^6.23.0",
         "jest": "^27.5.1",
@@ -39940,6 +39964,19 @@
           "dev": true,
           "requires": {
             "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "@types/babel__core": {
+          "version": "7.20.0",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
+          "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.20.7",
+            "@babel/types": "^7.20.7",
+            "@types/babel__generator": "*",
+            "@types/babel__template": "*",
+            "@types/babel__traverse": "*"
           }
         },
         "@types/jest": {
@@ -40637,6 +40674,9 @@
           }
         }
       }
+    },
+    "@realm/babel-preset": {
+      "version": "file:packages/babel-preset"
     },
     "@realm/bindgen": {
       "version": "file:packages/bindgen",
@@ -43736,6 +43776,8 @@
         "@react-native-community/art": "^1.2.0",
         "@react-native-community/eslint-config": "^3.0.0",
         "@realm/app-importer": "*",
+        "@realm/babel-plugin": "*",
+        "@realm/babel-preset": "*",
         "@realm/integration-tests": "*",
         "@realm/metro-config": "*",
         "@tsconfig/react-native": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "packages/realm-react",
     "packages/realm-common",
     "packages/realm-network-transport",
+    "packages/babel-preset",
     "packages/realm-app-importer",
     "packages/realm-tools",
     "packages/metro-config",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.17.9",
     "@babel/preset-typescript": "^7.16.7",
-    "@types/babel__core": "^7.1.19",
+    "@types/babel__core": "^7.20.0",
     "@types/jest": "^27.4.1",
     "babel": "^6.23.0",
     "jest": "^27.5.1",

--- a/packages/babel-plugin/src/plugin/index.ts
+++ b/packages/babel-plugin/src/plugin/index.ts
@@ -278,7 +278,7 @@ function findDecoratorCall(
 function visitRealmClassProperty(path: NodePath<types.ClassProperty>) {
   const keyPath = path.get("key");
   const valuePath = path.get("value");
-  const decoratorsPath: NodePath<types.Decorator>[] = path.get("decorators");
+  const decoratorsPath = path.get("decorators") as NodePath<types.Decorator>[];
 
   const indexDecorator = findDecoratorIdentifier(decoratorsPath, "index");
   if (indexDecorator) {

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2021 Realm Inc.
+// Copyright 2023 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,23 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
-module.exports = {
-  presets: ["module:metro-react-native-babel-preset", "@realm"],
+
+/* eslint-env node */
+
+module.exports = () => {
+  return {
+    // TODO: Add @realm/babel-plugin here
+    overrides: [
+      {
+        plugins: [
+          [
+            require("@babel/plugin-transform-flow-strip-types"),
+            {
+              allowDeclareFields: true,
+            },
+          ],
+        ],
+      },
+    ],
+  };
 };

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@realm/babel-preset",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./index.js"
+}


### PR DESCRIPTION
## What, How & Why?

The update for the integration tests targeting `es2022` the default for [`useDefineForClassFields`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields) changed to `true`, which [breaks creating objects via the constructor of a class-based model](https://github.com/realm/realm-js/issues/5527).
