### PR TITLE
Allow optional primary keys

### DIFF
--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -28,7 +28,7 @@ type Item<ValueType = Realm.Mixed> = {
 const DictSchema: Realm.ObjectSchema = {
   name: "Dictionary",
   properties: {
-    fields: "{}",
+    fields: "mixed{}",
   },
 };
 const Child: Realm.ObjectSchema = {
@@ -40,8 +40,8 @@ const Child: Realm.ObjectSchema = {
 const TwoDictSchema: Realm.ObjectSchema = {
   name: "Dictionary",
   properties: {
-    dict1: "{}",
-    dict2: "{}",
+    dict1: "mixed{}",
+    dict2: "mixed{}",
   },
 };
 const EmbeddedChild = {
@@ -63,8 +63,8 @@ const DictTypedSchema = {
 const DictMixedSchema = {
   name: "MixedDictionary",
   properties: {
-    dict1: "{}",
-    dict2: "{}",
+    dict1: "mixed{}",
+    dict2: "mixed{}",
   },
 };
 

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -153,9 +153,9 @@ const DefaultValuesSchema = {
     stringCol: { type: "string", default: "defaultString" },
     dateCol: { type: "date", default: new Date(1.111) },
     dataCol: { type: "data", default: new ArrayBuffer(1) },
-    objectCol: { type: "TestObject", default: { doubleCol: 1 } },
-    nullObjectCol: { type: "TestObject", default: null },
-    arrayCol: { type: "TestObject[]", default: [{ doubleCol: 2 }] },
+    objectCol: { type: "object", objectType: "TestObject", default: { doubleCol: 1 } },
+    nullObjectCol: { type: "object", objectType: "TestObject", default: null },
+    arrayCol: { type: "list", objectType: "TestObject", default: [{ doubleCol: 2 }] },
   },
 };
 

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -247,10 +247,6 @@ function normalizePropertySchemaShorthand(info: PropertyInfoUsingShorthand): Can
     optional = false;
   }
 
-  if (info.isPrimaryKey) {
-    assert(!optional, errMessage(info, "Optional properties cannot be used as a primary key."));
-  }
-
   const normalizedSchema: CanonicalPropertySchema = {
     name: info.propertyName,
     type: type as PropertyTypeName,
@@ -317,7 +313,6 @@ function normalizePropertySchemaObject(info: PropertyInfoUsingObject): Canonical
   }
 
   if (info.isPrimaryKey) {
-    assert(!optional, errMessage(info, "Optional properties cannot be used as a primary key."));
     assert(indexed !== false, errMessage(info, "Primary keys must always be indexed."));
     indexed = true;
   }

--- a/packages/realm/src/schema/types.ts
+++ b/packages/realm/src/schema/types.ts
@@ -38,7 +38,7 @@ export type PropertyTypeName = PrimitivePropertyTypeName | CollectionPropertyTyp
 /**
  * Valid types for an object primary key.
  */
-export type PrimaryKey = number | string | BSON.ObjectId | BSON.UUID;
+export type PrimaryKey = null | number | string | BSON.ObjectId | BSON.UUID;
 
 /**
  * The names of the supported Realm primitive property types.

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -184,6 +184,26 @@ describe("normalizePropertySchema", () => {
       },
       { isPrimaryKey: true },
     );
+
+    itNormalizes(
+      "string?",
+      {
+        type: "string",
+        indexed: true,
+        optional: true,
+      },
+      { isPrimaryKey: true },
+    );
+
+    itNormalizes(
+      "mixed?",
+      {
+        type: "mixed",
+        indexed: true,
+        optional: true,
+      },
+      { isPrimaryKey: true },
+    );
   });
 
   // ------------------------------------------------------------------------
@@ -248,14 +268,6 @@ describe("normalizePropertySchema", () => {
       "linkingObjects",
       "To define an inverse relationship, use { type: 'linkingObjects', objectType: 'MyObjectType', property: 'myObjectTypesProperty' }",
     );
-
-    // -------------------------
-    // Indexed & Primary Keys
-    // -------------------------
-
-    itThrowsWhenNormalizing("string?", "Optional properties cannot be used as a primary key.", { isPrimaryKey: true });
-
-    itThrowsWhenNormalizing("mixed", "Optional properties cannot be used as a primary key.", { isPrimaryKey: true });
   });
 
   // ------------------------------------------------------------------------
@@ -687,6 +699,44 @@ describe("normalizePropertySchema", () => {
       },
       { isPrimaryKey: false },
     );
+
+    itNormalizes(
+      {
+        type: "string",
+        optional: true,
+      },
+      {
+        type: "string",
+        indexed: true,
+        optional: true,
+      },
+      { isPrimaryKey: true },
+    );
+
+    itNormalizes(
+      {
+        type: "mixed",
+      },
+      {
+        type: "mixed",
+        indexed: true,
+        optional: true,
+      },
+      { isPrimaryKey: true },
+    );
+
+    itNormalizes(
+      {
+        type: "mixed",
+        optional: true,
+      },
+      {
+        type: "mixed",
+        indexed: true,
+        optional: true,
+      },
+      { isPrimaryKey: true },
+    );
   });
 
   // ------------------------------------------------------------------------
@@ -696,6 +746,7 @@ describe("normalizePropertySchema", () => {
   describe("using invalid object notation", () => {
     itThrowsWhenNormalizing(
       {
+        // @ts-expect-error Passing in the wrong type
         type: "",
       },
       "'type' must be specified",
@@ -740,6 +791,7 @@ describe("normalizePropertySchema", () => {
 
     itThrowsWhenNormalizing(
       {
+        // @ts-expect-error Passing in the wrong type
         type: "Person",
       },
       "If you meant to define a relationship, use { type: 'object', objectType: 'Person' } or { type: 'linkingObjects', objectType: 'Person', property: 'The Person property' }",
@@ -862,6 +914,7 @@ describe("normalizePropertySchema", () => {
 
     itThrowsWhenNormalizing(
       {
+        // @ts-expect-error Passing in the wrong type
         type: "int?",
       },
       "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
@@ -869,6 +922,7 @@ describe("normalizePropertySchema", () => {
 
     itThrowsWhenNormalizing(
       {
+        // @ts-expect-error Passing in the wrong type
         type: "int?[]",
       },
       "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
@@ -901,23 +955,6 @@ describe("normalizePropertySchema", () => {
     // -------------------------
     // Indexed & Primary Keys
     // -------------------------
-
-    itThrowsWhenNormalizing(
-      {
-        type: "string",
-        optional: true,
-      },
-      "Optional properties cannot be used as a primary key.",
-      { isPrimaryKey: true },
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "mixed",
-      },
-      "Optional properties cannot be used as a primary key.",
-      { isPrimaryKey: true },
-    );
 
     itThrowsWhenNormalizing(
       {


### PR DESCRIPTION
## What, How & Why?

The schema parser was implemented to reject optional primary keys, but that's allowed by core and was supported on v11.
