### PR TITLE
Allow user to use Xcode 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Suppress omitting `objcMsgsend` stubs to ensure backward compatibility with Xcode 13. It can be observed as `Undefined symbols for architecture arm64: "_objc_msgSend$allBundles", referenced from: realm::copy_bundled_realm_files() in librealm-js-ios.a(platform.o)` when using a React Native app for iOS. ([#5511](https://github.com/realm/realm-js/issues/5511), since v11.5.1)
 
 ### Compatibility
 * React Native >= v0.70.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,13 +81,6 @@ if (NOT MSVC)
     endif()
 endif()
 
-if(APPLE)
-    if(NOT DEFINED CMAKE_JS_VERSION)
-        # https://developer.apple.com/forums/thread/716965
-        add_cxx_flag_if_supported(-fno-objc-msgsend-selector-stubs)
-    endif()
-endif()
-
 option(REALM_JS_BUILD_CORE_FROM_SOURCE "Build Realm Core from source, as opposed to downloading prebuilt binaries" ON)
 if(REALM_JS_BUILD_CORE_FROM_SOURCE)
     set(REALM_BUILD_LIB_ONLY ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,13 @@ if (NOT MSVC)
     endif()
 endif()
 
+if(APPLE)
+    if(NOT DEFINED CMAKE_JS_VERSION)
+        # https://developer.apple.com/forums/thread/716965
+        add_cxx_flag_if_supported(-fno-objc-msgsend-selector-stubs)
+    endif()
+endif()
+
 option(REALM_JS_BUILD_CORE_FROM_SOURCE "Build Realm Core from source, as opposed to downloading prebuilt binaries" ON)
 if(REALM_JS_BUILD_CORE_FROM_SOURCE)
     set(REALM_BUILD_LIB_ONLY ON)

--- a/src/ios/CMakeLists.txt
+++ b/src/ios/CMakeLists.txt
@@ -1,3 +1,6 @@
+# https://developer.apple.com/forums/thread/716965
+add_cxx_flag_if_supported(-fno-objc-msgsend-selector-stubs)
+
 add_library(realm-js-ios STATIC
     platform.mm
 )


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

Xcode 14 emits stubs for Objective C code which is incompatible with Xcode 13. See https://developer.apple.com/forums/thread/716965 for details.

This closes #5511

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 📝 Update `COMPATIBILITY.md`~
* [ ] 🚦 Tests
* ~[ ] 🔀 Executed flexible sync tests locally if modifying flexible sync~
* ~[ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* [ ] 📱 Check the React Native/other sample apps work if necessary
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
