### PR TITLE
Moved `include(NodeJSTargets)´ above realm core

### DIFF
--- a/packages/bindgen/CMakeLists.txt
+++ b/packages/bindgen/CMakeLists.txt
@@ -77,6 +77,11 @@ if(CMAKE_GENERATOR MATCHES "^Ninja")
     set(NODE_FORCE_COLOR ${CMAKE_COMMAND} -E env FORCE_COLOR=1)
 endif()
 
+if(DEFINED CMAKE_JS_VERSION)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+    include(NodeJSTargets)
+endif()
+
 option(REALM_JS_BUILD_CORE_FROM_SOURCE "Build Realm Core from source, as opposed to downloading prebuilt binaries" ON)
 if(REALM_JS_BUILD_CORE_FROM_SOURCE)
     set(REALM_BUILD_LIB_ONLY ON)

--- a/packages/bindgen/node.cmake
+++ b/packages/bindgen/node.cmake
@@ -1,10 +1,5 @@
 # This file is based on src/node/CMakeLists.txt
 
-if(DEFINED CMAKE_JS_VERSION)
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
-    include(NodeJSTargets)
-endif()
-
 add_library(realm-js-node SHARED)
 
 set_target_properties(realm-js-node PROPERTIES


### PR DESCRIPTION
## What, How & Why?

This fix missing ZLIB when prebuilding for Linux on CI, by moving the include of `include(NodeJSTargets)` above the configuration of Realm Core.