### PR TITLE
Sync.flexible and deleteRealmIfMigrationNeeded is not an allowed combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* It is not allowed to specify `deleteRealmIfMigrationIsNeeded` and sync. This can lead to error messages like `Schema validation failed due to the following errors`. ([#5548](https://github.com/realm/realm-js/issues/5548), v10.12.0)
 
 ### Compatibility
 * React Native >= v0.70.0

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -32,7 +32,6 @@
 #include "realm/binary_data.hpp"
 #include "realm/util/functional.hpp"
 #include <exception>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <set>

--- a/src/js_realm.hpp
+++ b/src/js_realm.hpp
@@ -32,6 +32,7 @@
 #include "realm/binary_data.hpp"
 #include "realm/util/functional.hpp"
 #include <exception>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <set>
@@ -680,6 +681,10 @@ bool RealmClass<T>::get_realm_config(ContextType ctx, size_t argc, const ValueTy
                 if (config.sync_config && config.sync_config->partition_value != "") {
                     throw std::invalid_argument("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled "
                                                 "('sync.partitionValue' is set).");
+                }
+                if (config.sync_config && config.sync_config->flx_sync_requested) {
+                    throw std::invalid_argument("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled "
+                                                "('sync.flexible' is set).");
                 }
 
                 config.schema_mode = SchemaMode::SoftResetFile;


### PR DESCRIPTION

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes #5548 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
