### PR TITLE
Bundle on CI

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -10,6 +10,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  bundle:
+    name: Bundle TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Setup node version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Install dependencies
+        # Ignoring scripts to prevent a prebuilt from getting fetched / built
+        run: npm ci --ignore-scripts
+      - name: Bundle all packages
+        run: npm run bundle
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: realm-js-bundles
+          path: |
+            packages/*/dist
+
   build:
     name: Build for ${{ matrix.variant.os }} ${{ matrix.variant.arch }}
     runs-on: ${{ matrix.variant.runner }}
@@ -47,7 +72,6 @@ jobs:
         with:
           node-version: 16
           cache: npm
-          cache-dependency-path: package-lock.json
 
       - name: Get NPM cache directory
         id: npm-cache-dir
@@ -204,7 +228,7 @@ jobs:
 
   integration-tests:
     name: Integration tests (${{matrix.variant.target}}) for ${{ matrix.variant.environment }} on ${{ matrix.variant.os }}
-    needs: [build, ios-xcframework]
+    needs: [bundle, build, ios-xcframework]
     env:
       REALM_DISABLE_ANALYTICS: 1
       MOCHA_REMOTE_TIMEOUT: 60000
@@ -247,7 +271,6 @@ jobs:
         with:
           node-version: 16
           cache: npm
-          cache-dependency-path: package-lock.json
 
       - name: Get NPM cache directory
         id: npm-cache-dir
@@ -302,6 +325,11 @@ jobs:
         run: |
           sudo apt-get install xvfb
           echo "wrapper=xvfb-run" >> $GITHUB_ENV
+
+      - name: Download bundles
+        uses: actions/download-artifact@v3
+        with:
+          name: realm-js-bundles
 
       - name: Download prebuilds
         uses: actions/download-artifact@v3

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -247,18 +247,18 @@ jobs:
       max-parallel: 3
       matrix:
         variant:
-          - { os: linux, target: test, runner: ubuntu-latest, environment: node }
-          - { os: linux, target: "test:main", runner: ubuntu-latest, environment: electron }
-          - { os: linux, target: "test:renderer", runner: ubuntu-latest, environment: electron }
-          #- { os: windows, target: test, runner: windows-latest, environment: node}
-          #- { os: windows, target: "test:main", runner: windows-latest, environment: electron }
-          #- { os: windows, target: "test:renderer", runner: windows-latest, environment: electron }
-          - { os: darwin, target: "test:main", runner: macos-latest, environment: electron }
-          - { os: darwin, target: "test:renderer", runner: macos-latest, environment: electron }
-          - { os: darwin, target: test, runner: macos-latest, environment: node }
-          - { os: android, target: "test:android", runner: macos-latest, environment: react-native, arch: "armeabi-v7a" }
-          - { os: ios, target: "test:ios", runner: macos-latest, environment: react-native, arch: "ios" }
-          #- { os: ios, target: "test:catalyst", runner: macos-latest, environment: react-native, arch: "catalyst" }
+          - { os: linux, target: "test:ci", runner: ubuntu-latest, environment: node }
+          - { os: linux, target: "test:ci:main", runner: ubuntu-latest, environment: electron }
+          - { os: linux, target: "test:ci:renderer", runner: ubuntu-latest, environment: electron }
+          #- { os: windows, target: "test:ci", runner: windows-latest, environment: node}
+          #- { os: windows, target: "test:ci:main", runner: windows-latest, environment: electron }
+          #- { os: windows, target: "test:ci:renderer", runner: windows-latest, environment: electron }
+          - { os: darwin, target: "test:ci:main", runner: macos-latest, environment: electron }
+          - { os: darwin, target: "test:ci:renderer", runner: macos-latest, environment: electron }
+          - { os: darwin, target: "test:ci", runner: macos-latest, environment: node }
+          - { os: android, target: "test:ci:android", runner: macos-latest, environment: react-native, arch: "armeabi-v7a" }
+          - { os: ios, target: "test:ci:ios", runner: macos-latest, environment: react-native, arch: "ios" }
+          #- { os: ios, target: "test:ci:catalyst", runner: macos-latest, environment: react-native, arch: "catalyst" }
     timeout-minutes: 60
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -28,11 +28,14 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Bundle all packages
         run: npm run bundle
+      # Due to a limitation in upload-artifact a redundant file is needed to force
+      # preserving paths (https://github.com/actions/upload-artifact/issues/174)
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v3
         with:
           name: realm-js-bundles
           path: |
+            README.md
             packages/*/dist
 
   build:
@@ -195,7 +198,7 @@ jobs:
         with:
           name: realm-js-prebuilds
           path: |
-            dependencies.list
+            README.md
             ${{ matrix.variant.artifact-path }}
 
   ios-xcframework:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,13 +41,6 @@ jobs:
       - name: Update dependencies.list
         run: sed -i 's/^VERSION=.*/VERSION=${{ steps.update-changelog.outputs.new-version }}/' dependencies.list
 
-      - name: Update xcode project
-        uses: jacobtomlinson/gha-find-replace@0dfd0777cc234ef6947ec1f20873c632114c4167 #! 0.1.4
-        with:
-          find: 'CURRENT_PROJECT_VERSION = [^;]*'
-          replace: 'CURRENT_PROJECT_VERSION = ${{ steps.update-changelog.outputs.new-version }}'
-          include: react-native/ios/RealmReact.xcodeproj/project.pbxproj
-
       - name: Create Release PR
         uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad #! 3.10.1
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install node modules
       run: npm ci --ignore-scripts
 
-    - name: Download prebuild PR artifacts
+    - name: Download prebuild artifacts from PR
       uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
       with:
         workflow: pr-realm-js.yml
@@ -61,6 +61,16 @@ jobs:
         workflow_conclusion: "" # Ignores workflow conclusion
         github_token: ${{ secrets.REALM_CI_PAT }}
         name: realm-js-prebuilds
+
+    - name: Download bundle artifacts from PR
+      uses: dawidd6/action-download-artifact@d0f291cf39bd21965ea9c4c6e210fc355c3844ed
+      with:
+        workflow: pr-realm-js.yml
+        commit: ${{ inputs.commit || github.sha }}
+        path: ${{ github.workspace }}
+        workflow_conclusion: "" # Ignores workflow conclusion
+        github_token: ${{ secrets.REALM_CI_PAT }}
+        name: realm-js-bundles
 
     - name: Read version
       id: get-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -91,7 +91,7 @@ jobs:
         secret_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
 
     - name: Upload prebuilds to S3
-      run: s3cmd put --recursive --acl-public prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/${{ steps.get-version.outputs.version }}/
+      run: s3cmd put --recursive --acl-public packages/realm/prebuilds/realm-* s3://${{ secrets.PREBUILDS_S3_BUCKET_NAME }}/${{ steps.get-version.outputs.version }}/
 
     - name: Publish realm v${{ steps.get-version.outputs.version }} on NPM
       run: npm publish --tag '${{ inputs.tag}}'

--- a/integration-tests/environments/electron/package.json
+++ b/integration-tests/environments/electron/package.json
@@ -13,6 +13,9 @@
     "test": "wireit",
     "test:main": "wireit",
     "test:renderer": "wireit",
+    "test:ci": "wireit",
+    "test:ci:main": "wireit",
+    "test:ci:renderer": "wireit",
     "lint": "eslint .",
     "package": "electron-builder --dir"
   },
@@ -39,6 +42,15 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
+    },
+    "test:ci": {
+      "command": "npm run test:ci:main && npm run test:ci:renderer"
+    },
+    "test:ci:main": {
+      "command": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js main"
+    },
+    "test:ci:renderer": {
+      "command": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js renderer"
     }
   },
   "devDependencies": {

--- a/integration-tests/environments/electron/package.json
+++ b/integration-tests/environments/electron/package.json
@@ -13,9 +13,8 @@
     "test": "wireit",
     "test:main": "wireit",
     "test:renderer": "wireit",
-    "test:ci": "wireit",
-    "test:ci:main": "wireit",
-    "test:ci:renderer": "wireit",
+    "test:ci:main": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js main",
+    "test:ci:renderer": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js renderer",
     "lint": "eslint .",
     "package": "electron-builder --dir"
   },
@@ -42,15 +41,6 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
-    },
-    "test:ci": {
-      "command": "npm run test:ci:main && npm run test:ci:renderer"
-    },
-    "test:ci:main": {
-      "command": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js main"
-    },
-    "test:ci:renderer": {
-      "command": "mocha-remote --reporter @realm/mocha-reporter --id main node runner.js renderer"
     }
   },
   "devDependencies": {

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "wireit",
-    "test:ci": "wireit",
+    "test:ci": "mocha-remote --reporter @realm/mocha-reporter tsx index.mjs",
     "lint": "eslint --ext js,mjs ."
   },
   "wireit": {
@@ -18,9 +18,6 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
-    },
-    "test:ci": {
-      "command": "mocha-remote --reporter @realm/mocha-reporter tsx index.mjs"
     }
   },
   "dependencies": {

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "test": "wireit",
+    "test:ci": "wireit",
     "lint": "eslint --ext js,mjs ."
   },
   "wireit": {
@@ -17,6 +18,9 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
+    },
+    "test:ci": {
+      "command": "mocha-remote --reporter @realm/mocha-reporter tsx index.mjs"
     }
   },
   "dependencies": {

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -8,10 +8,13 @@
     "test:android": "wireit",
     "test:ios": "wireit",
     "test:catalyst": "wireit",
+    "test:ci:android": "wireit",
+    "test:ci:ios": "wireit",
     "watch:ios": "wireit",
     "watch:catalyst": "wireit",
     "watch:android": "wireit",
     "common": "wireit",
+    "common:ci": "wireit",
     "lint": "eslint .",
     "app-importer": "realm-app-importer serve ../../realm-apps",
     "metro": "react-native start --reset-cache",
@@ -42,6 +45,24 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
+    },
+    "common:ci": {
+      "command": "mocha-remote --template @realm/mocha-reporter --context appImporterIsRemote,$MOCHA_REMOTE_CONTEXT -- concurrently --kill-others-on-fail npm:metro npm:runner npm:app-importer"
+    },
+    "test:ci:android": {
+      "command": "npm run common:ci",
+      "env": {
+        "PLATFORM": "android"
+      }
+    },
+    "test:ci:ios": {
+      "command": "npm run common:ci",
+      "dependencies": [
+        "pod-install"
+      ],
+      "env": {
+        "PLATFORM": "ios"
+      }
     },
     "test:android": {
       "command": "npm run common",

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -8,13 +8,14 @@
     "test:android": "wireit",
     "test:ios": "wireit",
     "test:catalyst": "wireit",
-    "test:ci:android": "wireit",
-    "test:ci:ios": "wireit",
+    "test:ci:android": "PLATFORM=android npm run common:ci",
+    "test:ci:ios": "pod-install && PLATFORM=ios npm run common:ci",
     "watch:ios": "wireit",
     "watch:catalyst": "wireit",
     "watch:android": "wireit",
     "common": "wireit",
-    "common:ci": "wireit",
+    "common:ci": "mocha-remote --template @realm/mocha-reporter --context appImporterIsRemote,$MOCHA_REMOTE_CONTEXT -- concurrently --kill-others-on-fail npm:metro npm:runner npm:app-importer",
+
     "lint": "eslint .",
     "app-importer": "realm-app-importer serve ../../realm-apps",
     "metro": "react-native start --reset-cache",
@@ -45,24 +46,6 @@
         "../../../packages/realm-network-transport:build",
         "../../../packages/realm-app-importer:build"
       ]
-    },
-    "common:ci": {
-      "command": "mocha-remote --template @realm/mocha-reporter --context appImporterIsRemote,$MOCHA_REMOTE_CONTEXT -- concurrently --kill-others-on-fail npm:metro npm:runner npm:app-importer"
-    },
-    "test:ci:android": {
-      "command": "npm run common:ci",
-      "env": {
-        "PLATFORM": "android"
-      }
-    },
-    "test:ci:ios": {
-      "command": "npm run common:ci",
-      "dependencies": [
-        "pod-install"
-      ],
-      "env": {
-        "PLATFORM": "ios"
-      }
     },
     "test:android": {
       "command": "npm run common",

--- a/integration-tests/tests/tsconfig.json
+++ b/integration-tests/tests/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "es2022",
 		"module": "es2022",
 		"moduleResolution": "node",
+		"useDefineForClassFields": false,
 		"strict": true,
 		"strictFunctionTypes": false,
 		"esModuleInterop": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -31676,6 +31676,7 @@
       }
     },
     "packages/babel-plugin": {
+      "name": "@realm/babel-plugin",
       "version": "0.1.1",
       "license": "apache-2.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://realm.io",
   "scripts": {
     "build": "wireit",
+    "bundle": "wireit",
     "lint:cpp": "find src packages/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
     "lint:cpp:fix": "find src packages/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i"
   },
@@ -18,13 +19,18 @@
     "build": {
       "dependencies": [
         "submodules",
-        "./packages/realm:build",
+        "bundle",
+        "./packages/realm:build"
+      ]
+    },
+    "bundle": {
+      "dependencies": [
+        "./packages/realm:bundle",
         "./packages/babel-plugin:build",
         "./packages/mocha-reporter:build",
         "./packages/realm-react:build",
         "./packages/realm-tools:build",
-        "./packages/realm-web:build",
-        "./integration-tests/tests:build"
+        "./packages/realm-web:build"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "./packages/realm:bundle",
         "./packages/babel-plugin:build",
         "./packages/mocha-reporter:build",
+        "./packages/realm-app-importer:build",
         "./packages/realm-react:build",
         "./packages/realm-tools:build",
         "./packages/realm-web:build"

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -5,8 +5,15 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "wireit",
     "test": "jest"
+  },
+  "wireit": {
+    "build": {
+      "command": "tsc -p tsconfig.build.json",
+      "files": ["tsconfig.build.json", "tsconfig.json", "src"],
+      "output": ["dist"]
+    }
   },
   "keywords": [
     "realm",

--- a/packages/babel-plugin/src/plugin/index.ts
+++ b/packages/babel-plugin/src/plugin/index.ts
@@ -278,7 +278,8 @@ function findDecoratorCall(
 function visitRealmClassProperty(path: NodePath<types.ClassProperty>) {
   const keyPath = path.get("key");
   const valuePath = path.get("value");
-  const decoratorsPath: NodePath<types.Decorator>[] = path.get("decorators");
+  // TODO: Avoid this type assertion
+  const decoratorsPath = path.get("decorators") as NodePath<types.Decorator>[];
 
   const indexDecorator = findDecoratorIdentifier(decoratorsPath, "index");
   if (indexDecorator) {

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -17,7 +17,6 @@
       "command": "rollup --config",
       "dependencies": [
         "../realm:bundle",
-        "../realm:build:node",
         "../realm-common:build"
       ],
       "files": ["rollup.config.mjs", "src/**/*.ts", "src/**/*.tsx"],

--- a/packages/realm-tools/package.json
+++ b/packages/realm-tools/package.json
@@ -9,9 +9,16 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "wireit",
     "lint": "eslint --ext .js,.ts .",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "wireit": {
+    "build": {
+      "command": "tsc -p tsconfig.build.json",
+      "files": ["tsconfig.build.json", "tsconfig.json", "src"],
+      "output": ["dist"]
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/realm-tools/src/realm-schema.ts
+++ b/packages/realm-tools/src/realm-schema.ts
@@ -49,7 +49,7 @@ const mermaid: FormatterFunction = (realm: Realm) => {
     const name = objectSchema.name;
     writer(`class ${name} {`);
     Object.keys(objectSchema.properties).forEach((propertyName) => {
-      const prop = objectSchema.properties[propertyName] as Realm.PropertySchema;
+      const prop = objectSchema.properties[propertyName] as Realm.ObjectSchemaProperty;
       if (collectionTypes.includes(prop.type) || prop.type === "object") {
         const objectType = prop.objectType ?? "__unknown__";
         if (!primitiveTypes.includes(objectType)) {

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -27,7 +27,7 @@
     },
     "generate-types": {
       "command": "tsc --project src/dom/tsconfig.json --declaration --emitDeclarationOnly --declarationDir types/generated",
-      "dependencies": ["update-types"],
+      "dependencies": ["update-types", "../realm-common:build", "../realm-network-transport:build"],
       "files": ["src/**/*.ts", "src/**/tsconfig.json", "tsconfig.json"],
       "output": ["types/generated"]
     },

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -54,6 +54,8 @@
     "bundle": "wireit",
     "build:bindgen": "wireit",
     "rebuild:bindgen": "wireit",
+    "build:bindgen:typescript": "wireit",
+    "build:bindgen:node-wrapper": "wireit",
     "build:node": "wireit",
     "build:node:prebuild": "wireit",
     "build:node:prebuild:arm": "wireit",
@@ -81,7 +83,8 @@
       "command": "rollup --config",
       "dependencies": [
         "../realm-network-transport:build",
-        "build:bindgen"
+        "build:bindgen:typescript",
+        "build:bindgen:node-wrapper"
       ],
       "files": ["rollup.config.mjs", "src/**/*.ts", "tsconfig.json", "src/**/tsconfig.json"],
       "output": ["dist/bundle.*.js", "dist/bundle.*.mjs"]
@@ -96,6 +99,14 @@
         "generated/ts/native.mjs",
         "generated/ts/native-rn.mjs"
       ]
+    },
+    "build:bindgen:typescript": {
+      "command": "realm-bindgen --spec ../bindgen/spec.yml --spec ../bindgen/js_spec.yml --template typescript --output ./generated/ts",
+      "dependencies": ["../..:submodules", "../bindgen:generate:spec-schema"]
+    },
+    "build:bindgen:node-wrapper": {
+      "command": "realm-bindgen --spec ../bindgen/spec.yml --spec ../bindgen/js_spec.yml --template node-wrapper --output ./generated/ts",
+      "dependencies": ["../..:submodules", "../bindgen:generate:spec-schema"]
     },
     "rebuild:bindgen": {
       "command": "cmake-js rebuild --debug --directory ../bindgen",


### PR DESCRIPTION
## What, How & Why?

Our v11 SDK didn't need a step to build / bundle TypeScript code, but our new SDK does.
This PR adds a "bundle" job to the PR workflow which will run the `bundle` script in our root package, which will in turn depend on the build and bundle scripts for all sub-packages producing outputs derived from TypeScript source-files.

This also adjusts the prepare and publish workflows for releasing the new SDK.
