### PR TITLE
Import device-info platform module to React Native bundle

### DIFF
--- a/packages/realm/src/react-native/index.ts
+++ b/packages/realm/src/react-native/index.ts
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import "./fs";
+import "./device-info";
 
 export * from "../index";
 import { Realm } from "../index";


### PR DESCRIPTION
## What, How & Why?
React Native was crashing.  Seems the platform specific module wasn't imported for React Native.  This works now with the fix.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
