### PR TITLE
Fix commonjs bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Importing using `require` from Node.js would throw because it would accidentally import the ESM bundle. ([#5607](https://github.com/realm/realm-js/issues/5607), since v12.0.0-alpha.0)
+
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/integration-tests/environments/node/index.cjs
+++ b/integration-tests/environments/node/index.cjs
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+const os = require("node:os");
+const { Client } = require("mocha-remote-client");
+const fs = require("fs-extra");
+const path = require("path");
+
+const client = new Client({
+  title: `Node.js v${process.versions.node} on ${os.platform()} (via CommonJS)`,
+  tests(context) {
+    // Exposing the Realm constructor as a global
+    global.fs = fs;
+    global.path = path;
+    global.environment = { ...context, node: true };
+
+    // Add the integration test suite
+    require("@realm/integration-tests");
+    // Load the Node.js specific part of the integration tests
+    require("@realm/integration-tests/node");
+  },
+});
+
+client.on("error", (err) => {
+  console.error("Failure from Mocha Remote Client:", err);
+  process.exitCode = 1;
+});
+
+global.client = client;
+
+// TODO: Setup a watch to re-run when the tests change

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -5,12 +5,23 @@
   "private": true,
   "scripts": {
     "test": "wireit",
+    "test:commonjs": "wireit",
     "test:ci": "mocha-remote --reporter @realm/mocha-reporter tsx index.mjs",
     "lint": "eslint --ext js,mjs ."
   },
   "wireit": {
     "test": {
       "command": "mocha-remote --reporter @realm/mocha-reporter tsx index.mjs",
+      "dependencies": [
+        "../../../packages/realm:bundle",
+        "../../../packages/realm:build:node",
+        "../../../packages/mocha-reporter:build",
+        "../../../packages/realm-network-transport:build",
+        "../../../packages/realm-app-importer:build"
+      ]
+    },
+    "test:commonjs": {
+      "command": "mocha-remote --reporter @realm/mocha-reporter tsx index.cjs",
       "dependencies": [
         "../../../packages/realm:bundle",
         "../../../packages/realm:build:node",

--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^18.11.9",
     "concurrently": "^6.5.1",
     "mocha": "^10.1.0",
-    "node-fetch": "^3.2.10",
+    "node-fetch": "^2.6.9",
     "platform": "^1.3.6",
     "realm": "*"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1647,6 +1647,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "integration-tests/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "integration-tests/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -1961,7 +1981,7 @@
         "@types/node": "^18.11.9",
         "concurrently": "^6.5.1",
         "mocha": "^10.1.0",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "^2.6.9",
         "platform": "^1.3.6",
         "realm": "*"
       },
@@ -8895,6 +8915,7 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -8918,6 +8939,7 @@
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -8972,6 +8994,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -8993,6 +9016,7 @@
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -9000,6 +9024,7 @@
     },
     "node_modules/aws4": {
       "version": "1.12.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel": {
@@ -9335,6 +9360,7 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -9362,13 +9388,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -10056,6 +10075,7 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/chai": {
@@ -10189,13 +10209,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -10581,6 +10594,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -10717,6 +10731,7 @@
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
+      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -10730,6 +10745,7 @@
     },
     "node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -10743,10 +10759,12 @@
     },
     "node_modules/concat-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -11167,6 +11185,7 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -11177,6 +11196,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -11437,6 +11457,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -11846,6 +11867,7 @@
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
@@ -13809,6 +13831,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
@@ -13906,6 +13929,7 @@
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -14014,6 +14038,7 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14042,10 +14067,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -14253,6 +14274,7 @@
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -14273,6 +14295,7 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -14319,16 +14342,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/fs-monkey": {
@@ -14546,6 +14559,7 @@
     },
     "node_modules/getpass": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -14838,6 +14852,7 @@
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -14845,6 +14860,7 @@
     },
     "node_modules/har-validator": {
       "version": "5.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
@@ -14856,6 +14872,7 @@
     },
     "node_modules/har-validator/node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -14870,6 +14887,7 @@
     },
     "node_modules/har-validator/node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/has": {
@@ -15221,19 +15239,6 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/http-basic": {
-      "version": "2.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.6",
-        "http-response-object": "^1.0.0"
-      }
-    },
-    "node_modules/http-basic/node_modules/caseless": {
-      "version": "0.11.0",
-      "license": "Apache-2.0"
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "dev": true,
@@ -15318,12 +15323,9 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/http-response-object": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/http-signature": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -16052,6 +16054,7 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
@@ -16126,6 +16129,7 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -19933,6 +19937,7 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsc-android": {
@@ -20359,6 +20364,7 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
+      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -20371,6 +20377,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -20418,6 +20425,7 @@
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
@@ -21873,27 +21881,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "3.3.4",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "license": "MIT",
@@ -22559,6 +22546,7 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22576,6 +22564,7 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -22850,10 +22839,6 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/node-machine-id": {
-      "version": "1.1.12",
       "license": "MIT"
     },
     "node_modules/node-ninja": {
@@ -23413,6 +23398,7 @@
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -24033,6 +24019,7 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -24874,6 +24861,7 @@
     },
     "node_modules/psl": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/public-encrypt": {
@@ -25061,6 +25049,7 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -25617,6 +25606,7 @@
     },
     "node_modules/request": {
       "version": "2.88.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -25646,6 +25636,7 @@
     },
     "node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -25658,6 +25649,7 @@
     },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
@@ -25665,6 +25657,7 @@
     },
     "node_modules/request/node_modules/uuid": {
       "version": "3.4.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -26744,6 +26737,7 @@
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
@@ -26896,13 +26890,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stream-counter": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.20"
       }
     },
     "node_modules/string_decoder": {
@@ -27119,15 +27106,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/sync-request": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^1.4.7",
-        "http-response-object": "^1.0.1",
-        "then-request": "^2.0.1"
-      }
-    },
     "node_modules/table": {
       "version": "6.8.1",
       "dev": true,
@@ -27229,21 +27207,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.1.12",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tar-fs": {
@@ -27408,29 +27371,6 @@
       "version": "0.2.0",
       "license": "MIT"
     },
-    "node_modules/then-request": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.7",
-        "http-basic": "^2.5.1",
-        "http-response-object": "^1.1.0",
-        "promise": "^7.1.1",
-        "qs": "^6.1.0"
-      }
-    },
-    "node_modules/then-request/node_modules/caseless": {
-      "version": "0.11.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/then-request/node_modules/promise": {
-      "version": "7.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/throat": {
       "version": "5.0.0",
       "license": "MIT"
@@ -27565,6 +27505,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
@@ -29064,6 +29005,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type": {
@@ -29111,6 +29053,7 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
@@ -29566,6 +29509,7 @@
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -29670,6 +29614,7 @@
     },
     "node_modules/verror": {
       "version": "1.10.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -29682,6 +29627,7 @@
     },
     "node_modules/verror/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vlq": {
@@ -32454,7 +32400,7 @@
       "license": "apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.9",
         "prebuild-install": "^7.1.1"
       },
       "devDependencies": {
@@ -32500,7 +32446,7 @@
         "deepmerge": "^4.2.2",
         "fs-extra": "^10.1.0",
         "glob": "^8.0.3",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "^2.6.9",
         "yargs": "^17.6.0"
       },
       "bin": {
@@ -32566,6 +32512,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/realm-app-importer/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "packages/realm-app-importer/node_modules/supports-color": {
@@ -32864,7 +32829,7 @@
       "dependencies": {
         "@realm/common": "^0.1.4",
         "abort-controller": "^3.0.0",
-        "node-fetch": "^3.1.1"
+        "node-fetch": "^2.6.9"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.2",
@@ -32984,6 +32949,25 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/realm-network-transport/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "packages/realm-network-transport/node_modules/supports-color": {
       "version": "5.4.0",
@@ -33631,7 +33615,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "realm": ">=10",
+        "realm": "*",
         "ts-command-line-args": "^2.2.1"
       },
       "bin": {
@@ -33647,89 +33631,6 @@
       "version": "17.0.45",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/realm-tools/node_modules/bson": {
-      "version": "4.4.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/realm-tools/node_modules/deepmerge": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/realm-tools/node_modules/fs-extra": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "packages/realm-tools/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "packages/realm-tools/node_modules/node-addon-api": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "packages/realm-tools/node_modules/realm": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-11.5.2.tgz",
-      "integrity": "sha512-E5Ia4B2zsLge1o0jJ3NmlBKN8vtgQTt7CRvYHNNvWRoIEraZhOJtuyNMm/Yg8b9MvaLZPeDmVo8KO05lSoni6Q==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@realm/common": "^0.1.4",
-        "@realm/network-transport": "^0.7.2",
-        "bindings": "^1.5.0",
-        "bson": "4.4.1",
-        "command-line-args": "^5.1.1",
-        "deepmerge": "2.1.0",
-        "fs-extra": "^4.0.3",
-        "ini": "^1.3.7",
-        "node-addon-api": "4.2.0",
-        "node-fetch": "^3.2.10",
-        "node-machine-id": "^1.1.10",
-        "prebuild-install": "^7.0.1",
-        "progress": "^2.0.3",
-        "prop-types": "^15.6.2",
-        "request": "^2.88.0",
-        "stream-counter": "^1.0.0",
-        "sync-request": "^3.0.1",
-        "tar": "^6.0.1",
-        "url-parse": "^1.4.4"
-      },
-      "engines": {
-        "node": ">=13",
-        "npm": ">=7"
-      },
-      "peerDependencies": {
-        "react-native": ">=0.70.0"
-      },
-      "peerDependenciesMeta": {
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "packages/realm-tools/node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "packages/realm-web": {
       "version": "2.0.0",
@@ -33755,7 +33656,7 @@
         "chai": "^4.2.0",
         "fs-extra": "^10.0.0",
         "mocha": "^5.2.0",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "^2.6.9",
         "rollup-plugin-dts": "^1.4.0",
         "rollup-plugin-node-builtins": "^2.1.2"
       },
@@ -34414,6 +34315,26 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/realm-web/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "packages/realm-web/node_modules/rollup": {
       "version": "2.79.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32454,7 +32454,7 @@
       "license": "apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
-        "node-fetch": "^3.3.0",
+        "node-fetch": "^2.6.7",
         "prebuild-install": "^7.1.1"
       },
       "devDependencies": {
@@ -34671,6 +34671,25 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "packages/realm/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "packages/realm/node_modules/npmlog": {

--- a/packages/realm-app-importer/package.json
+++ b/packages/realm-app-importer/package.json
@@ -62,7 +62,7 @@
     "deepmerge": "^4.2.2",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
-    "node-fetch": "^3.2.10",
+    "node-fetch": "^2.6.9",
     "yargs": "^17.6.0"
   },
   "devDependencies": {

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@realm/common": "^0.1.4",
     "abort-controller": "^3.0.0",
-    "node-fetch": "^3.1.1"
+    "node-fetch": "^2.6.9"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^23.0.2",

--- a/packages/realm-tools/package.json
+++ b/packages/realm-tools/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "realm": ">=10",
+    "realm": "*",
     "ts-command-line-args": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -85,7 +85,7 @@
     "chai": "^4.2.0",
     "fs-extra": "^10.0.0",
     "mocha": "^5.2.0",
-    "node-fetch": "^3.2.10",
+    "node-fetch": "^2.6.9",
     "@realm/network-transport": "^0.7.2",
     "rollup-plugin-dts": "^1.4.0",
     "rollup-plugin-node-builtins": "^2.1.2"

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -198,7 +198,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "node-fetch": "^3.3.0",
+    "node-fetch": "^2.6.7",
     "prebuild-install": "^7.1.1"
   },
   "peerDependencies": {

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -22,21 +22,21 @@
     "email": "help@realm.io",
     "url": "https://realm.io"
   },
+  "main": "./dist/bundle.node.js",
+  "module": "./dist/bundle.node.mjs",
+  "types": "./dist/bundle.d.ts",
+  "react-native": "./dist/bundle.react-native.mjs",
   "exports": {
     ".": {
       "types": "./dist/bundle.d.ts",
-      "node": "./dist/bundle.node.mjs",
       "require": "./dist/bundle.node.js",
+      "node": "./dist/bundle.node.mjs",
       "react-native": "./dist/bundle.react-native.mjs"
     },
     "./scripts/submit-analytics": "./scripts/submit-analytics.mjs",
     "./react-native.config.js": "./react-native.config.js",
     "./package.json": "./package.json"
   },
-  "main": "./dist/bundle.node.js",
-  "module": "./dist/bundle.node.mjs",
-  "types": "./dist/bundle.d.ts",
-  "react-native": "./dist/bundle.react-native.mjs",
   "files": [
     "dist",
     "react-native/android",

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -198,7 +198,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "node-fetch": "^2.6.7",
+    "node-fetch": "^2.6.9",
     "prebuild-install": "^7.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## What, How & Why?

This closes #5607 by reordering the conditional exports and downgrading `node-fetch` to a version exporting a commonjs bundle.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests (locally, manually)
