### PR TITLE
Printing calling stack frame when accessing global `Realm`

### DIFF
--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1963,17 +1963,33 @@ declare global {
   }
 }
 
+function getCallstack() {
+  try {
+    throw new Error("Finding calling stack");
+  } catch (err) {
+    const stack = err instanceof Error ? err.stack || "" : "";
+    return stack
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("at"))
+      .splice(1); // Skipping this function
+  }
+}
+
 // Patch the global at runtime
 let warnedAboutGlobalRealmUse = false;
 Object.defineProperty(safeGlobalThis, "Realm", {
   get() {
     if (!warnedAboutGlobalRealmUse) {
+      // Skipping this function
+      const frame: string | undefined = getCallstack()[1];
       // eslint-disable-next-line no-console
       console.warn(
         "Your app is relying on a Realm global, which will be removed in realm-js v13,\n",
         "please update your code to ensure you import Realm via a named import:\n\n",
         'import { Realm } from "realm"; // For ES Modules\n',
-        'const { Realm } = require("realm"); // For CommonJS\n',
+        'const { Realm } = require("realm"); // For CommonJS\n\n',
+        frame ? `This is happening ${frame}\n` : "Can't determine caller.\n",
       );
       warnedAboutGlobalRealmUse = true;
     }


### PR DESCRIPTION
## What, How & Why?

This will improve the warning logged when someone access the global `Realm` from their code, by including the source-code frame reading it:

```
Your app is relying on a Realm global, which will be removed in realm-js v13,
 please update your code to ensure you import Realm via a named import:

 import { Realm } from "realm"; // For ES Modules
 const { Realm } = require("realm"); // For CommonJS
 
 This is happening at <anonymous> (/Users/kraen.hansen/Projects/realm-js/integration-tests/tests/src/tests/sync/realm.ts:384:26)
```