### PR TITLE
Added `SyncError.logUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * None
 
 ### Enhancements
+* Exposed `SyncError.logUrl`, that contains the URL to the server log related to the sync error. ([#5609](https://github.com/realm/realm-js/issues/5609))
 * Added a new error class `CompensatingWriteError` which indicates that one or more object changes have been reverted by the server. 
 This can happen when the client creates/updates objects that do not match any subscription, or performs writes on an object it didn't have permission to access. ([#5599](https://github.com/realm/realm-js/pull/5599))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* Exposed `SyncError.logUrl`, that contains the URL to the server log related to the sync error. ([#5609](https://github.com/realm/realm-js/issues/5609))
+* Exposed `SyncError.logUrl` which contains the URL to the server log related to the sync error. ([#5609](https://github.com/realm/realm-js/issues/5609))
 * Added a new error class `CompensatingWriteError` which indicates that one or more object changes have been reverted by the server. 
 This can happen when the client creates/updates objects that do not match any subscription, or performs writes on an object it didn't have permission to access. ([#5599](https://github.com/realm/realm-js/pull/5599))
 

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -412,7 +412,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
       const errorCallback: ErrorCallback = (_, error) => {
         expect(error.code).to.equal(231);
-        expect(error.isFatal).to.be.false;
+        expect(error.logUrl).to.be.not.empty;
         expect(error.message).to.contain(
           "Client attempted a write that is outside of permissions or query filters; it has been reverted",
         );

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -412,7 +412,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
       const errorCallback: ErrorCallback = (_, error) => {
         expect(error.code).to.equal(231);
-        expect(error.logUrl).to.be.not.empty;
+        expect(error.logUrl).to.not.be.empty;
         expect(error.message).to.contain(
           "Client attempted a write that is outside of permissions or query filters; it has been reverted",
         );

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -530,7 +530,7 @@ records:
      system_error:
        type: std::error_code
        cppName: get_system_error()
-     is_fatal: bool
+     # is_fatal: bool //Should not be exposed to SDK
      simple_message: StringData
      logURL: StringData
      user_info: std::unordered_map<StringData, StringData>

--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -530,7 +530,7 @@ records:
      system_error:
        type: std::error_code
        cppName: get_system_error()
-     # is_fatal: bool //Should not be exposed to SDK
+     is_fatal: bool
      simple_message: StringData
      logURL: StringData
      user_info: std::unordered_map<StringData, StringData>

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -103,11 +103,30 @@ export function fromBindingSyncError(error: binding.SyncError) {
   }
 }
 
+/**
+ * An class describing a sync error.
+ */
 export class SyncError extends Error {
   public name = "SyncError";
+
+  /**
+   * A numeric code representing the error.
+   */
   public code: number;
+
+  /**
+   * A string representing the error category.
+   */
   public category: string;
-  public isFatal: boolean;
+
+  /**
+   * The URL to the associated server log, if any.
+   */
+  public logUrl: string;
+
+  /**
+   * A record of extra user information associated with this error.
+   */
   public userInfo: Record<string, string>;
 
   /** @internal */
@@ -116,7 +135,7 @@ export class SyncError extends Error {
     const { systemError } = error;
     this.code = systemError.code;
     this.category = systemError.category;
-    this.isFatal = error.isFatal;
+    this.logUrl = error.logUrl;
     this.userInfo = error.userInfo;
   }
 }

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -120,7 +120,8 @@ export class SyncError extends Error {
   public category: string;
 
   /**
-   * The URL to the associated server log, if available.
+   * The URL to the associated server log, if available. The string will be empty
+   * if the sync error is not initiated by the server.
    */
   public logUrl: string;
 

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -110,17 +110,17 @@ export class SyncError extends Error {
   public name = "SyncError";
 
   /**
-   * A numeric code representing the error.
+   * The error code that represents this error.
    */
   public code: number;
 
   /**
-   * A string representing the error category.
+   * The category of this error.
    */
   public category: string;
 
   /**
-   * The URL to the associated server log, if any.
+   * The URL to the associated server log, if available.
    */
   public logUrl: string;
 

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -129,6 +129,11 @@ export class SyncError extends Error {
    */
   public userInfo: Record<string, string>;
 
+  /**
+   * @deprecated Check the error message instead.
+   */
+  public isFatal: boolean;
+
   /** @internal */
   constructor(error: binding.SyncError) {
     super(error.simpleMessage);
@@ -137,6 +142,7 @@ export class SyncError extends Error {
     this.category = systemError.category;
     this.logUrl = error.logUrl;
     this.userInfo = error.userInfo;
+    this.isFatal = error.isFatal;
   }
 }
 


### PR DESCRIPTION
This PR exposes `SyncError.logUrl`, that contains the URL pointing to the server log related to the sync error. 

As I was there:
- I added docs for `SyncError`
- I deprecated `SyncError.isFatal`, as it seems it's something that is only used internally and should probably not be exposed to SDK

This closes #5609 
## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests