### PR TITLE
Add missing method on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Added a missing (internal) method on iOS. Building a React Native app will failed with the error `Undefined symbol: realm::set_default_realm_file_directory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)`. ([#5633](https://github.com/realm/realm-js/issues/5633), since v11.6.0)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/src/ios/platform.mm
+++ b/src/ios/platform.mm
@@ -35,7 +35,14 @@ static NSString *error_description(NSError *error) {
   return error.localizedDescription;
 }
 
+static std::string s_default_realm_directory;
+
 namespace realm {
+
+void set_default_realm_file_directory(std::string dir)
+{
+    s_default_realm_directory = dir;
+}
 
 std::string default_realm_file_directory()
 {

--- a/src/ios/platform.mm
+++ b/src/ios/platform.mm
@@ -48,6 +48,9 @@ std::string default_realm_file_directory()
 {
     std::string ret;
     @autoreleasepool {
+        if (!s_default_realm_directory.empty()) {
+            return s_default_realm_directory;
+        }
 #if TARGET_OS_IPHONE
         // On iOS the Documents directory isn't user-visible, so put files there
         NSString *path = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];


### PR DESCRIPTION
## What, How & Why?

This closes #5633 

Adding a missing (internal) method on iOS. 

Building a React Native app will failed with the error `Undefined symbol: realm::set_default_realm_file_directory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)`

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 📝 Update `COMPATIBILITY.md`~
* ~[ ] 🚦 Tests~
* ~[ ] 🔀 Executed flexible sync tests locally if modifying flexible sync~
* ~[ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 📝 Public documentation PR created or is not necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~

*If this PR adds or changes public API's:*
* ~[ ] typescript definitions file is updated~
* ~[ ] jsdoc files updated~
