### PR TITLE
Pinning chai to fix dictionary tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,22 +1989,6 @@
         "realm": "*"
       }
     },
-    "integration-tests/tests/node_modules/chai": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "integration-tests/tests/node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -2047,16 +2031,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "integration-tests/tests/node_modules/deep-eql": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "integration-tests/tests/node_modules/escape-string-regexp": {
@@ -10079,12 +10053,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/chai": {
-      "version": "4.3.7",
-      "license": "MIT",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -10096,7 +10071,8 @@
     },
     "node_modules/chai-as-promised": {
       "version": "7.1.1",
-      "license": "WTFPL",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dependencies": {
         "check-error": "^1.0.2"
       },
@@ -11312,13 +11288,14 @@
       "license": "MIT"
     },
     "node_modules/deep-eql": {
-      "version": "4.1.2",
-      "license": "MIT",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=0.12"
       }
     },
     "node_modules/deep-extend": {
@@ -31601,7 +31578,7 @@
         "@types/chai": "^4.3.3",
         "@types/debug": "^4.1.7",
         "@types/mocha": "^10.0.0",
-        "chai": "^4.3.6",
+        "chai": "4.3.6",
         "cmake-js": "6.3.2",
         "mocha": "^10.1.0"
       }
@@ -32415,7 +32392,7 @@
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.9",
         "@types/path-browserify": "^1.0.0",
-        "chai": "^4.3.6",
+        "chai": "4.3.6",
         "cmake-js": "6.3.2",
         "cross-env": "^7.0.3",
         "mocha": "^10.1.0",
@@ -32553,7 +32530,7 @@
         "@rollup/plugin-typescript": "^4.1.1",
         "@types/chai": "^4.2.10",
         "@types/mocha": "^5",
-        "chai": "^4.2.0",
+        "chai": "4.3.6",
         "mocha": "^5.2.0",
         "rollup-plugin-dts": "^1.4.0"
       }
@@ -32838,7 +32815,7 @@
         "@types/chai": "^4.2.10",
         "@types/mocha": "^5",
         "@types/node-fetch": "^2.5.7",
-        "chai": "^4.2.0",
+        "chai": "4.3.6",
         "mocha": "^5.2.0",
         "rollup-plugin-dts": "^5.0.0"
       }
@@ -33653,7 +33630,7 @@
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.6",
         "abort-controller": "^3.0.0",
-        "chai": "^4.2.0",
+        "chai": "4.3.6",
         "fs-extra": "^10.0.0",
         "mocha": "^5.2.0",
         "node-fetch": "^2.6.9",
@@ -33669,7 +33646,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@realm/app-importer": "^0.1.0",
-        "chai": "^4.3.6",
+        "chai": "4.3.6",
         "js-base64": "^3.7.2",
         "jwt-encode": "^1.0.1",
         "mocha": "^8.3.2",

--- a/packages/bindgen/package.json
+++ b/packages/bindgen/package.json
@@ -35,7 +35,7 @@
     "@types/chai": "^4.3.3",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^10.0.0",
-    "chai": "^4.3.6",
+    "chai": "4.3.6",
     "cmake-js": "6.3.2",
     "mocha": "^10.1.0"
   },

--- a/packages/realm-common/package.json
+++ b/packages/realm-common/package.json
@@ -51,7 +51,7 @@
     "@rollup/plugin-typescript": "^4.1.1",
     "@types/chai": "^4.2.10",
     "@types/mocha": "^5",
-    "chai": "^4.2.0",
+    "chai": "4.3.6",
     "mocha": "^5.2.0",
     "rollup-plugin-dts": "^1.4.0"
   }

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -57,7 +57,7 @@
     "@types/chai": "^4.2.10",
     "@types/mocha": "^5",
     "@types/node-fetch": "^2.5.7",
-    "chai": "^4.2.0",
+    "chai": "4.3.6",
     "mocha": "^5.2.0",
     "rollup-plugin-dts": "^5.0.0"
   }

--- a/packages/realm-web-integration-tests/package-lock.json
+++ b/packages/realm-web-integration-tests/package-lock.json
@@ -8,7 +8,6 @@
       "name": "realm-web-integration-tests",
       "version": "0.1.0",
       "dependencies": {
-        "chai": "^4.3.6",
         "js-base64": "^3.7.2",
         "jwt-encode": "^1.0.1",
         "mocha": "^8.3.2",

--- a/packages/realm-web-integration-tests/package.json
+++ b/packages/realm-web-integration-tests/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "chai": "^4.3.6",
+    "chai": "4.3.6",
     "js-base64": "^3.7.2",
     "jwt-encode": "^1.0.1",
     "mocha": "^8.3.2",

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -82,7 +82,7 @@
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.7.6",
     "abort-controller": "^3.0.0",
-    "chai": "^4.2.0",
+    "chai": "4.3.6",
     "fs-extra": "^10.0.0",
     "mocha": "^5.2.0",
     "node-fetch": "^2.6.9",

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -219,7 +219,7 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
     "@types/path-browserify": "^1.0.0",
-    "chai": "^4.3.6",
+    "chai": "4.3.6",
     "cmake-js": "6.3.2",
     "cross-env": "^7.0.3",
     "mocha": "^10.1.0",


### PR DESCRIPTION
## What, How & Why?

This fixes some failing dictionary tests by pinning chai across all packages of the mono-repo.
See the last section of the integration-tests README.md on current limitations for details on why this is needed: https://github.com/realm/realm-js/blob/main/integration-tests/README.md#current-limitations
