### PR TITLE
Enable garbage collection between tests

### DIFF
--- a/integration-tests/environments/node/index.cjs
+++ b/integration-tests/environments/node/index.cjs
@@ -20,6 +20,10 @@ const os = require("node:os");
 const { Client } = require("mocha-remote-client");
 const fs = require("fs-extra");
 const path = require("path");
+const v8 = require("v8");
+const vm = require("vm");
+
+v8.setFlagsFromString("--expose_gc");
 
 const client = new Client({
   title: `Node.js v${process.versions.node} on ${os.platform()} (via CommonJS)`,
@@ -28,6 +32,7 @@ const client = new Client({
     global.fs = fs;
     global.path = path;
     global.environment = { ...context, node: true };
+    global.gc = vm.runInNewContext("gc");
 
     // Add the integration test suite
     require("@realm/integration-tests");

--- a/integration-tests/environments/node/index.mjs
+++ b/integration-tests/environments/node/index.mjs
@@ -21,6 +21,11 @@ import { Client } from "mocha-remote-client";
 import fs from "fs-extra";
 import path from "path";
 
+import v8 from "node:v8";
+import vm from "node:vm";
+
+v8.setFlagsFromString("--expose_gc");
+
 const client = new Client({
   title: `Node.js v${process.versions.node} on ${os.platform()}`,
   async tests(context) {
@@ -28,6 +33,7 @@ const client = new Client({
     global.fs = fs;
     global.path = path;
     global.environment = { ...context, node: true };
+    global.gc = vm.runInNewContext("gc");
 
     // Add the integration test suite
     await import("@realm/integration-tests");


### PR DESCRIPTION
## What, How & Why?

This change forces GC between tests when running them from `integration-tests/environments/node`.
I added this to tests when they were running via `integration-tests/tests` a while back, as it made makes the tests more deterministic and helped debug some lifetime related issues.

Having this is good because it make the tests behave more deterministic (as it eliminates races related to GC), but at the same time it hides some lifetime related issues (suchs as realms not being closed by core if a sync session is kept alive due to an SDK level object owning a shared pointer to it).

In the future, we should probably
- make this more configurable and run the tests on CI with and without GC between tests.
- investigate enabling this for the other supported platforms.
