### PR TITLE
Keep an `IterableWeakRefs` of `SyncSession`s to reset when clearing test state

### DIFF
--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -274,12 +274,12 @@ export class Realm {
     }
     Realm.internals.clear();
     binding.RealmCoordinator.clearAllCaches();
+    binding.App.clearCachedApps();
+    SyncSession.resetAllInternals();
 
     // Delete all Realm files in the default directory
     const defaultDirectoryPath = fs.getDefaultDirectoryPath();
     fs.removeRealmFilesFromDirectory(defaultDirectoryPath);
-
-    binding.App.clearCachedApps();
   }
 
   /**

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -295,8 +295,6 @@ export class SyncSession {
     if (!this._internal) return;
     this._internal.$resetSharedPtr();
     this._internal = null;
-    // No need to remember this instance, now that we've already resat the internal
-    SyncSession.instances.delete(this);
   }
 
   // TODO: Return the `error_handler`


### PR DESCRIPTION
## What, How & Why?

This adds clearing of `SyncSession` internal shared pointers when clearing test state between tests.
It makes our tests behave more predictably, since these shared pointers would otherwise keeps sessions and therefore realms open across tests.
