### PR TITLE
Improvements to perf tests

### DIFF
--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -24,13 +24,15 @@ type Value = ((realm: Realm) => unknown) | unknown;
 
 function getTypeName(type: Realm.PropertySchemaShorthand | Realm.PropertySchema) {
   if (typeof type === "object") {
+    const prefix = type.optional ? "optional " : "";
     if (type.objectType) {
-      return `${type.type}<${type.objectType}>`;
+      return prefix + `${type.type}<${type.objectType}>`;
     } else {
-      return type.type;
+      return prefix + type.type;
     }
   } else {
-    return type;
+    // All strings get `optional: true` added to them.
+    return `optional ${type}`;
   }
 }
 
@@ -61,7 +63,7 @@ function describeTypeRead({ type, value, schema = [] }: TestParameters) {
 
   describePerformance(`reading property of type '${typeName}'`, {
     schema: [defaultSchema, ...schema],
-    benchmarkTitle: `reads ${type}`,
+    benchmarkTitle: `reads ${typeName}`,
     before(this: Partial<RealmObjectContext> & RealmContext & Mocha.Context) {
       this.realm.write(() => {
         this.object = this.realm.create(objectSchemaName, {

--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -31,8 +31,7 @@ function getTypeName(type: Realm.PropertySchemaShorthand | Realm.PropertySchema)
       return prefix + type.type;
     }
   } else {
-    // All strings get `optional: true` added to them.
-    return `optional ${type}`;
+    return type;
   }
 }
 
@@ -51,13 +50,7 @@ function describeTypeRead({ type, value, schema = [] }: TestParameters) {
   const defaultSchema = {
     name: objectSchemaName,
     properties: {
-      [propertyName]:
-        typeof type === "object"
-          ? type
-          : {
-              type,
-              optional: true,
-            },
+      [propertyName]: type,
     },
   };
 
@@ -86,27 +79,27 @@ function describeTypeRead({ type, value, schema = [] }: TestParameters) {
 }
 
 const cases: Array<TestParameters | [Realm.PropertySchemaShorthand | Realm.PropertySchema, Value]> = [
+  ["bool?", true],
   ["bool", true],
-  [{ type: "bool", optional: false }, true],
+  ["int?", 123],
   ["int", 123],
-  [{ type: "int", optional: false }, 123],
   ["float", 123.456],
+  ["double?", 123.456],
   ["double", 123.456],
-  [{ type: "double", optional: false }, 123.456],
-  ["string", "Hello!"],
-  ["decimal128", new Realm.BSON.Decimal128("123")],
-  ["objectId", new Realm.BSON.ObjectId("0000002a9a7969d24bea4cf4")],
-  ["uuid", new Realm.BSON.UUID()],
-  ["date", new Date("2000-01-01")],
-  ["data", new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])],
+  ["string?", "Hello!"],
+  ["decimal128?", new Realm.BSON.Decimal128("123")],
+  ["objectId?", new Realm.BSON.ObjectId("0000002a9a7969d24bea4cf4")],
+  ["uuid?", new Realm.BSON.UUID()],
+  ["date?", new Date("2000-01-01")],
+  ["data?", new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])],
   {
-    type: { type: "object", objectType: "Car" },
+    type: "Car",
     schema: [{ name: "Car", properties: { model: "string" } }],
     value: (realm: Realm) => realm.create("Car", { model: "VW Touran" }),
   },
-  [{ type: "list", objectType: "bool" }, []],
-  [{ type: "set", objectType: "bool" }, []],
-  [{ type: "dictionary", objectType: "bool" }, {}],
+  ["bool?[]", []],
+  ["bool?<>", []],
+  ["bool?{}", {}],
 ];
 
 describe.skipIf(environment.performance !== true, "Property read performance", () => {

--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -95,16 +95,13 @@ const cases: Array<TestParameters | [Realm.PropertySchemaShorthand | Realm.Prope
   ["date", new Date("2000-01-01")],
   ["data", new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])],
   {
-    type: "Car",
+    type: { type: "object", objectType: "Car" },
     schema: [{ name: "Car", properties: { model: "string" } }],
     value: (realm: Realm) => realm.create("Car", { model: "VW Touran" }),
   },
-  // List of bool
-  ["bool[]", []],
-  // Set of bool
-  ["bool<>", []],
-  // Dictionary of bool
-  ["bool{}", {}],
+  [{ type: "list", objectType: "bool" }, []],
+  [{ type: "set", objectType: "bool" }, []],
+  [{ type: "dictionary", objectType: "bool" }, {}],
 ];
 
 describe.skipIf(environment.performance !== true, "Property read performance", () => {

--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -87,9 +87,12 @@ function describeTypeRead({ type, value, schema = [] }: TestParameters) {
 
 const cases: Array<TestParameters | [Realm.PropertySchemaShorthand | Realm.PropertySchema, Value]> = [
   ["bool", true],
+  [{ type: "bool", optional: false }, true],
   ["int", 123],
+  [{ type: "int", optional: false }, 123],
   ["float", 123.456],
   ["double", 123.456],
+  [{ type: "double", optional: false }, 123.456],
   ["string", "Hello!"],
   ["decimal128", new Realm.BSON.Decimal128("123")],
   ["objectId", new Realm.BSON.ObjectId("0000002a9a7969d24bea4cf4")],


### PR DESCRIPTION
Perf tests were broken by the new schema parser rules. This fixes them, improves the display, and adds testing of non-optional primitives. All three commits are focused, so I plan to merge unsquashed.

New output: 
```
  Property read performance
    reading property of type 'optional bool'
      ✓ reads optional bool (2,303,929 ops/sec, ±13.34%)
    reading property of type 'bool'
      ✓ reads bool (2,936,755 ops/sec, ±15.67%)
    reading property of type 'optional int'
      ✓ reads optional int (1,845,957 ops/sec, ±12.01%)
    reading property of type 'int'
      ✓ reads int (2,557,997 ops/sec, ±14.5%)
    reading property of type 'optional float'
      ✓ reads optional float (1,010,129 ops/sec, ±10.02%)
    reading property of type 'optional double'
      ✓ reads optional double (2,149,702 ops/sec, ±18.79%)
    reading property of type 'double'
      ✓ reads double (2,823,891 ops/sec, ±16.06%)
    reading property of type 'optional string'
      ✓ reads optional string (1,663,157 ops/sec, ±35.71%)
    reading property of type 'optional decimal128'
      ✓ reads optional decimal128 (46,450 ops/sec, ±7.81%)
    reading property of type 'optional objectId'
      ✓ reads optional objectId (609,219 ops/sec, ±13.18%)
    reading property of type 'optional uuid'
      ✓ reads optional uuid (419,110 ops/sec, ±10.5%)
    reading property of type 'optional date'
      ✓ reads optional date (382,338 ops/sec, ±207.84%)
    reading property of type 'optional data'
      ✓ reads optional data (659,072 ops/sec, ±59.2%)
    reading property of type 'object<Car>'
      ✓ reads object<Car> (552,954 ops/sec, ±265.21%)
    reading property of type 'list<bool>'
      ✓ reads list<bool> (42,740 ops/sec, ±25.22%)
    reading property of type 'set<bool>'
      ✓ reads set<bool> (71,332 ops/sec, ±34.78%)
    reading property of type 'dictionary<bool>'
      ✓ reads dictionary<bool> (153,826 ops/sec, ±19.51%)
```

 (I have a plan to improve optional read perf, but want to separate that from infra changes)