### PR TITLE
Throwing errors when using symbols as keys of dictionary

### DIFF
--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -176,11 +176,11 @@ describe("Dictionary", () => {
         expect(() => {
           //@ts-expect-error We need to verify using a symbol as a key throws
           item.dict.set(sym, "value1");
-        }).to.throw("Input key cannot be a symbol");
+        }).to.throw("Symbols cannot be used as keys of a dictionary");
 
         expect(() => {
           item.dict.set({ [sym]: "value2" });
-        }).to.throw("Input object cannot contain symbol keys");
+        }).to.throw("Symbols cannot be used as keys of a dictionary");
 
         expect(() => {
           //@ts-expect-error We need to verify using a symbol as a key throws

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -167,6 +167,26 @@ describe("Dictionary", () => {
       expect(Object.keys(item.dict).length).deep.equals(3);
     });
 
+    it("throws when using Symbol as key", function (this: RealmContext) {
+      const sym = Symbol("testSymbol");
+
+      this.realm.write(() => {
+        const item = this.realm.create<Item>("Item", {});
+
+        expect(() => {
+          item.dict.set(sym, "value1");
+        }).to.throw("Input key cannot be a symbol");
+
+        expect(() => {
+          item.dict.set({ [sym]: "value2" });
+        }).to.throw("Input object cannot contain symbol keys");
+
+        expect(() => {
+          item.dict[sym] = "value3";
+        }).to.throw("Symbols cannot be used as keys of a dictionary");
+      });
+    });
+
     it("set/remove methods return the dictionary", function (this: RealmContext) {
       const item = this.realm.write(() => this.realm.create<Item>("Item", {}));
 

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -174,6 +174,7 @@ describe("Dictionary", () => {
         const item = this.realm.create<Item>("Item", {});
 
         expect(() => {
+          //@ts-expect-error We need to verify using a symbol as a key throws
           item.dict.set(sym, "value1");
         }).to.throw("Input key cannot be a symbol");
 
@@ -182,6 +183,7 @@ describe("Dictionary", () => {
         }).to.throw("Input object cannot contain symbol keys");
 
         expect(() => {
+          //@ts-expect-error We need to verify using a symbol as a key throws
           item.dict[sym] = "value3";
         }).to.throw("Symbols cannot be used as keys of a dictionary");
       });

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -183,7 +183,7 @@ describe("Dictionary", () => {
         }).to.throw("Symbols cannot be used as keys of a dictionary");
 
         expect(() => {
-          //@ts-expect-error We need to verify using a symbol as a key throws
+          //@ts-expect-error Testing invalid key.
           item.dict[sym] = "value3";
         }).to.throw("Symbols cannot be used as keys of a dictionary");
       });

--- a/integration-tests/tests/src/tests/dictionary.ts
+++ b/integration-tests/tests/src/tests/dictionary.ts
@@ -174,7 +174,7 @@ describe("Dictionary", () => {
         const item = this.realm.create<Item>("Item", {});
 
         expect(() => {
-          //@ts-expect-error We need to verify using a symbol as a key throws
+          //@ts-expect-error Testing invalid key.
           item.dict.set(sym, "value1");
         }).to.throw("Symbols cannot be used as keys of a dictionary");
 

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -252,8 +252,8 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * Adds one or more elements with the specified key and value to the dictionary or updates value if key exists.
    * @param elementsOrKey The element to add or the key of the element to add.
    * @param value The value of the element to add.
-   * @throws {@link AssertionError} If not inside a write transaction, if using symbol as keys, or if any value violates type constraints
-   * @returns The dictionary
+   * @throws {@link AssertionError} If not inside a write transaction, if using symbol as keys, or if any value violates type constraints.
+   * @returns The dictionary.
    * @since 10.6.0
    */
   set(elementsOrKey: string | { [key: string]: T }, value?: T): this {

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -57,7 +57,7 @@ const PROXY_HANDLER: ProxyHandler<Dictionary> = {
       internal.insertAny(prop, toBinding(value, undefined));
       return true;
     } else {
-      assert(typeof prop != "symbol", "Symbols cannot be used as keys of a dictionary");
+      assert(typeof prop !== "symbol", "Symbols cannot be used as keys of a dictionary");
       return false;
     }
   },
@@ -257,7 +257,7 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * @since 10.6.0
    */
   set(elementsOrKey: string | { [key: string]: T }, value?: T): this {
-    const elements = typeof elementsOrKey == "object" ? elementsOrKey : { [elementsOrKey]: value };
+    const elements = typeof elementsOrKey === "object" ? elementsOrKey : { [elementsOrKey]: value };
     assert(Object.getOwnPropertySymbols(elements).length === 0, "Symbols cannot be used as keys of a dictionary");
     assert.inTransaction(this[REALM]);
     const internal = this[INTERNAL];

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -257,9 +257,8 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * @since 10.6.0
    */
   set(elementsOrKey: string | { [key: string]: T }, value?: T): this {
-    assert(typeof elementsOrKey != "symbol", "Input key cannot be a symbol");
-    const elements = typeof elementsOrKey == "string" ? { [elementsOrKey]: value } : elementsOrKey;
-    assert(Object.getOwnPropertySymbols(elements).length == 0, "Input object cannot contain symbol keys");
+    const elements = typeof elementsOrKey == "object" ? elementsOrKey : { [elementsOrKey]: value };
+    assert(Object.getOwnPropertySymbols(elements).length === 0, "Symbols cannot be used as keys of a dictionary");
     assert.inTransaction(this[REALM]);
     const internal = this[INTERNAL];
     const toBinding = this[HELPERS].toBinding;


### PR DESCRIPTION
This closes #5604 

## ☑️ ToDos
* [x] 🚦 Tests