### PR TITLE
Adopting `@realm/babel-plugin` to the changes in the v12 schema parser

### DIFF
--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -230,7 +230,8 @@ describe("Babel plugin", () => {
     });
 
     describeProperty("link", {
-      type: "Person",
+      type: "object",
+      objectTypes: ["Person"],
     });
 
     // LinkingObjects has sufficiently unique syntax that we test it manually

--- a/packages/babel-plugin/src/plugin/index.ts
+++ b/packages/babel-plugin/src/plugin/index.ts
@@ -102,14 +102,17 @@ function getRealmTypeForTSTypeReference(path: NodePath<types.TSTypeReference>): 
   } else if (isRealmTypeAlias(path, "Data") || typeName.isIdentifier({ name: "ArrayBuffer" })) {
     return { type: "data" };
   } else if (isRealmTypeAlias(path, "List") || isRealmTypeAlias(path, "List", null)) {
-    const objectType = getRealmTypeForTypeArgument(typeParameters);
-    return { type: "list", objectType: objectType?.type, optional: objectType?.optional };
+    const argumentType = getRealmTypeForTypeArgument(typeParameters);
+    const objectType = argumentType?.type === "object" ? argumentType.objectType : argumentType?.type;
+    return { type: "list", objectType: objectType, optional: argumentType?.optional };
   } else if (isRealmTypeAlias(path, "Set") || isRealmTypeAlias(path, "Set", null)) {
-    const objectType = getRealmTypeForTypeArgument(typeParameters);
-    return { type: "set", objectType: objectType?.type, optional: objectType?.optional };
+    const argumentType = getRealmTypeForTypeArgument(typeParameters);
+    const objectType = argumentType?.type === "object" ? argumentType.objectType : argumentType?.type;
+    return { type: "set", objectType: objectType, optional: argumentType?.optional };
   } else if (isRealmTypeAlias(path, "Dictionary") || isRealmTypeAlias(path, "Dictionary", null)) {
-    const objectType = getRealmTypeForTypeArgument(typeParameters);
-    return { type: "dictionary", objectType: objectType?.type, optional: objectType?.optional };
+    const argumentType = getRealmTypeForTypeArgument(typeParameters);
+    const objectType = argumentType?.type === "object" ? argumentType.objectType : argumentType?.type;
+    return { type: "dictionary", objectType: objectType, optional: argumentType?.optional };
   } else if (isRealmTypeAlias(path, "Mixed") || isRealmTypeAlias(path, "Mixed", null)) {
     return { type: "mixed" };
   } else if (isRealmTypeAlias(path, "LinkingObjects")) {
@@ -158,7 +161,7 @@ function getRealmTypeForTSTypeReference(path: NodePath<types.TSTypeReference>): 
     return { type: "linkingObjects", objectType, property };
   } else if (typeName.isIdentifier()) {
     // TODO: Consider checking the scope to ensure it is a declared identifier
-    return { type: typeName.node.name };
+    return { type: "object", objectType: typeName.node.name };
   }
 }
 

--- a/packages/babel-plugin/src/tests/generator/suite.ts
+++ b/packages/babel-plugin/src/tests/generator/suite.ts
@@ -16,12 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { PropertySchema } from "realm";
+import { PropertySchema, PropertyTypeName } from "realm";
 import { generatePropertyCode, generatePropertyVariants, PropertyTestOptions } from "./variants";
 import { extractSchema, transformProperty } from "./transform";
 
 type PropertySuiteOptions = {
-  type: string;
+  type: PropertyTypeName;
   objectTypes?: (undefined | string)[];
   defaults?: ({ source: string } | unknown)[];
   optionals?: boolean[];

--- a/packages/babel-plugin/src/tests/generator/variants.ts
+++ b/packages/babel-plugin/src/tests/generator/variants.ts
@@ -16,11 +16,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { PropertyTypeName } from "realm";
+
 type SourceCode = { source: string };
 
 export type PropertyTestOptions = {
   name: string;
-  type: string;
+  type: PropertyTypeName;
   objectType: string | undefined;
   default: SourceCode | undefined | unknown;
   optional: boolean;
@@ -127,12 +129,12 @@ function unionUndefined(type: string | undefined, optional: OptionalVariant) {
 // TODO: Consider generating variants for optional properties where both question mark and undefined before/after type are used
 export function generatePropertyVariants(options: PropertyTestOptions): PropertyVariant[] {
   const variants: PropertyVariant[] = [];
-  const typeVariants = generateTypeNameVariants(options.type);
+  const typeVariants = generateTypeNameVariants(options.type !== "object" ? options.type : options.objectType);
   if (DEFAULT_INFERABLE_TYPES.has(options.type) && typeof options.default !== "undefined") {
     typeVariants.push(undefined);
   }
   for (const type of typeVariants) {
-    for (const typeArgument of generateTypeNameVariants(options.objectType)) {
+    for (const typeArgument of generateTypeNameVariants(options.type !== "object" ? options.objectType : undefined)) {
       for (const optional of generateOptionalVariants(options)) {
         if (
           typeof type === "undefined" &&

--- a/packages/babel-plugin/src/tests/generator/variants.ts
+++ b/packages/babel-plugin/src/tests/generator/variants.ts
@@ -129,12 +129,12 @@ function unionUndefined(type: string | undefined, optional: OptionalVariant) {
 // TODO: Consider generating variants for optional properties where both question mark and undefined before/after type are used
 export function generatePropertyVariants(options: PropertyTestOptions): PropertyVariant[] {
   const variants: PropertyVariant[] = [];
-  const typeVariants = generateTypeNameVariants(options.type !== "object" ? options.type : options.objectType);
+  const typeVariants = generateTypeNameVariants(options.type === "object" ? options.objectType : options.type);
   if (DEFAULT_INFERABLE_TYPES.has(options.type) && typeof options.default !== "undefined") {
     typeVariants.push(undefined);
   }
   for (const type of typeVariants) {
-    for (const typeArgument of generateTypeNameVariants(options.type !== "object" ? options.objectType : undefined)) {
+    for (const typeArgument of generateTypeNameVariants(options.type === "object" ? undefined : options.objectType)) {
       for (const optional of generateOptionalVariants(options)) {
         if (
           typeof type === "undefined" &&


### PR DESCRIPTION
## What, How & Why?

This makes the babel plugin emit `{ type: "object", objectType: "Person" }` instead of `{ type: "Person" }` and updates the tests accordingly.
