### PR TITLE
Remove explicit obj.isNull() calls and let core return null values instead

### DIFF
--- a/packages/bindgen/spec.yml
+++ b/packages/bindgen/spec.yml
@@ -655,7 +655,7 @@ classes:
       get_column_type: '(column: ColKey) const -> DataType'
       get_link_target: '(column: ColKey) const -> ConstTableRef'
       get_object: '(key: ObjKey) const -> Obj'
-      try_get_object: '(key: ObjKey) const -> Obj'
+      try_get_object: '(key: ObjKey) const -> Nullable<Obj>'
       query: '(query_string: std::string, args: std::vector<QueryArg>, mapping: KeyPathMapping) const -> Query'
       find_primary_key: '(pk: Mixed) -> ObjKey'
 
@@ -689,7 +689,7 @@ classes:
         - '(column: ColKey, value: Mixed)'
         - sig: '(column: ColKey, value: Mixed, is_default: bool)'
           suffix: with_default
-      get_linked_object: '(column: ColKey) const -> Obj'
+      get_linked_object: '(column: ColKey) const -> Nullable<Obj>'
       to_string: () const -> std::string
       get_backlink_count: '() const -> count_t'
       get_backlink_view: '(src_table: TableRef, src_col_key: ColKey) -> TableView'

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -76,16 +76,12 @@ export type PropertyHelpers = TypeHelpers &
     objectType?: string;
   };
 
-const defaultGet = ({ typeHelpers: { fromBinding }, columnKey, optional }: PropertyOptions) =>
-  optional
-    ? (obj: binding.Obj) => {
-        assert.isValid(obj);
-        return obj.isNull(columnKey) ? null : fromBinding(obj.getAny(columnKey));
-      }
-    : (obj: binding.Obj) => {
-        assert.isValid(obj);
-        return fromBinding(obj.getAny(columnKey));
-      };
+const defaultGet =
+  ({ typeHelpers: { fromBinding }, columnKey }: PropertyOptions) =>
+  (obj: binding.Obj) => {
+    assert.isValid(obj); // TODO may be able to remove this, but need to ensure core will error in all cases when this is false.
+    return fromBinding(obj.getAny(columnKey));
+  };
 
 const defaultSet =
   ({ realm, typeHelpers: { toBinding }, columnKey }: PropertyOptions) =>
@@ -114,7 +110,7 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
     assert(options.optional, "Objects are always nullable");
     return {
       get(this: PropertyHelpers, obj) {
-        return obj.isNull(columnKey) ? null : fromBinding(obj.getLinkedObject(columnKey));
+        return fromBinding(obj.getLinkedObject(columnKey));
       },
       set: embedded ? embeddedSet(options) : defaultSet(options),
     };

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -961,7 +961,7 @@ export class Realm {
     try {
       const objKey = binding.stringToObjKey(objectKey);
       const obj = table.tryGetObject(objKey);
-      const result = wrapObject(obj) as T;
+      const result = obj && (wrapObject(obj) as T);
       return result === null ? undefined : result;
     } catch (err) {
       if (err instanceof binding.InvalidObjKey) {


### PR DESCRIPTION
Significant perf improvement.

Before:
```
  Property read performance
    reading property of type 'bool?'
      ✓ reads bool? (2,360,180 ops/sec, ±11.74%)
    reading property of type 'bool'
      ✓ reads bool (3,185,524 ops/sec, ±21.99%)
    reading property of type 'int?'
      ✓ reads int? (1,928,722 ops/sec, ±19.97%)
    reading property of type 'int'
      ✓ reads int (2,673,371 ops/sec, ±17.81%)
    reading property of type 'float'
      ✓ reads float (1,273,909 ops/sec, ±10.9%)
    reading property of type 'double?'
      ✓ reads double? (2,238,847 ops/sec, ±14.21%)
    reading property of type 'double'
      ✓ reads double (2,815,026 ops/sec, ±14.63%)
    reading property of type 'string?'
      ✓ reads string? (1,944,500 ops/sec, ±9.92%)
    reading property of type 'decimal128?'
      ✓ reads decimal128? (47,898 ops/sec, ±4.73%)
    reading property of type 'objectId?'
      ✓ reads objectId? (653,961 ops/sec, ±13.52%)
    reading property of type 'uuid?'
      ✓ reads uuid? (455,367 ops/sec, ±11.27%)
    reading property of type 'date?'
      ✓ reads date? (381,749 ops/sec, ±197.04%)
    reading property of type 'data?'
      ✓ reads data? (666,326 ops/sec, ±63.13%)
    reading property of type 'Car'
      ✓ reads Car (549,529 ops/sec, ±259.82%)
    reading property of type 'bool?[]'
      ✓ reads bool?[] (46,285 ops/sec, ±28.1%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (78,636 ops/sec, ±35.38%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (156,523 ops/sec, ±17.67%)
```

After:
(Optional vs required differences are within the noise and it is random which is faster between runs. Don't read too much into `bool` vs `bool?` perf now)
```
  Property read performance
    reading property of type 'bool?'
      ✓ reads bool? (3,274,631 ops/sec, ±10.71%)
    reading property of type 'bool'
      ✓ reads bool (3,184,231 ops/sec, ±18.11%)
    reading property of type 'int?'
      ✓ reads int? (2,434,316 ops/sec, ±17.21%)
    reading property of type 'int'
      ✓ reads int (2,765,443 ops/sec, ±11.42%)
    reading property of type 'float'
      ✓ reads float (1,247,335 ops/sec, ±13.08%)
    reading property of type 'double?'
      ✓ reads double? (2,869,277 ops/sec, ±14.34%)
    reading property of type 'double'
      ✓ reads double (2,874,972 ops/sec, ±14.77%)
    reading property of type 'string?'
      ✓ reads string? (2,581,351 ops/sec, ±10.98%)
    reading property of type 'decimal128?'
      ✓ reads decimal128? (48,203 ops/sec, ±4.61%)
    reading property of type 'objectId?'
      ✓ reads objectId? (717,574 ops/sec, ±10.42%)
    reading property of type 'uuid?'
      ✓ reads uuid? (467,422 ops/sec, ±10.1%)
    reading property of type 'date?'
      ✓ reads date? (433,956 ops/sec, ±218.08%)
    reading property of type 'data?'
      ✓ reads data? (705,173 ops/sec, ±66.33%)
    reading property of type 'Car'
      ✓ reads Car (629,489 ops/sec, ±281.56%)
    reading property of type 'bool?[]'
      ✓ reads bool?[] (45,277 ops/sec, ±26.86%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (78,706 ops/sec, ±33.43%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (156,501 ops/sec, ±17.46%)
```