### PR TITLE
Adding a `THROW_ON_GLOBAL_REALM` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This can happen when the client creates/updates objects that do not match any su
   * Significant (~99%) improvement when querying for a case insensitive match on a `mixed` property that has an index.
   * Moderate (~25%) improvement when querying for an exact match on a `bool` property that has an index.
   * Small (~5%) improvement when querying for a case insensitive match on a `mixed` property that does not have an index.
+* Added a `THROW_ON_GLOBAL_REALM` which will enable throwing when the app is accessing the `Realm` without first importing it from the Realm package.
 
 ### Fixed
 * Fixed passing RealmObject instances between shared Realms. ([#5634](https://github.com/realm/realm-js/pull/5634), since v12.0.0-alpha.0)

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -154,6 +154,7 @@ import {
   assert,
   binding,
   extendDebug,
+  flags,
   fromBindingRealmSchema,
   fs,
   index,
@@ -1966,33 +1967,23 @@ declare global {
   }
 }
 
-function getCallstack() {
-  try {
-    throw new Error("Finding calling stack");
-  } catch (err) {
-    const stack = err instanceof Error ? err.stack || "" : "";
-    return stack
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith("at"))
-      .splice(1); // Skipping this function
-  }
-}
-
 // Patch the global at runtime
 let warnedAboutGlobalRealmUse = false;
 Object.defineProperty(safeGlobalThis, "Realm", {
   get() {
-    if (!warnedAboutGlobalRealmUse) {
-      // Skipping this function
-      const frame: string | undefined = getCallstack()[1];
+    if (flags.THROW_ON_GLOBAL_REALM) {
+      throw new Error(
+        "Accessed global Realm, please update your code to ensure you import Realm via a named import:\nimport { Realm } from 'realm';",
+      );
+    } else if (!warnedAboutGlobalRealmUse) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Your app is relying on a Realm global, which will be removed in realm-js v13,\n",
-        "please update your code to ensure you import Realm via a named import:\n\n",
+        "Your app is relying on a Realm global, which will be removed in realm-js v13, please update your code to ensure you import Realm via a named import:\n\n",
         'import { Realm } from "realm"; // For ES Modules\n',
         'const { Realm } = require("realm"); // For CommonJS\n\n',
-        frame ? `This is happening ${frame}\n` : "Can't determine caller.\n",
+        "To determine where, put this in the top of your index file:\n",
+        `import { flags } from "realm";\n`,
+        `flags.THROW_ON_GLOBAL_REALM = true`,
       );
       warnedAboutGlobalRealmUse = true;
     }

--- a/packages/realm/src/flags.ts
+++ b/packages/realm/src/flags.ts
@@ -21,5 +21,9 @@ export const flags = {
    * When enabled, objects can be created by providing an array of values (in the order that they were declared in the object schema) in addition to of an object of property values.
    */
   ALLOW_VALUES_ARRAYS: false,
+  /**
+   * When enabled, accessing the `Realm` without first importing it from the Realm package, will throw.
+   * Helps finding places where the app is depending on the now deprecated way of using the package.
+   */
   THROW_ON_GLOBAL_REALM: false,
 };

--- a/packages/realm/src/flags.ts
+++ b/packages/realm/src/flags.ts
@@ -21,4 +21,5 @@ export const flags = {
    * When enabled, objects can be created by providing an array of values (in the order that they were declared in the object schema) in addition to of an object of property values.
    */
   ALLOW_VALUES_ARRAYS: false,
+  THROW_ON_GLOBAL_REALM: false,
 };


### PR DESCRIPTION
## What, How & Why?

As an alternative to https://github.com/realm/realm-js/pull/5628, this is a proposal to add a `THROW_ON_GLOBAL_REALM` which will throw when the global Realm is accessed. This gives a better experience on React Native since the error will result in a red-box with the stack being symbolicated and clickable:

### The initial warning

![Screenshot 2023-03-29 at 15 17 45](https://user-images.githubusercontent.com/1243959/228553360-ebf2e24b-a0c7-4b2c-b111-75f9412d2927.png)

### After setting the flag

```typescript
import { flags } from "realm";
flags.THROW_ON_GLOBAL_REALM = true;
```

Clicking the calling function (shown by the arrow) will open the offending piece of sourcecode.

![Screenshot 2023-03-29 at 15 23 12](https://user-images.githubusercontent.com/1243959/228553407-98c0480e-d9cd-4416-93e1-d79a9de11815.png)
