### PR TITLE
Adds a deprecation to the global `WeakRef` constructor

### DIFF
--- a/packages/realm/src/runtime.d.ts
+++ b/packages/realm/src/runtime.d.ts
@@ -42,7 +42,7 @@ declare module "buffer" {
   type Buffer = Uint8Array;
 }
 
-/** @deprecated React Native doesn't provide this */
+/** @deprecated React Native doesn't provide this, use our `binding.WeakRef` polyfill instead. */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 declare interface WeakRef<T extends object> {}
 /** @deprecated React Native doesn't provide this */

--- a/packages/realm/src/runtime.d.ts
+++ b/packages/realm/src/runtime.d.ts
@@ -41,3 +41,13 @@ declare const console: Console;
 declare module "buffer" {
   type Buffer = Uint8Array;
 }
+
+/** @deprecated React Native doesn't provide this */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+declare interface WeakRef<T extends object> {}
+/** @deprecated React Native doesn't provide this */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+declare interface WeakRefConstructor {
+  /** @deprecated React Native doesn't provide this */
+  new <T extends object>(target: T): WeakRef<T>;
+}


### PR DESCRIPTION
## What, How & Why?

Our SDK depends on the runtime types for the "ES2022" lib, since most of these are available in end-user projects, but this includes `WeakRef` which is currently not exposed on React Native. This adds a deprecation to the symbol to help us avoid relying on it in the SDK.

![Screenshot 2023-03-29 at 16 23 52](https://user-images.githubusercontent.com/1243959/228569724-38a059b4-5d2b-4959-8a82-ab2dd3accbf8.png)

