### PR TITLE
Stop doing our own isValid check and let core handle it

### DIFF
--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -1063,6 +1063,10 @@ describe("Realm.Object", () => {
         expect(obj.isValid()).to.be.true;
         this.realm.delete(obj);
         expect(obj.isValid()).to.be.false;
+        // Reading a column from deleted object should fail
+        expect(() => obj.doubleCol).to.throw("No object with key");
+        // Writing to a column from deleted object should fail
+        expect(() => (obj.doubleCol = 0)).to.throw("No object with key");
         return obj;
       });
 

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -79,7 +79,6 @@ export type PropertyHelpers = TypeHelpers &
 const defaultGet =
   ({ typeHelpers: { fromBinding }, columnKey }: PropertyOptions) =>
   (obj: binding.Obj) => {
-    assert.isValid(obj); // TODO may be able to remove this, but need to ensure core will error in all cases when this is false.
     return fromBinding(obj.getAny(columnKey));
   };
 


### PR DESCRIPTION
@finnschiermer confirmed in a slack thread in #realm-core that the `Obj::is_valid()` check should not be needed prior to calling `get_any()`, and there is a substantial perf boost from removing it.

Note that this **does** change the specific error being thrown from [this message in realm-js](https://github.com/realm/realm-js/blob/c47b41cfbf8f2344950e421050acf1ec00afe299/packages/realm/src/assert.ts#L151-L153) to [this message from realm-core](https://github.com/realm/realm-core/blob/87ea815f63639b6513a56232e7c8516bb4fad707/src/realm/cluster.cpp#L92). I think that is fine, but if we really care, we could catch that error and rethrow our own replacement.

Before (taken "After" from [last PR](https://github.com/realm/realm-js/pull/5659)): 

```
  Property read performance
    reading property of type 'bool?'
      ✓ reads bool? (3,274,631 ops/sec, ±10.71%)
    reading property of type 'bool'
      ✓ reads bool (3,184,231 ops/sec, ±18.11%)
    reading property of type 'int?'
      ✓ reads int? (2,434,316 ops/sec, ±17.21%)
    reading property of type 'int'
      ✓ reads int (2,765,443 ops/sec, ±11.42%)
    reading property of type 'float'
      ✓ reads float (1,247,335 ops/sec, ±13.08%)
    reading property of type 'double?'
      ✓ reads double? (2,869,277 ops/sec, ±14.34%)
    reading property of type 'double'
      ✓ reads double (2,874,972 ops/sec, ±14.77%)
    reading property of type 'string?'
      ✓ reads string? (2,581,351 ops/sec, ±10.98%)
    reading property of type 'decimal128?'
      ✓ reads decimal128? (48,203 ops/sec, ±4.61%)
    reading property of type 'objectId?'
      ✓ reads objectId? (717,574 ops/sec, ±10.42%)
    reading property of type 'uuid?'
      ✓ reads uuid? (467,422 ops/sec, ±10.1%)
    reading property of type 'date?'
      ✓ reads date? (433,956 ops/sec, ±218.08%)
    reading property of type 'data?'
      ✓ reads data? (705,173 ops/sec, ±66.33%)
    reading property of type 'Car'
      ✓ reads Car (629,489 ops/sec, ±281.56%)
    reading property of type 'bool?[]'
      ✓ reads bool?[] (45,277 ops/sec, ±26.86%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (78,706 ops/sec, ±33.43%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (156,501 ops/sec, ±17.46%)
```

After:

```
  Property read performance
    reading property of type 'bool?'
      ✓ reads bool? (4,264,360 ops/sec, ±15.65%)
    reading property of type 'bool'
      ✓ reads bool (3,995,069 ops/sec, ±17.98%)
    reading property of type 'int?'
      ✓ reads int? (3,049,290 ops/sec, ±15.62%)
    reading property of type 'int'
      ✓ reads int (3,326,671 ops/sec, ±15.77%)
    reading property of type 'float'
      ✓ reads float (1,332,529 ops/sec, ±8.48%)
    reading property of type 'double?'
      ✓ reads double? (3,624,318 ops/sec, ±15.54%)
    reading property of type 'double'
      ✓ reads double (3,833,162 ops/sec, ±16.25%)
    reading property of type 'string?'
      ✓ reads string? (3,005,196 ops/sec, ±15.98%)
    reading property of type 'decimal128?'
      ✓ reads decimal128? (47,621 ops/sec, ±6.19%)
    reading property of type 'objectId?'
      ✓ reads objectId? (783,582 ops/sec, ±11.07%)
    reading property of type 'uuid?'
      ✓ reads uuid? (518,738 ops/sec, ±8.17%)
    reading property of type 'date?'
      ✓ reads date? (440,376 ops/sec, ±228.7%)
    reading property of type 'data?'
      ✓ reads data? (735,524 ops/sec, ±69.26%)
    reading property of type 'Car'
      ✓ reads Car (577,848 ops/sec, ±284.03%)
    reading property of type 'bool?[]'
      ✓ reads bool?[] (42,556 ops/sec, ±24.84%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (78,273 ops/sec, ±34.24%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (158,067 ops/sec, ±18.42%)
```

(`Car` (a linked object) is slightly slower, but I think that is just noise. It is a very noisy test, and its code path isn't affected by this change, since it already wasn't checking validity prior to calling `getLinkedObject()`)
