### PR TITLE
Introducing `IterableWeakSet` and using it to close Realms when clearing test state

### DIFF
--- a/packages/realm/src/IterableWeakRefs.ts
+++ b/packages/realm/src/IterableWeakRefs.ts
@@ -22,7 +22,7 @@ import { binding } from "./internal";
  * An internal iterable set of {@link binding.WeakRef} objects wrapping objects of type {@link T}.
  * @internal
  */
-export class IterableWeakSet<T extends object> {
+export class IterableWeakRefs<T extends object> {
   private internal: Set<binding.WeakRef<T>>;
   constructor(values?: readonly T[] | null) {
     this.internal = new Set(values ? values.map((value) => new binding.WeakRef(value)) : undefined);

--- a/packages/realm/src/IterableWeakSet.ts
+++ b/packages/realm/src/IterableWeakSet.ts
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { binding } from "./internal";
+
+/**
+ * Implements an iterable `WeakSet`.
+ * @internal
+ */
+export class IterableWeakSet<T extends object> implements Set<T> {
+  private internal: Set<binding.WeakRef<T>>;
+  constructor(values?: readonly T[] | null) {
+    this.internal = new Set(values ? values.map((value) => new binding.WeakRef(value)) : undefined);
+  }
+
+  /**
+   * Deletes all weak references that no longer points to an object
+   */
+  clean() {
+    for (const ref of this.internal) {
+      if (!ref.deref()) {
+        this.internal.delete(ref);
+      }
+    }
+  }
+
+  get size() {
+    return this.internal.size;
+  }
+
+  get [Symbol.toStringTag]() {
+    return IterableWeakSet.name;
+  }
+
+  forEach(cb: (value: T, value2: T, set: Set<T>) => void, thisArg?: unknown) {
+    this.internal.forEach((valueRef, valueRef2) => {
+      const value = valueRef.deref();
+      const value2 = valueRef2.deref();
+      if (value && value2) {
+        cb.call(thisArg, value, value2, this);
+      }
+    }, this);
+  }
+
+  add(value: T) {
+    this.internal.add(new binding.WeakRef(value));
+    return this;
+  }
+
+  clear() {
+    this.internal.clear();
+  }
+
+  delete(value: T): boolean {
+    // This is a good time to get rid of entries that has been GC'ed
+    this.clean();
+    const ref = this.find(value);
+    if (ref) {
+      return this.internal.delete(ref);
+    }
+    return false;
+  }
+
+  has(value: T): boolean {
+    const ref = this.find(value);
+    return ref ? true : false;
+  }
+
+  *entries(): IterableIterator<[T, T]> {
+    for (const [valueRef, valueRef2] of this.internal.entries()) {
+      const value = valueRef.deref();
+      const value2 = valueRef2.deref();
+      if (value && value2) {
+        yield [value, value2];
+      }
+    }
+  }
+
+  *keys(): IterableIterator<T> {
+    for (const keyRef of this.internal.keys()) {
+      const key = keyRef.deref();
+      if (key) {
+        yield key;
+      }
+    }
+  }
+
+  *values(): IterableIterator<T> {
+    for (const valueRef of this.internal.values()) {
+      const value = valueRef.deref();
+      if (value) {
+        yield value;
+      }
+    }
+  }
+
+  *[Symbol.iterator](): IterableIterator<T> {
+    for (const value of this.values()) {
+      yield value;
+    }
+  }
+
+  /**
+   * Finds the weak reference given a value
+   */
+  private find(value: T) {
+    for (const ref of this.internal) {
+      if (ref.deref() === value) {
+        return ref;
+      }
+    }
+  }
+}

--- a/packages/realm/src/IterableWeakSet.ts
+++ b/packages/realm/src/IterableWeakSet.ts
@@ -19,10 +19,10 @@
 import { binding } from "./internal";
 
 /**
- * Implements an iterable `WeakSet`.
+ * An internal iterable set of {@link binding.WeakRef} objects wrapping objects of type {@link T}.
  * @internal
  */
-export class IterableWeakSet<T extends object> implements Set<T> {
+export class IterableWeakSet<T extends object> {
   private internal: Set<binding.WeakRef<T>>;
   constructor(values?: readonly T[] | null) {
     this.internal = new Set(values ? values.map((value) => new binding.WeakRef(value)) : undefined);
@@ -37,24 +37,6 @@ export class IterableWeakSet<T extends object> implements Set<T> {
         this.internal.delete(ref);
       }
     }
-  }
-
-  get size() {
-    return this.internal.size;
-  }
-
-  get [Symbol.toStringTag]() {
-    return IterableWeakSet.name;
-  }
-
-  forEach(cb: (value: T, value2: T, set: Set<T>) => void, thisArg?: unknown) {
-    this.internal.forEach((valueRef, valueRef2) => {
-      const value = valueRef.deref();
-      const value2 = valueRef2.deref();
-      if (value && value2) {
-        cb.call(thisArg, value, value2, this);
-      }
-    }, this);
   }
 
   add(value: T) {
@@ -76,42 +58,12 @@ export class IterableWeakSet<T extends object> implements Set<T> {
     return false;
   }
 
-  has(value: T): boolean {
-    const ref = this.find(value);
-    return ref ? true : false;
-  }
-
-  *entries(): IterableIterator<[T, T]> {
-    for (const [valueRef, valueRef2] of this.internal.entries()) {
-      const value = valueRef.deref();
-      const value2 = valueRef2.deref();
-      if (value && value2) {
-        yield [value, value2];
-      }
-    }
-  }
-
-  *keys(): IterableIterator<T> {
-    for (const keyRef of this.internal.keys()) {
-      const key = keyRef.deref();
-      if (key) {
-        yield key;
-      }
-    }
-  }
-
-  *values(): IterableIterator<T> {
-    for (const valueRef of this.internal.values()) {
+  *[Symbol.iterator](): IterableIterator<T> {
+    for (const valueRef of this.internal) {
       const value = valueRef.deref();
       if (value) {
         yield value;
       }
-    }
-  }
-
-  *[Symbol.iterator](): IterableIterator<T> {
-    for (const value of this.values()) {
-      yield value;
     }
   }
 

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -272,7 +272,7 @@ export class Realm {
         realm.close();
       }
     }
-    this.internals.clear();
+    Realm.internals.clear();
     binding.RealmCoordinator.clearAllCaches();
 
     // Delete all Realm files in the default directory

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -85,7 +85,7 @@ import {
   InsertManyResult,
   InsertOneResult,
   InvalidateEvent,
-  IterableWeakSet,
+  IterableWeakRefs,
   List,
   LocalAppConfiguration,
   LogLevel,
@@ -259,7 +259,7 @@ export class Realm {
 
   public static defaultPath = Realm.normalizePath("default.realm");
 
-  private static internals = new IterableWeakSet<binding.Realm>();
+  private static internals = new IterableWeakRefs<binding.Realm>();
 
   /**
    * Clears the state by closing and deleting any Realm in the default directory and logout all users.

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -24,6 +24,7 @@
 /** @internal */
 export * from "./debug";
 export * from "./safeGlobalThis";
+export * from "./IterableWeakSet";
 
 /** @internal */
 export * from "./platform";

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -24,7 +24,7 @@
 /** @internal */
 export * from "./debug";
 export * from "./safeGlobalThis";
-export * from "./IterableWeakSet";
+export * from "./IterableWeakRefs";
 
 /** @internal */
 export * from "./platform";


### PR DESCRIPTION
## What, How & Why?

As a prerequisite for a refactor of #5651 I wanted to add a primitive we could use for both situations.
Note: I wanted to get this up for review before I got too invested in writing unit tests for it too.
