### PR TITLE
Make reproducible builds on iOS

### DIFF
--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -41,7 +41,8 @@
       ],
       "clean": "if-file-deleted",
       "files": [
-        "ios/Podfile"
+        "ios/Podfile",
+        "../../../packages/realm/react-native/ios/realm-js-ios.xcframework"
       ],
       "output": [
         "ios/Pods",
@@ -65,7 +66,8 @@
         }
       ],
       "files": [
-        "ios/Podfile"
+        "ios/Podfile",
+        "../../../packages/realm/react-native/ios/realm-js-ios.xcframework"
       ],
       "output": [
         "ios/Pods",

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -66,17 +66,17 @@ for platform in "${PLATFORMS[@]}"; do
         ios)
             DESTINATIONS+=(-destination 'generic/platform=iOS')
             LIBRARIES+=(-library ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a -headers ./_include)
-            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a ./out/$CONFIGURATION-iphoneos/*.a")
+            BUILD_LIB_CMDS+=("xcrun libtool -static -D -o ./out/$CONFIGURATION-iphoneos/librealm-js-ios.a ./out/$CONFIGURATION-iphoneos/*.a")
         ;;
         catalyst)
             DESTINATIONS+=(-destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst')
             LIBRARIES+=(-library ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a -headers ./_include)
-            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a ./out/$CONFIGURATION-maccatalyst/*.a")
+            BUILD_LIB_CMDS+=("xcrun libtool -static -D -o ./out/$CONFIGURATION-maccatalyst/librealm-js-ios.a ./out/$CONFIGURATION-maccatalyst/*.a")
         ;;
         simulator)
             DESTINATIONS+=(-destination 'generic/platform=iOS Simulator')
             LIBRARIES+=(-library ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a -headers ./_include)
-            BUILD_LIB_CMDS+=("xcrun libtool -static -o ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a ./out/$CONFIGURATION-iphonesimulator/*.a")
+            BUILD_LIB_CMDS+=("xcrun libtool -static -D -o ./out/$CONFIGURATION-iphonesimulator/librealm-js-ios.a ./out/$CONFIGURATION-iphonesimulator/*.a")
         ;;
         *)
             echo "${platform} not supported"


### PR DESCRIPTION
Adding the `-D` flag to the `libtool` invocation makes sure it produces a static library archive with a zeroed-out timestamp, so two or more builds of the same source code should produce identical binaries.