### PR TITLE
Use src instead of d.ts for types in `@realm/react`

### DIFF
--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -4,7 +4,7 @@
   "description": "React specific hooks and implementation helpers for Realm",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.tsx",
   "source": "src/index.tsx",
   "scripts": {
     "bundle": "wireit",
@@ -20,7 +20,7 @@
         "../realm:bundle",
         "../realm-common:bundle"
       ],
-      "files": ["rollup.config.mjs", "src/**/*.ts", "src/**/*.tsx"],
+      "files": ["rollup.config.js", "src/**/*.ts", "src/**/*.tsx"],
       "output": ["dist"]
     },
     "test": {
@@ -77,7 +77,7 @@
     "dist",
     "types/realm",
     "LICENSE",
-    "lib",
+    "src",
     "package.json"
   ],
   "keywords": [

--- a/packages/realm-react/rollup.config.js
+++ b/packages/realm-react/rollup.config.js
@@ -35,17 +35,4 @@ export default [
     plugins: [nodeResolve(), typescript({ noEmitOnError: true })],
     external: ["realm", "react", "@realm/common", "lodash"],
   },
-  {
-    input: "src/index.tsx",
-    output: {
-      file: pkg.types,
-      format: "es",
-    },
-    plugins: [
-      dts({
-        respectExternal: true,
-      }),
-    ],
-    external: ["realm", "react", "@realm/common", "lodash"],
-  },
 ];


### PR DESCRIPTION
## What, How & Why?
The rollup plugin for type definitions was creating a very ugly output was unreadable for `@realm/react`.
For now, we will revert to using the src as the type definitions until we find a better way to generate the d.ts.

Before:
![image](https://user-images.githubusercontent.com/164606/229295062-681921ac-b2a1-497f-a785-1a9d5ca17858.png)

After:
![image](https://user-images.githubusercontent.com/164606/229295142-48c99b41-8a31-40a3-9077-76354d458975.png)

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
