### PR TITLE
Fix `realm.create` types and 'requiredProperties' on Realm.Object constructor

### DIFF
--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -802,17 +802,15 @@ export class Realm {
    *       should not be used.
    * @returns A {@link RealmObject} or `undefined` if the object is asymmetric.
    */
-  create<T = DefaultObject>(type: string, values: RealmInsertionModel<T>, mode?: UpdateMode.Never): RealmObject<T> & T;
   create<T = DefaultObject>(
     type: string,
     values: Partial<T> | Partial<RealmInsertionModel<T>>,
-    mode: UpdateMode.All | UpdateMode.Modified | boolean,
+    mode?: UpdateMode.Never | UpdateMode.All | UpdateMode.Modified | boolean,
   ): RealmObject<T> & T;
-  create<T extends AnyRealmObject>(type: Constructor<T>, values: RealmInsertionModel<T>, mode?: UpdateMode.Never): T;
   create<T extends AnyRealmObject>(
     type: Constructor<T>,
     values: Partial<T> | Partial<RealmInsertionModel<T>>,
-    mode: UpdateMode.All | UpdateMode.Modified | boolean,
+    mode?: UpdateMode.Never | UpdateMode.All | UpdateMode.Modified | boolean,
   ): T;
   create<T extends AnyRealmObject>(
     type: string | Constructor<T>,


### PR DESCRIPTION
## What, How & Why?
The partial type was not added for the default creation mode.  This would cause a type error when creating an object without its optional types defined.
The typings for the Realm.Object constructor didn't make use of 'requiredProperties', which was available in v11.  Required properties will show a type error if said properties are not defined on creation (only works with constructor, not create).

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
