### PR TITLE
Expose `Sync` as named export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This can happen when the client creates/updates objects that do not match any su
 * Adding an index to a `mixed` property on a non-empty class/objectType would crash with an assertion. ([realm/realm-core#6376](https://github.com/realm/realm-core/issues/6376), since v10.5.0)
 * `Realm.App.Sync#pause()` could hold a reference to the database open after shutting down the sync session, preventing users from being able to delete the Realm. ([realm/realm-core#6372](https://github.com/realm/realm-core/issues/6372), since v11.5.0)
 * Fixed a bug that may have resulted in `Realm.Results` and `Realm.List` being in different orders on different devices. Moreover, some cases of the error message `Invalid prior_size` may have be fixed too. ([realm/realm-core#6191](https://github.com/realm/realm-core/issues/6191), since v10.15.0)
+* Exposed `Sync` as named export. [#5649](https://github.com/realm/realm-js/issues/5649)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -139,6 +139,7 @@ export {
   SubscriptionOptions,
   SubscriptionSet,
   SubscriptionsState,
+  Sync,
   SyncConfiguration,
   SyncError,
   SyncSession,


### PR DESCRIPTION
## What, How & Why?

`Sync` was previously exposed via `Realm.App.Sync` but is now deprecated. This PR exposes `Sync` as a named export as such:

```js
import { Sync } from "realm";
```

This closes #5649.

## ☑️ ToDos
* [x] 📝 Changelog entry
