### PR TITLE
Fix return type of `App.allUsers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This can happen when the client creates/updates objects that do not match any su
 * `Realm.App.Sync#pause()` could hold a reference to the database open after shutting down the sync session, preventing users from being able to delete the Realm. ([realm/realm-core#6372](https://github.com/realm/realm-core/issues/6372), since v11.5.0)
 * Fixed a bug that may have resulted in `Realm.Results` and `Realm.List` being in different orders on different devices. Moreover, some cases of the error message `Invalid prior_size` may have be fixed too. ([realm/realm-core#6191](https://github.com/realm/realm-core/issues/6191), since v10.15.0)
 * Exposed `Sync` as named export. [#5649](https://github.com/realm/realm-js/issues/5649)
+* Fixed the return value of `App.allUsers` to return a record with the `User.id` as the key and the `User` as the value. [#5671](https://github.com/realm/realm-js/issues/5671)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -42,11 +42,8 @@ function expectIsSameUser(value: Realm.User, user: Realm.User | null) {
   expect(value.id).equals(user?.id);
 }
 
-function expectUserFromAll(all: Realm.User[], user: Realm.User) {
-  expectIsSameUser(
-    all.find((other) => other.id === user.id),
-    user,
-  );
+function expectUserFromAll(all: Record<string, Realm.User>, user: Realm.User) {
+  expectIsSameUser(all[user.id], user);
 }
 
 async function registerAndLogInEmailUser(app: Realm.App) {

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -217,8 +217,13 @@ export class App<FunctionsFactoryType = DefaultFunctionsFactory, CustomDataType 
     return currentUser ? User.get(currentUser) : null;
   }
 
-  public get allUsers(): User<FunctionsFactoryType, CustomDataType>[] {
-    return this.internal.allUsers.map((user) => User.get(user));
+  public get allUsers(): Readonly<Record<string, User<FunctionsFactoryType, CustomDataType>>> {
+    const result: Record<string, User<FunctionsFactoryType, CustomDataType>> = {};
+    for (const user of this.internal.allUsers) {
+      result[user.identity] = User.get(user);
+    }
+
+    return result;
   }
 
   public switchUser(): unknown {


### PR DESCRIPTION
## What, How & Why?

`App.allUsers` was returning an array of users but now returns a record with the `User.id` as the key and the `User` as the value as the [intended type](https://github.com/realm/realm-js/blob/715fa2dd70263c6ea86a84793d7c2f196db537ed/types/app.d.ts#L289).

This closes #5671.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Updated tests
