### PR TITLE
Build iOS prebuilds in release by default

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -183,8 +183,10 @@ jobs:
       - name: Build iOS
         if: ${{ (matrix.variant.os == 'ios') }}
         run: |
-          npm run build:ios --workspace realm -- ${{matrix.variant.arch}}
+          npm run build:ios --workspace realm
           rm -vf ${{ matrix.variant.artifact-path }}/Info.plist
+        env:
+          PLATFORMS: ${{ matrix.variant.arch }}
 
       # build the c++ library for Android
       - name: Build Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,7 @@ This can happen when the client creates/updates objects that do not match any su
 ### Internal
 * Fixed linting issues and running linting on CI.
 * Upgraded Realm Core from v13.6.0 to v13.8.0. ([#5638](https://github.com/realm/realm-js/pull/5638))
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Build iOS prebuilt binaries in release mode by default. ([#5709](https://github.com/realm/realm-js/pull/5709))
 
 ## 12.0.0-alpha.1 (2023-03-22)
 

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -35,7 +35,7 @@
       "command": "pod-install || (cd ios && bundle install && bundle exec pod install)",
       "dependencies": [
         {
-          "script": "../../../packages/realm:build:ios:simulator",
+          "script": "../../../packages/realm:build:ios:debug:simulator",
           "cascade": false
         }
       ],
@@ -61,7 +61,7 @@
       "command": "pod-install || (cd ios && bundle install && bundle exec pod install)",
       "dependencies": [
         {
-          "script": "../../../packages/realm:build:ios:catalyst",
+          "script": "../../../packages/realm:build:ios:debug:catalyst",
           "cascade": false
         }
       ],
@@ -151,7 +151,7 @@
       "command": "npm run common",
       "dependencies": [
         "pod-install:simulator",
-        "../../../packages/realm:build:ios:simulator",
+        "../../../packages/realm:build:ios:debug:simulator",
         "../../../packages/realm:bundle",
         "../../../packages/mocha-reporter:bundle",
         "../../../packages/realm-network-transport:bundle",
@@ -166,7 +166,7 @@
       "command": "npm run common",
       "dependencies": [
         "pod-install:catalyst",
-        "../../../packages/realm:build:ios:catalyst",
+        "../../../packages/realm:build:ios:debug:catalyst",
         "../../../packages/realm:bundle",
         "../../../packages/mocha-reporter:bundle",
         "../../../packages/realm-network-transport:bundle",

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -65,9 +65,9 @@
     "build:node:prebuild:ia32": "wireit",
     "build:android": "wireit",
     "build:ios": "wireit",
-    "build:ios:simulator": "wireit",
-    "build:ios:ios": "wireit",
-    "build:ios:catalyst": "wireit",
+    "build:ios:debug:simulator": "wireit",
+    "build:ios:debug:ios": "wireit",
+    "build:ios:debug:catalyst": "wireit",
     "install": "prebuild-install --runtime napi || echo 'Failed to download prebuild for Realm'",
     "docs": "wireit"
   },
@@ -189,7 +189,7 @@
       ]
     },
     "build:ios": {
-      "command": "../../scripts/build-ios.sh -c ${CONFIGURATION:=Debug} ${PLATFORMS}",
+      "command": "../../scripts/build-ios.sh -c ${CONFIGURATION:=Release} ${PLATFORMS}",
       "dependencies": [
         "../..:submodules"
       ],
@@ -207,22 +207,25 @@
         }
       }
     },
-    "build:ios:simulator": {
+    "build:ios:debug:simulator": {
       "command": "npm run build:ios",
       "env": {
-        "PLATFORMS": "simulator"
+        "PLATFORMS": "simulator",
+        "CONFIGURATION": "Debug"
       }
     },
-    "build:ios:ios": {
+    "build:ios:debug:ios": {
       "command": "npm run build:ios",
       "env": {
-        "PLATFORMS": "ios"
+        "PLATFORMS": "ios",
+        "CONFIGURATION": "Debug"
       }
     },
-    "build:ios:catalyst": {
+    "build:ios:debug:catalyst": {
       "command": "npm run build:ios",
       "env": {
-        "PLATFORMS": "catalyst"
+        "PLATFORMS": "catalyst",
+        "CONFIGURATION": "Debug"
       }
     },
     "docs": {


### PR DESCRIPTION
## What, How & Why?

This fixed a change to the package.json, which accidentally started producing debug builds for iOS on CI.

## ☑️ ToDos
* [x] 📝 Changelog entry
