### PR TITLE
Implement `User.state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* Added missing implementation of `User.state`. [#5686](https://github.com/realm/realm-js/issues/5686)
+* Added missing implementation of `User.state` and changed the `UserState` enum values to use pascal case to conform to the v11 implementation (except for `UserState.Active` that we now deprecate in favor of `UserState.LoggedIn`). [#5686](https://github.com/realm/realm-js/issues/5686)
 
 ### Compatibility
 * React Native >= v0.71.0
@@ -44,11 +44,7 @@ This can happen when the client creates/updates objects that do not match any su
 * `Realm.App.Sync#pause()` could hold a reference to the database open after shutting down the sync session, preventing users from being able to delete the Realm. ([realm/realm-core#6372](https://github.com/realm/realm-core/issues/6372), since v11.5.0)
 * Fixed a bug that may have resulted in `Realm.Results` and `Realm.List` being in different orders on different devices. Moreover, some cases of the error message `Invalid prior_size` may have be fixed too. ([realm/realm-core#6191](https://github.com/realm/realm-core/issues/6191), since v10.15.0)
 * Exposed `Sync` as named export. [#5649](https://github.com/realm/realm-js/issues/5649)
-<<<<<<< HEAD
 * Fixed the return value of `App.allUsers` to return a record with the `User.id` as the key and the `User` as the value. [#5671](https://github.com/realm/realm-js/issues/5671)
-=======
-* Added missing implementation of `User.state` and changed the `UserState` enum values to use pascal case to conform to the v11 implementation (except for `UserState.Active` that we now deprecate in favor of `UserState.LoggedIn`). [#5686](https://github.com/realm/realm-js/issues/5686)
->>>>>>> ed7b2643e (Update CHANGELOG entry.)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ This can happen when the client creates/updates objects that do not match any su
 * `Realm.App.Sync#pause()` could hold a reference to the database open after shutting down the sync session, preventing users from being able to delete the Realm. ([realm/realm-core#6372](https://github.com/realm/realm-core/issues/6372), since v11.5.0)
 * Fixed a bug that may have resulted in `Realm.Results` and `Realm.List` being in different orders on different devices. Moreover, some cases of the error message `Invalid prior_size` may have be fixed too. ([realm/realm-core#6191](https://github.com/realm/realm-core/issues/6191), since v10.15.0)
 * Exposed `Sync` as named export. [#5649](https://github.com/realm/realm-js/issues/5649)
+<<<<<<< HEAD
 * Fixed the return value of `App.allUsers` to return a record with the `User.id` as the key and the `User` as the value. [#5671](https://github.com/realm/realm-js/issues/5671)
+=======
+* Added missing implementation of `User.state` and changed the `UserState` enum values to use pascal case to conform to the v11 implementation (except for `UserState.Active` that we now deprecate in favor of `UserState.LoggedIn`). [#5686](https://github.com/realm/realm-js/issues/5686)
+>>>>>>> ed7b2643e (Update CHANGELOG entry.)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Added missing implementation of `User.state`. [#5686](https://github.com/realm/realm-js/issues/5686)
 
 ### Compatibility
 * React Native >= v0.71.0

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -23,6 +23,7 @@ import {
   randomVerifiableEmail,
 } from "../../utils/generators";
 import { KJUR } from "jsrsasign";
+import { UserState } from "realm";
 
 function expectIsUSer(user: Realm.User) {
   expect(user).to.not.be.undefined;
@@ -319,6 +320,26 @@ describe.skipIf(environment.missingServer, "User", () => {
           });
         expect(user2).to.be.undefined;
         expect(didFail).to.be.true;
+      });
+
+      describe("state", () => {
+        it("can fetch state when logged in with email password", async function (this: AppContext & RealmContext) {
+          expect(this.app.currentUser).to.be.null;
+          const user = await registerAndLogInEmailUser(this.app);
+          expect(user.state).to.equal(UserState.LoggedIn);
+        });
+
+        it("can fetch state when logged out with email password", async function (this: AppContext & RealmContext) {
+          const user = await registerAndLogInEmailUser(this.app);
+          await user.logOut();
+          expect(user.state).to.equal(UserState.LoggedOut);
+        });
+
+        it("can fetch state when removed with email password", async function (this: AppContext & RealmContext) {
+          const user = await registerAndLogInEmailUser(this.app);
+          await this.app.removeUser(user);
+          expect(user.state).to.equal(UserState.Removed);
+        });
       });
     });
   });

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -44,11 +44,11 @@ export type UserChangeCallback = () => void;
  */
 export enum UserState {
   /** Authenticated and available to communicate with services. */
-  Active = "active",
+  LoggedIn = "LoggedIn",
   /** Logged out, but ready to be logged in. */
-  LoggedOut = "logged-out",
+  LoggedOut = "LoggedOut",
   /** Removed from the app entirely. */
-  Removed = "removed",
+  Removed = "Removed",
 }
 
 /**
@@ -141,7 +141,17 @@ export class User<
    * The state of the user.
    */
   get state(): UserState {
-    throw new Error("Not yet implemented");
+    const state = this.internal.state;
+    switch (state) {
+      case binding.SyncUserState.LoggedIn:
+        return UserState.LoggedIn;
+      case binding.SyncUserState.LoggedOut:
+        return UserState.LoggedOut;
+      case binding.SyncUserState.Removed:
+        return UserState.Removed;
+      default:
+        throw new Error(`Unsupported SyncUserState value: ${state}`);
+    }
   }
 
   /**

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -43,6 +43,11 @@ export type UserChangeCallback = () => void;
  * The state of a user.
  */
 export enum UserState {
+  /**
+   * Authenticated and available to communicate with services.
+   * @deprecated Will be removed in v13. Please use {@link LoggedIn}
+   */
+  Active = "active",
   /** Authenticated and available to communicate with services. */
   LoggedIn = "LoggedIn",
   /** Logged out, but ready to be logged in. */


### PR DESCRIPTION
## What, How & Why?

Added missing implementation for `User.state` and updated the `UserState` enum to align with the [v11 implementation](https://github.com/realm/realm-js/blob/a681f1ad72b66ff50c9620e2f55b6c7d4e8af2de/src/js_user.hpp#L308-L324).

Related v11 issue:
* #5203
  * [Implementation](https://github.com/realm/realm-js/blob/a681f1ad72b66ff50c9620e2f55b6c7d4e8af2de/src/js_user.hpp#L308-L324) differs from [type definitions](https://github.com/realm/realm-js/blob/74470d0ecd2d9ddd07eaa7a1cb67f069a951ca74/types/app.d.ts#L533-L540).

This closes #5686.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
