### PR TITLE
Update usage of `assert.never()`

### DIFF
--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -478,7 +478,7 @@ export class RealmObject<T = DefaultObject> {
       } else if (value instanceof BSON.UUID) {
         return "uuid";
       } else {
-        throw assert.never(value, "value");
+        assert.never(value, "value");
       }
     } else {
       return typeName;

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1047,7 +1047,7 @@ export class Realm {
     } else if (eventName === RealmEvent.BeforeNotify) {
       this.beforeNotifyListeners.remove(callback);
     } else {
-      throw assert.never(eventName, "eventName");
+      assert.never(eventName, "eventName");
     }
   }
 
@@ -1072,7 +1072,7 @@ export class Realm {
       } else if (eventName === RealmEvent.BeforeNotify) {
         this.beforeNotifyListeners.removeAll();
       } else {
-        throw assert.never(eventName, "eventName");
+        assert.never(eventName, "eventName");
       }
     }
   }

--- a/packages/realm/src/assert.ts
+++ b/packages/realm/src/assert.ts
@@ -81,17 +81,6 @@ assert.symbol = (value: unknown, target?: string): asserts value is symbol => {
   assert(typeof value === "symbol", () => new TypeAssertionError("a symbol", value, target));
 };
 
-assert.primaryKey = (value: unknown, target?: string): asserts value is PrimaryKey => {
-  assert(
-    value === null ||
-      typeof value === "number" ||
-      typeof value === "string" ||
-      value instanceof BSON.UUID ||
-      value instanceof BSON.ObjectId,
-    () => new TypeAssertionError("a primary key", value, target),
-  );
-};
-
 assert.object = <K extends string | number | symbol = string, V = unknown>(
   value: unknown,
   target?: string,
@@ -133,11 +122,27 @@ assert.iterable = (value: unknown, target?: string): asserts value is Iterable<u
   assert(Symbol.iterator in value, () => new TypeAssertionError("iterable", value, target));
 };
 
-assert.never = (value: never, target?: string): asserts value is never => {
+// * Use arg type `value: never` rather than `value: unknown` to get a compile time
+//   error when e.g. not including if-checks for all enum values.
+// * Use return type `never` rather than `asserts value is never` to remove the
+//   need for callers to explicitly throw (i.e. `throw assert.never()`) as a way
+//   for TS to detect unreachable code.
+assert.never = (value: never, target?: string): never => {
   throw new TypeAssertionError("never", value, target);
 };
 
 // SDK specific
+
+assert.primaryKey = (value: unknown, target?: string): asserts value is PrimaryKey => {
+  assert(
+    value === null ||
+      typeof value === "number" ||
+      typeof value === "string" ||
+      value instanceof BSON.UUID ||
+      value instanceof BSON.ObjectId,
+    () => new TypeAssertionError("a primary key", value, target),
+  );
+};
 
 assert.open = (realm: Realm) => {
   assert(!realm.isClosed, "Cannot access realm that has been closed.");


### PR DESCRIPTION
## What, How & Why?

Updates return type of `assert.never()`:
* From: `asserts value is never`
* To: `never`

This change allows TS to detect unreachable code after calling `assert.never()` without explicitly throwing.

Example old usage:
```ts
throw assert.never(eventName, "eventName");
```

Updated usage:
```ts
assert.never(eventName, "eventName");
// Still unreachable
```

## ☑️ ToDos
--
