### PR TITLE
Rename `local-mongodb` to enable app replacements

### DIFF
--- a/integration-tests/realm-apps/with-custom-function/functions/customAuthentication/source.js
+++ b/integration-tests/realm-apps/with-custom-function/functions/customAuthentication/source.js
@@ -21,7 +21,7 @@
 
 exports = async function (loginPayload) {
   // Get a handle for the app.users collection
-  const users = context.services.get("local-mongodb").db("app").collection("users");
+  const users = context.services.get("mongodb").db("app").collection("users");
 
   // Parse out custom data from the FunctionCredential
 

--- a/integration-tests/realm-apps/with-custom-function/secrets.json
+++ b/integration-tests/realm-apps/with-custom-function/secrets.json
@@ -1,3 +1,3 @@
 {
-    "local-mongodb-uri": "mongodb://localhost:26000"
+    "mongodb_uri": "mongodb://localhost:26000"
 }

--- a/integration-tests/realm-apps/with-custom-function/services/local-mongodb/config.json
+++ b/integration-tests/realm-apps/with-custom-function/services/local-mongodb/config.json
@@ -1,8 +1,0 @@
-{
-    "name": "local-mongodb",
-    "type": "mongodb",
-    "config": {},
-    "secret_config": {
-        "uri": "local-mongodb-uri"
-    }
-}

--- a/integration-tests/realm-apps/with-custom-function/services/mongodb/config.json
+++ b/integration-tests/realm-apps/with-custom-function/services/mongodb/config.json
@@ -1,0 +1,9 @@
+{
+    "name": "mongodb",
+    "type": "mongodb",
+    "config": {},
+    "secret_config": {
+        "uri": "mongodb_uri"
+    },
+    "version": 1
+}


### PR DESCRIPTION
## What, How & Why?

This fixes consistent app import failures on CI.
