### PR TITLE
Fix User.callFunction JSDoc to match the v11+ API

### DIFF
--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -253,12 +253,13 @@ export class User<
    * Call a remote Atlas App Services Function by its name.
    * Note: Consider using `functions[name]()` instead of calling this method.
    *
-   * @param name Name of the function.
-   * @param args Arguments passed to the function.
+   * @param name Name of the App Services Function.
+   * @param args Arguments passed to the Function.
+   * @returns A promise that resolves to the value returned by the Function.
    *
    * @example
    * // These are all equivalent:
-   * await user.callFunction("doThing", [a1, a2, a3]);
+   * await user.callFunction("doThing", a1, a2, a3);
    * await user.functions.doThing(a1, a2, a3);
    * await user.functions["doThing"](a1, a2, a3);
    * @example


### PR DESCRIPTION
## What, How & Why?

The JSDoc for `User.callFunction()` has an incorrect example that still uses the pre-v11 function signature. This updates the example & tweaks the JSDoc descriptions.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [x] jsdoc files updated
