### PR TITLE
Fix mongodb client tests to avoid crosstalks

### DIFF
--- a/integration-tests/tests/src/tests/sync/mongo-db-client.ts
+++ b/integration-tests/tests/src/tests/sync/mongo-db-client.ts
@@ -555,14 +555,8 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         expect(result).to.deep.equal([{ count: 2 }]);
 
         // Note:
-        // If getting `Error: exec: "assisted_agg": executable file not found in $PATH`:
-        //  1) Download the file `assisted_agg` (if on Mac) or `libmongo.so` (if on Linux) and add it
-        //     to your PATH (see https://github.com/10gen/baas/blob/master/etc/docs/onboarding.md).
-        //  2) Load the PATH variable to the terminal window used for starting the BaaS server.
-        //  3) Allow the file to be executable (run: chmod +x your/path/to/assisted_agg).
-        //  4) When running the test again, Mac will block execution of the file. Then (for Mac) go
-        //     to `System Settings > Privacy & Security`, find blocked files, then allow `assisted_agg`.
-        //  5) Run the test.
+        // If getting an error on Mac blocking execution of a file called `assisted_agg`, go
+        // to `System Settings > Privacy & Security`, find blocked files, then allow `assisted_agg`.
       });
     });
 

--- a/integration-tests/tests/src/tests/sync/mongo-db-client.ts
+++ b/integration-tests/tests/src/tests/sync/mongo-db-client.ts
@@ -19,7 +19,7 @@
 import { expect } from "chai";
 import { BSON, ChangeEvent, Credentials, DeleteResult, Document, InsertEvent, MongoDBCollection, User } from "realm";
 
-import { importAppBefore } from "../../hooks";
+import { authenticateUserBefore, importAppBefore } from "../../hooks";
 import { sleep } from "../../utils/sleep";
 import { buildAppConfig } from "../../utils/build-app-config";
 
@@ -29,56 +29,42 @@ type TestDocument = {
   isLast?: boolean;
 };
 
+type CollectionContext = { collection: MongoDBCollection<TestDocument> };
+type TestContext = CollectionContext & AppContext & UserContext & Mocha.Context;
+
+const serviceName = "mongodb";
+const collectionName = "test-collection";
+
 describe.skipIf(environment.missingServer, "MongoDB Client", function () {
   this.timeout(60_000); // TODO: Temporarily hardcoded until envs are set up.
   importAppBefore(buildAppConfig("with-flx").anonAuth().flexibleSync());
+  authenticateUserBefore();
 
-  let collection: MongoDBCollection<TestDocument>;
-  const serviceName = "mongodb";
-  const dbName = "test-database"; // TODO: Change to randomly generated database name whenever AppImporter is refactored.
-  const collectionName = "test-collection";
-
-  function getCollection<T extends Document = TestDocument>(currentUser: User | null): MongoDBCollection<T> {
-    if (!currentUser) {
-      throw new Error("A user must be authenticated before getting a MongoDB collection.");
-    }
-    return currentUser.mongoClient(serviceName).db(dbName).collection<T>(collectionName);
-  }
-
-  function deleteAllDocuments(): Promise<DeleteResult> {
-    return collection.deleteMany();
-  }
-
-  async function logIn(app: App): Promise<User> {
-    return app.currentUser ?? app.logIn(Credentials.anonymous());
-  }
-
-  beforeEach(async function (this: AppContext & Mocha.Context) {
-    const user = await logIn(this.app);
-    collection = getCollection(user);
-    await deleteAllDocuments();
+  beforeEach(async function (this: TestContext) {
+    this.collection = this.user.mongoClient(serviceName).db(this.databaseName).collection(collectionName);
+    await this.collection.deleteMany();
   });
 
   describe("User", function () {
-    it("returns a MongoDB service when calling 'mongoClient()'", async function (this: AppContext & Mocha.Context) {
+    it("returns a MongoDB service when calling 'mongoClient()'", async function (this: TestContext) {
       const service = this.app.currentUser?.mongoClient(serviceName);
       expect(service).to.be.an("object");
       expect(service).to.have.property("db");
       expect(service).to.have.property("serviceName", serviceName);
 
-      const db = service?.db(dbName);
+      const db = service?.db(this.databaseName);
       expect(db).to.be.an("object");
-      expect(db).to.have.property("name", dbName);
+      expect(db).to.have.property("name", this.databaseName);
       expect(db).to.have.property("collection");
 
       const collection = db?.collection(collectionName);
       expect(collection).to.be.an("object");
       expect(collection).to.have.property("name", collectionName);
-      expect(collection).to.have.property("databaseName", dbName);
+      expect(collection).to.have.property("databaseName", this.databaseName);
       expect(collection).to.have.property("serviceName", serviceName);
     });
 
-    it("throws when calling 'mongoClient()' with incorrect type", async function (this: AppContext & Mocha.Context) {
+    it("throws when calling 'mongoClient()' with incorrect type", async function (this: TestContext) {
       const notAString = 1;
       //@ts-expect-error Testing incorrect type
       expect(() => this.app.currentUser?.mongoClient(notAString)).to.throw(
@@ -86,7 +72,7 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
       );
     });
 
-    it("throws when calling 'mongoClient()' with empty string", async function (this: AppContext & Mocha.Context) {
+    it("throws when calling 'mongoClient()' with empty string", async function (this: TestContext) {
       expect(() => this.app.currentUser?.mongoClient("")).to.throw(
         "Please provide the name of the MongoDB service to connect to",
       );
@@ -100,7 +86,7 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
     const insertedText = "Test document";
     const nonExistentId = 100;
 
-    async function insertThreeDocuments(): Promise<void> {
+    async function insertThreeDocuments(collection: MongoDBCollection<TestDocument>): Promise<void> {
       const { insertedIds } = await collection.insertMany([
         { _id: insertedId1, text: insertedText },
         { _id: insertedId2, text: insertedText },
@@ -109,7 +95,11 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
       expect(insertedIds).to.have.length(3);
     }
 
-    async function expectToFindDoc(doc: TestDocument, { expectedCount }: { expectedCount: number }): Promise<void> {
+    async function expectToFindDoc(
+      collection: MongoDBCollection<TestDocument>,
+      doc: TestDocument,
+      { expectedCount }: { expectedCount: number },
+    ): Promise<void> {
       const result = await collection.findOne({ _id: doc._id });
       expect(result).to.deep.equal(doc);
 
@@ -117,7 +107,11 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
       expect(count).to.equal(expectedCount);
     }
 
-    async function expectToNotFindDoc(doc: TestDocument, { expectedCount }: { expectedCount: number }): Promise<void> {
+    async function expectToNotFindDoc(
+      collection: MongoDBCollection<TestDocument>,
+      doc: TestDocument,
+      { expectedCount }: { expectedCount: number },
+    ): Promise<void> {
       const result = await collection.findOne({ _id: doc._id });
       expect(result).to.be.null;
 
@@ -125,13 +119,16 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
       expect(count).to.equal(expectedCount);
     }
 
-    async function expectTextToBeUnchanged({
-      text,
-      expectedCount,
-    }: {
-      text: string;
-      expectedCount: number;
-    }): Promise<void> {
+    async function expectTextToBeUnchanged(
+      collection: MongoDBCollection<TestDocument>,
+      {
+        text,
+        expectedCount,
+      }: {
+        text: string;
+        expectedCount: number;
+      },
+    ): Promise<void> {
       const docs = await collection.find();
       expect(docs).to.have.length(expectedCount);
       for (const doc of docs) {
@@ -140,21 +137,20 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
     }
 
     describe("#find", function () {
-      it("returns all documents using empty filter", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns all documents using empty filter", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const docs = await collection.find();
+        const docs = await this.collection.find();
         expect(docs).to.have.length(3);
         for (const doc of docs) {
           expect(doc).to.have.all.keys("_id", "text");
         }
       });
 
-      it("returns all documents excluding a field using 'projection' option", async function (this: AppContext &
-        Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns all documents excluding a field using 'projection' option", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const docs = await collection.find({}, { projection: { text: false } });
+        const docs = await this.collection.find({}, { projection: { text: false } });
         expect(docs).to.have.length(3);
         for (const doc of docs) {
           expect(doc).to.have.property("_id");
@@ -162,41 +158,41 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         }
       });
 
-      it("returns documents using query selector", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns documents using query selector", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const docs = await collection.find({ _id: { $gt: insertedId1 } });
+        const docs = await this.collection.find({ _id: { $gt: insertedId1 } });
         expect(docs).to.have.length(2);
         for (const doc of docs) {
           expect(doc._id > insertedId1).to.be.true;
         }
       });
 
-      it("returns empty array if collection is empty", async function (this: AppContext & Mocha.Context) {
-        const docs = await collection.find();
+      it("returns empty array if collection is empty", async function (this: TestContext) {
+        const docs = await this.collection.find();
         expect(docs).to.be.empty;
       });
     });
 
     describe("#findOne", function () {
-      it("returns specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const doc = await collection.findOne({ _id: insertedId3 });
+        const doc = await this.collection.findOne({ _id: insertedId3 });
         expect(doc).to.deep.equal({ _id: insertedId3, text: insertedText });
       });
 
-      it("returns first document using empty filter", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns first document using empty filter", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const doc = await collection.findOne();
+        const doc = await this.collection.findOne();
         expect(doc).to.deep.equal({ _id: insertedId1, text: insertedText });
       });
 
-      it("returns null when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns null when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const doc = await collection.findOne({ _id: nonExistentId });
+        const doc = await this.collection.findOne({ _id: nonExistentId });
         expect(doc).to.be.null;
       });
     });
@@ -204,10 +200,10 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
     describe("#findOneAndUpdate", function () {
       const updatedText = "Updated text";
 
-      it("updates specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("updates specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const newDoc = await collection.findOneAndUpdate(
+        const newDoc = await this.collection.findOneAndUpdate(
           { _id: insertedId3 },
           { $set: { text: updatedText } },
           { returnNewDocument: true },
@@ -215,10 +211,10 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         expect(newDoc).to.deep.equal({ _id: insertedId3, text: updatedText });
       });
 
-      it("returns null when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns null when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const newDoc = await collection.findOneAndUpdate(
+        const newDoc = await this.collection.findOneAndUpdate(
           { _id: nonExistentId },
           { $set: { text: updatedText } },
           { returnNewDocument: true },
@@ -226,19 +222,19 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         expect(newDoc).to.be.null;
       });
 
-      it("does not update any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not update any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndUpdate({ _id: nonExistentId }, { $set: { text: updatedText } });
+        const oldDoc = await this.collection.findOneAndUpdate({ _id: nonExistentId }, { $set: { text: updatedText } });
         expect(oldDoc).to.be.null;
 
-        await expectTextToBeUnchanged({ text: insertedText, expectedCount: 3 });
+        await expectTextToBeUnchanged(this.collection, { text: insertedText, expectedCount: 3 });
       });
 
-      it("inserts new document if no matches when using 'upsert'", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("inserts new document if no matches when using 'upsert'", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const newDoc = await collection.findOneAndUpdate(
+        const newDoc = await this.collection.findOneAndUpdate(
           { _id: nonExistentId },
           { $set: { text: updatedText } },
           {
@@ -248,7 +244,7 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         );
         expect(newDoc).to.deep.equal({ _id: nonExistentId, text: updatedText });
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(4);
       });
     });
@@ -256,10 +252,10 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
     describe("#findOneAndReplace", function () {
       const updatedText = "Updated text";
 
-      it("replaces specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("replaces specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const newDoc = await collection.findOneAndReplace(
+        const newDoc = await this.collection.findOneAndReplace(
           { _id: insertedId3 },
           { text: updatedText },
           { returnNewDocument: true },
@@ -267,94 +263,98 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         expect(newDoc).to.deep.equal({ _id: insertedId3, text: updatedText });
       });
 
-      it("returns null when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns null when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndReplace({ _id: nonExistentId }, { text: updatedText });
+        const oldDoc = await this.collection.findOneAndReplace({ _id: nonExistentId }, { text: updatedText });
         expect(oldDoc).to.be.null;
       });
 
-      it("does not replace any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not replace any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndReplace({ _id: nonExistentId }, { text: updatedText });
+        const oldDoc = await this.collection.findOneAndReplace({ _id: nonExistentId }, { text: updatedText });
         expect(oldDoc).to.be.null;
 
-        await expectTextToBeUnchanged({ text: insertedText, expectedCount: 3 });
+        await expectTextToBeUnchanged(this.collection, { text: insertedText, expectedCount: 3 });
       });
     });
 
     describe("#findOneAndDelete", function () {
-      it("deletes specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndDelete({ _id: insertedId3 });
+        const oldDoc = await this.collection.findOneAndDelete({ _id: insertedId3 });
         expect(oldDoc).to.deep.equal({ _id: insertedId3, text: insertedText });
 
-        await expectToNotFindDoc({ _id: insertedId3 }, { expectedCount: 2 });
+        await expectToNotFindDoc(this.collection, { _id: insertedId3 }, { expectedCount: 2 });
       });
 
-      it("deletes first returned document using empty filter", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes first returned document using empty filter", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndDelete();
+        const oldDoc = await this.collection.findOneAndDelete();
         expect(oldDoc).to.deep.equal({ _id: insertedId1, text: insertedText });
 
-        await expectToNotFindDoc({ _id: insertedId1 }, { expectedCount: 2 });
+        await expectToNotFindDoc(this.collection, { _id: insertedId1 }, { expectedCount: 2 });
       });
 
-      it("returns null when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns null when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndDelete({ _id: nonExistentId });
+        const oldDoc = await this.collection.findOneAndDelete({ _id: nonExistentId });
         expect(oldDoc).to.be.null;
       });
 
-      it("does not delete any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not delete any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const oldDoc = await collection.findOneAndDelete({ _id: nonExistentId });
+        const oldDoc = await this.collection.findOneAndDelete({ _id: nonExistentId });
         expect(oldDoc).to.be.null;
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(3);
       });
     });
 
     describe("#insertOne", function () {
-      it("inserts document with id", async function (this: AppContext & Mocha.Context) {
-        const result = await collection.insertOne({ _id: insertedId1 });
+      it("inserts document with id", async function (this: TestContext) {
+        const result = await this.collection.insertOne({ _id: insertedId1 });
         expect(result.insertedId).to.equal(insertedId1);
 
-        await expectToFindDoc({ _id: insertedId1 }, { expectedCount: 1 });
+        await expectToFindDoc(this.collection, { _id: insertedId1 }, { expectedCount: 1 });
       });
 
-      it("inserts document without id", async function (this: AppContext & Mocha.Context) {
-        const result = await collection.insertOne({ text: insertedText });
+      it("inserts document without id", async function (this: TestContext) {
+        const result = await this.collection.insertOne({ text: insertedText });
         expect(result.insertedId).to.be.instanceOf(BSON.ObjectId);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(1);
       });
 
-      it("throws if inserting document with existing id", async function (this: AppContext & Mocha.Context) {
-        await collection.insertOne({ _id: insertedId1 });
+      it("throws if inserting document with existing id", async function (this: TestContext) {
+        await this.collection.insertOne({ _id: insertedId1 });
 
-        await expect(collection.insertOne({ _id: insertedId1 })).to.be.rejectedWith("Duplicate key error");
+        await expect(this.collection.insertOne({ _id: insertedId1 })).to.be.rejectedWith("Duplicate key error");
       });
     });
 
     describe("#insertMany", function () {
-      it("inserts documents with ids", async function (this: AppContext & Mocha.Context) {
-        const result = await collection.insertMany([{ _id: insertedId1 }, { _id: insertedId2 }, { _id: insertedId3 }]);
+      it("inserts documents with ids", async function (this: TestContext) {
+        const result = await this.collection.insertMany([
+          { _id: insertedId1 },
+          { _id: insertedId2 },
+          { _id: insertedId3 },
+        ]);
         expect(result.insertedIds).to.have.length(3);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(3);
       });
 
-      it("inserts documents without ids", async function (this: AppContext & Mocha.Context) {
-        const result = await collection.insertMany([
+      it("inserts documents without ids", async function (this: TestContext) {
+        const result = await this.collection.insertMany([
           { text: insertedText },
           { text: insertedText },
           { text: insertedText },
@@ -364,42 +364,42 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
           expect(insertedId).to.be.instanceOf(BSON.ObjectId);
         }
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(3);
       });
 
-      it("throws if inserting document with existing id", async function (this: AppContext & Mocha.Context) {
-        await collection.insertMany([{ _id: insertedId1 }]);
+      it("throws if inserting document with existing id", async function (this: TestContext) {
+        await this.collection.insertMany([{ _id: insertedId1 }]);
 
-        await expect(collection.insertMany([{ _id: insertedId1 }])).to.be.rejectedWith("Duplicate key error");
+        await expect(this.collection.insertMany([{ _id: insertedId1 }])).to.be.rejectedWith("Duplicate key error");
       });
     });
 
     describe("#updateOne", function () {
       const updatedText = "Updated text";
 
-      it("updates specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("updates specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateOne({ _id: insertedId3 }, { $set: { text: updatedText } });
+        const result = await this.collection.updateOne({ _id: insertedId3 }, { $set: { text: updatedText } });
         expect(result).to.deep.equal({ matchedCount: 1, modifiedCount: 1 });
 
-        await expectToFindDoc({ _id: insertedId3, text: updatedText }, { expectedCount: 3 });
+        await expectToFindDoc(this.collection, { _id: insertedId3, text: updatedText }, { expectedCount: 3 });
       });
 
-      it("does not update any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not update any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateOne({ _id: nonExistentId }, { $set: { text: updatedText } });
+        const result = await this.collection.updateOne({ _id: nonExistentId }, { $set: { text: updatedText } });
         expect(result).to.deep.equal({ matchedCount: 0, modifiedCount: 0 });
 
-        await expectTextToBeUnchanged({ text: insertedText, expectedCount: 3 });
+        await expectTextToBeUnchanged(this.collection, { text: insertedText, expectedCount: 3 });
       });
 
-      it("inserts new document if no matches when using 'upsert'", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("inserts new document if no matches when using 'upsert'", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateOne(
+        const result = await this.collection.updateOne(
           { _id: nonExistentId },
           { $set: { text: updatedText } },
           { upsert: true },
@@ -410,36 +410,36 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
           upsertedId: nonExistentId,
         });
 
-        await expectToFindDoc({ _id: nonExistentId, text: updatedText }, { expectedCount: 4 });
+        await expectToFindDoc(this.collection, { _id: nonExistentId, text: updatedText }, { expectedCount: 4 });
       });
     });
 
     describe("#updateMany", function () {
       const updatedText = "Updated text";
 
-      it("updates documents using query selector", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("updates documents using query selector", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateMany({ _id: { $gt: insertedId1 } }, { $set: { text: updatedText } });
+        const result = await this.collection.updateMany({ _id: { $gt: insertedId1 } }, { $set: { text: updatedText } });
         expect(result).to.deep.equal({ matchedCount: 2, modifiedCount: 2 });
 
-        await expectToFindDoc({ _id: insertedId2, text: updatedText }, { expectedCount: 3 });
-        await expectToFindDoc({ _id: insertedId3, text: updatedText }, { expectedCount: 3 });
+        await expectToFindDoc(this.collection, { _id: insertedId2, text: updatedText }, { expectedCount: 3 });
+        await expectToFindDoc(this.collection, { _id: insertedId3, text: updatedText }, { expectedCount: 3 });
       });
 
-      it("does not update any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not update any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateMany({ _id: nonExistentId }, { $set: { text: updatedText } });
+        const result = await this.collection.updateMany({ _id: nonExistentId }, { $set: { text: updatedText } });
         expect(result).to.deep.equal({ matchedCount: 0, modifiedCount: 0 });
 
-        await expectTextToBeUnchanged({ text: insertedText, expectedCount: 3 });
+        await expectTextToBeUnchanged(this.collection, { text: insertedText, expectedCount: 3 });
       });
 
-      it("inserts new document if no matches when using 'upsert'", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("inserts new document if no matches when using 'upsert'", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.updateMany(
+        const result = await this.collection.updateMany(
           { _id: nonExistentId },
           { $set: { text: updatedText } },
           { upsert: true },
@@ -450,101 +450,101 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
           upsertedId: nonExistentId,
         });
 
-        await expectToFindDoc({ _id: nonExistentId, text: updatedText }, { expectedCount: 4 });
+        await expectToFindDoc(this.collection, { _id: nonExistentId, text: updatedText }, { expectedCount: 4 });
       });
     });
 
     describe("#deleteOne", function () {
-      it("deletes specific document", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes specific document", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteOne({ _id: insertedId3 });
+        const result = await this.collection.deleteOne({ _id: insertedId3 });
         expect(result.deletedCount).to.equal(1);
 
-        await expectToNotFindDoc({ _id: insertedId3 }, { expectedCount: 2 });
+        await expectToNotFindDoc(this.collection, { _id: insertedId3 }, { expectedCount: 2 });
       });
 
-      it("deletes first returned document using empty filter", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes first returned document using empty filter", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteOne();
+        const result = await this.collection.deleteOne();
         expect(result.deletedCount).to.equal(1);
 
-        await expectToNotFindDoc({ _id: insertedId1 }, { expectedCount: 2 });
+        await expectToNotFindDoc(this.collection, { _id: insertedId1 }, { expectedCount: 2 });
       });
 
-      it("does not delete any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not delete any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteOne({ _id: nonExistentId });
+        const result = await this.collection.deleteOne({ _id: nonExistentId });
         expect(result.deletedCount).to.equal(0);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(3);
       });
     });
 
     describe("#deleteMany", function () {
-      it("deletes all documents using empty filter", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes all documents using empty filter", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteMany();
+        const result = await this.collection.deleteMany();
         expect(result.deletedCount).to.equal(3);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(0);
       });
 
-      it("deletes documents using query selector", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("deletes documents using query selector", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteMany({ _id: { $gt: insertedId1 } });
+        const result = await this.collection.deleteMany({ _id: { $gt: insertedId1 } });
         expect(result.deletedCount).to.equal(2);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(1);
       });
 
-      it("does not delete any document when there are no matches", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("does not delete any document when there are no matches", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.deleteMany({ _id: nonExistentId });
+        const result = await this.collection.deleteMany({ _id: nonExistentId });
         expect(result.deletedCount).to.equal(0);
 
-        const count = await collection.count();
+        const count = await this.collection.count();
         expect(count).to.equal(3);
       });
     });
 
     describe("#count", function () {
-      it("returns total number of documents using empty filter", async function (this: AppContext & Mocha.Context) {
-        const countBefore = await collection.count();
+      it("returns total number of documents using empty filter", async function (this: TestContext) {
+        const countBefore = await this.collection.count();
         expect(countBefore).to.equal(0);
 
-        await insertThreeDocuments();
+        await insertThreeDocuments(this.collection);
 
-        const countAfter = await collection.count();
+        const countAfter = await this.collection.count();
         expect(countAfter).to.equal(3);
       });
 
-      it("returns number of documents using query selector", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("returns number of documents using query selector", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const count = await collection.count({ _id: { $gt: insertedId1 } });
+        const count = await this.collection.count({ _id: { $gt: insertedId1 } });
         expect(count).to.equal(2);
       });
 
-      it("returns zero when there are no matches", async function (this: AppContext & Mocha.Context) {
-        const count = await collection.count({ _id: nonExistentId });
+      it("returns zero when there are no matches", async function (this: TestContext) {
+        const count = await this.collection.count({ _id: nonExistentId });
         expect(count).to.equal(0);
       });
     });
 
     describe("#aggregate", function () {
-      it("aggregates documents using multiple pipeline stages", async function (this: AppContext & Mocha.Context) {
-        await insertThreeDocuments();
+      it("aggregates documents using multiple pipeline stages", async function (this: TestContext) {
+        await insertThreeDocuments(this.collection);
 
-        const result = await collection.aggregate([
+        const result = await this.collection.aggregate([
           // Filter all docs with `_id` > `insertedId1`.
           { $match: { _id: { $gt: insertedId1 } } },
           // Return a single doc (`_id: null`) with property `count` set to the number of filtered docs.
@@ -581,7 +581,7 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         }
       }
 
-      async function insertDocumentsOneByOne(): Promise<void> {
+      async function insertDocumentsOneByOne(collection: MongoDBCollection<TestDocument>): Promise<void> {
         // There is a race with creating the watch() streams, since they won't
         // see inserts from before they are created.
         // Wait 500ms (490+10) before first insert to try to avoid it.
@@ -593,20 +593,20 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
         await collection.insertOne(lastDocument);
       }
 
-      it("streams any inserted documents", async function (this: AppContext & Mocha.Context) {
+      it("streams any inserted documents", async function (this: TestContext) {
         const startWatching = async () => {
           let expectedId = 0;
-          for await (const event of collection.watch()) {
+          for await (const event of this.collection.watch()) {
             assertIsInsert(event);
             expect(event.fullDocument._id).to.equal(expectedId++);
             if (event.fullDocument.isLast) break;
           }
         };
 
-        await Promise.all([startWatching(), insertDocumentsOneByOne()]);
+        await Promise.all([startWatching(), insertDocumentsOneByOne(this.collection)]);
       });
 
-      it("streams inserted documents using 'filter' option", async function (this: AppContext & Mocha.Context) {
+      it("streams inserted documents using 'filter' option", async function (this: TestContext) {
         const watchedId = 3;
         const filter = {
           $or: [{ "fullDocument._id": watchedId, "fullDocument.text": text }, { "fullDocument.isLast": true }],
@@ -614,7 +614,7 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
 
         const startWatching = async () => {
           let seenIt = false;
-          for await (const event of collection.watch({ filter })) {
+          for await (const event of this.collection.watch({ filter })) {
             assertIsInsert(event);
             if (event.fullDocument.isLast) break;
             expect(event.fullDocument._id).to.equal(watchedId);
@@ -623,16 +623,16 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
           expect(seenIt).to.be.true;
         };
 
-        await Promise.all([startWatching(), insertDocumentsOneByOne()]);
+        await Promise.all([startWatching(), insertDocumentsOneByOne(this.collection)]);
       });
 
-      it("streams inserted documents using 'ids' option", async function (this: AppContext & Mocha.Context) {
+      it("streams inserted documents using 'ids' option", async function (this: TestContext) {
         const watchedId = 3;
         const ids = [watchedId, lastDocument._id];
 
         const startWatching = async () => {
           let seenIt = false;
-          for await (const event of collection.watch({ ids })) {
+          for await (const event of this.collection.watch({ ids })) {
             assertIsInsert(event);
             if (event.fullDocument.isLast) break;
             expect(event.fullDocument._id).to.equal(watchedId);
@@ -641,15 +641,15 @@ describe.skipIf(environment.missingServer, "MongoDB Client", function () {
           expect(seenIt).to.be.true;
         };
 
-        await Promise.all([startWatching(), insertDocumentsOneByOne()]);
+        await Promise.all([startWatching(), insertDocumentsOneByOne(this.collection)]);
       });
 
-      it("throws when the user is logged out", async function (this: AppContext & Mocha.Context) {
+      it("throws when the user is logged out", async function (this: TestContext) {
         await this.app.currentUser?.logOut();
         expect(this.app.currentUser).to.be.null;
 
         const startWatching = async () => {
-          for await (const _ of collection.watch()) {
+          for await (const _ of this.collection.watch()) {
             expect.fail("Expected 'watch()' to throw, but received a change stream.");
           }
         };


### PR DESCRIPTION
## What, How & Why?

This refactors the MongoDB Client tests to rely on a generated database name stored on the test context rather than a const name that would result in crosstalking between tests being ran in parallel on CI.
Note: I've sat the base-branch to `kh/reuse-imported-apps` since that is a dependency of this fix, but I expect that to merge before this PR.