### PR TITLE
Add Flexible Sync subscribe/unsubscribe APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@
 * Improve performance of equality queries on a non-indexed mixed property by about 30%. ([realm/realm-core#6506](https://github.com/realm/realm-core/pull/6506))
 * Improve performance of rolling back write transactions after making changes.  ([realm/realm-core#6513](https://github.com/realm/realm-core/pull/6513))
 * Extended `PropertySchema.indexed` with the `full-text` option, that allows to create an index for full-text search queries.  ([#5755](https://github.com/realm/realm-js/issues/5755))
+* Added APIs to facilitate adding and removing subscriptions ([#5772](https://github.com/realm/realm-js/pull/5772)):
+  * Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and `Results.unsubscribe()` (synchronous).
+  * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before returning from `Results.subscribe()`.
+  * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.
+  * Added an optional `unnamedOnly` parameter to `MutableSubscriptionSet.removeAll()` allowing the removal of only unnamed subscriptions.
+  ```javascript
+  const peopleOver20 = await realm
+    .objects("Person")
+    .filtered("age > 20")
+    .subscribe({
+      name: "peopleOver20",
+      behavior: WaitForSync.FirstTime, // Default
+      timeout: 2000,
+    });
+  ```
 
 ### Fixed
 * Fix a stack overflow crash when using the query parser with long chains of AND/OR conditions. ([realm/realm-core#6428](https://github.com/realm/realm-core/pull/6428), since v10.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 * Extended `PropertySchema.indexed` with the `full-text` option, that allows to create an index for full-text search queries.  ([#5755](https://github.com/realm/realm-js/issues/5755))
 * Added APIs to facilitate adding and removing subscriptions. ([#5772](https://github.com/realm/realm-js/pull/5772))
   * Experimental APIs: Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and `Results.unsubscribe()` (synchronous).
-  * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before returning from `Results.subscribe()`.
-  * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.
+    * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before resolving the promise returned from `Results.subscribe()`.
+    * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.
   * Added the instance method `MutableSubscriptionSet.removeUnnamed()` for removing only unnamed subscriptions.
   ```javascript
   const peopleOver20 = await realm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Improve performance of equality queries on a non-indexed mixed property by about 30%. ([realm/realm-core#6506](https://github.com/realm/realm-core/pull/6506))
 * Improve performance of rolling back write transactions after making changes.  ([realm/realm-core#6513](https://github.com/realm/realm-core/pull/6513))
 * Extended `PropertySchema.indexed` with the `full-text` option, that allows to create an index for full-text search queries.  ([#5755](https://github.com/realm/realm-js/issues/5755))
-* Added APIs to facilitate adding and removing subscriptions ([#5772](https://github.com/realm/realm-js/pull/5772)):
+* Added APIs to facilitate adding and removing subscriptions. ([#5772](https://github.com/realm/realm-js/pull/5772))
   * Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and the experimental `Results.unsubscribe()` (synchronous).
   * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before returning from `Results.subscribe()`.
   * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@
 * Improve performance of rolling back write transactions after making changes.  ([realm/realm-core#6513](https://github.com/realm/realm-core/pull/6513))
 * Extended `PropertySchema.indexed` with the `full-text` option, that allows to create an index for full-text search queries.  ([#5755](https://github.com/realm/realm-js/issues/5755))
 * Added APIs to facilitate adding and removing subscriptions ([#5772](https://github.com/realm/realm-js/pull/5772)):
-  * Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and `Results.unsubscribe()` (synchronous).
+  * Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and the experimental `Results.unsubscribe()` (synchronous).
   * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before returning from `Results.subscribe()`.
   * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.
-  * Added an optional `unnamedOnly` parameter to `MutableSubscriptionSet.removeAll()` allowing the removal of only unnamed subscriptions.
+  * Added the instance method `MutableSubscriptionSet.removeUnnamed()` for removing only unnamed subscriptions.
   ```javascript
   const peopleOver20 = await realm
     .objects("Person")
@@ -29,6 +29,8 @@
       behavior: WaitForSync.FirstTime, // Default
       timeout: 2000,
     });
+  // ...
+  peopleOver20.unsubscribe();
   ```
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Improve performance of rolling back write transactions after making changes.  ([realm/realm-core#6513](https://github.com/realm/realm-core/pull/6513))
 * Extended `PropertySchema.indexed` with the `full-text` option, that allows to create an index for full-text search queries.  ([#5755](https://github.com/realm/realm-js/issues/5755))
 * Added APIs to facilitate adding and removing subscriptions. ([#5772](https://github.com/realm/realm-js/pull/5772))
-  * Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and the experimental `Results.unsubscribe()` (synchronous).
+  * Experimental APIs: Enabled subscribing and unsubscribing directly to and from a `Results` instance via `Results.subscribe()` (asynchronous) and `Results.unsubscribe()` (synchronous).
   * Added a `WaitForSync` enum specifying whether to wait or not wait for subscribed objects to be downloaded before returning from `Results.subscribe()`.
   * Extended `SubscriptionOptions` to take a `WaitForSync` behavior and a maximum waiting timeout before returning from `Results.subscribe()`.
   * Added the instance method `MutableSubscriptionSet.removeUnnamed()` for removing only unnamed subscriptions.

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1655,13 +1655,15 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions).to.have.length(1);
         });
 
-        it("waits for objects to sync the first time only for different 'Results' instances", async function (this: RealmContext) {
+        it("waits for objects to sync the first time only for separate 'Results' instances w/ same query", async function (this: RealmContext) {
           expect(this.realm.subscriptions).to.have.length(0);
 
+          // Subscribe to a query on 'Results' instance 1.
           let peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
           expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
+          // Subscribe to the same query on 'Results' instance 2 (overwrite previous 'peopleOver10' value).
           peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
           expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -38,6 +38,7 @@ import {
   Realm,
   SessionStopPolicy,
   CompensatingWriteError,
+  WaitForSync,
 } from "realm";
 
 import { authenticateUserBefore, importAppBefore, openRealmBeforeEach } from "../../hooks";
@@ -1568,6 +1569,56 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await this.realm.subscriptions.waitForSynchronization();
             expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
+        });
+      });
+
+      describe("Results#subscribe", function () {
+        it("waits for objects to be downloaded the first time only", async function (this: RealmContext) {
+          expect(this.realm.subscriptions).to.have.length(0);
+
+          const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          // TODO: Expect it to wait.
+          await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
+          // TODO: Expect it not to wait.
+          await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
+
+          expect(this.realm.subscriptions).to.have.length(1);
+        });
+
+        it("waits for objects to be downloaded the first time only by default", async function (this: RealmContext) {
+          expect(this.realm.subscriptions).to.have.length(0);
+
+          const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          // TODO: Expect it to wait.
+          await peopleOver10.subscribe();
+          // TODO: Expect it not to wait.
+          await peopleOver10.subscribe();
+
+          expect(this.realm.subscriptions).to.have.length(1);
+        });
+
+        it("always waits for objects to be downloaded", async function (this: RealmContext) {
+          expect(this.realm.subscriptions).to.have.length(0);
+
+          const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          // TODO: Expect it to wait.
+          await peopleOver10.subscribe({ behavior: WaitForSync.Always });
+          // TODO: Expect it to wait.
+          await peopleOver10.subscribe({ behavior: WaitForSync.Always });
+
+          expect(this.realm.subscriptions).to.have.length(1);
+        });
+
+        it("never waits for objects to be downloaded", async function (this: RealmContext) {
+          expect(this.realm.subscriptions).to.have.length(0);
+
+          const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          // TODO: Expect it to not wait.
+          peopleOver10.subscribe({ behavior: WaitForSync.Never });
+          // TODO: Expect it to not wait.
+          peopleOver10.subscribe({ behavior: WaitForSync.Never });
+
+          expect(this.realm.subscriptions).to.have.length(1);
         });
       });
 

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1685,6 +1685,12 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
+
+        it("returns the same 'Results' instance", async function (this: RealmContext) {
+          const beforeSubscribe = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          const afterSubscribe = await beforeSubscribe.subscribe();
+          expect(beforeSubscribe).to.equal(afterSubscribe);
+        });
       });
 
       describe("Results#unsubscribe", function () {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1532,6 +1532,26 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
             expect(this.realm.subscriptions.isEmpty).to.be.true;
           });
+
+          it("removes all unnamed subscriptions and returns the number of subscriptions removed", async function (this: RealmContext) {
+            // Add 1 named and 2 unnamed subscriptions.
+            addSubscriptionForPerson(this.realm, { name: "name1" });
+            addSubscription(this.realm, this.realm.objects(FlexiblePersonSchema.name).filtered("age < 5"));
+            await addSubscriptionAndSync(
+              this.realm,
+              this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10"),
+            );
+            expect(this.realm.subscriptions).to.have.length(3);
+
+            let numRemoved = 0;
+            await this.realm.subscriptions.update((mutableSubs) => {
+              const unnamedOnly = true;
+              numRemoved = mutableSubs.removeAll(unnamedOnly);
+            });
+
+            expect(numRemoved).to.equal(2);
+            expect(this.realm.subscriptions).to.have.length(1);
+          });
         });
 
         describe("#removeByObjectType", function () {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1730,8 +1730,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           const peopleOver10 = await this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10").subscribe();
           expect(this.realm.subscriptions).to.have.length(1);
 
-          const unsubscribed = peopleOver10.unsubscribe();
-          expect(unsubscribed).to.be.true;
+          peopleOver10.unsubscribe();
           expect(this.realm.subscriptions).to.have.length(0);
         });
 
@@ -1739,22 +1738,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           expect(this.realm.subscriptions).to.have.length(0);
 
-          const unsubscribed = peopleOver10.unsubscribe();
-          expect(unsubscribed).to.be.false;
+          peopleOver10.unsubscribe();
           expect(this.realm.subscriptions).to.have.length(0);
         });
 
         it("does not unsubscribe multiple times", async function (this: RealmContext) {
+          await this.realm.objects(FlexiblePersonSchema.name).filtered("age < 10").subscribe();
           const peopleOver10 = await this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10").subscribe();
+          expect(this.realm.subscriptions).to.have.length(2);
+
+          peopleOver10.unsubscribe();
+          peopleOver10.unsubscribe();
+
           expect(this.realm.subscriptions).to.have.length(1);
-
-          let unsubscribed = peopleOver10.unsubscribe();
-          expect(unsubscribed).to.be.true;
-
-          unsubscribed = peopleOver10.unsubscribe();
-          expect(unsubscribed).to.be.false;
-
-          expect(this.realm.subscriptions).to.have.length(0);
         });
       });
 

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1403,7 +1403,6 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           it("returns true and removes a subscription with an empty name", async function (this: RealmContext) {
             addSubscription(this.realm, this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10"));
             const { subs } = addSubscriptionForPerson(this.realm, { name: "" });
-
             expect(subs).to.have.length(2);
 
             await subs.update((mutableSubs) => {
@@ -1734,12 +1733,14 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions).to.have.length(0);
         });
 
-        it("does not throw or unsubscribe when there is no subscription", function (this: RealmContext) {
+        it("does not throw or unsubscribe when there is no matching subscription", function (this: RealmContext) {
+          const peopleUnder10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age < 10").subscribe();
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
-          expect(this.realm.subscriptions).to.have.length(0);
+          expect(this.realm.subscriptions).to.have.length(1);
 
+          // Unsubscribe to the Results without a subscription.
           peopleOver10.unsubscribe();
-          expect(this.realm.subscriptions).to.have.length(0);
+          expect(this.realm.subscriptions).to.have.length(1);
         });
 
         it("does not unsubscribe multiple times", async function (this: RealmContext) {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -37,7 +37,7 @@ import {
   FlexibleSyncConfiguration,
   Realm,
   SessionStopPolicy,
-  SubscriptionsState,
+  SubscriptionSetState,
   CompensatingWriteError,
   WaitForSync,
 } from "realm";
@@ -1601,11 +1601,11 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           // Subscribing the first time should wait for synchronization.
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           // Subscribing the second time should return without waiting.
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1616,10 +1616,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
 
           await peopleOver10.subscribe();
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           await peopleOver10.subscribe();
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1629,11 +1629,11 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           let peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.FirstTime });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1644,10 +1644,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
 
           await peopleOver10.subscribe({ behavior: WaitForSync.Always });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           await peopleOver10.subscribe({ behavior: WaitForSync.Always });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1658,10 +1658,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
 
           await peopleOver10.subscribe({ behavior: WaitForSync.Never });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           await peopleOver10.subscribe({ behavior: WaitForSync.Never });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1671,7 +1671,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.Always, timeout: this.timeout() });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Complete);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });
@@ -1681,7 +1681,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
           await peopleOver10.subscribe({ behavior: WaitForSync.Always, timeout: 0 });
-          expect(this.realm.subscriptions.state).to.equal(SubscriptionsState.Pending);
+          expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Pending);
 
           expect(this.realm.subscriptions).to.have.length(1);
         });

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1685,6 +1685,19 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(unsubscribed).to.be.false;
           expect(this.realm.subscriptions).to.have.length(0);
         });
+
+        it("does not unsubscribe multiple times", async function (this: RealmContext) {
+          const peopleOver10 = await this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10").subscribe();
+          expect(this.realm.subscriptions).to.have.length(1);
+
+          let unsubscribed = peopleOver10.unsubscribe();
+          expect(unsubscribed).to.be.true;
+
+          unsubscribed = peopleOver10.unsubscribe();
+          expect(unsubscribed).to.be.false;
+
+          expect(this.realm.subscriptions).to.have.length(0);
+        });
       });
 
       // TODO Right now there is no is_valid method we can use to verify if the subs

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1545,8 +1545,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
             let numRemoved = 0;
             await this.realm.subscriptions.update((mutableSubs) => {
-              const unnamedOnly = true;
-              numRemoved = mutableSubs.removeAll(unnamedOnly);
+              numRemoved = mutableSubs.removeUnnamed();
             });
 
             expect(numRemoved).to.equal(2);

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1622,6 +1622,26 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
         });
       });
 
+      describe("Results#unsubscribe", function () {
+        it("unsubscribes from existing subscription", async function (this: RealmContext) {
+          const peopleOver10 = await this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10").subscribe();
+          expect(this.realm.subscriptions).to.have.length(1);
+
+          const unsubscribed = peopleOver10.unsubscribe();
+          expect(unsubscribed).to.be.true;
+          expect(this.realm.subscriptions).to.have.length(0);
+        });
+
+        it("does not unsubscribe when there is no subscription", function (this: RealmContext) {
+          const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          expect(this.realm.subscriptions).to.have.length(0);
+
+          const unsubscribed = peopleOver10.unsubscribe();
+          expect(unsubscribed).to.be.false;
+          expect(this.realm.subscriptions).to.have.length(0);
+        });
+      });
+
       // TODO Right now there is no is_valid method we can use to verify if the subs
       // are in a valid state... maybe need a different solution as this will crash
       xdescribe("when realm is closed", function () {

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -1701,6 +1701,8 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           expect(this.realm.subscriptions).to.have.length(0);
 
           const peopleOver10 = this.realm.objects(FlexiblePersonSchema.name).filtered("age > 10");
+          // `this.timeout()` is used so that it doesn't exceed the timeout that our tests
+          // are configured to use (which could vary).
           await peopleOver10.subscribe({ behavior: WaitForSync.Always, timeout: this.timeout() });
           expect(this.realm.subscriptions.state).to.equal(SubscriptionSetState.Complete);
 

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -171,8 +171,10 @@ export class ProgressRealmPromise implements Promise<Realm> {
     if (typeof timeOut === "number") {
       this.timeoutPromise = new TimeoutPromise(
         this.handle.promise, // Ensures the timeout gets cancelled when the realm opens
-        timeOut,
-        `Realm could not be downloaded in the allocated time: ${timeOut} ms.`,
+        {
+          ms: timeOut,
+          message: `Realm could not be downloaded in the allocated time: ${timeOut} ms.`,
+        },
       );
       if (timeOutBehavior === OpenRealmTimeOutBehavior.ThrowException) {
         // Make failing the timeout, reject the promise

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -125,10 +125,7 @@ export class Results<T = unknown> extends OrderedCollection<T> {
       if (typeof options.timeout === "number") {
         await new TimeoutPromise(
           subs.update((mutableSubs) => mutableSubs.add(this, options)),
-          {
-            ms: options.timeout,
-            rejectOnTimeout: false,
-          },
+          { ms: options.timeout, rejectOnTimeout: false },
         );
       } else {
         await subs.update((mutableSubs) => mutableSubs.add(this, options));

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2023 Realm Inc.
+// Copyright 2022 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,6 +120,7 @@ export class Results<T = unknown> extends OrderedCollection<T> {
    *
    * @param options Options to use when adding this subscription (e.g. a name or wait behavior).
    * @returns A promise that resolves to this {@link Results} instance.
+   * @experimental This API is experimental and may change or be removed.
    */
   async subscribe(options: SubscriptionOptions = { behavior: WaitForSync.FirstTime }): Promise<this> {
     const subs = this.realm.subscriptions;

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -43,8 +43,6 @@ export class Results<T = unknown> extends OrderedCollection<T> {
    * @internal
    */
   public declare internal: binding.Results;
-  /** @internal */
-  private isSubscribedTo = false; // TODO: Replace with call to Core
 
   /**
    * Create a `Results` wrapping a set of query `Results` from the binding.
@@ -69,11 +67,6 @@ export class Results<T = unknown> extends OrderedCollection<T> {
       configurable: false,
       writable: false,
       value: realm,
-    });
-    Object.defineProperty(this, "isSubscribedTo", {
-      enumerable: false,
-      configurable: false,
-      writable: true,
     });
   }
 
@@ -124,8 +117,10 @@ export class Results<T = unknown> extends OrderedCollection<T> {
    */
   async subscribe(options: SubscriptionOptions = { behavior: WaitForSync.FirstTime }): Promise<this> {
     const subs = this.realm.subscriptions;
+    // @ts-expect-error TODO: Fix type error from passing 'this'.
+    const isSubscribedTo = !!subs.findByQuery(this);
     const shouldWait =
-      (options.behavior === WaitForSync.FirstTime && !this.isSubscribedTo) || options.behavior === WaitForSync.Always;
+      (options.behavior === WaitForSync.FirstTime && !isSubscribedTo) || options.behavior === WaitForSync.Always;
     if (shouldWait) {
       if (typeof options.timeout === "number") {
         await new TimeoutPromise(
@@ -141,7 +136,6 @@ export class Results<T = unknown> extends OrderedCollection<T> {
     } else {
       subs.updateNoWait((mutableSubs) => mutableSubs.add(this, options));
     }
-    this.isSubscribedTo = true; // TODO: Remove when calling into Core instead.
 
     return this;
   }

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -125,7 +125,7 @@ export class Results<T = unknown> extends OrderedCollection<T> {
   async subscribe(options: SubscriptionOptions = { behavior: WaitForSync.FirstTime }): Promise<this> {
     const subs = this.realm.subscriptions;
     const shouldWait =
-      (options.behavior === WaitForSync.FirstTime && !subs.exists(this)) || options.behavior === WaitForSync.Always;
+      options.behavior === WaitForSync.Always || (options.behavior === WaitForSync.FirstTime && !subs.exists(this));
     if (shouldWait) {
       if (typeof options.timeout === "number") {
         await new TimeoutPromise(
@@ -143,7 +143,12 @@ export class Results<T = unknown> extends OrderedCollection<T> {
   }
 
   /**
-   * Unsubscribe from this query result.
+   * Unsubscribe from this query result. It returns immediately without waiting
+   * for synchronization.
+   *
+   * If the subscription is unnamed, the subscription matching the query will
+   * be removed.
+   *
    * @experimental This API is experimental and may change or be removed.
    */
   unsubscribe(): void {

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -136,16 +136,12 @@ export class Results<T = unknown> extends OrderedCollection<T> {
 
   /**
    * Unsubscribe from this query result.
-   * @returns `true` if this was previously subscribed to and now is not, otherwise `false`.
    * @experimental This API is experimental and may change or be removed.
    */
-  unsubscribe(): boolean {
-    let removed = false;
+  unsubscribe(): void {
     this.realm.subscriptions.updateNoWait((mutableSubs) => {
-      removed = mutableSubs.remove(this);
+      mutableSubs.remove(this);
     });
-
-    return removed;
   }
 
   isValid(): boolean {

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -148,12 +148,9 @@ export class Results<T = unknown> extends OrderedCollection<T> {
 
   unsubscribe(): boolean {
     let removed = false;
-    if (this.isSubscribedTo) {
-      this.realm.subscriptions.updateNoWait((mutableSubs) => {
-        removed = mutableSubs.remove(this);
-      });
-      this.isSubscribedTo = !removed;
-    }
+    this.realm.subscriptions.updateNoWait((mutableSubs) => {
+      removed = mutableSubs.remove(this);
+    });
 
     return removed;
   }

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -137,6 +137,7 @@ export class Results<T = unknown> extends OrderedCollection<T> {
   /**
    * Unsubscribe from this query result.
    * @returns `true` if this was previously subscribed to and now is not, otherwise `false`.
+   * @experimental This API is experimental and may change or be removed.
    */
   unsubscribe(): boolean {
     let removed = false;

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -125,6 +125,18 @@ export class Results<T = unknown> extends OrderedCollection<T> {
     return this;
   }
 
+  unsubscribe(): boolean {
+    let removed = false;
+    if (this.isSubscribedTo) {
+      this.realm.subscriptions.updateNoWait((mutableSubs) => {
+        removed = mutableSubs.remove(this);
+      });
+      this.isSubscribedTo = !removed;
+    }
+
+    return removed;
+  }
+
   isValid(): boolean {
     return this.internal.isValid;
   }

--- a/packages/realm/src/app-services/BaseSubscriptionSet.ts
+++ b/packages/realm/src/app-services/BaseSubscriptionSet.ts
@@ -196,6 +196,14 @@ export abstract class BaseSubscriptionSet {
     return subscription ? (new Subscription(subscription) as Subscription) : null; // TODO: Remove the type assertion into Subscription
   }
 
+  /** @internal */
+  exists(query: Results<any>): boolean {
+    if (query.subscriptionName === undefined) {
+      return !!this.internal.findByQuery(query.internal.query);
+    }
+    return !!this.internal.findByName(query.subscriptionName);
+  }
+
   /**
    * Makes the subscription set iterable.
    *

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -180,17 +180,22 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
   /**
    * Remove all subscriptions from the SubscriptionSet.
    *
-   * @param unnamedOnly Whether to only remove unnamed/anonymous subscriptions. (Default: `false`)
    * @returns The number of subscriptions removed.
    */
-  removeAll(unnamedOnly = false): number {
-    if (unnamedOnly) {
-      return this.removeByPredicate((subscription) => !subscription.name);
-    }
+  removeAll(): number {
     const numRemoved = this.internal.size;
     this.internal.clear();
 
     return numRemoved;
+  }
+
+  /**
+   * Remove all unnamed/anonymous subscriptions from the SubscriptionSet.
+   *
+   * @returns The number of subscriptions removed.
+   */
+  removeUnnamed(): number {
+    return this.removeByPredicate((subscription) => !subscription.name);
   }
 
   /** @internal */

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -109,7 +109,7 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
     const results = query.internal;
     const queryInternal = results.query;
 
-    if (options?.throwOnUpdate && options.name) {
+    if (options?.throwOnUpdate && options.name !== undefined) {
       const existingSubscription = subscriptions.findByName(options.name);
       if (existingSubscription) {
         const isSameQuery =
@@ -122,9 +122,11 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
       }
     }
 
-    const [subscription] = options?.name
-      ? subscriptions.insertOrAssignByName(options.name, queryInternal)
-      : subscriptions.insertOrAssignByQuery(queryInternal);
+    const [subscription] =
+      // Check for `undefined` rather than falsy since we treat empty names as named.
+      options?.name === undefined
+        ? subscriptions.insertOrAssignByQuery(queryInternal)
+        : subscriptions.insertOrAssignByName(options.name, queryInternal);
 
     return new Subscription(subscription);
   }
@@ -195,7 +197,7 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
    * @returns The number of subscriptions removed.
    */
   removeUnnamed(): number {
-    return this.removeByPredicate((subscription) => !subscription.name);
+    return this.removeByPredicate((subscription) => subscription.name === undefined);
   }
 
   /** @internal */

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -18,6 +18,9 @@
 
 import { BaseSubscriptionSet, Realm, Results, Subscription, SubscriptionSet, assert, binding } from "../internal";
 
+/**
+ * Behavior when waiting for subscribed objects to be synchronized/downloaded.
+ */
 export enum WaitForSync {
   /**
    * Waits until the objects have been downloaded from the server

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -128,6 +128,8 @@ export class MutableSubscriptionSet extends BaseSubscriptionSet {
         ? subscriptions.insertOrAssignByQuery(queryInternal)
         : subscriptions.insertOrAssignByName(options.name, queryInternal);
 
+    query.subscriptionName = subscription.name;
+
     return new Subscription(subscription);
   }
 

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -61,10 +61,9 @@ export type SubscriptionOptions = {
    */
   behavior?: WaitForSync;
   /**
-   * The maximum number of milliseconds to wait for objects to be downloaded.
+   * The maximum time (in milliseconds) to wait for objects to be downloaded.
    * If the time exceeds this limit, the `Results` is returned and the download
-   * continues in the background. (This value affects the timeout behavior
-   * similar to {@link setTimeout}.)
+   * continues in the background.
    */
   timeout?: number;
 };

--- a/packages/realm/src/app-services/MutableSubscriptionSet.ts
+++ b/packages/realm/src/app-services/MutableSubscriptionSet.ts
@@ -60,7 +60,8 @@ export type SubscriptionOptions = {
   /**
    * The maximum number of milliseconds to wait for objects to be downloaded.
    * If the time exceeds this limit, the `Results` is returned and the download
-   * continues in the background.
+   * continues in the background. (This value affects the timeout behavior
+   * similar to {@link setTimeout}.)
    */
   timeout?: number;
 };

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -364,22 +364,20 @@ export class SyncSession {
   downloadAllServerChanges(timeoutMs?: number): Promise<void> {
     return this.withInternal(
       (internal) =>
-        new TimeoutPromise(
-          internal.waitForDownloadCompletion(),
-          timeoutMs,
-          `Downloading changes did not complete in ${timeoutMs} ms.`,
-        ),
+        new TimeoutPromise(internal.waitForDownloadCompletion(), {
+          ms: timeoutMs,
+          message: `Downloading changes did not complete in ${timeoutMs} ms.`,
+        }),
     );
   }
 
   uploadAllLocalChanges(timeoutMs?: number): Promise<void> {
     return this.withInternal(
       (internal) =>
-        new TimeoutPromise(
-          internal.waitForUploadCompletion(),
-          timeoutMs,
-          `Uploading changes did not complete in ${timeoutMs} ms.`,
-        ),
+        new TimeoutPromise(internal.waitForUploadCompletion(), {
+          ms: timeoutMs,
+          message: `Uploading changes did not complete in ${timeoutMs} ms.`,
+        }),
     );
   }
 

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -167,6 +167,7 @@ export {
   UserChangeCallback,
   UserState,
   UserTypeName,
+  WaitForSync,
 } from "./internal";
 
 import { Realm, RealmObjectConstructor } from "./internal";


### PR DESCRIPTION
## What, How & Why?

### Additions:
* Experimental APIs: Adds the possibility to subscribe and unsubscribe directly to and from a `Results` instance via `Results.subscribe()` and the `Results.unsubscribe()`.
  * A `SubscriptionOptions` can be passed to `Results.subscribe()` which has been extended to include:
    * A `WaitForSync` behavior specifying how to wait or not wait for subscribed objects to be downloaded before the returned promise resolves.
    * A maximum waiting timeout before resolving.
* Adds the instance method `MutableSubscriptionSet.removeUnnamed()` allowing for the removal of unnamed subscriptions only.

### Example `subscribe()`:
```js
const peopleOver20 = await realm
  .objects("Person")
  .filtered("age > 20")
  .subscribe({
    name: "peopleOver20",
    behavior: WaitForSync.FirstTime, // Default
    timeout: 2000,
  });
// ...
peopleOver20.unsubscribe();
```

### Example `removeUnnamed()`:
```js
await realm.subscriptions.update((mutableSubs) => {
  mutableSubs.removeUnnamed();
});
```

This closes #5760.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [x] 📝 Public documentation PR created or is not necessary

