### PR TITLE
Deprecate `SubscriptionsState` in favor of `SubscriptionSetState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## vNext (TBD)
 
 ### Deprecations
-* None
+* Deprecated the `SubscriptionsState` enum (will be removed in v13) in favor of the now-named `SubscriptionSetState`. ([#5773](https://github.com/realm/realm-js/issues/5773))
 
 ### Enhancements
 * Opening a Realm with invalid schemas will throw a `SchemaParseError` (or one of its subtypes `ObjectSchemaParseError` and `PropertySchemaParseError`) rather than an `AssertionError` or `Error`. ([#5198](https://github.com/realm/realm-js/issues/5198))
 * Enable multiple processes to operate on an encrypted Realm simultaneously. ([realm/realm-core#1845](https://github.com/realm/realm-core/issues/1845))
 * Added `Realm.setLogger`, that allows to setup a single static logger for the duration of the app lifetime. Differently from the now deprecated sync logger (that was setup with `Sync.setLogger`), this new one will emit messages coming also from the local database, and not only from sync. It is also possible to change the log level during the whole duration of the app lifetime with `Realm.setLogLevel`. ([#2546](https://github.com/realm/realm-js/issues/2546))
-* Added support for a sync configuration option to provide an `SSLConfiguration` with a custom function for validating the server's SSL certificate. [#5485](https://github.com/realm/realm-js/issues/5485)
+* Added support for a sync configuration option to provide an `SSLConfiguration` with a custom function for validating the server's SSL certificate. ([#5485](https://github.com/realm/realm-js/issues/5485))
 
 ### Fixed
 * Fix a stack overflow crash when using the query parser with long chains of AND/OR conditions. ([realm/realm-core#6428](https://github.com/realm/realm-core/pull/6428), since v10.11.0)

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -314,7 +314,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
             try {
               expect(realm.subscriptions).to.have.length(1);
-              expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+              expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
             } finally {
               if (closeRealmAfter) {
                 closeRealm(realm);
@@ -340,7 +340,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await realm.subscriptions.waitForSynchronization();
 
             expect(realm.subscriptions).to.have.length(1);
-            expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
 
             closeRealm(realm);
           });
@@ -602,11 +602,11 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
           it("waits for subscriptions to be in a complete state", async function (this: RealmContext) {
             const { subs } = addSubscriptionForPerson(this.realm);
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Pending);
 
             await subs.waitForSynchronization();
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
 
           it("resolves if subscriptions are already in a complete state", async function (this: RealmContext) {
@@ -614,7 +614,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await subs.waitForSynchronization();
             await subs.waitForSynchronization();
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
 
           // Should only pass if `"development_mode_enabled": true`
@@ -623,30 +623,30 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               this.realm,
               this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
             );
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Pending);
 
             await subs.waitForSynchronization();
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("is rejected if there is an error synchronising subscriptions", async function (this: RealmContext) {
             const { subs } = addSubscription(
               this.realm,
               this.realm.objects(FlexiblePersonSchema.name).filtered("nonQueryable == 'test'"),
             );
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Pending);
 
             await expect(subs.waitForSynchronization()).to.be.rejectedWith(
               'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
             );
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("is rejected if subscriptions are already in an error state", async function (this: RealmContext) {
             const { subs } = addSubscription(
@@ -662,7 +662,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
             );
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
           });
 
           it("cannot be called on a MutableSubscriptionSet instance", async function (this: RealmContext) {
@@ -864,16 +864,16 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
           // Since the tests now await realm.open and realm.sync.waitForSynchronization, this will no longer be pending
           it.skip("is Pending by default", function (this: RealmContext) {
             const subs = this.realm.subscriptions;
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Pending);
           });
 
           it("is Complete once synchronisation is complete", async function (this: RealmContext) {
             const { subs } = await addSubscriptionForPersonAndSync(this.realm);
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("is Error if there is an error during synchronisation", async function (this: RealmContext) {
             await expect(
@@ -885,10 +885,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
             );
 
-            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("is Error if there are two errors in a row", async function (this: RealmContext) {
             await expect(
@@ -900,7 +900,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
             );
 
-            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
 
             await expect(
               addSubscriptionAndSync(
@@ -911,7 +911,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
             );
 
-            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
           });
 
           it("is Superseded if another update is synchronised after this one", async function (this: RealmContext) {
@@ -921,7 +921,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             await addSubscriptionForPersonAndSync(this.realm);
             await subs.waitForSynchronization();
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Superseded);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Superseded);
           });
 
           // TODO verify correct behaviour - right now this doesn't work
@@ -949,7 +949,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(this.realm.subscriptions.error).to.be.null;
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("contains the error message if there was an error synchronising subscriptions", async function (this: RealmContext) {
             await expect(
@@ -964,7 +964,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             );
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("is null if there was an error but it was subsequently corrected", async function (this: RealmContext) {
             await expect(
@@ -988,7 +988,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(this.realm.subscriptions.error).to.be.null;
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("still contains the erroring subscription in the set if there was an error synchronising", async function (this: RealmContext) {
             await expect(
@@ -1110,10 +1110,10 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
                 mutableSubs.add(this.realm.objects(FlexiblePersonSchema.name));
               });
 
-              expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+              expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
             });
 
-            // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+            // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
             //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
             it.skip("returns a promise which is rejected if there is an error synchronising", async function (this: RealmContext) {
               const subs = this.realm.subscriptions;
@@ -1126,7 +1126,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
                 'Client provided query with bad syntax: unsupported query for table "Person": key "nonQueryable" is not a queryable field',
               );
 
-              expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+              expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
             });
           });
 
@@ -1136,7 +1136,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               mutableSubs.add(this.realm.objects(FlexiblePersonSchema.name));
             });
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Pending);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Pending);
             await result;
           });
 
@@ -1190,7 +1190,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
             expect(subsCopy[2].objectType).to.equal(DogSchema.name);
           });
 
-          // TODO: Enable test when we can find another way of triggering a `SubscriptionsState.Error`.
+          // TODO: Enable test when we can find another way of triggering a `SubscriptionSetState.Error`.
           //       (This is due to non queryable fields now being queryable since BaaS automatically adds them when in Dev Mode)
           it.skip("still applies all updates in a batch if one errors", async function (this: RealmContext) {
             const { subs } = await addSubscriptionForPersonAndSync(this.realm);
@@ -1203,7 +1203,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
               }),
             ).to.be.rejected;
 
-            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionsState.Error);
+            expect(subs.state).to.equal(Realm.App.Sync.SubscriptionSetState.Error);
             expect(subs).to.have.length(4);
           });
 
@@ -1565,7 +1565,7 @@ describe.skipIf(environment.missingServer, "Flexible sync", function () {
 
             expect(this.realm.subscriptions).to.have.length(1);
             await this.realm.subscriptions.waitForSynchronization();
-            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionsState.Complete);
+            expect(this.realm.subscriptions.state).to.equal(Realm.App.Sync.SubscriptionSetState.Complete);
           });
         });
       });

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -23,7 +23,7 @@ import {
   ProgressNotificationCallback,
   PromiseHandle,
   Realm,
-  SubscriptionsState,
+  SubscriptionSetState,
   TimeoutError,
   TimeoutPromise,
   assert,
@@ -115,7 +115,7 @@ export class ProgressRealmPromise implements Promise<Realm> {
             });
             if (config.sync?.flexible && !config.openSyncedRealmLocally) {
               const { subscriptions } = realm;
-              if (subscriptions.state === SubscriptionsState.Pending) {
+              if (subscriptions.state === SubscriptionSetState.Pending) {
                 await subscriptions.waitForSynchronization();
               }
             }

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -139,7 +139,7 @@ import {
   Subscription,
   SubscriptionOptions,
   SubscriptionSet,
-  SubscriptionsState,
+  SubscriptionSetState,
   SyncConfiguration,
   SyncError,
   SyncSession,
@@ -1332,7 +1332,7 @@ type MutableSubscriptionSetType = MutableSubscriptionSet;
 type PartitionValueType = PartitionValue;
 type SubscriptionOptionsType = SubscriptionOptions;
 type SubscriptionSetType = SubscriptionSet;
-type SubscriptionsStateType = SubscriptionsState;
+type SubscriptionSetStateType = SubscriptionSetState;
 type SubscriptionType = Subscription;
 
 type ObjectIdType = BSON.ObjectId;
@@ -1575,7 +1575,9 @@ export declare namespace Realm {
       /** @deprecated Please use named imports */
       export type SubscriptionSet = SubscriptionSetType;
       /** @deprecated Please use named imports */
-      export type SubscriptionsState = SubscriptionsStateType;
+      export type SubscriptionSetState = SubscriptionSetStateType;
+      /** @deprecated Please use {@link SubscriptionSetState} as a named import */
+      export type SubscriptionsState = SubscriptionSetStateType;
       /** @deprecated Please use named imports */
       export type Subscription = SubscriptionType;
       /** @deprecated Please use named imports */
@@ -1922,7 +1924,9 @@ declare global {
         /** @deprecated Please use named imports */
         export type SubscriptionSet = SubscriptionSetType;
         /** @deprecated Please use named imports */
-        export type SubscriptionsState = SubscriptionsStateType;
+        export type SubscriptionSetState = SubscriptionSetStateType;
+        /** @deprecated Please use {@link SubscriptionSetState} as a named import */
+        export type SubscriptionsState = SubscriptionSetStateType;
         /** @deprecated Please use named imports */
         export type Subscription = SubscriptionType;
         /** @deprecated Please use named imports */

--- a/packages/realm/src/app-services/BaseSubscriptionSet.ts
+++ b/packages/realm/src/app-services/BaseSubscriptionSet.ts
@@ -30,7 +30,7 @@ import {
 /**
  * Enum representing the state of a {@link SubscriptionSet}.
  */
-export enum SubscriptionsState {
+export enum SubscriptionSetState {
   /**
    * The subscription update has been persisted locally, but the server hasn't
    * yet returned all the data that matched the updated subscription queries.
@@ -61,6 +61,16 @@ export enum SubscriptionsState {
    * and instead obtain a new instance from {@link Realm.subscriptions}.
    */
   Superseded = "superseded",
+}
+
+/**
+ * @deprecated Will be removed in v13.0.0. Please use {@link SubscriptionSetState}.
+ */
+export enum SubscriptionsState {
+  Pending = SubscriptionSetState.Pending,
+  Complete = SubscriptionSetState.Complete,
+  Error = SubscriptionSetState.Error,
+  Superseded = SubscriptionSetState.Superseded,
 }
 
 const DEFAULT_PROPERTY_DESCRIPTOR: PropertyDescriptor = { configurable: true, enumerable: true, writable: false };
@@ -127,31 +137,31 @@ export abstract class BaseSubscriptionSet {
   /**
    * The state of the SubscriptionSet.
    */
-  get state(): SubscriptionsState {
+  get state(): SubscriptionSetState {
     const state = this.internal.state;
     switch (state) {
       case binding.SyncSubscriptionSetState.Uncommitted:
       case binding.SyncSubscriptionSetState.Pending:
       case binding.SyncSubscriptionSetState.Bootstrapping:
       case binding.SyncSubscriptionSetState.AwaitingMark:
-        return SubscriptionsState.Pending;
+        return SubscriptionSetState.Pending;
       case binding.SyncSubscriptionSetState.Complete:
-        return SubscriptionsState.Complete;
+        return SubscriptionSetState.Complete;
       case binding.SyncSubscriptionSetState.Error:
-        return SubscriptionsState.Error;
+        return SubscriptionSetState.Error;
       case binding.SyncSubscriptionSetState.Superseded:
-        return SubscriptionsState.Superseded;
+        return SubscriptionSetState.Superseded;
       default:
-        throw new Error(`Unsupported SubscriptionsState value: ${state}`);
+        throw new Error(`Unsupported SubscriptionSetState value: ${state}`);
     }
   }
 
   /**
-   * If `state` is {@link SubscriptionsState.Error}, this will be a `string` representing
+   * If `state` is {@link SubscriptionSetState.Error}, this will be a `string` representing
    * why the SubscriptionSet is in an error state. It will be `null` if there is no error.
    */
   get error(): string | null {
-    return this.state === SubscriptionsState.Error ? this.internal.errorStr : null;
+    return this.state === SubscriptionSetState.Error ? this.internal.errorStr : null;
   }
 
   /**

--- a/packages/realm/src/app-services/SubscriptionSet.ts
+++ b/packages/realm/src/app-services/SubscriptionSet.ts
@@ -21,7 +21,7 @@ import {
   FlexibleSyncConfiguration,
   MutableSubscriptionSet,
   Realm,
-  SubscriptionsState,
+  SubscriptionSetState,
   assert,
   binding,
 } from "../internal";
@@ -53,9 +53,9 @@ export class SubscriptionSet extends BaseSubscriptionSet {
    * Wait for the server to acknowledge this set of subscriptions and return the
    * matching objects.
    *
-   * If `state` is {@link SubscriptionsState.Complete}, the promise will be resolved immediately.
+   * If `state` is {@link SubscriptionSetState.Complete}, the promise will be resolved immediately.
    *
-   * If `state` is {@link SubscriptionsState.Error}, the promise will be rejected immediately.
+   * If `state` is {@link SubscriptionSetState.Error}, the promise will be rejected immediately.
    *
    * @returns A promise which is resolved when synchronization is complete, or is
    *  rejected if there is an error during synchronization.

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -29,7 +29,7 @@ import {
   PartitionValue,
   Subscription,
   SubscriptionSet,
-  SubscriptionsState,
+  SubscriptionSetState,
   SyncSession,
   User,
   assert,
@@ -52,7 +52,9 @@ export class Sync {
   /** @deprecated Please use named imports */
   static MutableSubscriptionSet = MutableSubscriptionSet;
   /** @deprecated Please use named imports */
-  static SubscriptionsState = SubscriptionsState;
+  static SubscriptionSetState = SubscriptionSetState;
+  /** @deprecated Please use {@link SubscriptionSetState} as a named import */
+  static SubscriptionsState = SubscriptionSetState;
   /** @deprecated Please use named imports */
   static NumericLogLevel = NumericLogLevel;
 

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -146,6 +146,7 @@ export {
   Subscription,
   SubscriptionOptions,
   SubscriptionSet,
+  SubscriptionSetState,
   SubscriptionsState,
   Sync,
   SyncConfiguration,

--- a/packages/realm/type-tests/type-tests.ts
+++ b/packages/realm/type-tests/type-tests.ts
@@ -31,5 +31,5 @@ declare const options2: Realm.App.Sync.SubscriptionOptions;
 Realm.deleteFile({});
 
 // Mixing enums is supported
-declare const state1: Realm.App.Sync.SubscriptionsState;
-const state2: Realm2.App.Sync.SubscriptionsState = state1;
+declare const state1: Realm.App.Sync.SubscriptionSetState;
+const state2: Realm2.App.Sync.SubscriptionSetState = state1;


### PR DESCRIPTION
## What, How & Why?

Deprecates `SubscriptionsState` in v12 in favor of `SubscriptionSetState` to better align with `SubscriptionSet`.

This closes #5773.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 Public documentation PR created
