### PR TITLE
Update install tests to specify Ruby version

### DIFF
--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'ios' }}
         with:
+          ruby-version: '3.0'
           bundler-cache: true
           working-directory: install-tests/react-native/app
 


### PR DESCRIPTION
## What, How & Why?

Due to https://github.com/facebook/react-native/pull/36423 we need specify a Ruby version.
