### PR TITLE
Hold SyncSessions with a std::weak_ptr, except while calling a method

### DIFF
--- a/packages/realm/bindgen/js_spec.yml
+++ b/packages/realm/bindgen/js_spec.yml
@@ -17,3 +17,12 @@ classes:
       get_cpu_arch: () -> std::string
       # print: (const char* fmt, ...) # can't expose varargs directly. Could expose a fixed overload.
 
+  WeakSyncSession:
+    cppName: std::weak_ptr<SyncSession>
+    constructors:
+      weakCopyOf: '(shared: SharedSyncSession)'
+    methods:
+      rawDereference:
+        sig: '() const -> Nullable<SharedSyncSession>'
+        cppName: lock
+

--- a/packages/realm/bindgen/src/realm_js_jsi_helpers.h
+++ b/packages/realm/bindgen/src/realm_js_jsi_helpers.h
@@ -134,7 +134,7 @@ REALM_NOINLINE inline jsi::Value toJsiException(jsi::Runtime& env, const std::ex
 
 [[noreturn]] REALM_NOINLINE inline void throwNullSharedPtrError(jsi::Runtime& env, const char* clsName)
 {
-    throw jsi::JSError(env, util::format("Attempting to use an instanace of $1 holding a null shared_ptr. "
+    throw jsi::JSError(env, util::format("Attempting to use an instanace of %1 holding a null shared_ptr. "
                                          "Did you call $resetSharedPtr on it already?",
                                          clsName));
 }

--- a/packages/realm/bindgen/src/realm_js_node_helpers.h
+++ b/packages/realm/bindgen/src/realm_js_node_helpers.h
@@ -66,7 +66,7 @@ REALM_NOINLINE inline Napi::Object toNodeException(Napi::Env& env, const std::ex
 
 [[noreturn]] REALM_NOINLINE inline void throwNullSharedPtrError(Napi::Env& env, const char* clsName)
 {
-    throw Napi::Error::New(env, util::format("Attempting to use an instanace of $1 holding a null shared_ptr. "
+    throw Napi::Error::New(env, util::format("Attempting to use an instanace of %1 holding a null shared_ptr. "
                                              "Did you call $resetSharedPtr on it already?",
                                              clsName));
 }

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -310,7 +310,6 @@ export class Realm {
     binding.RealmCoordinator.clearAllCaches();
     binding.App.clearCachedApps();
     ProgressRealmPromise.cancelAll();
-    SyncSession.resetAllInternals();
 
     // Delete all Realm files in the default directory
     const defaultDirectoryPath = fs.getDefaultDirectoryPath();
@@ -811,7 +810,6 @@ export class Realm {
    */
   close(): void {
     this.internal.close();
-    this.syncSession?.resetInternal();
   }
 
   // TODO: Support embedded objects

--- a/packages/realm/src/app-services/SyncSession.ts
+++ b/packages/realm/src/app-services/SyncSession.ts
@@ -103,7 +103,6 @@ export function toBindingErrorHandler(onError: ErrorCallback) {
     const session = new SyncSession(sessionInternal);
     const error = fromBindingSyncError(bindingError);
     onError(session, error);
-    session.resetInternal();
   };
 }
 
@@ -208,7 +207,7 @@ export function toBindingClientResetMode(resetMode: ClientResetMode): binding.Cl
 }
 
 type ListenerToken = {
-  internal: binding.SyncSession;
+  weakInternal: binding.WeakSyncSession;
   token: binding.Int64;
 };
 
@@ -229,19 +228,19 @@ const mockApp = new Proxy({} as App, {
 const PROGRESS_LISTENERS = new Listeners<
   ProgressNotificationCallback,
   ListenerToken,
-  [binding.SyncSession, ProgressDirection, ProgressMode]
+  [binding.WeakSyncSession, binding.SyncSession, ProgressDirection, ProgressMode]
 >({
   throwOnReAdd: true,
-  add(callback, internal, direction, mode) {
+  add(callback, weakInternal, internal, direction, mode) {
     const token = internal.registerProgressNotifier(
       (transferred, transferable) => callback(Number(transferred), Number(transferable)),
       toBindingDirection(direction),
       mode === ProgressMode.ReportIndefinitely,
     );
-    return { internal, token };
+    return { weakInternal, token };
   },
-  remove({ internal, token }) {
-    return internal.unregisterProgressNotifier(token);
+  remove({ weakInternal, token }) {
+    weakInternal.withDeref((internal) => internal?.unregisterProgressNotifier(token));
   },
 });
 
@@ -249,86 +248,70 @@ const PROGRESS_LISTENERS = new Listeners<
  * Connection listeners are shared across instances of the SyncSession, making it possible to deregister a listener on another session
  * TODO: Consider adding a check to verify that the callback is removed from the correct SyncSession (although that would break the API)
  */
-const CONNECTION_LISTENERS = new Listeners<ConnectionNotificationCallback, ListenerToken, [binding.SyncSession]>({
+const CONNECTION_LISTENERS = new Listeners<
+  ConnectionNotificationCallback,
+  ListenerToken,
+  [binding.WeakSyncSession, binding.SyncSession]
+>({
   throwOnReAdd: true,
-  add(callback, internal) {
+  add(callback, weakInternal, internal) {
     const token = internal.registerConnectionChangeCallback((oldState, newState) =>
       callback(fromBindingConnectionState(newState), fromBindingConnectionState(oldState)),
     );
-    return { internal, token };
+    return { weakInternal, token };
   },
-  remove({ internal, token }) {
-    internal.unregisterConnectionChangeCallback(token);
+  remove({ weakInternal, token }) {
+    weakInternal.withDeref((internal) => internal?.unregisterConnectionChangeCallback(token));
   },
 });
 
 export class SyncSession {
-  private static instances = new Set<binding.WeakRef<SyncSession>>();
-
-  /**
-   * Resets the internal shared pointer of all instances returned since this message was last called.
-   * @internal
-   */
-  public static resetAllInternals() {
-    assert(flags.ALLOW_CLEAR_TEST_STATE, "Set the flags.ALLOW_CLEAR_TEST_STATE = true before calling this.");
-    for (const sessionRef of SyncSession.instances) {
-      sessionRef.deref()?.resetInternal();
-    }
-    SyncSession.instances.clear();
-  }
-
   /** @internal */
-  private _internal: binding.SyncSession | null;
+  private weakInternal: binding.WeakSyncSession;
   /** @internal */
-  public get internal() {
-    assert(this._internal, "This SyncSession is no longer valid");
-    return this._internal;
+  public withInternal<Ret = void>(cb: (syncSession: binding.SyncSession) => Ret) {
+    return this.weakInternal.withDeref((syncSession) => {
+      assert(syncSession, "This SyncSession is no longer valid");
+      return cb(syncSession);
+    });
   }
 
   /** @internal */
   constructor(internal: binding.SyncSession) {
-    this._internal = internal;
-    if (flags.ALLOW_CLEAR_TEST_STATE) {
-      SyncSession.instances.add(new binding.WeakRef(this));
-    }
-  }
-
-  /**@internal*/
-  resetInternal() {
-    if (!this._internal) return;
-    this._internal.$resetSharedPtr();
-    this._internal = null;
+    this.weakInternal = binding.WeakSyncSession.weaken(internal);
   }
 
   // TODO: Return the `error_handler`
   // TODO: Figure out a way to avoid passing a mocked app instance when constructing the User.
   get config(): SyncConfiguration {
-    const user = new User(this.internal.user, mockApp);
-    const { partitionValue, flxSyncRequested, customHttpHeaders, clientValidateSsl, sslTrustCertificatePath } =
-      this.internal.config;
-    if (flxSyncRequested) {
-      return {
-        user,
-        flexible: true,
-        customHttpHeaders,
-        ssl: { validate: clientValidateSsl, certificatePath: sslTrustCertificatePath },
-      };
-    } else {
-      return {
-        user,
-        partitionValue: EJSON.parse(partitionValue) as PartitionValue,
-        customHttpHeaders,
-        ssl: { validate: clientValidateSsl, certificatePath: sslTrustCertificatePath },
-      };
-    }
+    return this.withInternal((internal) => {
+      const user = new User(internal.user, mockApp);
+      const { partitionValue, flxSyncRequested, customHttpHeaders, clientValidateSsl, sslTrustCertificatePath } =
+        internal.config;
+      if (flxSyncRequested) {
+        return {
+          user,
+          flexible: true,
+          customHttpHeaders,
+          ssl: { validate: clientValidateSsl, certificatePath: sslTrustCertificatePath },
+        };
+      } else {
+        return {
+          user,
+          partitionValue: EJSON.parse(partitionValue) as PartitionValue,
+          customHttpHeaders,
+          ssl: { validate: clientValidateSsl, certificatePath: sslTrustCertificatePath },
+        };
+      }
+    });
   }
 
   get state(): SessionState {
-    return fromBindingSessionState(this.internal.state);
+    return fromBindingSessionState(this.withInternal((internal) => internal.state));
   }
 
   get url() {
-    const url = this.internal.fullRealmUrl;
+    const url = this.withInternal((internal) => internal.fullRealmUrl);
     if (url) {
       return url;
     } else {
@@ -337,32 +320,34 @@ export class SyncSession {
   }
 
   get user() {
-    return User.get(this.internal.user);
+    return User.get(this.withInternal((internal) => internal.user));
   }
 
   get connectionState() {
-    return fromBindingConnectionState(this.internal.connectionState);
+    return fromBindingConnectionState(this.withInternal((internal) => internal.connectionState));
   }
 
   // TODO: Make this a getter instead of a method
   isConnected() {
-    const { connectionState, state } = this.internal;
-    return (
-      connectionState === binding.SyncSessionConnectionState.Connected &&
-      (state === binding.SyncSessionState.Active || state === binding.SyncSessionState.Dying)
-    );
+    return this.withInternal((internal) => {
+      const { connectionState, state } = internal;
+      return (
+        connectionState === binding.SyncSessionConnectionState.Connected &&
+        (state === binding.SyncSessionState.Active || state === binding.SyncSessionState.Dying)
+      );
+    });
   }
 
   pause() {
-    this.internal.forceClose();
+    this.withInternal((internal) => internal.forceClose());
   }
 
   resume() {
-    this.internal.reviveIfNeeded();
+    this.withInternal((internal) => internal.reviveIfNeeded());
   }
 
   addProgressNotification(direction: ProgressDirection, mode: ProgressMode, callback: ProgressNotificationCallback) {
-    PROGRESS_LISTENERS.add(callback, this.internal, direction, mode);
+    this.withInternal((internal) => PROGRESS_LISTENERS.add(callback, this.weakInternal, internal, direction, mode));
   }
 
   removeProgressNotification(callback: ProgressNotificationCallback) {
@@ -370,30 +355,36 @@ export class SyncSession {
   }
 
   addConnectionNotification(callback: ConnectionNotificationCallback) {
-    CONNECTION_LISTENERS.add(callback, this.internal);
+    this.withInternal((internal) => CONNECTION_LISTENERS.add(callback, this.weakInternal, internal));
   }
   removeConnectionNotification(callback: ConnectionNotificationCallback) {
     CONNECTION_LISTENERS.remove(callback);
   }
 
   downloadAllServerChanges(timeoutMs?: number): Promise<void> {
-    return new TimeoutPromise(
-      this.internal.waitForDownloadCompletion(),
-      timeoutMs,
-      `Downloading changes did not complete in ${timeoutMs} ms.`,
+    return this.withInternal(
+      (internal) =>
+        new TimeoutPromise(
+          internal.waitForDownloadCompletion(),
+          timeoutMs,
+          `Downloading changes did not complete in ${timeoutMs} ms.`,
+        ),
     );
   }
 
   uploadAllLocalChanges(timeoutMs?: number): Promise<void> {
-    return new TimeoutPromise(
-      this.internal.waitForUploadCompletion(),
-      timeoutMs,
-      `Uploading changes did not complete in ${timeoutMs} ms.`,
+    return this.withInternal(
+      (internal) =>
+        new TimeoutPromise(
+          internal.waitForUploadCompletion(),
+          timeoutMs,
+          `Uploading changes did not complete in ${timeoutMs} ms.`,
+        ),
     );
   }
 
   /** @internal */
   _simulateError(code: number, message: string, type: string, isFatal: boolean) {
-    binding.Helpers.simulateSyncError(this.internal, code, message, type, isFatal);
+    this.withInternal((internal) => binding.Helpers.simulateSyncError(internal, code, message, type, isFatal));
   }
 }

--- a/packages/realm/src/binding.ts
+++ b/packages/realm/src/binding.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { IndexSet, Int64, ObjKey, Timestamp } from "realm/binding";
+import { IndexSet, Int64, ObjKey, SyncSession, Timestamp, WeakSyncSession } from "realm/binding";
 
 /** @internal */
 export * from "realm/binding";
@@ -32,6 +32,21 @@ declare module "realm/binding" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Timestamp {
     export function fromDate(d: Date): Timestamp;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace WeakSyncSession {
+    /** Returns a WeakSyncSession and releases the strong reference held by `shared` */
+    export function weaken(shared: SyncSession): WeakSyncSession;
+  }
+  interface WeakSyncSession {
+    /**
+     * Similar to WeakRef.deref(), but takes a callback so that the strong reference can be
+     * automatically released when the callback exists (either by returning or throwing).
+     * It is not legal to hold on to the SyncSession after this returns because its
+     * strong reference will have been deleted.
+     */
+    withDeref<Ret = void>(callback: (shared: SyncSession | null) => Ret): Ret;
   }
 }
 
@@ -50,6 +65,23 @@ Timestamp.fromDate = (d: Date) =>
 
 Timestamp.prototype.toDate = function () {
   return new Date(Number(this.seconds) * 1000 + this.nanoseconds / 1000_000);
+};
+
+WeakSyncSession.weaken = function (shared: SyncSession) {
+  try {
+    return WeakSyncSession.weakCopyOf(shared);
+  } finally {
+    shared.$resetSharedPtr();
+  }
+};
+
+WeakSyncSession.prototype.withDeref = function <Ret = void>(callback: (shared: SyncSession | null) => Ret) {
+  const shared = this.rawDereference();
+  try {
+    return callback(shared);
+  } finally {
+    shared?.$resetSharedPtr();
+  }
 };
 
 /** @internal */


### PR DESCRIPTION
This avoids keeping SyncSessions alive due to lazy GC. This also matches the implementation technique of v11, which also held a weak_ptr for the same reasons.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
