### PR TITLE
Adding `next` to install test matrix

### DIFF
--- a/.github/workflows/install-test-react-native.yml
+++ b/.github/workflows/install-test-react-native.yml
@@ -25,6 +25,7 @@ jobs:
         realm-version:
           # - v10 # Enable if we feel the need
           - latest
+          - next
         react-native-version:
           - latest
           - next


### PR DESCRIPTION
## What, How & Why?

This includes our `next` (v12) release in the matrix when testing installation into a React Native app.
A dispatch of this change: https://github.com/realm/realm-js/actions/runs/5003827500 which is all 🟢 