### PR TITLE
Use Object.defineProperty rather than Object.defineProperties because it is faster

### DIFF
--- a/packages/realm/src/Collection.ts
+++ b/packages/realm/src/Collection.ts
@@ -56,12 +56,10 @@ export abstract class Collection<
       },
     });
     // Make the internal properties non-enumerable
-    Object.defineProperties(this, {
-      listeners: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
+    Object.defineProperty(this, "listeners", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
     });
   }
 

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -142,25 +142,23 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
 
     const proxied = new Proxy(this, PROXY_HANDLER) as Dictionary<T>;
 
-    Object.defineProperties(this, {
-      [REALM]: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: realm,
-      },
-      [INTERNAL]: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: internal,
-      },
-      [HELPERS]: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: helpers,
-      },
+    Object.defineProperty(this, REALM, {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: realm,
+    });
+    Object.defineProperty(this, INTERNAL, {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: internal,
+    });
+    Object.defineProperty(this, HELPERS, {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: helpers,
     });
 
     return proxied;

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -168,18 +168,18 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * The representation in the binding.
    * @internal
    */
-  private [REALM]!: Realm;
+  private declare [REALM]: Realm;
 
   /**
    * The representation in the binding.
    * @internal
    */
-  private [INTERNAL]!: binding.Dictionary;
+  private declare [INTERNAL]: binding.Dictionary;
 
   /**
    * @internal
    */
-  private [HELPERS]!: TypeHelpers;
+  private declare [HELPERS]: TypeHelpers;
 
   /** @ts-expect-error We're exposing methods in the end-users namespace of keys */
   [key: string]: T;

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -57,19 +57,17 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     const isEmbedded =
       baseType === binding.PropertyType.Object && internal.objectSchema.tableType === binding.TableType.Embedded;
 
-    Object.defineProperties(this, {
-      internal: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: internal,
-      },
-      isEmbedded: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: isEmbedded,
-      },
+    Object.defineProperty(this, "internal", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: internal,
+    });
+    Object.defineProperty(this, "isEmbedded", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: isEmbedded,
     });
   }
 

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -40,10 +40,10 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
    * The representation in the binding.
    * @internal
    */
-  public internal!: binding.List;
+  public declare internal: binding.List;
 
   /** @internal */
-  private isEmbedded!: boolean;
+  private declare isEmbedded: boolean;
 
   /** @internal */
   constructor(realm: Realm, internal: binding.List, helpers: OrderedCollectionHelpers) {

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -104,9 +104,9 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   extends Collection<number, T, EntryType, T, CollectionChangeCallback<T, EntryType>>
   implements Omit<ReadonlyArray<T>, "entries">
 {
-  /** @internal */ protected realm!: Realm;
-  /** @internal */ protected results!: binding.Results;
-  /** @internal */ protected helpers!: OrderedCollectionHelpers;
+  /** @internal */ protected declare realm: Realm;
+  /** @internal */ protected declare results: binding.Results;
+  /** @internal */ protected declare helpers: OrderedCollectionHelpers;
   /** @internal */
   constructor(realm: Realm, results: binding.Results, helpers: OrderedCollectionHelpers) {
     if (arguments.length === 0) {
@@ -170,8 +170,8 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   }
 
   /** @internal */
-  protected classHelpers!: ClassHelpers | null;
-  private mixedToBinding!: (value: unknown) => binding.MixedArg;
+  protected declare classHelpers: ClassHelpers | null;
+  private declare mixedToBinding: (value: unknown) => binding.MixedArg;
 
   /**
    * Get an element of the ordered collection by index

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -104,17 +104,16 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   extends Collection<number, T, EntryType, T, CollectionChangeCallback<T, EntryType>>
   implements Omit<ReadonlyArray<T>, "entries">
 {
+  /** @internal */ protected realm!: Realm;
+  /** @internal */ protected results!: binding.Results;
+  /** @internal */ protected helpers!: OrderedCollectionHelpers;
   /** @internal */
-  constructor(
-    /** @internal */ protected realm: Realm,
-    /** @internal */ protected results: binding.Results,
-    /** @internal */ protected helpers: OrderedCollectionHelpers,
-  ) {
+  constructor(realm: Realm, results: binding.Results, helpers: OrderedCollectionHelpers) {
     if (arguments.length === 0) {
       throw new IllegalConstructorError("OrderedCollection");
     }
     super((callback) => {
-      return this.results.addNotificationCallback((changes) => {
+      return results.addNotificationCallback((changes) => {
         try {
           callback(proxied, {
             deletions: unwind(changes.deletions),
@@ -135,46 +134,44 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     const proxied = new Proxy(this, PROXY_HANDLER as ProxyHandler<this>);
     // Get the class helpers for later use, if available
     const { objectType } = results;
-    if (typeof objectType === "string" && objectType !== "") {
-      this.classHelpers = this.realm.getClassHelpers(objectType);
-    } else {
-      this.classHelpers = null;
-    }
-    this.mixedToBinding = mixedToBinding.bind(undefined, realm.internal);
+    const classHelpers = typeof objectType === "string" && objectType !== "" ? realm.getClassHelpers(objectType) : null;
     // Make the internal properties non-enumerable
-    Object.defineProperties(this, {
-      realm: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
-      results: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
-      helpers: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
-      classHelpers: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
-      mixedToBinding: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
+    Object.defineProperty(this, "realm", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: realm,
+    });
+    Object.defineProperty(this, "results", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: results,
+    });
+    Object.defineProperty(this, "helpers", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: helpers,
+    });
+    Object.defineProperty(this, "classHelpers", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: classHelpers,
+    });
+    Object.defineProperty(this, "mixedToBinding", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: mixedToBinding.bind(undefined, realm.internal),
     });
     return proxied;
   }
 
   /** @internal */
-  protected classHelpers: ClassHelpers | null;
-  private mixedToBinding: (value: unknown) => binding.MixedArg;
+  protected classHelpers!: ClassHelpers | null;
+  private mixedToBinding!: (value: unknown) => binding.MixedArg;
 
   /**
    * Get an element of the ordered collection by index

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -672,17 +672,15 @@ export class Realm {
       this.schemaExtras = schemaExtras || {};
     }
 
-    Object.defineProperties(this, {
-      classes: {
-        enumerable: false,
-        configurable: false,
-        writable: true,
-      },
-      internal: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
+    Object.defineProperty(this, "classes", {
+      enumerable: false,
+      configurable: false,
+      writable: true,
+    });
+    Object.defineProperty(this, "internal", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
     });
 
     this.classes = new ClassMap(this, this.internal.schema, this.schema);

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -53,19 +53,17 @@ export class Results<T = unknown> extends OrderedCollection<T> {
       throw new IllegalConstructorError("Results");
     }
     super(realm, internal, helpers);
-    Object.defineProperties(this, {
-      internal: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: internal,
-      },
-      realm: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: realm,
-      },
+    Object.defineProperty(this, "internal", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: internal,
+    });
+    Object.defineProperty(this, "realm", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: realm,
     });
   }
 

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -39,7 +39,7 @@ export class Results<T = unknown> extends OrderedCollection<T> {
    * The representation in the binding.
    * @internal
    */
-  public internal!: binding.Results;
+  public declare internal: binding.Results;
 
   /**
    * Create a `Results` wrapping a set of query `Results` from the binding.

--- a/packages/realm/src/Set.ts
+++ b/packages/realm/src/Set.ts
@@ -40,7 +40,7 @@ import {
  */
 export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
   /** @internal */
-  private internal!: binding.Set;
+  private declare internal: binding.Set;
 
   /** @internal */
   constructor(realm: Realm, internal: binding.Set, helpers: OrderedCollectionHelpers) {

--- a/packages/realm/src/app-services/BaseSubscriptionSet.ts
+++ b/packages/realm/src/app-services/BaseSubscriptionSet.ts
@@ -107,14 +107,12 @@ const PROXY_HANDLER: ProxyHandler<BaseSubscriptionSet> = {
 export abstract class BaseSubscriptionSet {
   /**@internal */
   protected constructor(/**@internal */ protected internal: binding.SyncSubscriptionSet) {
-    Object.defineProperties(this, {
-      internal: {
-        enumerable: false,
-        configurable: false,
-        // `internal` needs to be writable due to `SubscriptionSet.updateNoWait()`
-        // overwriting `this.internal` with the new committed set.
-        writable: true,
-      },
+    Object.defineProperty(this, "internal", {
+      enumerable: false,
+      configurable: false,
+      // `internal` needs to be writable due to `SubscriptionSet.updateNoWait()`
+      // overwriting `this.internal` with the new committed set.
+      writable: true,
     });
     return new Proxy<BaseSubscriptionSet>(this, PROXY_HANDLER);
   }

--- a/packages/realm/src/app-services/SubscriptionSet.ts
+++ b/packages/realm/src/app-services/SubscriptionSet.ts
@@ -40,12 +40,10 @@ export class SubscriptionSet extends BaseSubscriptionSet {
   constructor(/**@internal */ private realm: Realm, internal: binding.SyncSubscriptionSet) {
     super(internal);
 
-    Object.defineProperties(this, {
-      realm: {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      },
+    Object.defineProperty(this, "realm", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
     });
   }
 


### PR DESCRIPTION
Yes, this is kinda stupid, but the results are fairly significant. And, IMO at least, the code is as clear or clearer like this.

FYI, I'm looking into how to get our list perf back up to v11 levels (or better), and this was part of that work. Once I discovered the impact of this, I figured I might as well globally replace all of `Object.defineProperties` and bank that improvement, before doing additional List/OrderedCollection-specific optimization. I'll pick those back up tomorrow.

Edit: I decided to sneak a second related commit in once I remembered that the combination of `prop!: Type` and `Object.declareProperty()` was bad news. The first commit made it more obvious that we were doing that.

Before:
```
    reading property of type 'bool?[]'
      ✓ reads bool?[] (81,881 ops/sec, ±22%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (108,726 ops/sec, ±14.99%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (211,068 ops/sec, ±15.59%)
```

After first commit (using `Object.declareProperty`):
```
    reading property of type 'bool?[]'
      ✓ reads bool?[] (90,663 ops/sec, ±29.44%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (117,569 ops/sec, ±24.64%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (255,618 ops/sec, ±24.08%)
```

After second commit (using `declare property`):
```
    reading property of type 'bool?[]'
      ✓ reads bool?[] (142,468 ops/sec, ±42.28%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (185,514 ops/sec, ±28.95%)
    reading property of type 'bool?{}'
      ✓ reads bool?{} (316,215 ops/sec, ±27.6%)
```

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
