### PR TITLE
Enable cleartext traffic in android test app to make tests work in release builds

### DIFF
--- a/integration-tests/environments/react-native/android/app/src/main/AndroidManifest.xml
+++ b/integration-tests/environments/react-native/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
One less file to edit in order to test in release builds. Unfortunately you still need to edit `build.gradle` to point it to your `hermesc`, and `MainApplication.java` to comment out the flipper init. I don't think we want to commit those because A) the hermesc path will be different on different machines (I think?) and B) we still want flipper to work in debug builds. I assume there is _some_ way to fix both of those issues cleanly, but I'd rather not spend any more time on that right now and just bank the easy win here.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
