### PR TITLE
Backporting to v11 fixes to enable running benchmarks in release mode.

### DIFF
--- a/integration-tests/environments/react-native/android/app/src/main/AndroidManifest.xml
+++ b/integration-tests/environments/react-native/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/integration-tests/environments/react-native/android/app/src/release/java/com/realmreactnativetests/ReactNativeFlipper.java
+++ b/integration-tests/environments/react-native/android/app/src/release/java/com/realmreactnativetests/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package com.realmreactnativetests;
 import android.content.Context;
 import com.facebook.react.ReactInstanceManager;
 /**


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

I don't think this needs a changelog entry.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
