### PR TITLE
OrderedCollection no longer requires a Results

### DIFF
--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -359,7 +359,7 @@ export class RealmObject<T = DefaultObject> {
     assert(collectionHelpers, "collection helpers");
     const tableView = this[INTERNAL].getBacklinkView(tableRef, columnKey);
     const results = binding.Results.fromTableView(this[REALM].internal, tableView);
-    return new Results(this[REALM], results, collectionHelpers);
+    return new Results(this[REALM], results, collectionHelpers, linkedObjectSchema.name);
   }
 
   /**

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1022,16 +1022,18 @@ export class Realm {
 
     const table = binding.Helpers.getTable(this.internal, objectSchema.tableKey);
     const results = binding.Results.fromTable(this.internal, table);
-    return new Results<T>(this, results, {
-      get(results: binding.Results, index: number) {
-        return results.getObj(index);
+    return new Results<T>(
+      this,
+      results,
+      {
+        fromBinding: wrapObject,
+        toBinding(value: unknown) {
+          assert.instanceOf(value, RealmObject);
+          return value[INTERNAL];
+        },
       },
-      fromBinding: wrapObject,
-      toBinding(value: unknown) {
-        assert.instanceOf(value, RealmObject);
-        return value[INTERNAL];
-      },
-    });
+      objectSchema.name,
+    );
   }
 
   /**

--- a/packages/realm/src/Set.ts
+++ b/packages/realm/src/Set.ts
@@ -16,14 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import {
-  IllegalConstructorError,
-  OrderedCollection,
-  OrderedCollectionHelpers,
-  Realm,
-  assert,
-  binding,
-} from "./internal";
+import { IllegalConstructorError, OrderedCollection, Realm, TypeHelpers, assert, binding } from "./internal";
 
 /**
  * Instances of this class will be returned when accessing object properties whose type is `"Set"`
@@ -40,20 +33,14 @@ import {
  */
 export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
   /** @internal */
-  private declare internal: binding.Set;
+  protected declare internal: binding.Set;
 
   /** @internal */
-  constructor(realm: Realm, internal: binding.Set, helpers: OrderedCollectionHelpers) {
+  constructor(realm: Realm, internal: binding.Set, helpers: TypeHelpers, objectSchemaName: string | undefined | null) {
     if (arguments.length === 0 || !(internal instanceof binding.Set)) {
       throw new IllegalConstructorError("Set");
     }
-    super(realm, internal.asResults(), helpers);
-    Object.defineProperty(this, "internal", {
-      enumerable: false,
-      configurable: false,
-      writable: false,
-      value: internal,
-    });
+    super(realm, internal, helpers, objectSchemaName);
   }
   /**
    * Number of items in the set

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -308,16 +308,10 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
       fromBinding: defaultFromBinding,
     };
   },
-  [binding.PropertyType.Array]({ realm, getClassHelpers, name, objectSchemaName }) {
-    assert.string(objectSchemaName, "objectSchemaName");
-    const classHelpers = getClassHelpers(objectSchemaName);
+  [binding.PropertyType.Array]() {
     return {
-      fromBinding(value: unknown) {
-        assert.instanceOf(value, binding.List);
-        const propertyHelpers = classHelpers.properties.get(name);
-        const collectionHelpers = propertyHelpers.collectionHelpers;
-        assert.object(collectionHelpers);
-        return new List(realm, value, collectionHelpers);
+      fromBinding() {
+        throw new Error("Not supported");
       },
       toBinding() {
         throw new Error("Not supported");


### PR DESCRIPTION
Previously it always held a `Results` object, even for the `List` and `Set` subclasses. That was expensive to construct, and possibly changed the runtime complexity. Now it will directly work with whatever native object it's subclass represents. This required a small change to the core spec file to give Results and Collections a compatible API.

Before
```
Node:
    reading property of type 'bool?[]'
      ✓ reads bool?[] (129,694 ops/sec, ±48.46%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (178,647 ops/sec, ±31.71%)
Hermes:
    reading property of type 'bool?[]'
      ✓ reads bool?[] (43,417 ops/sec, ±11.36%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (48,925 ops/sec, ±12.1%)
```

After
```
Node:
    reading property of type 'bool?[]'
      ✓ reads bool?[] (211,569 ops/sec, ±34.5%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (237,292 ops/sec, ±20.4%)
Hermes:
    reading property of type 'bool?[]'
      ✓ reads bool?[] (56,075 ops/sec, ±13.68%)
    reading property of type 'bool?<>'
      ✓ reads bool?<> (59,356 ops/sec, ±11.46%)
```
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->



## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
