### PR TITLE
[v11] Remove 'v' from node.js version

### DIFF
--- a/integration-tests/tests/src/node/analytics.ts
+++ b/integration-tests/tests/src/node/analytics.ts
@@ -41,7 +41,7 @@ describe("Analytics", () => {
     expect(data.Binding).equals("Javascript");
     expect(data["Host OS Type"]).equals(os.platform());
     expect(data["Host OS Version"]).equals(os.release());
-    expect(data["Node.js version"]).equals(process.version);
+    expect(data["Node.js version"]).equals(process.version.slice(1));
     expect(data["Realm Version"]).equals(getRealmVersion());
     expect(data.token).equals("ce0fac19508f6c8f20066d345d360fd0");
     expect(data["Anonymized Builder Id"]).is.not.undefined;
@@ -55,7 +55,7 @@ describe("Analytics", () => {
     expectCommon(data);
     expect(data.Version).equals("1.2.3");
     expect(data.Framework).equals("node.js");
-    expect(data["Framework Version"]).equals(process.version);
+    expect(data["Framework Version"]).equals(process.version.slice(1));
     expect(data["Runtime Engine"]).equals("v8");
     expect(data["Anonymized Bundle Id"]).equals("TfvqclDWR/+6sIPfZc73MetEj0DLskCtWXjWXXXIg6k=");
     expect(data.Language).equals("javascript");
@@ -67,7 +67,7 @@ describe("Analytics", () => {
     expectCommon(data);
     expect(data.Version).equals("1.2.3");
     expect(data.Framework).equals("node.js");
-    expect(data["Framework Version"]).equals(process.version);
+    expect(data["Framework Version"]).equals(process.version.slice(1));
     expect(data["Runtime Engine"]).equals("v8");
     expect(data["Anonymized Bundle Id"]).equals("ajQjGK7Tztb3WeVhmPitQFDRV24loZVttnXWSlXUjEc=");
     expect(data.Language).equals("typescript");

--- a/scripts/submit-analytics.js
+++ b/scripts/submit-analytics.js
@@ -168,7 +168,7 @@ async function collectPlatformData(packagePath = getProjectRoot()) {
   const realmCoreVersion = getRealmCoreVersion();
 
   let framework = "node.js";
-  let frameworkVersion = process.version;
+  let frameworkVersion = process.version.slice(1); // remove 'v'
   let jsEngine = "v8";
   let bundleId = "unknown";
 
@@ -267,7 +267,7 @@ async function collectPlatformData(packagePath = getProjectRoot()) {
     "Host OS Type": os.platform(),
     "Host OS Version": os.release(),
     "Host CPU Arch": os.arch(),
-    "Node.js version": process.version,
+    "Node.js version": process.version.slice(1), // remove 'v'
     "Core Version": realmCoreVersion,
     "Sync Enabled": true,
     "Installation Method": installationMethod[0],


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
