### PR TITLE
Only export a CJS bundle (using rollup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## vNext (TBD)
 
 ### Breaking changes
+* Now exporting only as CommonJS, to align with the way we exported from v11 in an attempt to keep breakage across the major version to an absolute minimum. This is a breaking change compared to the previous pre-releases of v12, since users have to update code which is doing named import of `Realm` to use default or `* as Realm` imports of the `Realm` constructor. ([#5882](https://github.com/realm/realm-js/pull/5882))
 * `SyncSession` JS objects no longer keep their associated C++ objects, and therefore the sync network connection, alive. This was causing issues because JS garbage collection is lazy so the `SyncSession` may survive much longer than the last reference held to it. We now use the same technique as v11 to avoid keeping the C++ object alive (`std::weak_ptr`). ([#5815](https://github.com/realm/realm-js/pull/5815), since v12.0.0-alpha.0)
   * Breaking change: On v11, if the C++ object had been destroyed already, we would often return `undefined` or some other default value when calling methods or accessing properties on the JS `SyncSession` object, even if that would violate our declared TS types. Now, in v12, we will throw from all methods and property accessors in this case.
 

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Realm, AppConfiguration } from "realm";
+import Realm, { AppConfiguration } from "realm";
 
 import { importApp } from "../utils/import-app";
 import { AppConfig } from "@realm/app-importer";

--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { describePerformance } from "../utils/benchmark";
 

--- a/integration-tests/tests/src/schemas/contact.ts
+++ b/integration-tests/tests/src/schemas/contact.ts
@@ -18,7 +18,7 @@
 
 /* tslint:disable max-classes-per-file */
 
-import { Realm } from "realm";
+import Realm from "realm";
 
 export interface IContact {
   name: string;

--- a/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
+++ b/integration-tests/tests/src/schemas/person-and-dog-with-object-ids.ts
@@ -18,7 +18,7 @@
 
 /* tslint:disable max-classes-per-file */
 
-import { Realm } from "realm";
+import Realm from "realm";
 
 export interface IPerson {
   _id: Realm.BSON.ObjectId;

--- a/integration-tests/tests/src/schemas/person-and-dogs.ts
+++ b/integration-tests/tests/src/schemas/person-and-dogs.ts
@@ -18,7 +18,7 @@
 
 /* tslint:disable max-classes-per-file */
 
-import { Realm } from "realm";
+import Realm from "realm";
 
 export interface IPerson {
   name: string;

--- a/integration-tests/tests/src/setup-globals.ts
+++ b/integration-tests/tests/src/setup-globals.ts
@@ -63,7 +63,7 @@ describe("Test Harness", function (this: Mocha.Suite) {
   Context.prototype.longTimeout = longTimeout;
 });
 
-import { Realm } from "realm";
+import Realm from "realm";
 
 // Disable the logger to avoid console flooding
 const { defaultLogLevel = "off" } = environment;

--- a/integration-tests/tests/src/tests/class-models.ts
+++ b/integration-tests/tests/src/tests/class-models.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { openRealmBeforeEach } from "../hooks";
 

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 import { openRealmBeforeEach } from "../hooks";
 
 import { PersonSchema, DogSchema } from "../schemas/person-and-dogs";

--- a/integration-tests/tests/src/tests/enums.ts
+++ b/integration-tests/tests/src/tests/enums.ts
@@ -23,6 +23,7 @@ import {
   OpenRealmBehaviorType,
   OpenRealmTimeOutBehavior,
   SessionStopPolicy,
+  WaitForSync,
 } from "realm";
 
 describe("Enums", function () {
@@ -81,6 +82,15 @@ describe("Enums", function () {
         Error: 6,
         Fatal: 7,
         Off: 8,
+      });
+    });
+  });
+  describe("WaitForSync", function () {
+    it("is accessible", function () {
+      expect(WaitForSync).deep.equals({
+        Always: "always",
+        FirstTime: "first-time",
+        Never: "never",
       });
     });
   });

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Realm, BSON } from "realm";
+import Realm, { BSON } from "realm";
 import { expectArraysEqual, expectSimilar } from "../utils/comparisons";
 import { expect } from "chai";
 import { CanonicalObjectSchema } from "realm";

--- a/integration-tests/tests/src/tests/listeners.ts
+++ b/integration-tests/tests/src/tests/listeners.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 import { openRealmBeforeEach } from "../hooks";
 
 import { PersonSchema, DogSchema } from "../schemas/person-and-dogs";

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { IPerson, Person, PersonSchema } from "../schemas/person-and-dogs";
 import {

--- a/integration-tests/tests/src/tests/realm-constructor.ts
+++ b/integration-tests/tests/src/tests/realm-constructor.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { IPerson, PersonSchema, DogSchema } from "../schemas/person-and-dogs";
 

--- a/integration-tests/tests/src/tests/schema.ts
+++ b/integration-tests/tests/src/tests/schema.ts
@@ -18,7 +18,7 @@
 
 import { expect } from "chai";
 import { openRealmBefore } from "../hooks";
-import { Realm } from "realm";
+import Realm from "realm";
 
 interface Test {
   primary: number;

--- a/integration-tests/tests/src/tests/serialization.ts
+++ b/integration-tests/tests/src/tests/serialization.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 type DefaultObject = Record<string, unknown>;
 

--- a/integration-tests/tests/src/tests/set.ts
+++ b/integration-tests/tests/src/tests/set.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { openRealmBefore } from "../hooks";
 

--- a/integration-tests/tests/src/tests/shared-realms.ts
+++ b/integration-tests/tests/src/tests/shared-realms.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm, List } from "realm";
+import Realm, { List } from "realm";
 
 import { openRealmBefore, openRealmBeforeEach } from "../hooks";
 import { createLocalConfig } from "../utils/open-realm";

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -29,13 +29,12 @@
 // fraction too long.
 
 import { expect } from "chai";
-import {
+import Realm, {
   BSON,
   ClientResetMode,
   ConfigurationWithSync,
   ErrorCallback,
   FlexibleSyncConfiguration,
-  Realm,
   SessionStopPolicy,
   SubscriptionSetState,
   CompensatingWriteError,

--- a/integration-tests/tests/src/tests/sync/mixed.ts
+++ b/integration-tests/tests/src/tests/sync/mixed.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { importAppBefore, authenticateUserBefore, openRealmBefore } from "../../hooks";
 

--- a/integration-tests/tests/src/tests/sync/open.ts
+++ b/integration-tests/tests/src/tests/sync/open.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { authenticateUserBefore, importAppBefore } from "../../hooks";
 import { buildAppConfig } from "../../utils/build-app-config";

--- a/integration-tests/tests/src/tests/sync/realm-conversions.ts
+++ b/integration-tests/tests/src/tests/sync/realm-conversions.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Realm, BSON } from "realm";
+import Realm, { BSON } from "realm";
 import { expect } from "chai";
 import { importAppBefore } from "../../hooks";
 import { getRegisteredEmailPassCredentials } from "../../utils/credentials";

--- a/integration-tests/tests/src/tests/sync/sync-as-local.ts
+++ b/integration-tests/tests/src/tests/sync/sync-as-local.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 import { PersonSchema, IPerson } from "../../schemas/person-and-dog-with-object-ids";
 import { authenticateUserBefore, importAppBefore, openRealmBefore } from "../../hooks";

--- a/integration-tests/tests/src/tests/sync/sync-session.ts
+++ b/integration-tests/tests/src/tests/sync/sync-session.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm, ConnectionState, ObjectSchema, BSON, User, SyncConfiguration } from "realm";
+import Realm, { ConnectionState, ObjectSchema, BSON, User, SyncConfiguration } from "realm";
 import { importAppBefore } from "../../hooks";
 import { DogSchema } from "../../schemas/person-and-dog-with-object-ids";
 import { getRegisteredEmailPassCredentials } from "../../utils/credentials";

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -23,7 +23,7 @@ import {
   randomVerifiableEmail,
 } from "../../utils/generators";
 import { KJUR } from "jsrsasign";
-import { Realm, UserState } from "realm";
+import Realm, { UserState } from "realm";
 
 import { buildAppConfig } from "../../utils/build-app-config";
 

--- a/integration-tests/tests/src/tests/types.ts
+++ b/integration-tests/tests/src/tests/types.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Realm } from "realm";
+import Realm from "realm";
 
 describe("Realm.Types namespace", () => {
   // We specify explicit types on the instance so TS will error if the type def is wrong

--- a/integration-tests/tests/src/utils/open-realm.ts
+++ b/integration-tests/tests/src/utils/open-realm.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Realm, Configuration, SyncConfiguration, User, BSON } from "realm";
+import Realm, { Configuration, SyncConfiguration, User, BSON } from "realm";
 
 // Either the sync property is left out (local Realm)
 export type LocalConfiguration = Omit<Configuration, "sync"> & { sync?: never };

--- a/packages/realm-react/custom-resolver.cjs
+++ b/packages/realm-react/custom-resolver.cjs
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/* eslint-env node */
+
+module.exports = function (request, options) {
+  if (request === "react-native") {
+    // Ensure that "react-native" always resolve relative to the rootDir
+    options.basedir = options.rootDir;
+  } else if (request === "realm") {
+    // Ensure the node binding is used when testing with Jest on node
+    options.conditions = ["require", "default", "node"];
+  }
+  return options.defaultResolver(request, options);
+};

--- a/packages/realm-react/jest.config.json
+++ b/packages/realm-react/jest.config.json
@@ -1,6 +1,7 @@
 {
   "verbose": true,
   "preset": "react-native",
+  "resolver": "./custom-resolver.cjs",
   "roots": [
     "<rootDir>/src"
   ],

--- a/packages/realm/index.node.js
+++ b/packages/realm/index.node.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2022 Realm Inc.
+// Copyright 2023 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import "./fs";
-import "./device-info";
+/* eslint-disable @typescript-eslint/no-var-requires -- We're exporting using CJS assignment */
+/* eslint-env commonjs */
 
-export * from "../../index";
+module.exports = require("./dist/bundle.node").Realm;

--- a/packages/realm/index.react-native.js
+++ b/packages/realm/index.react-native.js
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2022 Realm Inc.
+// Copyright 2023 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import "./fs";
-import "./device-info";
+/* eslint-disable @typescript-eslint/no-var-requires -- We're exporting using CJS assignment */
+/* eslint-env commonjs */
 
-export * from "../../index";
+module.exports = require("./dist/bundle.node").Realm;

--- a/packages/realm/index.react-native.js
+++ b/packages/realm/index.react-native.js
@@ -19,4 +19,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires -- We're exporting using CJS assignment */
 /* eslint-env commonjs */
 
-module.exports = require("./dist/bundle.node").Realm;
+module.exports = require("./dist/bundle.react-native").Realm;

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -22,16 +22,14 @@
     "email": "help@realm.io",
     "url": "https://realm.io"
   },
-  "main": "./dist/bundle.node.js",
-  "module": "./dist/bundle.node.mjs",
-  "types": "./dist/bundle.d.ts",
-  "react-native": "./dist/bundle.react-native.mjs",
+  "types": "./types.d.cts",
+  "main": "./index.node.js",
+  "react-native": "./index.react-native.js",
   "exports": {
     ".": {
-      "types": "./dist/bundle.d.ts",
-      "require": "./dist/bundle.node.js",
-      "node": "./dist/bundle.node.mjs",
-      "react-native": "./dist/bundle.react-native.mjs"
+      "types": "./types.d.cts",
+      "node": "./index.node.js",
+      "react-native": "./index.react-native.js"
     },
     "./scripts/submit-analytics": "./scripts/submit-analytics.mjs",
     "./react-native.config.js": "./react-native.config.js",

--- a/packages/realm/rollup.config.mjs
+++ b/packages/realm/rollup.config.mjs
@@ -41,16 +41,9 @@ export default [
     input: "src/platform/node/index.ts",
     output: [
       {
-        file: mainExport.node,
-        format: "esm",
-        sourcemap: true,
-        exports: "named",
-      },
-      {
-        file: mainExport.require,
+        file: "./dist/bundle.node.js",
         format: "cjs",
         sourcemap: true,
-        exports: "named",
       },
     ],
     plugins: [
@@ -82,8 +75,8 @@ export default [
   {
     input: "src/platform/react-native/index.ts",
     output: {
-      file: mainExport["react-native"],
-      format: "es",
+      file: "./dist/bundle.react-native.js",
+      format: "cjs",
       sourcemap: true,
     },
     plugins: [
@@ -106,7 +99,7 @@ export default [
   {
     input: "src/index.ts",
     output: {
-      file: mainExport.types,
+      file: "dist/bundle.d.ts",
       format: "es",
     },
     plugins: [

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -50,6 +50,7 @@ import {
   Collection,
   CollectionChangeCallback,
   CollectionChangeSet,
+  CompensatingWriteError,
   Configuration,
   ConfigurationWithSync,
   ConfigurationWithoutSync,
@@ -220,12 +221,14 @@ export class Realm {
   public static ClientResetMode = ClientResetMode;
   /** @deprecated Please use named imports */
   public static Collection = Collection;
+  public static CompensatingWriteError = CompensatingWriteError;
   /** @deprecated Please use named imports */
   public static ConnectionState = ConnectionState;
   /** @deprecated Please use named imports */
   public static Credentials = Credentials;
   /** @deprecated Please use named imports */
   public static Dictionary = Dictionary;
+  public static flags = flags;
   /** @deprecated Please use named imports */
   public static List = List;
   // TODO: Decide if we want to deprecate this as well
@@ -1291,6 +1294,7 @@ type CollectionType<
   T = ValueType,
   ChangeCallbackType = unknown,
 > = Collection<KeyType, ValueType, EntryType, T, ChangeCallbackType>;
+type CompensatingWriteErrorType = CompensatingWriteError;
 type ConnectionStateType = ConnectionState;
 type CredentialsType = Credentials;
 type DictionaryType<T> = Dictionary<T>;
@@ -1433,6 +1437,7 @@ export declare namespace Realm {
     CollectionChangeSet,
     /** @deprecated Please use named imports */
     CollectionType as Collection,
+    CompensatingWriteErrorType,
     /** @deprecated Please use named imports */
     ConfigurationWithoutSync,
     /** @deprecated Please use named imports */

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -156,6 +156,7 @@ import {
   User,
   UserChangeCallback,
   UserState,
+  WaitForSync,
   assert,
   binding,
   defaultLogger,
@@ -232,6 +233,7 @@ export class Realm {
   public static flags = flags;
   /** @deprecated Please use named imports */
   public static List = List;
+  public static NumericLogLevel = NumericLogLevel;
   // TODO: Decide if we want to deprecate this as well
   public static Object = RealmObject;
   /** @deprecated Please use named imports */
@@ -264,6 +266,7 @@ export class Realm {
   public static User = User;
   /** @deprecated Please use named imports */
   public static UserState = UserState;
+  public static WaitForSync = WaitForSync;
   /** @deprecated Please use named imports */
   public static mapTo = mapTo;
   /** @deprecated Please use named imports */
@@ -1377,6 +1380,7 @@ type UpdateDescriptionType = UpdateDescription;
 type UpdateEventType<T extends Document> = UpdateEvent<T>;
 type UpdateOptionsType = UpdateOptions;
 type UpdateResultType<IdType> = UpdateResult<IdType>;
+type WaitForSyncType = WaitForSync;
 
 type GlobalDate = Date;
 
@@ -1477,6 +1481,7 @@ export declare namespace Realm {
     MigrationCallback,
     /** @deprecated Please use named imports */
     Mixed,
+    NumericLogLevelType as NumericLogLevel,
     /** @deprecated Please use named imports */
     ObjectChangeCallback,
     /** @deprecated Please use named imports */
@@ -1554,6 +1559,7 @@ export declare namespace Realm {
     UserChangeCallback,
     /** @deprecated Please use named imports */
     UserStateType as UserState,
+    WaitForSyncType as WaitForSync,
   };
 
   /** @deprecated Please use named imports */

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -117,6 +117,7 @@ import {
   PropertiesTypes,
   PropertySchema,
   PropertySchemaShorthand,
+  PropertyTypeName,
   ProviderType,
   PushClient,
   REALM,
@@ -1511,6 +1512,7 @@ export declare namespace Realm {
     PropertySchema,
     /** @deprecated Please use named imports */
     PropertySchemaShorthand,
+    PropertyTypeName,
     /** @deprecated Please use named imports */
     ProviderTypeType as ProviderType,
     /** @deprecated Please use named imports */

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -248,6 +248,7 @@ export class Realm {
   public static ProgressMode = ProgressMode;
   /** @deprecated Please use named imports */
   public static ProviderType = ProviderType;
+  public static SubscriptionSetState = SubscriptionSetState;
   /** @deprecated Please use named imports */
   public static Results = Results;
   /** @deprecated Please use named imports */
@@ -1545,6 +1546,7 @@ export declare namespace Realm {
     SSLVerifyCallbackType as SSLVerifyCallback,
     /** @deprecated Please use named imports */
     SSLVerifyObjectType as SSLVerifyObject,
+    SubscriptionSetStateType as SubscriptionSetState,
     /** @deprecated Please use named imports */
     SyncConfiguration,
     /** @deprecated Please use named imports */

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -19,6 +19,7 @@
 import { EJSON, ObjectId, UUID } from "bson";
 
 import {
+  AnyUser,
   BSON,
   ClientResetError,
   MutableSubscriptionSet,
@@ -171,7 +172,7 @@ export type SSLVerifyObject = {
 };
 
 export type BaseSyncConfiguration = {
-  user: User;
+  user: AnyUser;
   newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   onError?: ErrorCallback;

--- a/packages/realm/src/platform/node/tsconfig.json
+++ b/packages/realm/src/platform/node/tsconfig.json
@@ -11,8 +11,9 @@
     }
   },
   "exclude": [
-    "../../tests/",
     "../react-native/",
+    "../../tests/",
+    "../../index.cjs.ts",
     "../../../type-tests/"
   ],
 }

--- a/packages/realm/src/platform/react-native/index.ts
+++ b/packages/realm/src/platform/react-native/index.ts
@@ -19,5 +19,3 @@ import "./fs";
 import "./device-info";
 
 export * from "../../index";
-import { Realm } from "../../index";
-export default Realm;

--- a/packages/realm/src/platform/react-native/tsconfig.json
+++ b/packages/realm/src/platform/react-native/tsconfig.json
@@ -14,8 +14,9 @@
     }
   },
   "exclude": [
-    "../../tests/",
     "../node/",
+    "../../tests/",
+    "../../index.cjs.ts",
     "../../../type-tests/"
   ],
 }

--- a/packages/realm/types.d.cts
+++ b/packages/realm/types.d.cts
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2022 Realm Inc.
+// Copyright 2023 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,5 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import "./fs";
-import "./device-info";
-
-export * from "../../index";
+import { Realm } from "./dist/bundle";
+export = Realm;


### PR DESCRIPTION
## What, How & Why?

This supersedes https://github.com/realm/realm-js/pull/5853 and fixes https://github.com/realm/realm-js/issues/5857 by removing the ESM exports from the rollup config and adding CJS entrypoint files which export via `module.exports =` assignments as our v11 SDK does as well.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
