### PR TITLE
Clean up TypeDoc implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,7 @@
         "react-native": "0.71.7",
         "rollup": "^3.15.0",
         "tsx": "^3.12.3",
-        "typedoc": "^0.23.28",
-        "typedoc-plugin-extras": "^2.3.2",
+        "typedoc": "^0.24.8",
         "typescript": "^4.9.3",
         "wireit": "^0.9.5"
       },
@@ -24571,9 +24570,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
-      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -27560,13 +27559,13 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "bin": {
@@ -27576,15 +27575,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
-      }
-    },
-    "node_modules/typedoc-plugin-extras": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.2.tgz",
-      "integrity": "sha512-g2m8UuGgaD5lNKO6f1p3atEugtTEb/le8IYkAiksmGYZyyF44SvRe8NcaJLq61mC+XRHHszQ664v3Vw9avIrMw==",
-      "peerDependencies": {
-        "typedoc": "0.23.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -27596,14 +27587,14 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -53369,9 +53360,9 @@
       "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ=="
     },
     "shiki": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
-      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
       "requires": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -55670,13 +55661,13 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "dependencies": {
@@ -55689,20 +55680,14 @@
           }
         },
         "minimatch": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-          "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         }
       }
-    },
-    "typedoc-plugin-extras": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.2.tgz",
-      "integrity": "sha512-g2m8UuGgaD5lNKO6f1p3atEugtTEb/le8IYkAiksmGYZyyF44SvRe8NcaJLq61mC+XRHHszQ664v3Vw9avIrMw==",
-      "requires": {}
     },
     "typescript": {
       "version": "4.9.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52037,7 +52037,7 @@
         "debug": "^4.3.4",
         "mocha": "^10.1.0",
         "node-fetch": "^2.6.9",
-        "node-machine-id": "*",
+        "node-machine-id": "^1.1.12",
         "path-browserify": "^1.0.1",
         "prebuild": "^11.0.4",
         "prebuild-install": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -85,9 +85,8 @@
     "react-native": "0.71.7",
     "rollup": "^3.15.0",
     "tsx": "^3.12.3",
+    "typedoc": "^0.24.8",
     "typescript": "^4.9.3",
-    "typedoc": "^0.23.28",
-    "typedoc-plugin-extras": "^2.3.2",
     "wireit": "^0.9.5"
   },
   "peerDependencies": {

--- a/packages/realm-react/typedoc.json
+++ b/packages/realm-react/typedoc.json
@@ -7,7 +7,7 @@
   "media": "./media",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  "favicon": "../../media/favicon.ico",
+  // "favicon": "../../media/favicon.ico",
   "visibilityFilters": {},
   "categorizeByGroup": false,
   "navigationLinks": {

--- a/packages/realm-react/typedoc.json
+++ b/packages/realm-react/typedoc.json
@@ -1,11 +1,16 @@
 {
+  "name": "Realm React",
   "entryPoints": ["src/index.tsx"],
   "tsconfig": "./tsconfig.json",
   "excludeInternal": true,
   "customCss": "../../typedoc/style.css",
   "media": "./media",
-  "name": "Realm React",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  "favicon": "../../media/favicon.ico"
+  "favicon": "../../media/favicon.ico",
+  "visibilityFilters": {},
+  "categorizeByGroup": false,
+  "navigationLinks": {
+    "GitHub": "https://github.com/realm/realm-js/tree/main/packages/realm-react#readme"
+  }
 }

--- a/packages/realm-react/typedoc.json
+++ b/packages/realm-react/typedoc.json
@@ -7,7 +7,6 @@
   "media": "./media",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  // "favicon": "../../media/favicon.ico",
   "visibilityFilters": {},
   "categorizeByGroup": false,
   "navigationLinks": {

--- a/packages/realm-web/typedoc.json
+++ b/packages/realm-web/typedoc.json
@@ -7,5 +7,4 @@
   "name": "Realm Web",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  // "favicon": "../../media/favicon.ico"
 }

--- a/packages/realm-web/typedoc.json
+++ b/packages/realm-web/typedoc.json
@@ -7,5 +7,5 @@
   "name": "Realm Web",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  "favicon": "../../media/favicon.ico"
+  // "favicon": "../../media/favicon.ico"
 }

--- a/packages/realm/typedoc.json
+++ b/packages/realm/typedoc.json
@@ -7,5 +7,5 @@
   "name": "Realm JavaScript",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  "favicon": "../../media/favicon.ico"
+  // "favicon": "../../media/favicon.ico"
 }

--- a/packages/realm/typedoc.json
+++ b/packages/realm/typedoc.json
@@ -7,5 +7,4 @@
   "name": "Realm JavaScript",
   "includeVersion": true,
   "sourceLinkTemplate": "https://github.com/realm/realm-js/blob/{gitRevision}/{path}#L{line}",
-  // "favicon": "../../media/favicon.ico"
 }

--- a/typedoc/style.css
+++ b/typedoc/style.css
@@ -142,19 +142,6 @@
   }
 }
 
-html {
-  color-scheme: var(--color-scheme);
-}
-
-body {
-  font-family: var(--font-family-default);
-  margin: 0;
-}
-
-p {
-  line-height: 1.8rem;
-}
-
 :root[data-theme="light"] {
   --color-background: var(--light-color-background);
   --color-background-secondary: var(--light-color-background-secondary);
@@ -206,9 +193,20 @@ p {
   stroke: var(--light-color-text);
 }
 
-.always-visible,
-.always-visible .tsd-signatures {
-  display: inherit !important;
+html {
+  color-scheme: var(--color-scheme);
+}
+
+body {
+  font-family: var(--font-family-default);
+  margin: 0;
+  background: var(--color-background);
+  font-size: 16px;
+  color: var(--color-text);
+}
+
+p {
+  line-height: 1.8rem;
 }
 
 h1,
@@ -252,10 +250,6 @@ h6 {
   margin: 2.33rem 0;
 }
 
-.uppercase {
-  text-transform: uppercase;
-}
-
 pre {
   white-space: pre;
   white-space: pre-wrap;
@@ -273,87 +267,15 @@ dd {
   margin: 0 0 0 40px;
 }
 
-.container {
-  max-width: 1600px;
-  padding: 0 2rem;
-}
-
-.container-main {
-  flex-direction: row-reverse;
-}
-
-@media (min-width: 640px) {
-  .container {
-    padding: 0 4rem;
-  }
-}
-@media (min-width: 1200px) {
-  .container {
-    padding: 0 8rem;
-  }
-
-  .col-menu {
-    border-left: 0;
-    border-right: 1px solid var(--color-accent);
-    margin-right: 1rem;
-  }
-}
-@media (min-width: 1600px) {
-  .container {
-    padding: 0 12rem;
-  }
-}
-
-/* Footer */
-.tsd-generator {
-  border-top: 1px solid var(--color-accent);
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  max-height: 3.5rem;
-}
-
-.tsd-generator > p {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding: 0 1rem;
-}
-
-.container-main {
-  display: flex;
-  justify-content: space-between;
-  position: relative;
-  margin: 0 auto;
-}
-
-.col-4,
-.col-8 {
-  box-sizing: border-box;
-  float: left;
-  padding: 2rem 1rem;
-}
-
-.col-4 {
-  flex: 0 0 25%;
-}
-
-.col-8 {
-  flex: 1 0;
-  flex-wrap: wrap;
-}
-
-body {
-  background: var(--color-background);
-  font-size: 16px;
-  color: var(--color-text);
-}
-
 a {
   color: var(--color-link);
   text-decoration: none;
 }
+
 a:hover {
   text-decoration: underline;
 }
+
 a.external[target="_blank"] {
   background-image: var(--external-icon);
   background-position: top 3px right;
@@ -375,81 +297,17 @@ pre {
   padding: 10px;
   border: 0.1em solid var(--color-accent);
 }
+
 pre code {
   padding: 0;
   font-size: 100%;
 }
 
-blockquote {
-  margin: 1em 0;
-  padding-left: 1em;
-  border-left: 4px solid gray;
-}
-
-.tsd-typography {
-  line-height: 1.333em;
-}
-.tsd-typography ul {
-  list-style: square;
-  padding: 0 0 0 20px;
-  margin: 0;
-}
-.tsd-typography h4,
-.tsd-typography .tsd-index-panel h3,
-.tsd-index-panel .tsd-typography h3,
-.tsd-typography h5,
-.tsd-typography h6 {
-  font-size: 1em;
-  margin: 0;
-}
-.tsd-typography h5,
-.tsd-typography h6 {
-  font-weight: normal;
-}
-.tsd-typography p,
-.tsd-typography ul,
-.tsd-typography ol {
-  margin: 1em 0;
+.tsd-page-navigation ul {
+  padding-left: 1rem;
 }
 
 @media (max-width: 1024px) {
-  html .col-content {
-    float: none;
-    max-width: 100%;
-    width: 100%;
-    padding-top: 3rem;
-  }
-  html .col-menu {
-    position: fixed !important;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    z-index: 1024;
-    top: 0 !important;
-    bottom: 0 !important;
-    left: auto !important;
-    right: 0 !important;
-    padding: 1.5rem 1.5rem 0 0;
-    max-width: 25rem;
-    visibility: hidden;
-    background-color: var(--color-background);
-    transform: translate(100%, 0);
-  }
-  html .col-menu > *:last-child {
-    padding-bottom: 20px;
-  }
-  html .overlay {
-    content: "";
-    display: block;
-    position: fixed;
-    z-index: 1023;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.75);
-    visibility: hidden;
-  }
-
   .to-has-menu .overlay {
     animation: fade-in 0.4s;
   }
@@ -497,795 +355,6 @@ blockquote {
   }
 }
 
-.tsd-breadcrumb {
-  margin: 0;
-  padding: 0;
-  color: var(--color-text-aside);
-}
-.tsd-breadcrumb a {
-  color: var(--color-text-aside);
-  text-decoration: none;
-}
-.tsd-breadcrumb a:hover {
-  text-decoration: underline;
-}
-.tsd-breadcrumb li {
-  display: inline;
-}
-.tsd-breadcrumb li:after {
-  content: " / ";
-}
-
-.tsd-comment-tags {
-  display: flex;
-  flex-direction: column;
-}
-dl.tsd-comment-tag-group {
-  display: flex;
-  align-items: center;
-  overflow: hidden;
-  margin: 0.5em 0;
-}
-dl.tsd-comment-tag-group dt {
-  display: flex;
-  margin-right: 0.5em;
-  font-size: 0.875em;
-  font-weight: normal;
-}
-dl.tsd-comment-tag-group dd {
-  margin: 0;
-}
-code.tsd-tag {
-  padding: 0.25em 0.4em;
-  border: 0.1em solid var(--color-accent);
-  margin-right: 0.25em;
-  font-size: 70%;
-}
-h1 code.tsd-tag:first-of-type {
-  margin-left: 0.25em;
-}
-
-dl.tsd-comment-tag-group dd:before,
-dl.tsd-comment-tag-group dd:after {
-  content: " ";
-}
-dl.tsd-comment-tag-group dd pre,
-dl.tsd-comment-tag-group dd:after {
-  clear: both;
-}
-dl.tsd-comment-tag-group p {
-  margin: 0;
-}
-
-.tsd-panel.tsd-comment .lead {
-  font-size: 1.1em;
-  line-height: 1.333em;
-  margin-bottom: 2em;
-}
-.tsd-panel.tsd-comment .lead:last-child {
-  margin-bottom: 0;
-}
-
-.tsd-filter-visibility h4 {
-  font-size: 1rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-.tsd-filter-item:not(:last-child) {
-  margin-bottom: 0.5rem;
-}
-.tsd-filter-input {
-  display: flex;
-  width: fit-content;
-  width: -moz-fit-content;
-  align-items: center;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  cursor: pointer;
-}
-.tsd-filter-input input[type="checkbox"] {
-  cursor: pointer;
-  position: absolute;
-  width: 1.5em;
-  height: 1.5em;
-  opacity: 0;
-}
-.tsd-filter-input input[type="checkbox"]:disabled {
-  pointer-events: none;
-}
-.tsd-filter-input svg {
-  cursor: pointer;
-  width: 1.5em;
-  height: 1.5em;
-  margin-right: 0.5em;
-  border-radius: 0.33em;
-  /* Leaving this at full opacity breaks event listeners on Firefox.
-  Don't remove unless you know what you're doing. */
-  opacity: 0.99;
-}
-.tsd-filter-input input[type="checkbox"]:focus + svg {
-  transform: scale(0.95);
-}
-.tsd-filter-input input[type="checkbox"]:focus:not(:focus-visible) + svg {
-  transform: scale(1);
-}
-.tsd-checkbox-background {
-  fill: var(--color-accent);
-}
-input[type="checkbox"]:checked ~ svg .tsd-checkbox-checkmark {
-  stroke: var(--color-text);
-}
-.tsd-filter-input input:disabled ~ svg > .tsd-checkbox-background {
-  fill: var(--color-background);
-  stroke: var(--color-accent);
-  stroke-width: 0.25rem;
-}
-.tsd-filter-input input:disabled ~ svg > .tsd-checkbox-checkmark {
-  stroke: var(--color-accent);
-}
-
-.tsd-theme-toggle {
-  padding-top: 0.75rem;
-}
-.tsd-theme-toggle > h4 {
-  display: inline;
-  vertical-align: middle;
-  margin-right: 0.75rem;
-}
-
-.tsd-hierarchy {
-  list-style: square;
-  margin: 0;
-}
-.tsd-hierarchy .target {
-  font-weight: bold;
-}
-
-.tsd-panel-group.tsd-index-group {
-  margin-bottom: 0;
-}
-.tsd-index-panel .tsd-index-list {
-  list-style: none;
-  line-height: 1.333em;
-  margin: 0;
-  padding: 0.25rem 0 0 0;
-  overflow: hidden;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  column-gap: 1rem;
-  grid-template-rows: auto;
-}
-@media (max-width: 1024px) {
-  .tsd-index-panel .tsd-index-list {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-@media (max-width: 768px) {
-  .tsd-index-panel .tsd-index-list {
-    grid-template-columns: repeat(1, 1fr);
-  }
-}
-.tsd-index-panel .tsd-index-list li {
-  -webkit-page-break-inside: avoid;
-  -moz-page-break-inside: avoid;
-  -ms-page-break-inside: avoid;
-  -o-page-break-inside: avoid;
-  page-break-inside: avoid;
-}
-.tsd-index-panel a,
-.tsd-index-panel a.tsd-parent-kind-module {
-  color: var(--color-ts);
-}
-.tsd-index-panel a.tsd-parent-kind-interface {
-  color: var(--color-ts-interface);
-}
-.tsd-index-panel a.tsd-parent-kind-enum {
-  color: var(--color-ts-enum);
-}
-.tsd-index-panel a.tsd-parent-kind-class {
-  color: var(--color-ts-class);
-}
-.tsd-index-panel a.tsd-kind-module {
-  color: var(--color-ts-namespace);
-}
-.tsd-index-panel a.tsd-kind-interface {
-  color: var(--color-ts-interface);
-}
-.tsd-index-panel a.tsd-kind-enum {
-  color: var(--color-ts-enum);
-}
-.tsd-index-panel a.tsd-kind-class {
-  color: var(--color-ts-class);
-}
-.tsd-index-panel a.tsd-kind-function {
-  color: var(--color-ts-function);
-}
-.tsd-index-panel a.tsd-kind-namespace {
-  color: var(--color-ts-namespace);
-}
-.tsd-index-panel a.tsd-kind-variable {
-  color: var(--color-ts-variable);
-}
-.tsd-index-panel a.tsd-is-private {
-  color: var(--color-ts-private);
-}
-
-.tsd-flag {
-  display: inline-block;
-  padding: 0.25em 0.4em;
-  border-radius: 4px;
-  color: var(--color-comment-tag-text);
-  background-color: var(--color-comment-tag);
-  text-indent: 0;
-  font-size: 75%;
-  line-height: 1;
-  font-weight: normal;
-}
-
-.tsd-anchor {
-  position: absolute;
-  top: -100px;
-}
-
-.tsd-member {
-  position: relative;
-}
-.tsd-member .tsd-anchor + h3 {
-  display: flex;
-  align-items: center;
-  margin-top: 0;
-  margin-bottom: 0;
-  border-bottom: none;
-}
-.tsd-member [data-tsd-kind] {
-  color: var(--color-ts);
-}
-.tsd-member [data-tsd-kind="Interface"] {
-  color: var(--color-ts-interface);
-}
-.tsd-member [data-tsd-kind="Enum"] {
-  color: var(--color-ts-enum);
-}
-.tsd-member [data-tsd-kind="Class"] {
-  color: var(--color-ts-class);
-}
-.tsd-member [data-tsd-kind="Private"] {
-  color: var(--color-ts-private);
-}
-
-.tsd-navigation a {
-  display: block;
-  margin: 0.4rem 0;
-  border-left: 2px solid transparent;
-  color: var(--color-text);
-  text-decoration: none;
-  transition: border-left-color 0.1s;
-}
-.tsd-navigation a:hover {
-  text-decoration: underline;
-}
-.tsd-navigation ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.tsd-navigation li {
-  padding: 0;
-}
-
-.tsd-navigation.primary .tsd-accordion-details > ul {
-  margin-top: 0.75rem;
-}
-.tsd-navigation.primary a {
-  padding: 0.75rem 0.5rem;
-  margin: 0;
-}
-.tsd-navigation.primary ul li a {
-  margin-left: 0.5rem;
-}
-.tsd-navigation.primary ul li li a {
-  margin-left: 1.5rem;
-}
-.tsd-navigation.primary ul li li li a {
-  margin-left: 2.5rem;
-}
-.tsd-navigation.primary ul li li li li a {
-  margin-left: 3.5rem;
-}
-.tsd-navigation.primary ul li li li li li a {
-  margin-left: 4.5rem;
-}
-.tsd-navigation.primary ul li li li li li li a {
-  margin-left: 5.5rem;
-}
-.tsd-navigation.primary li.current > a {
-  border-left: 0.15rem var(--color-text) solid;
-}
-.tsd-navigation.primary li.selected > a {
-  font-weight: bold;
-  border-left: 0.2rem var(--color-text) solid;
-}
-.tsd-navigation.primary ul li a:hover {
-  border-left: 0.2rem var(--color-text-aside) solid;
-}
-.tsd-navigation.primary li.globals + li > span,
-.tsd-navigation.primary li.globals + li > a {
-  padding-top: 20px;
-}
-
-.tsd-navigation.secondary.tsd-navigation--toolbar-hide {
-  max-height: calc(100vh - 1rem);
-  top: 0.5rem;
-}
-.tsd-navigation.secondary > ul {
-  display: inline;
-  padding-right: 0.5rem;
-  transition: opacity 0.2s;
-}
-.tsd-navigation.secondary ul li a {
-  padding-left: 0;
-}
-.tsd-navigation.secondary ul li li a {
-  padding-left: 1.1rem;
-}
-.tsd-navigation.secondary ul li li li a {
-  padding-left: 2.2rem;
-}
-.tsd-navigation.secondary ul li li li li a {
-  padding-left: 3.3rem;
-}
-.tsd-navigation.secondary ul li li li li li a {
-  padding-left: 4.4rem;
-}
-.tsd-navigation.secondary ul li li li li li li a {
-  padding-left: 5.5rem;
-}
-
-#tsd-sidebar-links a {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  line-height: 1.25rem;
-}
-#tsd-sidebar-links a:last-of-type {
-  margin-bottom: 0;
-}
-
-a.tsd-index-link {
-  margin: 0.25rem 0;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  display: inline-flex;
-  align-items: center;
-}
-.tsd-accordion-summary > h1,
-.tsd-accordion-summary > h2,
-.tsd-accordion-summary > h3,
-.tsd-accordion-summary > h4,
-.tsd-accordion-summary > h5 {
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-  margin-bottom: 0;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-}
-.tsd-accordion-summary {
-  display: block;
-  cursor: pointer;
-}
-.tsd-accordion-summary > * {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-.tsd-accordion-summary::-webkit-details-marker {
-  display: none;
-}
-.tsd-index-accordion .tsd-accordion-summary svg {
-  margin-right: 0.25rem;
-}
-.tsd-index-content > :not(:first-child) {
-  margin-top: 0.75rem;
-}
-.tsd-index-heading {
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.tsd-kind-icon {
-  margin-right: 0.5rem;
-  width: 1.25rem;
-  height: 1.25rem;
-  min-width: 1.25rem;
-  min-height: 1.25rem;
-}
-.tsd-kind-icon path {
-  transform-origin: center;
-  transform: scale(1.1);
-}
-.tsd-signature > .tsd-kind-icon {
-  margin-right: 0.8rem;
-}
-
-@media (min-width: 1025px) {
-  .col-content {
-    margin: 2rem auto;
-  }
-
-  .menu-sticky-wrap {
-    position: sticky;
-    height: calc(100vh - 2rem);
-    top: 4rem;
-    right: 0;
-    padding: 0 1.5rem;
-    padding-top: 1rem;
-    margin-top: 3rem;
-    transition: 0.3s ease-in-out;
-    transition-property: top, padding-top, padding, height;
-    overflow-y: auto;
-  }
-  .col-menu {
-    border-left: 1px solid var(--color-accent);
-  }
-  .col-menu--hide {
-    top: 1rem;
-  }
-  .col-menu .tsd-navigation:not(:last-child) {
-    padding-bottom: 1.75rem;
-  }
-}
-
-.tsd-panel {
-  margin-bottom: 2.5rem;
-}
-.tsd-panel.tsd-member {
-  margin-bottom: 4rem;
-}
-.tsd-panel:empty {
-  display: none;
-}
-.tsd-panel > h1,
-.tsd-panel > h2,
-.tsd-panel > h3 {
-  margin: 1.5rem -1.5rem 0.75rem -1.5rem;
-  padding: 0 1.5rem 0.75rem 1.5rem;
-}
-.tsd-panel > h1.tsd-before-signature,
-.tsd-panel > h2.tsd-before-signature,
-.tsd-panel > h3.tsd-before-signature {
-  margin-bottom: 0;
-  border-bottom: none;
-}
-
-.tsd-panel-group {
-  margin: 4rem 0;
-}
-.tsd-panel-group.tsd-index-group {
-  margin: 2rem 0;
-}
-.tsd-panel-group.tsd-index-group details {
-  margin: 2rem 0;
-}
-
-#tsd-search {
-  transition: background-color 0.2s;
-}
-#tsd-search .title {
-  position: relative;
-  z-index: 2;
-}
-#tsd-search .field {
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 2.5rem;
-  height: 100%;
-}
-#tsd-search .field input {
-  box-sizing: border-box;
-  position: relative;
-  top: -50px;
-  z-index: 1;
-  width: 100%;
-  padding: 0 10px;
-  opacity: 0;
-  outline: 0;
-  border: 0;
-  background: transparent;
-  color: var(--color-text);
-}
-#tsd-search .field label {
-  position: absolute;
-  overflow: hidden;
-  right: -40px;
-}
-#tsd-search .field input,
-#tsd-search .title,
-#tsd-toolbar-links a {
-  transition: opacity 0.2s;
-}
-#tsd-search .results {
-  position: absolute;
-  visibility: hidden;
-  top: 40px;
-  width: 100%;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
-}
-#tsd-search .results li {
-  padding: 0 10px;
-  background-color: var(--color-background);
-}
-#tsd-search .results li:nth-child(even) {
-  background-color: var(--color-background-secondary);
-}
-#tsd-search .results li.state {
-  display: none;
-}
-#tsd-search .results li.current,
-#tsd-search .results li:hover {
-  background-color: var(--color-accent);
-}
-#tsd-search .results a {
-  display: block;
-}
-#tsd-search .results a:before {
-  top: 10px;
-}
-#tsd-search .results span.parent {
-  color: var(--color-text-aside);
-  font-weight: normal;
-}
-#tsd-search.has-focus {
-  background-color: var(--color-accent);
-}
-#tsd-search.has-focus .field input {
-  top: 0;
-  opacity: 1;
-}
-#tsd-search.has-focus .title,
-#tsd-search.has-focus #tsd-toolbar-links a {
-  z-index: 0;
-  opacity: 0;
-}
-#tsd-search.has-focus .results {
-  visibility: visible;
-}
-#tsd-search.loading .results li.state.loading {
-  display: block;
-}
-#tsd-search.failure .results li.state.failure {
-  display: block;
-}
-
-#tsd-toolbar-links {
-  position: absolute;
-  top: 0;
-  right: 2rem;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-}
-#tsd-toolbar-links a {
-  margin-left: 1.5rem;
-}
-#tsd-toolbar-links a:hover {
-  text-decoration: underline;
-}
-
-.tsd-signature {
-  margin: 0 0 1rem 0;
-  padding: 1rem 0.5rem;
-  border: 1px solid var(--color-accent);
-  background-color: var(--code-background);
-  font-family: var(--font-family-code);
-  border-radius: 0.8em;
-  line-height: 1.5rem;
-  font-size: 0.9rem;
-  overflow-x: auto;
-}
-
-.tsd-signature-symbol {
-  color: var(--color-text-aside);
-  font-weight: normal;
-}
-
-.tsd-signature-type {
-  font-style: italic;
-  font-weight: normal;
-}
-
-.tsd-signatures {
-  padding: 0;
-  margin: 0 0 1em 0;
-  list-style-type: none;
-}
-.tsd-signatures .tsd-signature {
-  margin: 0;
-  border-color: var(--color-accent);
-  border-width: 1px 0;
-  transition: background-color 0.1s;
-}
-.tsd-description .tsd-signatures .tsd-signature {
-  border-width: 1px;
-}
-
-ul.tsd-parameter-list,
-ul.tsd-type-parameter-list {
-  list-style: square;
-  margin: 0;
-  padding-left: 20px;
-}
-ul.tsd-parameter-list > li.tsd-parameter-signature,
-ul.tsd-type-parameter-list > li.tsd-parameter-signature {
-  list-style: none;
-  margin-left: -20px;
-}
-ul.tsd-parameter-list h5,
-ul.tsd-type-parameter-list h5 {
-  font-size: 16px;
-  margin: 1em 0 0.5em 0;
-}
-.tsd-sources {
-  font-family: var(--font-family-default);
-  color: var(--color-text-aside);
-  margin-top: 1rem;
-  font-size: 0.875em;
-}
-.tsd-sources a {
-  color: var(--color-text-aside);
-  text-decoration: underline;
-}
-.tsd-sources ul {
-  list-style: none;
-  padding: 0;
-}
-
-.tsd-page-toolbar {
-  position: fixed;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  width: 100%;
-  color: var(--color-text);
-  background: var(--color-background-secondary);
-  border-bottom: 1px var(--color-accent) solid;
-  transition: transform 0.3s ease-in-out;
-}
-.tsd-page-toolbar a {
-  color: var(--color-text);
-  text-decoration: none;
-}
-.tsd-page-toolbar a.title {
-  font-weight: bold;
-}
-.tsd-page-toolbar a.title:hover {
-  text-decoration: underline;
-}
-.tsd-page-toolbar .tsd-toolbar-contents {
-  display: flex;
-  justify-content: space-between;
-  height: 2.5rem;
-  margin: 0 auto;
-}
-.tsd-page-toolbar .table-cell {
-  position: relative;
-  white-space: nowrap;
-  line-height: 40px;
-}
-.tsd-page-toolbar .table-cell:first-child {
-  width: 100%;
-}
-.tsd-page-toolbar .tsd-toolbar-icon {
-  box-sizing: border-box;
-  line-height: 0;
-  padding: 12px 0;
-}
-
-.tsd-page-toolbar--hide {
-  transform: translateY(-100%);
-}
-
-.tsd-widget {
-  display: inline-block;
-  overflow: hidden;
-  opacity: 0.8;
-  height: 40px;
-  transition: opacity 0.1s, background-color 0.2s;
-  vertical-align: bottom;
-  cursor: pointer;
-}
-.tsd-widget:hover {
-  opacity: 0.9;
-}
-.tsd-widget.active {
-  opacity: 1;
-  background-color: var(--color-accent);
-}
-.tsd-widget.no-caption {
-  width: 40px;
-}
-.tsd-widget.no-caption:before {
-  margin: 0;
-}
-
-.tsd-widget.options,
-.tsd-widget.menu {
-  display: none;
-}
-@media (max-width: 1024px) {
-  .tsd-widget.options,
-  .tsd-widget.menu {
-    display: inline-block;
-  }
-}
-input[type="checkbox"] + .tsd-widget:before {
-  background-position: -120px 0;
-}
-input[type="checkbox"]:checked + .tsd-widget:before {
-  background-position: -160px 0;
-}
-
-img {
-  max-width: 100%;
-}
-
-.tsd-anchor-icon {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 0.5rem;
-  vertical-align: middle;
-  color: var(--color-text);
-}
-
-.tsd-anchor-icon svg {
-  width: 1em;
-  height: 1em;
-  visibility: hidden;
-}
-
-.tsd-anchor-link:hover > .tsd-anchor-icon svg {
-  visibility: visible;
-}
-
-.deprecated {
-  text-decoration: line-through;
-}
-
-.warning {
-  padding: 1rem;
-  color: var(--color-warning-text);
-  background: var(--color-background-warning);
-}
-
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-accent) var(--color-icon-background);
-}
-
-*::-webkit-scrollbar {
-  width: 0.75rem;
-}
-
-*::-webkit-scrollbar-track {
-  background: var(--color-icon-background);
-}
-
-*::-webkit-scrollbar-thumb {
-  background-color: var(--color-accent);
-  border-radius: 999rem;
-  border: 0.25rem solid var(--color-icon-background);
-}
-
 @keyframes fade-in {
   from {
     opacity: 0;
@@ -1294,6 +363,7 @@ img {
     opacity: 1;
   }
 }
+
 @keyframes fade-out {
   from {
     opacity: 1;
@@ -1303,6 +373,7 @@ img {
     opacity: 0;
   }
 }
+
 @keyframes fade-in-delayed {
   0% {
     opacity: 0;
@@ -1314,6 +385,7 @@ img {
     opacity: 1;
   }
 }
+
 @keyframes fade-out-delayed {
   0% {
     opacity: 1;
@@ -1326,6 +398,7 @@ img {
     opacity: 0;
   }
 }
+
 @keyframes shift-to-left {
   from {
     transform: translate(0, 0);
@@ -1334,6 +407,7 @@ img {
     transform: translate(-25%, 0);
   }
 }
+
 @keyframes unshift-to-left {
   from {
     transform: translate(-25%, 0);
@@ -1342,6 +416,7 @@ img {
     transform: translate(0, 0);
   }
 }
+
 @keyframes pop-in-from-right {
   from {
     transform: translate(100%, 0);
@@ -1350,6 +425,7 @@ img {
     transform: translate(0, 0);
   }
 }
+
 @keyframes pop-out-to-right {
   from {
     transform: translate(0, 0);

--- a/typedoc/style.css
+++ b/typedoc/style.css
@@ -40,21 +40,27 @@
   font-weight: 500;
   font-display: swap;
 }
+
 /* Default theme overrides */
 :root {
+  --font-family-default: "Euclid Circular A", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family-serif: "MongoDB Value Serif", "Times New Roman", serif;
+  --font-family-code: "Source Code Pro", Menlo, monospace;
+
   /* Light */
-  --light-color-background: #f2f4f8;
-  --light-color-background-secondary: #eff0f1;
-  --light-color-warning-text: #222;
-  --light-color-background-warning: #e6e600;
+  --light-color-background: #ffffff;
+  --light-color-background-secondary: #f9fbfa;
+  --light-color-warning-text: #db3030;
+  --light-color-background-warning: #ffec9e;
   --light-color-icon-background: var(--light-color-background);
-  --light-color-accent: #c5c7c9;
+  --light-color-accent: #e8edeb;
   --light-color-text: #001e2b;
   --light-color-text-aside: #707070;
   --light-color-link: #016bf8;
   --light-color-ts: #db1373;
   --light-color-ts-interface: #139d2c;
   --light-color-ts-enum: #9c891a;
+  /* Used in TypeScript class icon */
   --light-color-ts-class: #2484e5;
   --light-color-ts-function: #572be7;
   --light-color-ts-namespace: #b111c9;
@@ -62,15 +68,16 @@
   --light-color-ts-variable: #4d68ff;
   --light-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23000' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
   --light-color-scheme: light;
+  --light-code-background: #e8edeb;
 
   /* Dark */
-  --dark-color-background: #2b2e33;
-  --dark-color-background-secondary: #1e2024;
-  --dark-color-background-warning: #bebe00;
+  --dark-color-background: #001e2b;
+  --dark-color-background-secondary: #3d4f58;
+  --dark-color-background-warning: #ffcdc7;
   --dark-color-warning-text: #222;
   --dark-color-icon-background: var(--dark-color-background-secondary);
-  --dark-color-accent: #9096a2;
-  --dark-color-text: #f5f5f5;
+  --dark-color-accent: #e3fcf7;
+  --dark-color-text: #f9fbfa;
   --dark-color-text-aside: #dddddd;
   --dark-color-link: #016bf8;
   --dark-color-ts: #ff6492;
@@ -106,6 +113,7 @@
     --color-ts-variable: var(--light-color-ts-variable);
     --external-icon: var(--light-external-icon);
     --color-scheme: var(--light-color-scheme);
+    --code-background: var(--light-color-background-secondary);
   }
 }
 
@@ -130,6 +138,7 @@
     --color-ts-variable: var(--dark-color-ts-variable);
     --external-icon: var(--dark-external-icon);
     --color-scheme: var(--dark-color-scheme);
+    --code-background: var(--dark-color-background-secondary);
   }
 }
 
@@ -138,7 +147,12 @@ html {
 }
 
 body {
+  font-family: var(--font-family-default);
   margin: 0;
+}
+
+p {
+  line-height: 1.8rem;
 }
 
 :root[data-theme="light"] {
@@ -161,6 +175,7 @@ body {
   --color-ts-variable: var(--light-color-ts-variable);
   --external-icon: var(--light-external-icon);
   --color-scheme: var(--light-color-scheme);
+  --code-background: var(--light-color-background-secondary);
 }
 
 :root[data-theme="dark"] {
@@ -183,6 +198,12 @@ body {
   --color-ts-variable: var(--dark-color-ts-variable);
   --external-icon: var(--dark-external-icon);
   --color-scheme: var(--dark-color-scheme);
+  --code-background: var(--dark-color-background-secondary);
+}
+
+/* Specific dark theme styles */
+:root[data-theme="dark"] input[type="checkbox"]:checked ~ svg .tsd-checkbox-checkmark {
+  stroke: var(--light-color-text);
 }
 
 .always-visible,
@@ -192,17 +213,12 @@ body {
 
 h1,
 h2,
-h3 {
-  color: var(--color-heading);
-  font-family: "MongoDB Value Serif", "Times New Roman", serif;
-}
-
-h1,
-h2,
 h3,
 h4,
 h5,
 h6 {
+  font-family: var(--font-family-serif);
+  color: var(--color-heading);
   line-height: 1.2;
 }
 
@@ -262,6 +278,10 @@ dd {
   padding: 0 2rem;
 }
 
+.container-main {
+  flex-direction: row-reverse;
+}
+
 @media (min-width: 640px) {
   .container {
     padding: 0 4rem;
@@ -270,6 +290,12 @@ dd {
 @media (min-width: 1200px) {
   .container {
     padding: 0 8rem;
+  }
+
+  .col-menu {
+    border-left: 0;
+    border-right: 1px solid var(--color-accent);
+    margin-right: 1rem;
   }
 }
 @media (min-width: 1600px) {
@@ -309,88 +335,14 @@ dd {
 .col-4 {
   flex: 0 0 25%;
 }
+
 .col-8 {
   flex: 1 0;
   flex-wrap: wrap;
-  padding-left: 0;
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes fade-out {
-  from {
-    opacity: 1;
-    visibility: visible;
-  }
-  to {
-    opacity: 0;
-  }
-}
-@keyframes fade-in-delayed {
-  0% {
-    opacity: 0;
-  }
-  33% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-@keyframes fade-out-delayed {
-  0% {
-    opacity: 1;
-    visibility: visible;
-  }
-  66% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-@keyframes shift-to-left {
-  from {
-    transform: translate(0, 0);
-  }
-  to {
-    transform: translate(-25%, 0);
-  }
-}
-@keyframes unshift-to-left {
-  from {
-    transform: translate(-25%, 0);
-  }
-  to {
-    transform: translate(0, 0);
-  }
-}
-@keyframes pop-in-from-right {
-  from {
-    transform: translate(100%, 0);
-  }
-  to {
-    transform: translate(0, 0);
-  }
-}
-@keyframes pop-out-to-right {
-  from {
-    transform: translate(0, 0);
-    visibility: visible;
-  }
-  to {
-    transform: translate(100%, 0);
-  }
-}
 body {
   background: var(--color-background);
-  font-family: "Euclid Circular A", Akzidenz, "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
   color: var(--color-text);
 }
@@ -411,11 +363,12 @@ a.external[target="_blank"] {
 
 code,
 pre {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: var(--font-family-code);
   padding: 0.2em;
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   border-radius: 0.8em;
+  line-height: 1.5rem;
 }
 
 pre {
@@ -1133,8 +1086,11 @@ a.tsd-index-link {
   margin: 0 0 1rem 0;
   padding: 1rem 0.5rem;
   border: 1px solid var(--color-accent);
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-size: 14px;
+  background-color: var(--code-background);
+  font-family: var(--font-family-code);
+  border-radius: 0.8em;
+  line-height: 1.5rem;
+  font-size: 0.9rem;
   overflow-x: auto;
 }
 
@@ -1180,6 +1136,8 @@ ul.tsd-type-parameter-list h5 {
   margin: 1em 0 0.5em 0;
 }
 .tsd-sources {
+  font-family: var(--font-family-default);
+  color: var(--color-text-aside);
   margin-top: 1rem;
   font-size: 0.875em;
 }
@@ -1326,4 +1284,78 @@ img {
   background-color: var(--color-accent);
   border-radius: 999rem;
   border: 0.25rem solid var(--color-icon-background);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes fade-out {
+  from {
+    opacity: 1;
+    visibility: visible;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes fade-in-delayed {
+  0% {
+    opacity: 0;
+  }
+  33% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@keyframes fade-out-delayed {
+  0% {
+    opacity: 1;
+    visibility: visible;
+  }
+  66% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes shift-to-left {
+  from {
+    transform: translate(0, 0);
+  }
+  to {
+    transform: translate(-25%, 0);
+  }
+}
+@keyframes unshift-to-left {
+  from {
+    transform: translate(-25%, 0);
+  }
+  to {
+    transform: translate(0, 0);
+  }
+}
+@keyframes pop-in-from-right {
+  from {
+    transform: translate(100%, 0);
+  }
+  to {
+    transform: translate(0, 0);
+  }
+}
+@keyframes pop-out-to-right {
+  from {
+    transform: translate(0, 0);
+    visibility: visible;
+  }
+  to {
+    transform: translate(100%, 0);
+  }
 }

--- a/typedoc/style.css
+++ b/typedoc/style.css
@@ -41,13 +41,18 @@
   font-display: swap;
 }
 
-/* Default theme overrides */
+/* ==========================================================================
+   Theme color and font definitions and overrides
+   ========================================================================== */
+
 :root {
   --font-family-default: "Euclid Circular A", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-family-serif: "MongoDB Value Serif", "Times New Roman", serif;
   --font-family-code: "Source Code Pro", Menlo, monospace;
 
-  /* Light */
+  /* Light theme colors
+   ========================================================================== */
+
   --light-color-background: #ffffff;
   --light-color-background-secondary: #f9fbfa;
   --light-color-warning-text: #db3030;
@@ -60,17 +65,24 @@
   --light-color-ts: #db1373;
   --light-color-ts-interface: #139d2c;
   --light-color-ts-enum: #9c891a;
-  /* Used in TypeScript class icon */
-  --light-color-ts-class: #2484e5;
-  --light-color-ts-function: #572be7;
-  --light-color-ts-namespace: #b111c9;
+  --light-color-ts-class: #7c25ff;
+  --light-color-ts-function: #b45af2;
+  --light-color-ts-namespace: #5400f8;
   --light-color-ts-private: #707070;
   --light-color-ts-variable: #4d68ff;
+  --light-color-ts-property: #00684a;
+  --light-color-ts-call-signature: #00684a;
+  --light-color-ts-parameter: #0d427c;
+  --light-color-ts-type-parameter: #023430;
+  --light-color-ts-type-alias: #b45af2;
+  --light-color-active-menu-item: #f9ebff;
   --light-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23000' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
   --light-color-scheme: light;
   --light-code-background: #e8edeb;
 
-  /* Dark */
+  /* Dark theme colors
+   ========================================================================== */
+
   --dark-color-background: #001e2b;
   --dark-color-background-secondary: #3d4f58;
   --dark-color-background-warning: #ffcdc7;
@@ -88,9 +100,18 @@
   --dark-color-ts-namespace: #e14dff;
   --dark-color-ts-private: #e2e2e2;
   --dark-color-ts-variable: #4d68ff;
+  --dark-color-ts-property: #e9ff99;
+  --dark-color-ts-call-signature: #e9ff99;
+  --dark-color-ts-parameter: #e3fcf7;
+  --dark-color-ts-type-parameter: #ffeea9;
+  --dark-color-ts-type-alias: #f9ebff;
+  --dark-color-active-menu-item: #0d427c;
   --dark-external-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='10' height='10'><path fill-opacity='0' stroke='%23fff' stroke-width='10' d='m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z'/></svg>");
   --dark-color-scheme: dark;
 }
+
+/* `prefers-color-scheme` theme variable mapping
+   ========================================================================== */
 
 @media (prefers-color-scheme: light) {
   :root {
@@ -111,6 +132,12 @@
     --color-ts-namespace: var(--light-color-ts-namespace);
     --color-ts-private: var(--light-color-ts-private);
     --color-ts-variable: var(--light-color-ts-variable);
+    --color-ts-property: var(--light-color-ts-property);
+    --color-ts-call-signature: var(--light-color-ts-call-signature);
+    --color-ts-parameter: var(--light-color-ts-parameter);
+    --color-ts-type-parameter: var(--light-color-ts-type-parameter);
+    --color-ts-type-alias: var(--light-color-ts-type-alias);
+    --color-active-menu-item: var(--light-color-active-menu-item);
     --external-icon: var(--light-external-icon);
     --color-scheme: var(--light-color-scheme);
     --code-background: var(--light-color-background-secondary);
@@ -136,12 +163,20 @@
     --color-ts-namespace: var(--dark-color-ts-namespace);
     --color-ts-private: var(--dark-color-ts-private);
     --color-ts-variable: var(--dark-color-ts-variable);
+    --color-ts-property: var(--dark-color-ts-property);
+    --color-ts-call-signature: var(--dark-color-ts-call-signature);
+    --color-ts-parameter: var(--dark-color-ts-parameter);
+    --color-ts-type-parameter: var(--dark-color-ts-type-parameter);
+    --color-ts-type-alias: var(--dark-color-ts-type-alias);
+    --color-active-menu-item: var(--dark-color-active-menu-item);
     --external-icon: var(--dark-external-icon);
     --color-scheme: var(--dark-color-scheme);
     --code-background: var(--dark-color-background-secondary);
   }
 }
 
+/* Theme variable mapping
+   ========================================================================== */
 :root[data-theme="light"] {
   --color-background: var(--light-color-background);
   --color-background-secondary: var(--light-color-background-secondary);
@@ -160,6 +195,12 @@
   --color-ts-namespace: var(--light-color-ts-namespace);
   --color-ts-private: var(--light-color-ts-private);
   --color-ts-variable: var(--light-color-ts-variable);
+  --color-ts-property: var(--light-color-ts-property);
+  --color-ts-call-signature: var(--light-color-ts-call-signature);
+  --color-ts-parameter: var(--light-color-ts-parameter);
+  --color-ts-type-parameter: var(--light-color-ts-type-parameter);
+  --color-ts-type-alias: var(--light-color-ts-type-alias);
+  --color-active-menu-item: var(--light-color-active-menu-item);
   --external-icon: var(--light-external-icon);
   --color-scheme: var(--light-color-scheme);
   --code-background: var(--light-color-background-secondary);
@@ -183,15 +224,34 @@
   --color-ts-namespace: var(--dark-color-ts-namespace);
   --color-ts-private: var(--dark-color-ts-private);
   --color-ts-variable: var(--dark-color-ts-variable);
+  --color-ts-property: var(--dark-color-ts-property);
+  --color-ts-call-signature: var(--dark-color-ts-call-signature);
+  --color-ts-parameter: var(--dark-color-ts-parameter);
+  --color-ts-type-parameter: var(--dark-color-ts-type-parameter);
+  --color-ts-type-alias: var(--dark-color-ts-type-alias);
+  --color-active-menu-item: var(--dark-color-active-menu-item);
   --external-icon: var(--dark-external-icon);
   --color-scheme: var(--dark-color-scheme);
   --code-background: var(--dark-color-background-secondary);
 }
 
-/* Specific dark theme styles */
+/* ==========================================================================
+   Specific dark theme style overrides
+   ========================================================================== */
+
 :root[data-theme="dark"] input[type="checkbox"]:checked ~ svg .tsd-checkbox-checkmark {
   stroke: var(--light-color-text);
 }
+
+:root[data-theme="dark"] #tsd-search .field input,
+:root[data-theme="dark"] .tsd-page-toolbar a:hover,
+:root[data-theme="dark"] .tsd-page-toolbar #tsd-search .results a:hover span.parent {
+  color: var(--color-background);
+}
+
+/* ==========================================================================
+   Basic element style overrides
+   ========================================================================== */
 
 html {
   color-scheme: var(--color-scheme);
@@ -230,22 +290,27 @@ h2 {
   margin: 0.83rem 0;
 }
 
-h3 {
+h3,
+.tsd-typography .tsd-index-panel h3,
+.tsd-index-panel .tsd-typography h3 {
   font-size: 1.25rem;
   margin: 1rem 0;
 }
 
-h4 {
+h4,
+.tsd-typography h4 {
   font-size: 1.05rem;
   margin: 1.33rem 0;
 }
 
-h5 {
+h5,
+.tsd-typography h5 {
   font-size: 1rem;
   margin: 1.5rem 0;
 }
 
-h6 {
+h6,
+.tsd-typography h6 {
   font-size: 0.875rem;
   margin: 2.33rem 0;
 }
@@ -303,135 +368,10 @@ pre code {
   font-size: 100%;
 }
 
+/* ==========================================================================
+   TypeDoc theme layout overrides
+   ========================================================================== */
+
 .tsd-page-navigation ul {
   padding-left: 1rem;
-}
-
-@media (max-width: 1024px) {
-  .to-has-menu .overlay {
-    animation: fade-in 0.4s;
-  }
-
-  .to-has-menu :is(header, footer, .col-content) {
-    animation: shift-to-left 0.4s;
-  }
-
-  .to-has-menu .col-menu {
-    animation: pop-in-from-right 0.4s;
-  }
-
-  .from-has-menu .overlay {
-    animation: fade-out 0.4s;
-  }
-
-  .from-has-menu :is(header, footer, .col-content) {
-    animation: unshift-to-left 0.4s;
-  }
-
-  .from-has-menu .col-menu {
-    animation: pop-out-to-right 0.4s;
-  }
-
-  .has-menu body {
-    overflow: hidden;
-  }
-  .has-menu .overlay {
-    visibility: visible;
-  }
-  .has-menu :is(header, footer, .col-content) {
-    transform: translate(-25%, 0);
-  }
-  .has-menu .col-menu {
-    visibility: visible;
-    transform: translate(0, 0);
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    max-height: 100vh;
-    padding: 1rem 2rem;
-  }
-  .has-menu .tsd-navigation {
-    max-height: 100%;
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes fade-out {
-  from {
-    opacity: 1;
-    visibility: visible;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes fade-in-delayed {
-  0% {
-    opacity: 0;
-  }
-  33% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes fade-out-delayed {
-  0% {
-    opacity: 1;
-    visibility: visible;
-  }
-  66% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes shift-to-left {
-  from {
-    transform: translate(0, 0);
-  }
-  to {
-    transform: translate(-25%, 0);
-  }
-}
-
-@keyframes unshift-to-left {
-  from {
-    transform: translate(-25%, 0);
-  }
-  to {
-    transform: translate(0, 0);
-  }
-}
-
-@keyframes pop-in-from-right {
-  from {
-    transform: translate(100%, 0);
-  }
-  to {
-    transform: translate(0, 0);
-  }
-}
-
-@keyframes pop-out-to-right {
-  from {
-    transform: translate(0, 0);
-    visibility: visible;
-  }
-  to {
-    transform: translate(100%, 0);
-  }
 }


### PR DESCRIPTION
## What, How & Why?

The TypeDoc implementation from #5709 didn't do much with styling or customization. This PR overrides the default theme to come closer to the MongoDB look and feel.

Also, upgraded to the latest version of TypeDoc to fix some issues.

Unfortunately, I don't have a preview on a server. You'll need to check out my branch, build the docs, then preview locally.

To build the docs, navigate to `packages/realm-react` and then run `npm run docs`. A new docs directory will be added that contains the generated docs site.
