### PR TITLE
Fix global `Realm` usage in integration tests

### DIFF
--- a/integration-tests/tests/src/setup-globals.ts
+++ b/integration-tests/tests/src/setup-globals.ts
@@ -68,3 +68,5 @@ import Realm from "realm";
 // Disable the logger to avoid console flooding
 const { defaultLogLevel = "off" } = environment;
 Realm.setLogLevel(defaultLogLevel);
+
+Realm.flags.THROW_ON_GLOBAL_REALM = true;

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -16,8 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { BSON } from "realm";
 import { expect } from "chai";
+import Realm, { BSON } from "realm";
+
 import { importAppBefore } from "../../hooks";
 import { generatePartition } from "../../utils/generators";
 import { baseUrl } from "../../utils/import-app";

--- a/integration-tests/tests/src/tests/sync/encryption.ts
+++ b/integration-tests/tests/src/tests/sync/encryption.ts
@@ -17,6 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
+import Realm from "realm";
+
 import { importAppBefore } from "../../hooks";
 import { buildAppConfig } from "../../utils/build-app-config";
 

--- a/integration-tests/tests/src/tests/sync/realm.ts
+++ b/integration-tests/tests/src/tests/sync/realm.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { CollectionChangeSet } from "realm";
+import Realm, { CollectionChangeSet } from "realm";
 
 import { importAppBefore, openRealmBeforeEach } from "../../hooks";
 import { expectArraysEqual, expectDecimalEqual } from "../../utils/comparisons";

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1789,17 +1789,17 @@ Object.defineProperty(safeGlobalThis, "Realm", {
   get() {
     if (flags.THROW_ON_GLOBAL_REALM) {
       throw new Error(
-        "Accessed global Realm, please update your code to ensure you import Realm via a named import:\nimport { Realm } from 'realm';",
+        "Accessed global Realm, please update your code to ensure you import Realm:\nimport Realm from 'realm';",
       );
     } else if (!warnedAboutGlobalRealmUse) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Your app is relying on a Realm global, which will be removed in realm-js v13, please update your code to ensure you import Realm via a named import:\n\n",
-        'import { Realm } from "realm"; // For ES Modules\n',
-        'const { Realm } = require("realm"); // For CommonJS\n\n',
+        "Your app is relying on a Realm global, which will be removed in realm-js v13, please update your code to ensure you import Realm:\n\n",
+        'import Realm from "realm"; // For ES Modules\n',
+        'const Realm = require("realm"); // For CommonJS\n\n',
         "To determine where, put this in the top of your index file:\n",
-        `import { flags } from "realm";\n`,
-        `flags.THROW_ON_GLOBAL_REALM = true`,
+        `import Realm from "realm";\n`,
+        `Realm.flags.THROW_ON_GLOBAL_REALM = true`,
       );
       warnedAboutGlobalRealmUse = true;
     }


### PR DESCRIPTION
## What, How & Why?

This updates updates the warning and error emitted when accessing the global `Realm` to reflect the change to CommonJS and updates the integration tests to import accordingly.
