### PR TITLE
Enabling session multiplexing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 * Upgraded Realm Core from v13.10.1 to v13.11.0. ([#5811](https://github.com/realm/realm-js/issues/5811))
 * Bump sync protocol to v9 to indicate client has fix for client reset error during async open. ([realm/realm-core#6609](https://github.com/realm/realm-core/issues/6609))
 * Aligning analytics with other Realm SDKs. You can still disable the submission by setting environment variable `REALM_DISABLE_ANALYTICS`, and you can print out what is submitted by setting the environment variable `REALM_PRINT_ANALYTICS`.
-* Disabling sync session multiplexing by default in the SDK, since Core's default changed to enabled with v13.11.0. ([#5831](https://github.com/realm/realm-js/pull/5831))
+* Enabling sync session multiplexing by default in the SDK. ([#5831](https://github.com/realm/realm-js/pull/5831) & [#5912](https://github.com/realm/realm-js/pull/5912))
 * Applied use of an opt-in list for Bindgen. ([#5820](https://github.com/realm/realm-js/pull/5820))
 * Upgraded Realm Core from v13.11.1 to v13.15.1. ([#5873](https://github.com/realm/realm-js/pull/5873) & [#5909](https://github.com/realm/realm-js/pull/5909))
 

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -114,6 +114,7 @@ records:
       - base_file_path
       - metadata_mode
       - user_agent_binding_info
+      - multiplex_sessions
 
   SyncError:
    fields:

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -58,6 +58,13 @@ export type AppConfiguration = {
    * The timeout for requests (in milliseconds)
    */
   timeout?: number;
+
+  /**
+   * Use the same underlying connection towards the server across multiple sync sessions.
+   * This use less resources on the server and provide a small increase in speed when opening subsequent synced Realms.
+   * @default true
+   */
+  multiplexSessions?: boolean;
 };
 
 /**
@@ -177,7 +184,7 @@ export class App<FunctionsFactoryType = DefaultFunctionsFactory, CustomDataType 
   constructor(configOrId: AppConfiguration | string) {
     const config: AppConfiguration = typeof configOrId === "string" ? { id: configOrId } : configOrId;
     assert.object(config, "config");
-    const { id, baseUrl, app, timeout } = config;
+    const { id, baseUrl, app, timeout, multiplexSessions = true } = config;
     assert.string(id, "id");
     if (timeout !== undefined) {
       assert.number(timeout, "timeout");
@@ -197,8 +204,7 @@ export class App<FunctionsFactoryType = DefaultFunctionsFactory, CustomDataType 
         baseFilePath: fs.getDefaultDirectoryPath(),
         metadataMode: binding.MetadataMode.NoEncryption,
         userAgentBindingInfo: App.userAgent,
-        // Default session multiplexing to being disabled.
-        multiplexSessions: false,
+        multiplexSessions,
       },
     );
   }

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -189,6 +189,7 @@ export class App<FunctionsFactoryType = DefaultFunctionsFactory, CustomDataType 
     if (timeout !== undefined) {
       assert.number(timeout, "timeout");
     }
+    assert.boolean(multiplexSessions, "multiplexSessions");
     // TODO: This used getSharedApp in the legacy SDK, but it's failing AppTests
     this.internal = binding.App.getUncachedApp(
       {

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -61,7 +61,7 @@ export type AppConfiguration = {
 
   /**
    * Use the same underlying connection towards the server across multiple sync sessions.
-   * This use less resources on the server and provide a small increase in speed when opening subsequent synced Realms.
+   * This uses less resources on the server and provides a small increase in speed when opening subsequent synced Realms.
    * @default true
    */
   multiplexSessions?: boolean;


### PR DESCRIPTION
## What, How & Why?

With the merge of https://github.com/realm/realm-core/pull/6676 it's now possible to enable session multiplexing by default.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [x] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [x] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 📝 Public documentation PR created or is not necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
