### PR TITLE
Add missing enums for OpenRealmTimeOutBehavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Add missing enums for `OpenRealmTimeOutBehavior`
 
 ### Compatibility
 * React Native >= v0.71.3

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -550,6 +550,11 @@ module.exports = function (realmConstructor) {
       DownloadBeforeOpen: "downloadBeforeOpen",
       OpenImmediately: "openImmediately",
     };
+
+    realmConstructor.OpenRealmTimeOutBehavior = {
+      OpenLocalRealm: "openLocalRealm",
+      ThrowException: "throwException",
+    };
   }
 
   realmConstructor.Types = {


### PR DESCRIPTION
## What, How & Why?
Found out the enums were missing and this was causing a crash in the example app.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
