### PR TITLE
Added RealmObject.entries()

### DIFF
--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -965,6 +965,35 @@ describe("Realm.Object", () => {
         obj.getPropertyType("foo");
       }).throws("Property 'foo' does not exist on 'AllTypesObject' objects");
     });
+
+    it.only("returns entries correctly", function (this: Mocha.Context & RealmContext) {
+      const obj = this.realm.write(() => {
+        return this.realm.create<IPrimaryString>(PrimaryStringSchema.name, {
+          pk: "one",
+          value: 1,
+        });
+      });
+
+      const entries = obj.entries();
+      expect(entries).to.have.length(2);
+      expect(entries).to.have.deep.members([
+        ["pk", "one"],
+        ["value", 1],
+      ]);
+    });
+
+    it.only("returns keys correctly", function (this: Mocha.Context & RealmContext) {
+      const obj = this.realm.write(() => {
+        return this.realm.create<IPrimaryString>(PrimaryStringSchema.name, {
+          pk: "one",
+          value: 1,
+        });
+      });
+
+      const keys = obj.keys();
+      expect(keys).to.have.length(2);
+      expect(keys).to.have.deep.members(["pk", "value"]);
+    });
   });
 
   describe("linktype properties", () => {

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -974,7 +974,14 @@ describe("Realm.Object", () => {
         });
       });
 
-      const entries = obj.entries();
+      let entries = obj.entries();
+      expect(entries).to.have.length(2);
+      expect(entries).to.have.deep.members([
+        ["pk", "one"],
+        ["value", 1],
+      ]);
+
+      entries = Object.entries(obj);
       expect(entries).to.have.length(2);
       expect(entries).to.have.deep.members([
         ["pk", "one"],
@@ -990,7 +997,11 @@ describe("Realm.Object", () => {
         });
       });
 
-      const keys = obj.keys();
+      let keys = obj.keys();
+      expect(keys).to.have.length(2);
+      expect(keys).to.have.deep.members(["pk", "value"]);
+
+      keys = Object.keys(obj);
       expect(keys).to.have.length(2);
       expect(keys).to.have.deep.members(["pk", "value"]);
     });

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -966,7 +966,7 @@ describe("Realm.Object", () => {
       }).throws("Property 'foo' does not exist on 'AllTypesObject' objects");
     });
 
-    it.only("returns entries correctly", function (this: Mocha.Context & RealmContext) {
+    it("returns entries correctly", function (this: Mocha.Context & RealmContext) {
       const obj = this.realm.write(() => {
         return this.realm.create<IPrimaryString>(PrimaryStringSchema.name, {
           pk: "one",
@@ -982,7 +982,7 @@ describe("Realm.Object", () => {
       ]);
     });
 
-    it.only("returns keys correctly", function (this: Mocha.Context & RealmContext) {
+    it("returns keys correctly", function (this: Mocha.Context & RealmContext) {
       const obj = this.realm.write(() => {
         return this.realm.create<IPrimaryString>(PrimaryStringSchema.name, {
           pk: "one",

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -274,11 +274,13 @@ export class RealmObject<T = DefaultObject> {
    */
   private declare readonly [KEY_SET]: ReadonlySet<string>;
 
+  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys|Object.keys()}  */
   keys(): string[] {
     // copying to prevent caller from modifying the static array.
     return [...this[KEY_ARRAY]];
   }
 
+  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries|Object.entries()}*/
   entries(): [string, unknown][] {
     return Object.entries(this);
   }

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -280,7 +280,7 @@ export class RealmObject<T = DefaultObject> {
   }
 
   entries(): [string, unknown][] {
-    throw new Error("Not yet implemented");
+    return Object.entries(this);
   }
 
   /**

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -274,13 +274,13 @@ export class RealmObject<T = DefaultObject> {
    */
   private declare readonly [KEY_SET]: ReadonlySet<string>;
 
-  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys|Object.keys()}  */
+  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys | Object.keys()}  */
   keys(): string[] {
     // copying to prevent caller from modifying the static array.
     return [...this[KEY_ARRAY]];
   }
 
-  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries|Object.entries()}*/
+  /** @deprecated Please use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries | Object.entries()} */
   entries(): [string, unknown][] {
     return Object.entries(this);
   }


### PR DESCRIPTION
Added `RealmObject.entries()`

I am not sure this method (or `RealmObject.values()`) need docs, as they are equivalent to the default `Object`  methods. Also I'm not sure if we should add it to the changelog

This closes #5923 and #5605

## ☑️ ToDos
* [x] 🚦 Tests
