### PR TITLE
Fix failing `@realm/react` async unit test

### DIFF
--- a/packages/realm-react/src/__tests__/useQueryRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryRender.test.tsx
@@ -398,7 +398,7 @@ describe.each`
   });
   // This replicates the issue https://github.com/realm/realm-js/issues/4375
   it("will handle multiple async transactions", async () => {
-    const { queryByTestId } = await setupTest({ queryType, useUseObject: true });
+    const { queryByTestId, unmount } = await setupTest({ queryType, useUseObject: true });
     const performTest = async () => {
       testRealm.write(() => {
         testRealm.deleteAll();
@@ -426,6 +426,8 @@ describe.each`
     });
 
     await waitFor(() => queryByTestId(`name${109}`));
+
+    unmount();
   });
 
   it("will return the same reference when state changes", async () => {


### PR DESCRIPTION
## What, How & Why?

This is an attempt to fix the sporadically failing `@realm/react` test, by unmounting the test component before completing the test. This will make sure the list doesn't try to access the size of the results after the Realm has been closed (most likely as an effect of the after each hook calling `Realm.clearTestState`)
