### PR TITLE
Reenable list snapshot test

### DIFF
--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -1131,8 +1131,7 @@ describe("Lists", () => {
       expect(array.length).equals(2);
       expect(objects.length).equals(4);
     });
-    // TODO reenable this test. https://github.com/realm/realm-js/issues/5817
-    it.skipIf(true, "supports snapshots", function (this: RealmContext) {
+    it("supports snapshots", function (this: RealmContext) {
       const objects = this.realm.objects<ITestObjectSchema>("TestObject");
       let array!: Realm.List<ITestObjectSchema>;
 


### PR DESCRIPTION
## What, How & Why?

A prior [commit](https://github.com/realm/realm-core/commit/6e127d38af2b450aecdaabb990246388bf54ae99) changed the behavior in Core causing the now-reenabled test to fail. From the [merged fix](https://github.com/realm/realm-core/pull/6641/files) it looks like we can reenable the test w/o any modifications.

The test is passing in its current state.

This closes #5817

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
