### PR TITLE
Support nested updates of objects through `realm.create` via `UpdateMode.All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Fixed
 * Fixed updating helpers (the `ClassMap`) used by `Realm` before notifying schema change listeners when the schema is changed during runtime. ([#5574](https://github.com/realm/realm-js/issues/5574))
-* Fix crashes on refresh of the React Native application. ([#5904](https://github.com/realm/realm-js/issues/5904))
+* Fixed crashes on refresh of the React Native application. ([#5904](https://github.com/realm/realm-js/issues/5904))
+* Fixed applying `UpdateMode` recursively to all objects when passed to `Realm.create()`. ([#5933](https://github.com/realm/realm-js/issues/5933))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -588,6 +588,8 @@ describe("Realm.Object", () => {
       });
 
       it("can be updated recursively", function (this: Mocha.Context & RealmContext) {
+        console.log("\n==== WRITE TRANSACTION: CREATE OBJECTS ====\n");
+
         // Create two mutual friends
         const { alice, bob } = this.realm.write(() => {
           const alice = this.realm.create(PersonWithId, {
@@ -605,6 +607,8 @@ describe("Realm.Object", () => {
           bob.friends.push(alice);
           return { alice, bob };
         });
+
+        console.log("\n==== WRITE TRANSACTION: CREATE W/ UPDATE MODE ALL ====\n");
 
         // Now update them
         this.realm.write(() => {
@@ -625,6 +629,10 @@ describe("Realm.Object", () => {
           );
         });
       });
+
+      // TODO: Add tests:
+      // * Child objects should also exist in a Dictionary and Set.
+      // * Child objects should also be embedded.
     });
   });
 

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -639,8 +639,8 @@ describe("Realm.Object", () => {
         });
 
         it("can be updated recursively in lists", function (this: Mocha.Context & RealmContext) {
-          this.realm.write(() => {
-            this.realm.create(
+          const alice = this.realm.write(() => {
+            return this.realm.create(
               CollectionSchema.name,
               {
                 _id: aliceId,
@@ -661,11 +661,22 @@ describe("Realm.Object", () => {
               Realm.UpdateMode.All,
             );
           });
+
+          expect(alice._id.equals(aliceId)).to.be.true;
+          expect(alice.name).to.equal("UpdatedAlice");
+
+          const bob = alice.list[0];
+          expect(bob._id.equals(bobId)).to.be.true;
+          expect(bob.name).to.equal("UpdatedBob");
+
+          const max = bob.list[0];
+          expect(max._id.equals(maxId)).to.be.true;
+          expect(max.name).to.equal("UpdatedMax");
         });
 
         it("can be updated recursively in dictionaries", function (this: Mocha.Context & RealmContext) {
-          this.realm.write(() => {
-            this.realm.create(
+          const alice = this.realm.write(() => {
+            return this.realm.create(
               CollectionSchema.name,
               {
                 _id: aliceId,
@@ -686,11 +697,22 @@ describe("Realm.Object", () => {
               Realm.UpdateMode.All,
             );
           });
+
+          expect(alice._id.equals(aliceId)).to.be.true;
+          expect(alice.name).to.equal("UpdatedAlice");
+
+          const { bob } = alice.dictionary;
+          expect(bob._id.equals(bobId)).to.be.true;
+          expect(bob.name).to.equal("UpdatedBob");
+
+          const { max } = bob.dictionary;
+          expect(max._id.equals(maxId)).to.be.true;
+          expect(max.name).to.equal("UpdatedMax");
         });
 
         it("can be updated recursively in sets", function (this: Mocha.Context & RealmContext) {
-          this.realm.write(() => {
-            this.realm.create(
+          const alice = this.realm.write(() => {
+            return this.realm.create(
               CollectionSchema.name,
               {
                 _id: aliceId,
@@ -711,6 +733,17 @@ describe("Realm.Object", () => {
               Realm.UpdateMode.All,
             );
           });
+
+          expect(alice._id.equals(aliceId)).to.be.true;
+          expect(alice.name).to.equal("UpdatedAlice");
+
+          const bob = alice.set[0];
+          expect(bob._id.equals(bobId)).to.be.true;
+          expect(bob.name).to.equal("UpdatedBob");
+
+          const max = bob.set[0];
+          expect(max._id.equals(maxId)).to.be.true;
+          expect(max.name).to.equal("UpdatedMax");
         });
       });
     });

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -586,6 +586,45 @@ describe("Realm.Object", () => {
         const persons = this.realm.objects(PersonWithId);
         expect(persons.length).equals(1);
       });
+
+      it("can be updated recursively", function (this: Mocha.Context & RealmContext) {
+        // Create two mutual friends
+        const { alice, bob } = this.realm.write(() => {
+          const alice = this.realm.create(PersonWithId, {
+            _id: new Realm.BSON.ObjectId(),
+            name: "Alice",
+            age: 32,
+          });
+          const bob = this.realm.create(PersonWithId, {
+            _id: new Realm.BSON.ObjectId(),
+            name: "Bob",
+            age: 42,
+          });
+          // Make them mutual friends
+          alice.friends.push(bob);
+          bob.friends.push(alice);
+          return { alice, bob };
+        });
+
+        // Now update them
+        this.realm.write(() => {
+          this.realm.create(
+            PersonWithId,
+            {
+              _id: alice._id,
+              age: 33,
+              friends: [
+                {
+                  _id: bob._id,
+                  age: 43,
+                  name: "Bobby",
+                },
+              ],
+            },
+            Realm.UpdateMode.All,
+          );
+        });
+      });
     });
   });
 

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -57,7 +57,7 @@ const PROXY_HANDLER: ProxyHandler<Dictionary> = {
     if (typeof prop === "string") {
       const internal = target[INTERNAL];
       const toBinding = target[HELPERS].toBinding;
-      internal.insertAny(prop, toBinding(value, undefined));
+      internal.insertAny(prop, toBinding(value));
       return true;
     } else {
       assert(typeof prop !== "symbol", "Symbols cannot be used as keys of a dictionary");
@@ -280,7 +280,7 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
     const toBinding = this[HELPERS].toBinding;
 
     for (const [key, val] of Object.entries(elements)) {
-      internal.insertAny(key, toBinding(val, undefined));
+      internal.insertAny(key, toBinding(val));
     }
     return this;
   }

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -91,7 +91,10 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     } = this;
     assert.inTransaction(realm);
     // TODO: Consider a more performant way to determine if the list is embedded
-    internal.setAny(index, toBinding(value, isEmbedded ? () => [internal.insertEmbedded(index), true] : undefined));
+    internal.setAny(
+      index,
+      toBinding(value, isEmbedded ? { createObj: () => [internal.insertEmbedded(index), true] } : undefined),
+    );
   }
 
   get length(): number {
@@ -142,7 +145,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
       const index = start + offset;
       if (isEmbedded) {
         // Simply transforming to binding will insert the embedded object
-        toBinding(item, () => [internal.insertEmbedded(index), true]);
+        toBinding(item, { createObj: () => [internal.insertEmbedded(index), true] });
       } else {
         internal.insertAny(index, toBinding(item));
       }
@@ -186,7 +189,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     for (const [index, item] of items.entries()) {
       if (isEmbedded) {
         // Simply transforming to binding will insert the embedded object
-        toBinding(item, () => [internal.insertEmbedded(index), true]);
+        toBinding(item, { createObj: () => [internal.insertEmbedded(index), true] });
       } else {
         internal.insertAny(index, toBinding(item));
       }
@@ -270,7 +273,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
       const index = start + offset;
       if (isEmbedded) {
         // Simply transforming to binding will insert the embedded object
-        toBinding(item, () => [internal.insertEmbedded(index), true]);
+        toBinding(item, { createObj: () => [internal.insertEmbedded(index), true] });
       } else {
         internal.insertAny(index, toBinding(item));
       }

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -207,7 +207,7 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
    * Create an object in the database and populate its primary key value, if required
    * @internal
    */
-  public static createObj(
+  private static createObj(
     realm: Realm,
     values: DefaultObject,
     mode: UpdateMode,

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -186,16 +186,9 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
       const propertyValue = values[propertyName];
       if (typeof propertyValue !== "undefined") {
         if (mode !== UpdateMode.Modified || result[propertyName] !== propertyValue) {
-          console.log({ propertyName });
-          console.log({ propertyValue });
-          console.log({ previousValue: result[propertyName] });
-          console.log("Setting previous value (result[propertyName]) to the propertyValue...");
-
           // This will call into the property setter in PropertyHelpers.ts.
-          // (The setter for [binding.PropertyType.Array] in the case of Realm lists.)
+          // (E.g. the setter for [binding.PropertyType.Array] in the case of lists.)
           result[propertyName] = propertyValue;
-
-          console.log("Done!");
         }
       } else {
         if (typeof defaultValue !== "undefined") {
@@ -209,7 +202,6 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
         }
       }
     }
-    console.log("Object_create_END");
     return result as RealmObject;
   }
 
@@ -250,19 +242,14 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
       );
 
       const result = binding.Helpers.getOrCreateObjectWithPrimaryKey(table, pk);
-
-      console.log({ Object_updateMode: mode });
-
       const [, created] = result;
       if (mode === UpdateMode.Never && !created) {
         throw new Error(
           `Attempting to create an object of type '${name}' with an existing primary key value '${primaryKeyValue}'.`,
         );
       }
-      console.log("Object_createObj_END1");
       return result;
     } else {
-      console.log("Object_createObj_END2");
       return [table.createObject(), true];
     }
   }

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -237,7 +237,6 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
         typeof primaryKeyValue !== "undefined" && primaryKeyValue !== null
           ? primaryKeyValue
           : primaryKeyHelpers.default,
-        undefined,
       );
       const result = binding.Helpers.getOrCreateObjectWithPrimaryKey(table, pk);
       const [, created] = result;

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -186,7 +186,16 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
       const propertyValue = values[propertyName];
       if (typeof propertyValue !== "undefined") {
         if (mode !== UpdateMode.Modified || result[propertyName] !== propertyValue) {
+          console.log({ propertyName });
+          console.log({ propertyValue });
+          console.log({ previousValue: result[propertyName] });
+          console.log("Setting previous value (result[propertyName]) to the propertyValue...");
+
+          // This will call into the property setter in PropertyHelpers.ts.
+          // (The setter for [binding.PropertyType.Array] in the case of Realm lists.)
           result[propertyName] = propertyValue;
+
+          console.log("Done!");
         }
       } else {
         if (typeof defaultValue !== "undefined") {
@@ -200,6 +209,7 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
         }
       }
     }
+    console.log("Object_create_END");
     return result as RealmObject;
   }
 
@@ -238,15 +248,21 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
           ? primaryKeyValue
           : primaryKeyHelpers.default,
       );
+
       const result = binding.Helpers.getOrCreateObjectWithPrimaryKey(table, pk);
+
+      console.log({ Object_updateMode: mode });
+
       const [, created] = result;
       if (mode === UpdateMode.Never && !created) {
         throw new Error(
           `Attempting to create an object of type '${name}' with an existing primary key value '${primaryKeyValue}'.`,
         );
       }
+      console.log("Object_createObj_END1");
       return result;
     } else {
+      console.log("Object_createObj_END2");
       return [table.createObject(), true];
     }
   }

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -336,7 +336,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       assert.instanceOf(searchElement, RealmObject);
       return this.results.indexOfObj(searchElement[INTERNAL]);
     } else {
-      return this.results.indexOf(this.helpers.toBinding(searchElement, undefined));
+      return this.results.indexOf(this.helpers.toBinding(searchElement));
     }
   }
   /**

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -100,7 +100,7 @@ function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions)
   return (obj: binding.Obj, value: unknown) => {
     // Asking for the toBinding will create the object and link it to the parent in one operation
     // no need to actually set the value on the `obj`
-    toBinding(value, () => [obj.createAndSetLinkedObject(columnKey), true]);
+    toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
   };
 }
 
@@ -212,9 +212,9 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
             for (const value of values) {
               try {
                 if (embedded) {
-                  itemToBinding(value, () => [internal.insertEmbedded(index), true]);
+                  itemToBinding(value, { createObj: () => [internal.insertEmbedded(index), true] });
                 } else {
-                  bindingValues.push(itemToBinding(value, undefined));
+                  bindingValues.push(itemToBinding(value));
                 }
               } catch (err) {
                 if (err instanceof TypeAssertionError) {
@@ -260,9 +260,9 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
         for (const [k, v] of Object.entries(value)) {
           try {
             if (embedded) {
-              itemHelpers.toBinding(v, () => [internal.insertEmbedded(k), true]);
+              itemHelpers.toBinding(v, { createObj: () => [internal.insertEmbedded(k), true] });
             } else {
-              internal.insertAny(k, itemHelpers.toBinding(v, undefined));
+              internal.insertAny(k, itemHelpers.toBinding(v));
             }
           } catch (err) {
             if (err instanceof TypeAssertionError) {

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -214,8 +214,7 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
                 if (embedded) {
                   itemToBinding(value, { createObj: () => [internal.insertEmbedded(index), true] });
                 } else {
-                  console.log("In PropertyHelpers ([binding.PropertyType.Array] setter)");
-                  bindingValues.push(itemToBinding(value)); // Need to pass update mode
+                  bindingValues.push(itemToBinding(value));
                 }
               } catch (err) {
                 if (err instanceof TypeAssertionError) {

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -214,7 +214,8 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
                 if (embedded) {
                   itemToBinding(value, { createObj: () => [internal.insertEmbedded(index), true] });
                 } else {
-                  bindingValues.push(itemToBinding(value));
+                  console.log("In PropertyHelpers ([binding.PropertyType.Array] setter)");
+                  bindingValues.push(itemToBinding(value)); // Need to pass update mode
                 }
               } catch (err) {
                 if (err instanceof TypeAssertionError) {

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -862,7 +862,9 @@ export class Realm {
       throw new Error("Cannot create an object from a detached RealmObject instance");
     }
     if (!Object.values(UpdateMode).includes(mode)) {
-      throw new Error(`Unsupported 'updateMode'. Only '${UpdateMode.Never}', '${UpdateMode.Modified}' or '${UpdateMode.All}' is supported.`);
+      throw new Error(
+        `Unsupported 'updateMode'. Only '${UpdateMode.Never}', '${UpdateMode.Modified}' or '${UpdateMode.All}' is supported.`,
+      );
     }
     this.internal.verifyOpen();
     const helpers = this.classes.getHelpers(type);

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -605,6 +605,8 @@ export class Realm {
   private changeListeners = new RealmListeners(this, RealmEvent.Change);
   private beforeNotifyListeners = new RealmListeners(this, RealmEvent.BeforeNotify);
   private schemaListeners = new RealmListeners(this, RealmEvent.Schema);
+  /** @internal */
+  public currentUpdateMode: UpdateMode | undefined;
 
   /**
    * Create a new {@link Realm} instance, at the default path.
@@ -860,11 +862,13 @@ export class Realm {
       throw new Error("Cannot create an object from a detached RealmObject instance");
     }
     if (!Object.values(UpdateMode).includes(mode)) {
-      throw new Error("Unsupported 'updateMode'. Only 'never', 'modified' or 'all' is supported.");
+      throw new Error(`Unsupported 'updateMode'. Only '${UpdateMode.Never}', '${UpdateMode.Modified}' or '${UpdateMode.All}' is supported.`);
     }
     this.internal.verifyOpen();
     const helpers = this.classes.getHelpers(type);
+    this.currentUpdateMode = mode;
     const realmObject = RealmObject.create(this, values, mode, { helpers });
+    this.currentUpdateMode = undefined;
 
     return isAsymmetric(helpers.objectSchema) ? undefined : realmObject;
   }

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -605,6 +605,8 @@ export class Realm {
   private changeListeners = new RealmListeners(this, RealmEvent.Change);
   private beforeNotifyListeners = new RealmListeners(this, RealmEvent.BeforeNotify);
   private schemaListeners = new RealmListeners(this, RealmEvent.Schema);
+  /** @internal */
+  public currentUpdateMode: UpdateMode | undefined;
 
   /**
    * Create a new {@link Realm} instance, at the default path.
@@ -866,7 +868,14 @@ export class Realm {
     }
     this.internal.verifyOpen();
     const helpers = this.classes.getHelpers(type);
-    const realmObject = RealmObject.create(this, values, mode, { helpers });
+
+    this.currentUpdateMode = mode;
+    let realmObject: RealmObject;
+    try {
+      realmObject = RealmObject.create(this, values, mode, { helpers });
+    } finally {
+      this.currentUpdateMode = undefined;
+    }
 
     return isAsymmetric(helpers.objectSchema) ? undefined : realmObject;
   }

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -605,8 +605,6 @@ export class Realm {
   private changeListeners = new RealmListeners(this, RealmEvent.Change);
   private beforeNotifyListeners = new RealmListeners(this, RealmEvent.BeforeNotify);
   private schemaListeners = new RealmListeners(this, RealmEvent.Schema);
-  /** @internal */
-  public currentUpdateMode: UpdateMode | undefined;
 
   /**
    * Create a new {@link Realm} instance, at the default path.
@@ -868,9 +866,7 @@ export class Realm {
     }
     this.internal.verifyOpen();
     const helpers = this.classes.getHelpers(type);
-    this.currentUpdateMode = mode;
     const realmObject = RealmObject.create(this, values, mode, { helpers });
-    this.currentUpdateMode = undefined;
 
     return isAsymmetric(helpers.objectSchema) ? undefined : realmObject;
   }
@@ -960,7 +956,7 @@ export class Realm {
       throw new Error("You cannot query an asymmetric object.");
     }
     const table = binding.Helpers.getTable(this.internal, objectSchema.tableKey);
-    const value = properties.get(objectSchema.primaryKey).toBinding(primaryKey, undefined);
+    const value = properties.get(objectSchema.primaryKey).toBinding(primaryKey);
     try {
       const objKey = table.findPrimaryKey(value);
       if (binding.isEmptyObjKey(objKey)) {

--- a/packages/realm/src/Set.ts
+++ b/packages/realm/src/Set.ts
@@ -78,7 +78,7 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
    */
   delete(value: T): boolean {
     assert.inTransaction(this.realm);
-    const [, success] = this.internal.removeAny(this.helpers.toBinding(value, undefined));
+    const [, success] = this.internal.removeAny(this.helpers.toBinding(value));
     return success;
   }
 
@@ -92,7 +92,7 @@ export class RealmSet<T = unknown> extends OrderedCollection<T, [T, T]> {
    */
   add(value: T): this {
     assert.inTransaction(this.realm);
-    this.internal.insertAny(this.helpers.toBinding(value, undefined));
+    this.internal.insertAny(this.helpers.toBinding(value));
     return this;
   }
 

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -261,6 +261,9 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
           assert.object(value, name);
           // Use the update mode if set; otherwise, the object is assumed to be an
           // unmanaged object that the user wants to create.
+
+          console.log({ TypeHelpers_updateMode: options?.updateMode });
+
           const createdObject = RealmObject.create(realm, value, options?.updateMode ?? UpdateMode.Never, {
             helpers,
             createObj: options?.createObj,

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -261,10 +261,8 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
           assert.object(value, name);
           // Use the update mode if set; otherwise, the object is assumed to be an
           // unmanaged object that the user wants to create.
-
-          console.log({ TypeHelpers_updateMode: options?.updateMode });
-
-          const createdObject = RealmObject.create(realm, value, options?.updateMode ?? UpdateMode.Never, {
+          // TODO: Ideally use `options?.updateMode` instead of `realm.currentUpdateMode`.
+          const createdObject = RealmObject.create(realm, value, realm.currentUpdateMode ?? UpdateMode.Never, {
             helpers,
             createObj: options?.createObj,
           });

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -22,7 +22,6 @@ import {
   Collection,
   GeoBox,
   GeoCircle,
-  GeoPoint,
   GeoPolygon,
   INTERNAL,
   List,
@@ -260,8 +259,9 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
         } else {
           // TODO: Consider exposing a way for calling code to disable object creation
           assert.object(value, name);
-          // Some other object is assumed to be an unmanged object, that the user wants to create
-          const createdObject = RealmObject.create(realm, value, UpdateMode.Never, {
+          // Use the update mode if set; otherwise, the object is assumed to be an
+          // unmanaged object that the user wants to create.
+          const createdObject = RealmObject.create(realm, value, realm.currentUpdateMode ?? UpdateMode.Never, {
             helpers,
             createObj,
           });

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -72,7 +72,7 @@ export function toArrayBuffer(value: unknown, stringToBase64 = true) {
 
 /** @internal */
 export type TypeHelpers<T = unknown> = {
-  toBinding(value: T, createObj?: ObjCreator): binding.MixedArg;
+  toBinding(value: T, options?: { createObj?: ObjCreator; updateMode?: UpdateMode }): binding.MixedArg;
   fromBinding(value: unknown): T;
 };
 
@@ -249,7 +249,7 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
     const helpers = getClassHelpers(objectType);
     const { wrapObject } = helpers;
     return {
-      toBinding: nullPassthrough((value, createObj) => {
+      toBinding: nullPassthrough((value, options) => {
         if (
           value instanceof RealmObject &&
           value.constructor.name === objectType &&
@@ -261,9 +261,9 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
           assert.object(value, name);
           // Use the update mode if set; otherwise, the object is assumed to be an
           // unmanaged object that the user wants to create.
-          const createdObject = RealmObject.create(realm, value, realm.currentUpdateMode ?? UpdateMode.Never, {
+          const createdObject = RealmObject.create(realm, value, options?.updateMode ?? UpdateMode.Never, {
             helpers,
-            createObj,
+            createObj: options?.createObj,
           });
           return createdObject[INTERNAL];
         }


### PR DESCRIPTION
## What, How & Why?

This PR implements an initial solution for applying the `UpdateMode` to all objects when passed to `Realm.create()`.

This closes #5933.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests