### PR TITLE
Use recommended presets for `OpenRealmBehaviorConfiguration`

### DIFF
--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -33,7 +33,7 @@ const DogForSyncSchema = {
   },
 };
 
-async function getRegisteredEmailPassCredentials(app: Realm.App) {
+async function getRegisteredEmailPassCredentials(app: Realm.App<any, any>) {
   if (!app) {
     throw new Error("No app supplied to 'getRegisteredEmailPassCredentials'");
   }

--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -33,7 +33,7 @@ const DogForSyncSchema = {
   },
 };
 
-async function getRegisteredEmailPassCredentials(app: Realm.App<any, any>) {
+async function getRegisteredEmailPassCredentials(app: Realm.App) {
   if (!app) {
     throw new Error("No app supplied to 'getRegisteredEmailPassCredentials'");
   }
@@ -129,6 +129,7 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
+        //@ts-expect-error const enum is removed at runtime, should either remove const or leave this as is.
         _sessionStopPolicy: "immediately",
         //@ts-expect-error const enum is removed at runtime, should either remove const or leave this as is.
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -187,6 +188,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           existingRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -207,6 +209,7 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
+        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         newRealmFileBehavior: {
           //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -252,6 +255,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -314,6 +318,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           newRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -394,6 +399,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -460,6 +466,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -488,6 +495,7 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
+        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -522,6 +530,7 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
+        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -544,6 +553,7 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
+        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -585,6 +595,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "foo" },
@@ -598,6 +609,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "openLocalRealm", timeOutBehavior: "foo" },
@@ -611,6 +623,7 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
+          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "openLocalRealm", timeOut: "bar" },

--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -33,7 +33,7 @@ const DogForSyncSchema = {
   },
 };
 
-async function getRegisteredEmailPassCredentials(app: Realm.App) {
+async function getRegisteredEmailPassCredentials(app: Realm.App<any, any>) {
   if (!app) {
     throw new Error("No app supplied to 'getRegisteredEmailPassCredentials'");
   }
@@ -129,7 +129,6 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
-        //@ts-expect-error const enum is removed at runtime, should either remove const or leave this as is.
         _sessionStopPolicy: "immediately",
         //@ts-expect-error const enum is removed at runtime, should either remove const or leave this as is.
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -188,7 +187,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           existingRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -209,7 +207,6 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
-        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         newRealmFileBehavior: {
           //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -255,7 +252,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -318,7 +314,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           newRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -399,7 +394,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -466,7 +460,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           existingRealmFileBehavior: {
             //@ts-expect-error TYPEBUG: cannot access const enum at runtime
@@ -495,7 +488,6 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
-        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -530,7 +522,6 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
-        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -553,7 +544,6 @@ describe("OpenBehaviour", function () {
       sync: {
         user,
         partitionValue,
-        //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         _sessionStopPolicy: "immediately",
         //@ts-expect-error TYPEBUG: cannot access const enum at runtime
         newRealmFileBehavior: { type: "downloadBeforeOpen" },
@@ -595,7 +585,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "foo" },
@@ -609,7 +598,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "openLocalRealm", timeOutBehavior: "foo" },
@@ -623,7 +611,6 @@ describe("OpenBehaviour", function () {
         sync: {
           user,
           partitionValue,
-          //@ts-expect-error TYPEBUG: cannot access const enum at runtime
           _sessionStopPolicy: "immediately",
           //@ts-expect-error testing invalid value for newRealmFileBehaviour
           newRealmFileBehavior: { type: "openLocalRealm", timeOut: "bar" },

--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -21,6 +21,7 @@ import { generatePartition, randomVerifiableEmail } from "../../utils/generators
 import { importAppBefore } from "../../hooks";
 import { sleep } from "../../utils/sleep";
 import { buildAppConfig } from "../../utils/build-app-config";
+import { OpenRealmBehaviorType } from "realm/dist/bundle";
 
 const DogForSyncSchema = {
   name: "Dog",
@@ -51,9 +52,9 @@ describe("OpenBehaviour", function () {
   importAppBefore(buildAppConfig("with-pbs").anonAuth().emailPasswordAuth().partitionBasedSync());
   afterEach(() => Realm.clearTestState());
 
-  it("static references are defined", () => {
-    expect(Realm.App.Sync.openLocalRealmBehavior).to.not.be.undefined;
-    expect(Realm.App.Sync.downloadBeforeOpenBehavior).to.not.be.undefined;
+  it.only("static references are defined", () => {
+    expect(Realm.App.Sync.openLocalRealmBehavior.type).to.equal(OpenRealmBehaviorType.OpenImmediately);
+    expect(Realm.App.Sync.downloadBeforeOpenBehavior.type).to.equal(OpenRealmBehaviorType.DownloadBeforeOpen);
   });
 
   it("open synced realm with localRealmBehaviour", async function (this: AppContext) {

--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -16,12 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 import { expect } from "chai";
-import Realm, { BSON } from "realm";
+import Realm, { BSON, OpenRealmBehaviorType, OpenRealmTimeOutBehavior } from "realm";
 import { generatePartition, randomVerifiableEmail } from "../../utils/generators";
 import { importAppBefore } from "../../hooks";
 import { sleep } from "../../utils/sleep";
 import { buildAppConfig } from "../../utils/build-app-config";
-import { OpenRealmBehaviorType } from "realm/dist/bundle";
 
 const DogForSyncSchema = {
   name: "Dog",
@@ -52,9 +51,12 @@ describe("OpenBehaviour", function () {
   importAppBefore(buildAppConfig("with-pbs").anonAuth().emailPasswordAuth().partitionBasedSync());
   afterEach(() => Realm.clearTestState());
 
-  it.only("static references are defined", () => {
+  it("static references are defined", () => {
     expect(Realm.App.Sync.openLocalRealmBehavior.type).to.equal(OpenRealmBehaviorType.OpenImmediately);
+
     expect(Realm.App.Sync.downloadBeforeOpenBehavior.type).to.equal(OpenRealmBehaviorType.DownloadBeforeOpen);
+    expect(Realm.App.Sync.downloadBeforeOpenBehavior.timeOut).to.equal(30000);
+    expect(Realm.App.Sync.downloadBeforeOpenBehavior.timeOutBehavior).to.equal(OpenRealmTimeOutBehavior.ThrowException);
   });
 
   it("open synced realm with localRealmBehaviour", async function (this: AppContext) {

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -41,7 +41,7 @@ type OpenBehavior = {
 function determineBehavior(config: Configuration, realmExists: boolean): OpenBehavior {
   const { sync, openSyncedRealmLocally } = config;
   if (!sync || openSyncedRealmLocally) {
-    return { openBehavior: OpenRealmBehaviorType.OpenImmediately };
+    return { openBehavior: Realm.App.Sync.openLocalRealmBehavior.type };
   } else {
     const configProperty = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
     const configBehavior = sync[configProperty];
@@ -52,7 +52,8 @@ function determineBehavior(config: Configuration, realmExists: boolean): OpenBeh
       }
       return { openBehavior: type, timeOut, timeOutBehavior };
     } else {
-      return { openBehavior: OpenRealmBehaviorType.DownloadBeforeOpen }; // Default is downloadBeforeOpen
+      const { type, timeOut, timeOutBehavior } = Realm.App.Sync.downloadBeforeOpenBehavior;
+      return { openBehavior: type, timeOut, timeOutBehavior };
     }
   }
 }

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -41,7 +41,7 @@ type OpenBehavior = {
 function determineBehavior(config: Configuration, realmExists: boolean): OpenBehavior {
   const { sync, openSyncedRealmLocally } = config;
   if (!sync || openSyncedRealmLocally) {
-    return { openBehavior: Realm.App.Sync.openLocalRealmBehavior.type };
+    return { openBehavior: Realm.App.Sync.defaultLocalOpenRealmConfiguration.type };
   } else {
     const configProperty = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
     const configBehavior = sync[configProperty];
@@ -52,7 +52,7 @@ function determineBehavior(config: Configuration, realmExists: boolean): OpenBeh
       }
       return { openBehavior: type, timeOut, timeOutBehavior };
     } else {
-      const { type, timeOut, timeOutBehavior } = Realm.App.Sync.downloadBeforeOpenBehavior;
+      const { type, timeOut, timeOutBehavior } = Realm.App.Sync.defaultSyncOpenRealmConfiguration;
       return { openBehavior: type, timeOut, timeOutBehavior };
     }
   }

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -41,7 +41,7 @@ type OpenBehavior = {
 function determineBehavior(config: Configuration, realmExists: boolean): OpenBehavior {
   const { sync, openSyncedRealmLocally } = config;
   if (!sync || openSyncedRealmLocally) {
-    return { openBehavior: Realm.App.Sync.defaultLocalOpenRealmConfiguration.type };
+    return { openBehavior: OpenRealmBehaviorType.OpenImmediately };
   } else {
     const configProperty = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
     const configBehavior = sync[configProperty];
@@ -52,8 +52,11 @@ function determineBehavior(config: Configuration, realmExists: boolean): OpenBeh
       }
       return { openBehavior: type, timeOut, timeOutBehavior };
     } else {
-      const { type, timeOut, timeOutBehavior } = Realm.App.Sync.defaultSyncOpenRealmConfiguration;
-      return { openBehavior: type, timeOut, timeOutBehavior };
+      return {
+        openBehavior: OpenRealmBehaviorType.DownloadBeforeOpen,
+        timeOut: 30 * 1000,
+        timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+      };
     }
   }
 }

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -172,33 +172,22 @@ export class Sync {
   }
 
   /**
-   * The default OpenRealmBehaviorConfiguration used for local realms.
-   * This is used if the behavior is not specified by the developer when opening the realm.
-   * @internal
+   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
+   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
+   * @deprecated since v12
    */
-  static defaultLocalOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
+
+  static openLocalRealmBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.OpenImmediately,
   };
 
   /**
-   * The default OpenRealmBehaviorConfiguration used for synced realms.
-   * This is used if the behavior is not specified by the developer when opening the realm.
-   * @internal
+   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
+   * @deprecated since v12
    */
-  static defaultSyncOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
+  static downloadBeforeOpenBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.DownloadBeforeOpen,
     timeOut: 30 * 1000,
     timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
   };
-
-  /**
-   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
-   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
-   */
-  static openLocalRealmBehavior = Sync.defaultLocalOpenRealmConfiguration;
-
-  /**
-   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
-   */
-  static downloadBeforeOpenBehavior = Sync.defaultSyncOpenRealmConfiguration;
 }

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -195,10 +195,10 @@ export class Sync {
    * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
    * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
    */
-  static openLocalRealmBehavior = this.defaultLocalOpenRealmConfiguration;
+  static openLocalRealmBehavior = Sync.defaultLocalOpenRealmConfiguration;
 
   /**
    * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
    */
-  static downloadBeforeOpenBehavior = this.defaultSyncOpenRealmConfiguration;
+  static downloadBeforeOpenBehavior = Sync.defaultSyncOpenRealmConfiguration;
 }

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -172,19 +172,33 @@ export class Sync {
   }
 
   /**
-   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
-   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
+   * The default OpenRealmBehaviorConfiguration used for local realms.
+   * This is used if the behavior is not specified by the developer when opening the realm.
+   * @internal
    */
-  static openLocalRealmBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
+  static defaultLocalOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.OpenImmediately,
   };
 
   /**
-   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
+   * The default OpenRealmBehaviorConfiguration used for synced realms.
+   * This is used if the behavior is not specified by the developer when opening the realm.
+   * @internal
    */
-  static downloadBeforeOpenBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
+  static defaultSyncOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.DownloadBeforeOpen,
     timeOut: 30 * 1000,
     timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
   };
+
+  /**
+   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
+   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
+   */
+  static openLocalRealmBehavior = this.defaultLocalOpenRealmConfiguration;
+
+  /**
+   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
+   */
+  static downloadBeforeOpenBehavior = this.defaultSyncOpenRealmConfiguration;
 }

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -208,11 +208,23 @@ export type BaseSyncConfiguration = {
   user: AnyUser;
   /**
    * Whether to create a new file and sync in background or wait for the file to be synced.
+   * @default
+   * {
+   *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
+   *   timeOut: 30 * 1000,
+   *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+   * }
    */
   newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**
    * Whether to open existing file and sync in background or wait for the sync of the file to complete and then open.
    * If not set, the Realm will be downloaded before opened.
+   * @default
+   * {
+   *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
+   *   timeOut: 30 * 1000,
+   *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+   * }
    */
   existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**


### PR DESCRIPTION
Use recommended presets for `OpenRealmBehaviorConfiguration` when the user didn't define values themselves