### PR TITLE
Fix Prepare Release Workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
         id: update-changelog
         uses: realm/ci-actions/update-changelog@main
         with:
-          version: ${{ inputs.version }} 
+          version: ${{ inputs.version }}
           changelog: ${{ github.workspace }}/CHANGELOG.md
 
       - name: Update version
@@ -42,7 +42,7 @@ jobs:
           body: An automated PR for next release.
           commit-message: "[${{ steps.update-changelog.outputs.new-version }}] Bump version"
           token: ${{ secrets.REALM_CI_PAT }}
-          assignees: ${{ github.event.sender }}
-      
+          assignees: ${{ github.event.sender.login }}
+
       - name: Update summary
         run: echo "Created [PR for v${{ steps.update-changelog.outputs.new-version }}](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION

## What, How & Why?
* `github.event.sender` returns an object, not a string
* The GitHub username is stored in `sender.login`


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
