### PR TITLE
Update `ClassMap` before notifying schema change listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fixed updating helpers (the `ClassMap`) used by `Realm` before notifying schema change listeners when the schema is changed during runtime. ([#5574](https://github.com/realm/realm-js/issues/5574))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -170,19 +170,12 @@ describe("realm._updateSchema", () => {
     });
   });
 
-  it("can access updated ClassMap after schema change event", function (this: RealmContext, done) {
+  it("updates the ClassMap before notifying the schema change listener", function (this: RealmContext, done) {
     this.realm.addListener("schema", () => {
-      // `setImmediate()` is used so that `getClassHelpers()` is called in the next tick.
-      // Without this, `MyClass` cannot be found (Error: Object type 'MyClass' not found in schema).
-      // It seems that the listener is fired before the ClassMap is fully constructed and before
-      // the write transaction is committed. (Any logs following `_updateSchema()` in the write
-      // transaction will not be logged when not using `setImmediate()`.)
-      setImmediate(() => {
-        // @ts-expect-error Internal method
-        const classHelpers = this.realm.getClassHelpers("MyClass");
-        expect(classHelpers.objectSchema.name).to.equal("MyClass");
-        done();
-      });
+      // @ts-expect-error Internal method
+      const classHelpers = this.realm.getClassHelpers("MyClass");
+      expect(classHelpers.objectSchema.name).to.equal("MyClass");
+      done();
     });
 
     this.realm.write(() => {

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -170,6 +170,43 @@ describe("realm._updateSchema", () => {
     });
   });
 
+  it("can access updated ClassMap after schema change event", function (this: RealmContext, done) {
+    this.realm.addListener("schema", () => {
+      console.log("SCHEMA LISTENER..");
+      // See note at the end of this test regarding `setImmediate()`.
+      setImmediate(() => {
+        // @ts-expect-error Internal method
+        const classHelpers = this.realm.getClassHelpers("MyClass");
+        expect(classHelpers.objectSchema.name).to.equal("MyClass");
+        console.log("SCHEMA LISTENER DONE!");
+        done();
+      });
+    });
+
+    this.realm.write(() => {
+      console.log("UPDATING SCHEMA..");
+      // @ts-expect-error Internal method
+      this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: { myField: "string" } }]);
+      console.log("UPDATING SCHEMA DONE!");
+    });
+
+    // Temporary note
+    // -----------------
+    // `setImmediate()` is used so that `getClassHelpers()` is called in the next tick.
+    // Without this, `MyClass` cannot be found (Error: Object type 'MyClass' not found in schema).
+    // It seems that the listener is fired before the ClassMap is fully constructed.
+    //
+    // Logs without using `setImmediate()`:
+    //    UPDATING SCHEMA..
+    //    SCHEMA LISTENER..
+    //
+    // Logs when using `setImmediate()`:
+    //    UPDATING SCHEMA..
+    //    SCHEMA LISTENER..
+    //    UPDATING SCHEMA DONE!
+    //    SCHEMA LISTENER DONE!
+  });
+
   it("throws if creating a class schema outside of a transaction", function (this: RealmContext) {
     expect(() => {
       // @ts-expect-error Internal method

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -31,6 +31,7 @@ describe("realm._updateSchema", () => {
   it("is a function", function (this: RealmContext) {
     expect(this.realm.schema).to.be.an("array");
     // There is a function defined on the Realm
+    // @ts-expect-error Internal method
     expect(this.realm._updateSchema).to.be.a("function");
     // Expect no enumerable field on the schema property
     expect(Object.keys(this.realm.schema)).to.not.contain("update");
@@ -40,6 +41,7 @@ describe("realm._updateSchema", () => {
 
   it("creates a class schema from a name", function (this: RealmContext) {
     this.realm.write(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: {} }]);
     });
     const classNames = this.realm.schema.map((s) => s.name);
@@ -48,6 +50,7 @@ describe("realm._updateSchema", () => {
 
   it("creates a class schema from a name and properties", function (this: RealmContext) {
     this.realm.write(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: { myField: "string" } }]);
     });
     const MyClassSchema = this.realm.schema.find((s) => s.name === "MyClass");
@@ -80,6 +83,7 @@ describe("realm._updateSchema", () => {
     dogSchema.properties.friends = "Dog[]";
     // Update the schema
     this.realm.write(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema(updatedSchema);
     });
 
@@ -130,6 +134,7 @@ describe("realm._updateSchema", () => {
 
   it("can use a newly added class", function (this: RealmContext) {
     this.realm.write(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: { myField: "string" } }]);
       type MyClass = { myField: string };
       this.realm.create("MyClass", { myField: "some string" });
@@ -148,12 +153,26 @@ describe("realm._updateSchema", () => {
     });
 
     this.realm.write(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: { myField: "string" } }]);
+    });
+  });
+
+  it("updates the ClassMap", function (this: RealmContext) {
+    this.realm.write(() => {
+      // @ts-expect-error Internal method
+      expect(() => this.realm.getClassHelpers("MyClass")).to.throw("Object type 'MyClass' not found in schema");
+      // @ts-expect-error Internal method
+      this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: { myField: "string" } }]);
+      // @ts-expect-error Internal method
+      const classHelpers = this.realm.getClassHelpers("MyClass");
+      expect(classHelpers.objectSchema.name).to.equal("MyClass");
     });
   });
 
   it("throws if creating a class schema outside of a transaction", function (this: RealmContext) {
     expect(() => {
+      // @ts-expect-error Internal method
       this.realm._updateSchema([...this.realm.schema, { name: "MyClass", properties: {} }]);
     }).to.throw("Can only create object schema within a transaction.");
   });
@@ -161,6 +180,7 @@ describe("realm._updateSchema", () => {
   it("throws if asked to create a class that already exists", function (this: RealmContext) {
     expect(() => {
       this.realm.write(() => {
+        // @ts-expect-error Internal method
         this.realm._updateSchema([...this.realm.schema, { name: "Person", properties: {} }]);
       });
     }).to.throw("Type 'Person' appears more than once in the schema.");

--- a/packages/realm/src/ClassHelpers.ts
+++ b/packages/realm/src/ClassHelpers.ts
@@ -26,8 +26,6 @@ import {
   binding,
 } from "./internal";
 
-type BindingObjectSchema = binding.Realm["schema"][0];
-
 type ObjectWrapper = (obj: binding.Obj) => (RealmObject & DefaultObject) | null;
 
 /**
@@ -35,8 +33,7 @@ type ObjectWrapper = (obj: binding.Obj) => (RealmObject & DefaultObject) | null;
  */
 export type ClassHelpers = {
   constructor: RealmObjectConstructor;
-  // TODO: Use a different type, once exposed by the binding
-  objectSchema: BindingObjectSchema;
+  objectSchema: binding.ObjectSchema;
   properties: PropertyMap;
   wrapObject: ObjectWrapper;
   canonicalObjectSchema: CanonicalObjectSchema;

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -601,7 +601,7 @@ export class Realm {
   public readonly syncSession: SyncSession | null;
 
   private schemaExtras: RealmSchemaExtra = {};
-  private classes!: ClassMap;
+  private classes: ClassMap;
   private changeListeners = new RealmListeners(this, RealmEvent.Change);
   private beforeNotifyListeners = new RealmListeners(this, RealmEvent.BeforeNotify);
   private schemaListeners = new RealmListeners(this, RealmEvent.Schema);
@@ -661,7 +661,7 @@ export class Realm {
         },
         schemaDidChange: (r) => {
           r.verifyOpen();
-          this.updateClassMap();
+          this.classes = new ClassMap(this, this.internal.schema, this.schema);
           this.schemaListeners.notify(this.schema);
         },
         beforeNotify: (r) => {
@@ -687,7 +687,7 @@ export class Realm {
       writable: false,
     });
 
-    this.updateClassMap();
+    this.classes = new ClassMap(this, this.internal.schema, this.schema);
 
     const syncSession = this.internal.syncSession;
     this.syncSession = syncSession ? new SyncSession(syncSession) : null;
@@ -1242,13 +1242,6 @@ export class Realm {
     arg: string | binding.TableKey | RealmObject<T> | Constructor<RealmObject<T>>,
   ): ClassHelpers {
     return this.classes.getHelpers<T>(arg);
-  }
-
-  /**
-   * @internal
-   */
-  private updateClassMap() {
-    this.classes = new ClassMap(this, this.internal.schema, this.schema);
   }
 
   /**


### PR DESCRIPTION
## What, How & Why?

When calling `Realm._updateSchema()` in a write transaction, the schema change listener is fired after the call into Core, but before `_updateSchema()` returns (and thus before the write transaction is completed).

The `ClassMap` instance on the Realm was previously updated/reinitialized in `_updateSchema()`, but since the listener was fired before that, the `ClassMap` had not been updated in time. This PR moves that update into the `schemaDidChange` callback, updating it before notifying schema change listeners.

This closes #5574 

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
