### PR TITLE
Suggestion for default open behavior

### DIFF
--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -38,10 +38,20 @@ type OpenBehavior = {
   timeOutBehavior?: OpenRealmTimeOutBehavior;
 };
 
+const defaultLocalOpenRealmConfiguration = {
+  openBehavior: OpenRealmBehaviorType.OpenImmediately,
+};
+
+const defaultSyncOpenRealmConfiguration = {
+  openBehavior: OpenRealmBehaviorType.DownloadBeforeOpen,
+  timeOut: 30 * 1000,
+  timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+};
+
 function determineBehavior(config: Configuration, realmExists: boolean): OpenBehavior {
   const { sync, openSyncedRealmLocally } = config;
   if (!sync || openSyncedRealmLocally) {
-    return { openBehavior: Realm.App.Sync.defaultLocalOpenRealmConfiguration.type };
+    return defaultLocalOpenRealmConfiguration;
   } else {
     const configProperty = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
     const configBehavior = sync[configProperty];
@@ -52,8 +62,7 @@ function determineBehavior(config: Configuration, realmExists: boolean): OpenBeh
       }
       return { openBehavior: type, timeOut, timeOutBehavior };
     } else {
-      const { type, timeOut, timeOutBehavior } = Realm.App.Sync.defaultSyncOpenRealmConfiguration;
-      return { openBehavior: type, timeOut, timeOutBehavior };
+      return defaultSyncOpenRealmConfiguration;
     }
   }
 }

--- a/packages/realm/src/ProgressRealmPromise.ts
+++ b/packages/realm/src/ProgressRealmPromise.ts
@@ -38,20 +38,10 @@ type OpenBehavior = {
   timeOutBehavior?: OpenRealmTimeOutBehavior;
 };
 
-const defaultLocalOpenRealmConfiguration = {
-  openBehavior: OpenRealmBehaviorType.OpenImmediately,
-};
-
-const defaultSyncOpenRealmConfiguration = {
-  openBehavior: OpenRealmBehaviorType.DownloadBeforeOpen,
-  timeOut: 30 * 1000,
-  timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
-};
-
 function determineBehavior(config: Configuration, realmExists: boolean): OpenBehavior {
   const { sync, openSyncedRealmLocally } = config;
   if (!sync || openSyncedRealmLocally) {
-    return defaultLocalOpenRealmConfiguration;
+    return { openBehavior: OpenRealmBehaviorType.OpenImmediately };
   } else {
     const configProperty = realmExists ? "existingRealmFileBehavior" : "newRealmFileBehavior";
     const configBehavior = sync[configProperty];
@@ -62,7 +52,11 @@ function determineBehavior(config: Configuration, realmExists: boolean): OpenBeh
       }
       return { openBehavior: type, timeOut, timeOutBehavior };
     } else {
-      return defaultSyncOpenRealmConfiguration;
+      return {
+        openBehavior: OpenRealmBehaviorType.DownloadBeforeOpen,
+        timeOut: 30 * 1000,
+        timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+      };
     }
   }
 }

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -23,6 +23,7 @@ import {
   Logger,
   MutableSubscriptionSet,
   NumericLogLevel,
+  OpenRealmBehaviorConfiguration,
   OpenRealmBehaviorType,
   OpenRealmTimeOutBehavior,
   PartitionValue,
@@ -175,7 +176,8 @@ export class Sync {
    * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
    * @deprecated since v12
    */
-  static openLocalRealmBehavior = {
+
+  static openLocalRealmBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.OpenImmediately,
   };
 
@@ -183,7 +185,7 @@ export class Sync {
    * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
    * @deprecated since v12
    */
-  static downloadBeforeOpenBehavior = {
+  static downloadBeforeOpenBehavior: Readonly<OpenRealmBehaviorConfiguration> = {
     type: OpenRealmBehaviorType.DownloadBeforeOpen,
     timeOut: 30 * 1000,
     timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -23,7 +23,6 @@ import {
   Logger,
   MutableSubscriptionSet,
   NumericLogLevel,
-  OpenRealmBehaviorConfiguration,
   OpenRealmBehaviorType,
   OpenRealmTimeOutBehavior,
   PartitionValue,
@@ -172,33 +171,21 @@ export class Sync {
   }
 
   /**
-   * The default OpenRealmBehaviorConfiguration used for local realms.
-   * This is used if the behavior is not specified by the developer when opening the realm.
-   * @internal
+   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
+   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
+   * @deprecated since v12
    */
-  static defaultLocalOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
+  static openLocalRealmBehavior = {
     type: OpenRealmBehaviorType.OpenImmediately,
   };
 
   /**
-   * The default OpenRealmBehaviorConfiguration used for synced realms.
-   * This is used if the behavior is not specified by the developer when opening the realm.
-   * @internal
+   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
+   * @deprecated since v12
    */
-  static defaultSyncOpenRealmConfiguration: Readonly<OpenRealmBehaviorConfiguration> = {
+  static downloadBeforeOpenBehavior = {
     type: OpenRealmBehaviorType.DownloadBeforeOpen,
     timeOut: 30 * 1000,
     timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
   };
-
-  /**
-   * The default behavior settings if you want to open a synchronized Realm immediately and start working on it.
-   * If this is the first time you open the Realm, it will be empty while the server data is being downloaded in the background.
-   */
-  static openLocalRealmBehavior = Sync.defaultLocalOpenRealmConfiguration;
-
-  /**
-   * The default behavior settings if you want to wait for downloading a synchronized Realm to complete before opening it.
-   */
-  static downloadBeforeOpenBehavior = Sync.defaultSyncOpenRealmConfiguration;
 }

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -208,27 +208,23 @@ export type BaseSyncConfiguration = {
   user: AnyUser;
   /**
    * Whether to create a new file and sync in background or wait for the file to be synced.
-   * The default behavior is:
-   *```
+   * @default
    * {
    *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
    *   timeOut: 30 * 1000,
    *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
    * }
-   * ```
    */
   newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**
    * Whether to open existing file and sync in background or wait for the sync of the file to complete and then open.
    * If not set, the Realm will be downloaded before opened.
-   * The default behavior is:
-   *```
+   * @default
    * {
    *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
    *   timeOut: 30 * 1000,
    *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
    * }
-   * ```
    */
   existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**

--- a/packages/realm/src/app-services/SyncConfiguration.ts
+++ b/packages/realm/src/app-services/SyncConfiguration.ts
@@ -208,11 +208,27 @@ export type BaseSyncConfiguration = {
   user: AnyUser;
   /**
    * Whether to create a new file and sync in background or wait for the file to be synced.
+   * The default behavior is:
+   *```
+   * {
+   *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
+   *   timeOut: 30 * 1000,
+   *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+   * }
+   * ```
    */
   newRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**
    * Whether to open existing file and sync in background or wait for the sync of the file to complete and then open.
    * If not set, the Realm will be downloaded before opened.
+   * The default behavior is:
+   *```
+   * {
+   *   type: OpenRealmBehaviorType.DownloadBeforeOpen,
+   *   timeOut: 30 * 1000,
+   *   timeOutBehavior: OpenRealmTimeOutBehavior.ThrowException,
+   * }
+   * ```
    */
   existingRealmFileBehavior?: OpenRealmBehaviorConfiguration;
   /**


### PR DESCRIPTION
    * deprecate the static types that were imported from v11
    * define the defaults locally in the ProgressRealmPromise
    * document what the defaults for these fields are in SyncConfiguration

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
