### PR TITLE
Add peer version support for RN 72

### DIFF
--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -268,7 +268,7 @@
   },
   "peerDependencies": {
     "bson": "^4",
-    "react-native": "^0.71.0"
+    "react-native": ">=0.71.0"
   },
   "peerDependenciesMeta": {
     "react-native": {


### PR DESCRIPTION

## What, How & Why?
The current package.json had a pinned peer dependency on RN 71.  This would cause an error when running npm install on RN 72 projects.  The change ensures that we at least install on the newer version of RN.


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
