### PR TITLE
Refactor post-install script to not depend on fs-extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 <!-- * Either mention core version or upgrade -->
 <!-- * Using Realm Core vX.Y.Z -->
 <!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Installation failed due to missing dependency (`fs-extra`), and the post-install script has been refactored to use `fs` instead.
 
 ## 12.0.0-rc.1 (2023-06-30)
 

--- a/packages/realm/scripts/submit-analytics.mjs
+++ b/packages/realm/scripts/submit-analytics.mjs
@@ -52,7 +52,6 @@ import { createHmac } from "node:crypto";
 import { Buffer } from "node:buffer";
 
 import machineId from "node-machine-id";
-import fse from "fs-extra";
 
 import createDebug from "debug";
 export const debug = createDebug("realm:submit-analytics");
@@ -105,7 +104,9 @@ function getProjectRoot() {
  */
 function getPackageJson(packagePath) {
   const packageJson = path.resolve(packagePath, "package.json");
-  return fse.readJsonSync(packageJson);
+  const buffer = fs.readFileSync(packageJson);
+  const asJson = JSON.parse(buffer);
+  return asJson;
 }
 
 /**
@@ -127,8 +128,7 @@ function isAnalyticsDisabled() {
 }
 
 function getRealmVersion() {
-  const packageJsonPath = path.resolve(__dirname, "../package.json");
-  const packageJson = fse.readJsonSync(packageJsonPath);
+  const packageJson = getPackageJson(__dirname);
   return packageJson["version"];
 }
 
@@ -139,7 +139,7 @@ function getRealmVersion() {
  */
 function getRealmCoreVersion() {
   const dependenciesListPath = path.resolve(__dirname, "../dependencies.list");
-  const dependenciesList = fse
+  const dependenciesList = fs
     .readFileSync(dependenciesListPath)
     .toString()
     .split("\n")


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

No open issue for this.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
