### PR TITLE
Remove type error on OrderedCollection

### DIFF
--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -748,4 +748,12 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       return DEFAULT_COLUMN_KEY;
     }
   }
+
+  /**
+   * This symbol was required for implementing ReadOnlyArray, but we don't need
+   * it for anything.  It's just here to make TypeScript happy.
+   * For more reading see:
+   * @see (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables)
+   */
+  readonly [Symbol.unscopables] = {};
 }


### PR DESCRIPTION
## What, How & Why?
* TypeScript was yelling since we weren't implementing [Symbol.unscopables]
* Set to empty object to remove error (this has no negatives effects)
* See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables for more info

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
