### PR TITLE
[useObject] Update primaryKeyRef on change (#5620)

### DIFF
--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -90,6 +90,8 @@ export function createUseObject(useRealm: () => Realm) {
             updatedRef,
           });
           originalObjectRef.current = originalObject;
+          // Update the primaryKeyRef, so we can check if the primaryKey has changed on the next render
+          primaryKeyRef.current = primaryKey;
         }
         return cachedObjectRef.current;
       },


### PR DESCRIPTION
## What, How & Why?
Within the `useObject` hook, the internal ref `primaryKeyRef` is never updated, causing successive calls to `arePrimaryKeysIdentical` to fail. 

This causes two issues:
- If `useObject`  is called with a primary key `a`, then again with `b`, and then again with `a`, it will return the object for the primary key `b`.
- After a primary key change, `arePrimaryKeysIdentical` will always return false, potentially causing the cached object to be recreated on each render.

Updating `primaryKeyRef` after `arePrimaryKeysIdentical` fails solves these two issues, and `useObject` works as expected.

This closes #5620 

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [X] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [X] 📱 Check the React Native/other sample apps work if necessary
* [X] 📝 Public documentation PR created or is not necessary
* [X] 💥 `Breaking` label has been applied or is not necessary
