### PR TITLE
Fix Date and ObjectId arguments in MDB client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * None
 
 ### Fixed
-* Fix Jest issues when testing against Realm ([#6003](https://github.com/realm/realm-js/issues/6003))
-* None
+* Fix Jest issues when testing against Realm. ([#6003](https://github.com/realm/realm-js/issues/6003))
+* Fix Date and ObjectId arguments being empty objects in MongoDB client. ([#6030](https://github.com/realm/realm-js/issues/6030))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm/src/app-services/utils.ts
+++ b/packages/realm/src/app-services/utils.ts
@@ -25,7 +25,8 @@ export function cleanArguments(args: unknown[] | unknown): unknown[] | unknown {
     // Note: `undefined` elements in the array is not removed.
     return args.map(cleanArguments);
   }
-  if (args === null || typeof args !== "object") {
+  // Checking for constructor to allow for `new Date()` and `new ObjectId()` and similar.
+  if (args === null || typeof args !== "object" || args?.constructor !== Object) {
     return args;
   }
   const result: { [key: string]: unknown } = {};


### PR DESCRIPTION
## What, How & Why?
* Date and ObjectId were being transformed into an empty object on the way to the MDB client
* Modified the cleanArguments utility to not overwrite these objects with an empty one

This closes #6030

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
