### PR TITLE
[useObject] Update primaryKeyRef on change (#5620)

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fix for `useObject`` not updating when using previously used primary key. ([#5620](https://github.com/realm/realm-js/issues/5620), since v0.4.2. Thanks @RS1-Project)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm-react/src/__tests__/useObjectRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectRender.test.tsx
@@ -392,16 +392,33 @@ describe("useObject: rendering objects with a Realm.List property", () => {
     it("renders a different list if the target primary key changes", async () => {
       const { rerender, getByTestId } = await setupTest();
 
-      const newParentObjectId = new Realm.BSON.ObjectId();
+      const secondListId = new Realm.BSON.ObjectId();
 
       testRealm.write(() => {
-        testRealm.create(List, { id: newParentObjectId, title: "Other List", items: [] });
+        testRealm.create(List, { id: secondListId, title: "Second List", items: [] });
       });
 
-      rerender(<App targetPrimaryKey={newParentObjectId} />);
+      rerender(<App targetPrimaryKey={secondListId} />);
 
-      const titleElement = getByTestId(`listTitle${newParentObjectId.toHexString()}`);
-      expect(titleElement).toHaveTextContent("Other List");
+      let titleElement = getByTestId(`listTitle${secondListId.toHexString()}`);
+      expect(titleElement).toHaveTextContent("Second List");
+
+      const thirdListId = new Realm.BSON.ObjectId();
+
+      testRealm.write(() => {
+        testRealm.create(List, { id: thirdListId, title: "Third List", items: [] });
+      });
+
+      rerender(<App targetPrimaryKey={thirdListId} />);
+
+      titleElement = getByTestId(`listTitle${thirdListId.toHexString()}`);
+      expect(titleElement).toHaveTextContent("Third List");
+
+      // Render the old id
+      rerender(<App targetPrimaryKey={secondListId} />);
+
+      titleElement = getByTestId(`listTitle${secondListId.toHexString()}`);
+      expect(titleElement).toHaveTextContent("Second List");
     });
     it("will return the same reference when state changes", async () => {
       const { getByTestId } = await setupTest();

--- a/packages/realm-react/src/__tests__/useObjectRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectRender.test.tsx
@@ -417,6 +417,7 @@ describe("useObject: rendering objects with a Realm.List property", () => {
       // Render the old id
       rerender(<App targetPrimaryKey={secondListId} />);
 
+      await waitFor(() => getByTestId(`listTitle${secondListId.toHexString()}`));
       titleElement = getByTestId(`listTitle${secondListId.toHexString()}`);
       expect(titleElement).toHaveTextContent("Second List");
     });

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -90,6 +90,8 @@ export function createUseObject(useRealm: () => Realm) {
             updatedRef,
           });
           originalObjectRef.current = originalObject;
+          // Update the primaryKeyRef, so we can check if the primaryKey has changed on the next render
+          primaryKeyRef.current = primaryKey;
         }
         return cachedObjectRef.current;
       },

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -90,8 +90,11 @@ export function createUseObject(useRealm: () => Realm) {
             updatedRef,
           });
           originalObjectRef.current = originalObject;
-          // Update the primaryKeyRef, so we can check if the primaryKey has changed on the next render
+
+          // Primary key has updated, so update the reference
           primaryKeyRef.current = primaryKey;
+          // Signal that the object reference needs to be updated
+          updatedRef.current = true;
         }
         return cachedObjectRef.current;
       },


### PR DESCRIPTION
Original PR by @RS1-Project 

## What, How & Why?
Within the `useObject` hook, the internal ref `primaryKeyRef` was never updated, causing successive calls to `arePrimaryKeysIdentical` to fail.
Issue 1:
If the hook is called with a primary key `a`, then again with `b`, and then again with `a`, it will return the object for the primary key `b`.
Issue 2:
After a primary key change, `arePrimaryKeysIdentical` will always return false, potentially causing the cached object to be recreated on each render.
Issue 3:
After the primary key reference is updated, the original object reference also needs to be re-proxied in order to signal re-render of the component implementing `useObject`

This closes #5620

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
