### PR TITLE
Add flag to keep Realm open on RealmProvider unmount

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -11,14 +11,10 @@
 * None
 
 ### Compatibility
-* React Native >= v0.71.4
-* Realm Studio v14.0.0.
-* File format: generates Realms with format v23 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+* Realm >= 11.0.0
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Added more documentation to provider params.
 
 ## 0.5.2 (2023-08-09)
 

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* Add flag to keep realm open on unmount of RealmProvider. ([#6023](https://github.com/realm/realm-js/issues/6023))
+* Add flag to keep realm open on unmount of `RealmProvider`. ([#6023](https://github.com/realm/realm-js/issues/6023))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* None
+* Add flag to keep realm open on unmount of RealmProvider. ([#6023](https://github.com/realm/realm-js/issues/6023))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -234,6 +234,19 @@ const AppWrapper = () => {
   )
 }
 ```
+
+It may also be necessary to render multiple `RealmProvider`s of the same Realm in an app.  In this case, the flag `closeOnUnmount` can be set to `false`` to prevent both Realm instances from closing when one has been removed from the component tree.
+This is set to `true` by default.
+
+```tsx
+const AppWrapper = () => {
+  return (
+    <RealmProvider closeOnUnmount={false}>
+      <App/>
+    <RealmProvider>
+  )
+}
+```
 ### Dynamically Updating a Realm Configuration
 
 It is possible to update the realm configuration by setting props on the `RealmProvider`.  The `RealmProvider` takes props for all possible realm configuration properties.

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -235,7 +235,7 @@ const AppWrapper = () => {
 }
 ```
 
-It may also be necessary to render multiple `RealmProvider`s of the same Realm in an app.  In this case, the flag `closeOnUnmount` can be set to `false`` to prevent both Realm instances from closing when one has been removed from the component tree.
+It may also be necessary to render multiple `RealmProvider`s of the same Realm in an app. In this case, the flag `closeOnUnmount` can be set to `false`` to prevent both Realm instances from closing when one has been removed from the component tree.
 This is set to `true` by default.
 
 ```tsx

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -52,8 +52,12 @@ const AuthOperationProvider: React.FC<AuthOperationProps> = ({ children }) => {
  * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
  */
 type AppProviderProps = Realm.AppConfiguration & {
-  children: React.ReactNode;
+  /**
+   * A ref to the App instance. This is useful if you need to access the App
+   * instance outside of a component that uses the App hooks.
+   */
   appRef?: React.MutableRefObject<Realm.App | null>;
+  children: React.ReactNode;
 };
 
 /**

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -26,8 +26,19 @@ type PartialRealmConfiguration = Omit<Partial<Realm.Configuration>, "sync"> & {
 };
 
 type ProviderProps = PartialRealmConfiguration & {
+  /**
+   * The fallback component to render if the Realm is not opened.
+   */
   fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
+  /**
+   * If false, Realm will not be closed when the component unmounts.
+   * @default true
+   */
   closeOnUnmount?: boolean;
+  /**
+   * A ref to the Realm instance. This is useful if you need to access the Realm
+   * instance outside of a component that uses the Realm hooks.
+   */
   realmRef?: React.MutableRefObject<Realm | null>;
   children: React.ReactNode;
 };

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -26,7 +26,10 @@ import { useApp } from "./AppProvider";
 export const UserContext = createContext<Realm.User | null>(null);
 
 type UserProviderProps = {
-  // Optional fallback component to render when unauthenticated
+  /**
+   * The fallback component to render if there is no authorized user.  This can be used
+   * to render a login screen or another component which will log the user in.
+   */
   fallback?: React.ComponentType<unknown> | React.ReactElement | null | undefined;
   children: React.ReactNode;
 };

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -68,6 +68,19 @@ describe("RealmProvider", () => {
     expect(realm.isClosed).toBe(true);
   });
 
+  it("returns the configured realm with useRealm and stays open if flagged", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <RealmProvider closeOnUnmount={false}>{children}</RealmProvider>
+    );
+    const { result, unmount } = renderHook(() => useRealm(), { wrapper });
+    await waitFor(() => expect(result.current).not.toBe(null));
+    const realm = result.current;
+    expect(realm).not.toBe(null);
+    expect(realm.schema[0].name).toBe("dog");
+    unmount();
+    expect(realm.isClosed).toBe(false);
+  });
+
   it("will override the the configuration provided in createRealmContext", async () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <RealmProvider schema={[catSchema]}>{children}</RealmProvider>

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -75,7 +75,6 @@ describe("RealmProvider", () => {
     const { result, unmount } = renderHook(() => useRealm(), { wrapper });
     await waitFor(() => expect(result.current).not.toBe(null));
     const realm = result.current;
-    expect(realm).not.toBe(null);
     expect(realm.schema[0].name).toBe("dog");
     unmount();
     expect(realm.isClosed).toBe(false);


### PR DESCRIPTION
## What, How & Why?
Add flag to keep Realm open on RealmProvider unmount
* There are a few valid use cases for doing this as calling realm.close will close all open instances of said realm.

This closes #6023

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
