### PR TITLE
Refactor function tests and disable custom function auth tests

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -27,7 +27,7 @@ jobs:
           echo "subdomain=${subdomain}" >> $GITHUB_OUTPUT;
           echo "hostname=${subdomain}.ngrok.io" >> $GITHUB_OUTPUT;
       - name: Start Ngrok
-        run: docker run --detach --network host --env NGROK_AUTHTOKEN ngrok/ngrok http --subdomain ${{ steps.ngrok-config.outputs.subdomain }} 9090
+        run: docker run --detach --network host --env NGROK_AUTHTOKEN ngrok/ngrok http --host-header="${{ steps.ngrok-config.outputs.subdomain }}:9090" --subdomain ${{ steps.ngrok-config.outputs.subdomain }} 9090
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
       - name: Preparing server entrypoint

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -27,7 +27,7 @@ jobs:
           echo "subdomain=${subdomain}" >> $GITHUB_OUTPUT;
           echo "hostname=${subdomain}.ngrok.io" >> $GITHUB_OUTPUT;
       - name: Start Ngrok
-        run: docker run --detach --network host --env NGROK_AUTHTOKEN ngrok/ngrok http --host-header="${{ steps.ngrok-config.outputs.subdomain }}:9090" --subdomain ${{ steps.ngrok-config.outputs.subdomain }} 9090
+        run: docker run --detach --network host --env NGROK_AUTHTOKEN ngrok/ngrok http --subdomain ${{ steps.ngrok-config.outputs.subdomain }} 9090
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
       - name: Preparing server entrypoint

--- a/integration-tests/tests/src/tests/credentials/function.ts
+++ b/integration-tests/tests/src/tests/credentials/function.ts
@@ -33,7 +33,7 @@ describe.skipIf(environment.missingServer, "custom-function credentials", () => 
           const { username, secret } = loginPayload;
 
           if (secret !== "v3ry-s3cret") {
-            throw new Error("Ah ah ah, you didn't say the magic word");
+            throw new Error("Ah ah ah, you did not say the magic word");
           }
           // Query for an existing user document with the specified username
 

--- a/integration-tests/tests/src/tests/credentials/function.ts
+++ b/integration-tests/tests/src/tests/credentials/function.ts
@@ -21,7 +21,9 @@ import { Credentials, User } from "realm";
 import { importAppBefore } from "../../hooks";
 import { buildAppConfig } from "../../utils/build-app-config";
 
-describe.skipIf(environment.missingServer, "custom-function credentials", () => {
+// FIXME: when importing customFunctionAuth we are almost consistently getting "Syntax error: unexpected EOF (400 Bad Request)".
+// describe.skipIf(environment.missingServer, "custom-function credentials", () => {
+describe.skip("custom-function credentials", () => {
   importAppBefore(
     buildAppConfig("with-custom-function").mongodbService().customFunctionAuth(`
         exports = async function (loginPayload) {

--- a/integration-tests/tests/src/tests/credentials/function.ts
+++ b/integration-tests/tests/src/tests/credentials/function.ts
@@ -22,6 +22,7 @@ import { importAppBefore } from "../../hooks";
 import { buildAppConfig } from "../../utils/build-app-config";
 
 // FIXME: when importing customFunctionAuth we are almost consistently getting "Syntax error: unexpected EOF (400 Bad Request)".
+// https://jira.mongodb.org/browse/RJS-2545
 // describe.skipIf(environment.missingServer, "custom-function credentials", () => {
 describe.skip("custom-function credentials", () => {
   importAppBefore(

--- a/integration-tests/tests/src/tests/credentials/function.ts
+++ b/integration-tests/tests/src/tests/credentials/function.ts
@@ -36,7 +36,7 @@ describe.skip("custom-function credentials", () => {
           const { username, secret } = loginPayload;
 
           if (secret !== "v3ry-s3cret") {
-            throw new Error("Ah ah ah, you did not say the magic word");
+            throw new Error("Ah ah ah, you didn't say the magic word");
           }
           // Query for an existing user document with the specified username
 

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -474,7 +474,8 @@ describe.skipIf(environment.missingServer, "User", () => {
     });
   });
 
-  describe("custom auth functions", () => {
+  // FIXME: when importing customFunctionAuth we are almost consistently getting "Syntax error: unexpected EOF (400 Bad Request)".
+  describe.skip("custom auth functions", () => {
     importAppBefore(
       buildAppConfig("with-custom-function")
         .anonAuth()

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -475,6 +475,7 @@ describe.skipIf(environment.missingServer, "User", () => {
   });
 
   // FIXME: when importing customFunctionAuth we are almost consistently getting "Syntax error: unexpected EOF (400 Bad Request)".
+  // https://jira.mongodb.org/browse/RJS-2545
   describe.skip("custom auth functions", () => {
     importAppBefore(
       buildAppConfig("with-custom-function")

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -509,6 +509,34 @@ describe.skipIf(environment.missingServer, "User", () => {
           };
           `,
         })
+        // .customFunctionAuth(
+        //   `
+        //   exports = async function (loginPayload) {
+        //     // Get a handle for the app.users collection
+        //     const users = context.services.get("mongodb").db("app").collection("users");
+
+        //     // Parse out custom data from the FunctionCredential
+
+        //     const { username, secret } = loginPayload;
+
+        //     if (secret !== "v3ry-s3cret") {
+        //       throw new Error("Ah ah ah, you didn't say the magic word");
+        //     }
+        //     // Query for an existing user document with the specified username
+
+        //     const user = await users.findOne({ username });
+
+        //     if (user) {
+        //       // If the user document exists, return its unique ID
+        //       return user._id.toString();
+        //     } else {
+        //       // If the user document does not exist, create it and then return its unique ID
+        //       const result = await users.insertOne({ username });
+        //       return result.insertedId.toString();
+        //     }
+        //   };
+        // `,
+        // )
         .function({
           name: "resetFunc",
           private: false,
@@ -558,34 +586,6 @@ describe.skipIf(environment.missingServer, "User", () => {
     importAppBefore(
       buildAppConfig("with-custom-function")
         .anonAuth()
-        .customFunctionAuth(
-          `
-          exports = async function (loginPayload) {
-            // Get a handle for the app.users collection
-            const users = context.services.get("mongodb").db("app").collection("users");
-
-            // Parse out custom data from the FunctionCredential
-
-            const { username, secret } = loginPayload;
-
-            if (secret !== "v3ry-s3cret") {
-              throw new Error("Ah ah ah, you didn't say the magic word");
-            }
-            // Query for an existing user document with the specified username
-
-            const user = await users.findOne({ username });
-
-            if (user) {
-              // If the user document exists, return its unique ID
-              return user._id.toString();
-            } else {
-              // If the user document does not exist, create it and then return its unique ID
-              const result = await users.insertOne({ username });
-              return result.insertedId.toString();
-            }
-          };
-        `,
-        )
         .function({
           can_evaluate: {},
           name: "sumFunc",

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -509,34 +509,34 @@ describe.skipIf(environment.missingServer, "User", () => {
           };
           `,
         })
-        // .customFunctionAuth(
-        //   `
-        //   exports = async function (loginPayload) {
-        //     // Get a handle for the app.users collection
-        //     const users = context.services.get("mongodb").db("app").collection("users");
+        .customFunctionAuth(
+          `
+          exports = async function (loginPayload) {
+            // Get a handle for the app.users collection
+            const users = context.services.get("mongodb").db("app").collection("users");
 
-        //     // Parse out custom data from the FunctionCredential
+            // Parse out custom data from the FunctionCredential
 
-        //     const { username, secret } = loginPayload;
+            const { username, secret } = loginPayload;
 
-        //     if (secret !== "v3ry-s3cret") {
-        //       throw new Error("Ah ah ah, you didn't say the magic word");
-        //     }
-        //     // Query for an existing user document with the specified username
+            if (secret !== "v3ry-s3cret") {
+              throw new Error("Ah ah ah, you did not say the magic word");
+            }
+            // Query for an existing user document with the specified username
 
-        //     const user = await users.findOne({ username });
+            const user = await users.findOne({ username });
 
-        //     if (user) {
-        //       // If the user document exists, return its unique ID
-        //       return user._id.toString();
-        //     } else {
-        //       // If the user document does not exist, create it and then return its unique ID
-        //       const result = await users.insertOne({ username });
-        //       return result.insertedId.toString();
-        //     }
-        //   };
-        // `,
-        // )
+            if (user) {
+              // If the user document exists, return its unique ID
+              return user._id.toString();
+            } else {
+              // If the user document does not exist, create it and then return its unique ID
+              const result = await users.insertOne({ username });
+              return result.insertedId.toString();
+            }
+          };
+        `,
+        )
         .function({
           name: "resetFunc",
           private: false,

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -522,7 +522,7 @@ describe.skipIf(environment.missingServer, "User", () => {
             const { username, secret } = loginPayload;
 
             if (secret !== "v3ry-s3cret") {
-              throw new Error("Ah ah ah, you did not say the magic word");
+              throw new Error("Ah ah ah, you didn't say the magic word");
             }
             // Query for an existing user document with the specified username
 


### PR DESCRIPTION
## What, How & Why?

Tests using custom function auth are disabled. In order to continue to test Altas functions, the tests have been split into multiple tests.

