### PR TITLE
Fix `Object.linkingObjects()` across different classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 * Fixed toolchain on Linux. On older Linux installations, the error `GLIBC_2.34' not found (required by /home/user/MyProject/node_modules/realm/generated/ts/realm.node)` could be observed. ([#6082](https://github.com/realm/realm-js/issues/6082), since v12.0.0)
-* Fixed accessing `Realm.Object.linkingObjects()` when the origin and target are of different object types. ([#6108](https://github.com/realm/realm-js/pull/6108))
+* Fixed accessing `Realm.Object.linkingObjects()` when the origin and target are of different object types. ([#6108](https://github.com/realm/realm-js/pull/6108), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fixed toolchain on Linux. On older Linux installations, the error `GLIBC_2.34' not found (required by /home/user/MyProject/node_modules/realm/generated/ts/realm.node)` could be observed. ([#6082](https://github.com/realm/realm-js/issues/6082), since v12.0.0)
+* Fixed accessing `Realm.Object.linkingObjects()` when the origin and target are of different object types. ([#6108](https://github.com/realm/realm-js/pull/6108))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/linking-objects.ts
+++ b/integration-tests/tests/src/tests/linking-objects.ts
@@ -361,6 +361,7 @@ describe("Linking objects", () => {
 
       const linkedManufacturer = car.linkingObjects(Manufacturer, "cars")[0];
       expect(linkedManufacturer.name).to.equal("Nissan");
+      expect(linkedManufacturer.cars.length).to.equal(2);
       expect(linkedManufacturer.cars[0].model).to.equal("Sentra");
       expect(linkedManufacturer.cars[1].model).to.equal("Pathfinder");
     });

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -29,6 +29,7 @@ import {
   ObjectListeners,
   OmittedRealmTypes,
   OrderedCollection,
+  OrderedCollectionHelpers,
   Realm,
   RealmObjectConstructor,
   Results,
@@ -434,10 +435,10 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
 
     assert(
       originObjectSchema.name === targetProperty.objectType,
-      () => `'${objectType}#${propertyName}' is not a relationship to '${originObjectSchema.name}'`,
+      () => `'${targetObjectSchema.name}#${propertyName}' is not a relationship to '${originObjectSchema.name}'`,
     );
 
-    const collectionHelpers = {
+    const collectionHelpers: OrderedCollectionHelpers = {
       // See `[binding.PropertyType.LinkingObjects]` in `TypeHelpers.ts`.
       toBinding(value: unknown) {
         return value as binding.MixedArg;

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -430,10 +430,15 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
     const { objectSchema: linkedObjectSchema, properties } = this[REALM].getClassHelpers(objectType);
     const tableRef = binding.Helpers.getTable(this[REALM].internal, linkedObjectSchema.tableKey);
     const property = properties.get(propertyName);
+    const currentObjectSchema = this.objectSchema();
+
+    console.log({ "linkedObjectSchema.name": linkedObjectSchema.name });
+    console.log({ "currentObjectSchema.name": currentObjectSchema.name });
+    console.log({ "property.objectType": property.objectType });
 
     assert(
-      linkedObjectSchema.name === property.objectType,
-      () => `'${linkedObjectSchema.name}#${propertyName}' is not a relationship to '${this.objectSchema().name}'`,
+      currentObjectSchema.name === property.objectType,
+      () => `'${objectType}#${propertyName}' is not a relationship to '${currentObjectSchema.name}'`,
     );
 
     // Create the Result for the backlink view
@@ -441,6 +446,12 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
     assert(collectionHelpers, "collection helpers");
     const tableView = this[INTERNAL].getBacklinkView(tableRef, columnKey);
     const results = binding.Results.fromTableView(this[REALM].internal, tableView);
+
+    // Note: I think it's the wrong `collectionHelpers` because `results` is
+    //       `Manufacturer` and `property` (where `collectionHelpers` come from) is `Car`.
+    console.log({ collectionHelpers });
+    console.log({ "results.objectType": results.objectType });
+
     return new Results(this[REALM], results, collectionHelpers);
   }
 

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -430,11 +430,11 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
     const targetClassHelpers = this[REALM].getClassHelpers(objectType);
     const { objectSchema: targetObjectSchema, properties, wrapObject } = targetClassHelpers;
     const targetProperty = properties.get(propertyName);
-    const currentObjectSchema = this.objectSchema();
+    const originObjectSchema = this.objectSchema();
 
     assert(
-      currentObjectSchema.name === targetProperty.objectType,
-      () => `'${objectType}#${propertyName}' is not a relationship to '${currentObjectSchema.name}'`,
+      originObjectSchema.name === targetProperty.objectType,
+      () => `'${objectType}#${propertyName}' is not a relationship to '${originObjectSchema.name}'`,
     );
 
     const collectionHelpers = {

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -449,8 +449,8 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
       // See `[binding.PropertyType.Array]` in `PropertyHelpers.ts`.
       get(results: binding.Results, index: number) {
         return results.getObj(index);
-      }
-    }
+      },
+    };
 
     // Create the Result for the backlink view.
     const tableRef = binding.Helpers.getTable(this[REALM].internal, targetObjectSchema.tableKey);


### PR DESCRIPTION
## What, How & Why?

When calling `Object.linkingObjects()` on an object linking to an object of a different object type, the following error would be generated:

```
<linking object type>#<linking property> is not a relationship to '<object type>'

// Example
Manufacturer#cars is not a relationship to 'Car'
```

Our assertion in the `Object.linkingObjects()` API has been corrected as well as the `collectionHelpers` passed when instantiating the returned `Results`. (It previously used the `collectionHelpers` from the `targetProperty` rather than target itself.)

**Note:**
* Previously existing tests were using linking objects of the same object type, thus the bug was not detected.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
