### PR TITLE
Add types dev dependency for `node:process` to example app

### DIFF
--- a/examples/node-connection-and-error/README.md
+++ b/examples/node-connection-and-error/README.md
@@ -1,4 +1,4 @@
-# Connection State Change & Error Handling In Realm Node.js SDK
+# Connection State Change & Error Handling in Realm Node.js SDK
 
 A skeleton app to be used as a reference for how to use the [Realm Node.js SDK](https://www.mongodb.com/docs/realm/sdk/node/) specifically around detecting various changes in e.g. connection state, user state, and sync errors, in order to better guide developers.
 

--- a/examples/node-connection-and-error/package.json
+++ b/examples/node-connection-and-error/package.json
@@ -15,6 +15,7 @@
     "realm": "^12.0.0"
   },
   "devDependencies": {
+    "@types/node": "^20.5.7",
     "typescript": "^5.1.6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,13 +128,21 @@
       }
     },
     "examples/node-connection-and-error": {
+      "name": "@realm/node-connection-and-error",
       "version": "1.0.0",
       "dependencies": {
         "realm": "^12.0.0"
       },
       "devDependencies": {
+        "@types/node": "^20.5.7",
         "typescript": "^5.1.6"
       }
+    },
+    "examples/node-connection-and-error/node_modules/@types/node": {
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
+      "dev": true
     },
     "examples/node-connection-and-error/node_modules/typescript": {
       "version": "5.2.2",
@@ -36262,10 +36270,17 @@
     "@realm/node-connection-and-error": {
       "version": "file:examples/node-connection-and-error",
       "requires": {
+        "@types/node": "^20.5.7",
         "realm": "^12.0.0",
         "typescript": "^5.1.6"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "20.5.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+          "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
+          "dev": true
+        },
         "typescript": {
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",


### PR DESCRIPTION
## What, How & Why?

Adds the `@types/node` dev dependency for working with `node:process` in the Node example app.

## ☑️ ToDos
--
