### PR TITLE
Handle dark mode selected by OS preference

### DIFF
--- a/typedoc/style.css
+++ b/typedoc/style.css
@@ -249,6 +249,14 @@
   color: var(--color-background);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="os"] #tsd-search .field input,
+  :root[data-theme="os"] .tsd-page-toolbar a:hover,
+  :root[data-theme="os"] .tsd-page-toolbar #tsd-search .results a:hover span.parent {
+    color: var(--color-background);
+  }
+}
+
 /* ==========================================================================
    Basic element style overrides
    ========================================================================== */


### PR DESCRIPTION
## What, How & Why?

The current TypeDoc theme doesn't properly account for an override when the dark theme is selected by OS preference. This PR fixes that.