### PR TITLE
Rename test jobs in the pr-realm-js workflow

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -232,7 +232,7 @@ jobs:
             packages/realm/react-native/ios/realm-js-ios.xcframework/Info.plist
 
   integration-tests:
-    name: Integration tests (${{matrix.variant.target}}) for ${{ matrix.variant.environment }} on ${{ matrix.variant.os }}
+    name: Test ${{ matrix.variant.environment }} on ${{ matrix.variant.os }} (${{matrix.variant.target}})
     needs: [bundle, build, ios-xcframework]
     if: ${{ success() || failure() }}
     env:


### PR DESCRIPTION
## What, How & Why?

Now that we don't have other tests than the "integration tests", I think its best to simplify the naming of jobs when ran on CI. The actual platform gets cut off in the summary on GitHub, because the name of the job is too long.
(which doesn't look good in my presentation for React Summit 🙈)
