### PR TITLE
Update deploy-cluster workflow to stop scheduled deployments

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -7,10 +7,6 @@ on:
         options:
           - M10
           - M20
-  schedule:
-    # We deploy three times per day,
-    # to avoid downtime as the cluster gets deleted after 12 hours
-    - cron: '0 6,14,22 * * *' # 6:00, 14:00, 22:00 every day
 jobs:
   deploy-cluster:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What, How & Why?

This workflow keeps a cluster on QA alive for v11 to test against - which is no longer needed are we're focussing work on v12 going forward. We could migrate v11 to test against the local BaaS + Ngrok as v12, but choose not to (see https://github.com/realm/realm-js/pull/5786#issuecomment-1696158441)

💥 NOTE: Once this is merged, v11 won't be able to execute integration tests, without first triggering a manual run of the workflow.
