### PR TITLE
Remove `postinstall` script

### DIFF
--- a/contrib/building.md
+++ b/contrib/building.md
@@ -145,12 +145,13 @@ export PATH=<ccache location>/libexec:$PATH
 
 ## Cloning the repository
 
-To clone the RealmJS repository and install git submodules:
+To clone the RealmJS repository and install git submodules and dependencies.
 
 ```sh
 git clone https://github.com/realm/realm-js.git
 cd realm-js
 git submodule update --init --recursive
+npm install
 ```
 
 In order to improve the accuracy of `git blame` locally by ignoring commits in which the code was reformatted by an automated tool, run: `git config blame.ignoreRevsFile .gitignore-revs` from inside the repository.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "lint": "wireit",
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
-    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
-    "postinstall": "git submodule update --init --recursive && npm install --prefix ./packages/realm/bindgen/vendor/realm-core"
+    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i"
   },
   "wireit": {
     "build": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
     "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
-    "postinstall": "git submodule update --init --recursive"
+    "postinstall": "git submodule update --init --recursive && npm install --prefix ./packages/realm/bindgen/vendor/realm-core"
   },
   "wireit": {
     "build": {


### PR DESCRIPTION
## What, How & Why?

Our `bindgen:generate:typescript` and `bindgen:generate:wrappers` scripts rely on the `realm-bindgen` command. For Bindgen's  node dependencies in Core to be installed correctly and allow for the `realm-bindgen` command to be run, `npm install` needs to be run after `git submodule update --init --recursive` (which was previously in our `postinstall` script).

Replacing the `postinstall` with a `preinstall` does not fix this issue.

This PR removes the `postinstall` script all together, moving the responsibility of fetching the submodule to the developer:

```sh
git submodule update --init --recursive
npm install

# Now you can e.g. run tests (which will build etc. automatically).
npm run test --workspace realm # Unit tests
```

## ☑️ ToDos
--
