### PR TITLE
Add updates to the addition of `deleteUser` in example app

### DIFF
--- a/examples/rn-connection-and-error/README.md
+++ b/examples/rn-connection-and-error/README.md
@@ -71,6 +71,7 @@ It specifically addresses the following points:
       * With invalid password
       * With non-existent email
 * Listening (and triggering) when a user gets logged out.
+* Listening (and triggering) when a user gets removed.
 * Listening (and triggering) when a user's tokens are refreshed.
 * Listening (and triggering) when the underlying sync session:
   * Tries to connect

--- a/examples/rn-connection-and-error/frontend/app/hooks/useDemoSyncTriggers.ts
+++ b/examples/rn-connection-and-error/frontend/app/hooks/useDemoSyncTriggers.ts
@@ -18,7 +18,7 @@
 
 import {useCallback, useEffect, useState} from 'react';
 import {BSON, ConnectionState, UserState} from 'realm';
-import {useRealm, useUser} from '@realm/react';
+import {useApp, useRealm, useUser} from '@realm/react';
 
 import {Store} from '../models/Store';
 import {logger} from '../utils/logger';
@@ -37,6 +37,7 @@ let mostRecentAccessToken: string | null = null;
  * You can also add a listener to the App (via `useApp()`).
  */
 export function useDemoSyncTriggers() {
+  const app = useApp();
   const realm = useRealm();
   const currentUser = useUser();
   const [isConnected, setIsConnected] = useState(true);
@@ -147,6 +148,18 @@ export function useDemoSyncTriggers() {
     await currentUser.refreshCustomData();
   }, [currentUser]);
 
+  /**
+   * Trigger the user event listener by removing the user from the app.
+   */
+  const deleteUser = useCallback(() => {
+    // TODO: Update to use only `deleteUser`.
+    // We currently call both `deleteUser` (deletes from server and client) and
+    // `removeUser` (deletes from client) due to a bug in `deleteUser` where the
+    // `currentUser` is not updated to `null`.
+    app.deleteUser(currentUser);
+    app.removeUser(currentUser);
+  }, [app, currentUser]);
+
   useEffect(() => {
     /**
      * The user listener - Will be invoked on various user related events including
@@ -196,5 +209,6 @@ export function useDemoSyncTriggers() {
     triggerSyncError,
     triggerClientReset,
     refreshAccessToken,
+    deleteUser,
   };
 }

--- a/examples/rn-connection-and-error/frontend/app/screens/StoreScreen.tsx
+++ b/examples/rn-connection-and-error/frontend/app/screens/StoreScreen.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import {Alert, FlatList, StyleSheet, Text, View} from 'react-native';
-import {useAuth, useApp, useUser} from '@realm/react';
+import {useAuth} from '@realm/react';
 
 import {Button} from '../components/Button';
 import {KioskItem} from '../components/KioskItem';
@@ -41,11 +41,9 @@ export function StoreScreen() {
     triggerSyncError,
     triggerClientReset,
     refreshAccessToken,
+    deleteUser,
   } = useDemoSyncTriggers();
   const {logOut} = useAuth();
-  const user = useUser();
-  const app = useApp();
-
 
   return (
     <View style={styles.container}>
@@ -115,10 +113,7 @@ export function StoreScreen() {
               />
               <Button
                 extraStyles={[styles.button]}
-                onPress={() => {
-                  app.deleteUser(user);
-                  app.removeUser(user);
-                }}
+                onPress={deleteUser}
                 text="Delete User"
               />
             </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29506,7 +29506,6 @@
         "react-native": "0.72.6",
         "react-test-renderer": "18.2.0",
         "realm": "*",
-        "rollup-plugin-dts": "^5.0.0",
         "ts-jest": "^29.0.5"
       },
       "optionalDependencies": {
@@ -35994,7 +35993,6 @@
         "react-native": "0.72.6",
         "react-test-renderer": "18.2.0",
         "realm": "*",
-        "rollup-plugin-dts": "^5.0.0",
         "ts-jest": "^29.0.5"
       },
       "dependencies": {


### PR DESCRIPTION
## What, How & Why?

Makes a few updates to the addition of `deleteUser` to the example app:
* Moves `deleteUser` responsibility to `useDemoSyncTriggers`.
* Updates the README with the new use case.
* Removes rollup related changes in `package-lock.json`.

## ☑️ ToDos
--
