### PR TITLE
Implement `Symbol.unscopables` on `OrderedCollection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* None
+* `Symbol.unscopables` has been implemented on the base class of `Realm.Results`, `Realm.List`, and `Realm.Set`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 * None
 
 ### Enhancements
-* `Symbol.unscopables` has been implemented on the base class of `Realm.Results`, `Realm.List`, and `Realm.Set`.
+* None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* `Symbol.unscopables` has been implemented on the base class of `Realm.Results`, `Realm.List`, and `Realm.Set`. ([#6215](https://github.com/realm/realm-js/pull/6215))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "wireit",
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
-    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i"
+    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
+    "postinstall": "git submodule update --init --recursive"
   },
   "wireit": {
     "build": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "lint": "wireit",
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
-    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
-    "postinstall": "git submodule update --init --recursive && npm install --prefix ./packages/realm/bindgen/vendor/realm-core"
+    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i"
   },
   "wireit": {
     "build": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
     "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
-    "postinstall": "git submodule update --init --recursive"
+    "postinstall": "git submodule update --init --recursive && npm install --prefix ./packages/realm/bindgen/vendor/realm-core"
   },
   "wireit": {
     "build": {

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -178,7 +178,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       writable: false,
       value: mixedToBinding.bind(undefined, realm.internal),
     });
-    // See https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.unscopables
+    // See https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@unscopables
     Object.defineProperty(this, Symbol.unscopables, {
       enumerable: false,
       configurable: true,

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -178,7 +178,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       writable: false,
       value: mixedToBinding.bind(undefined, realm.internal),
     });
-    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables#value
+    // See https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.unscopables
     Object.defineProperty(this, Symbol.unscopables, {
       enumerable: false,
       configurable: true,

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -636,38 +636,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * An Object whose truthy properties are properties that are excluded from the 'with'
    * environment bindings of the associated objects.
    */
-  readonly [Symbol.unscopables] = Object.assign(
-    // Using `Object.assign(Object.create(null), /* ... */)`
-    // rather than `{ __proto__: null, /* ... */ }` due to
-    // TypeScript incompatibilities with using `__proto__`.
-    // https://github.com/microsoft/TypeScript/issues/38385
-
-    // Make the object have `null` prototype to prevent
-    // `Object.prototype` methods from being unscopable.
-    Object.create(null),
-
-    // The default Array properties that are ignored for
-    // `with` statement-binding purposes:
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables#description
-    {
-      at: true,
-      copyWithin: true,
-      entries: true,
-      fill: true,
-      find: true,
-      findIndex: true,
-      findLast: true,
-      findLastIndex: true,
-      flat: true,
-      flatMap: true,
-      includes: true,
-      keys: true,
-      toReversed: true,
-      toSorted: true,
-      toSpliced: true,
-      values: true,
-    },
-  );
+  readonly [Symbol.unscopables] = Array.prototype[Symbol.unscopables];
 
   // Other methods
 

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -178,6 +178,12 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       writable: false,
       value: mixedToBinding.bind(undefined, realm.internal),
     });
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables#value
+    Object.defineProperty(this, Symbol.unscopables, {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+    });
     return proxied;
   }
 
@@ -625,6 +631,43 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   [Symbol.iterator](): IterableIterator<T> {
     return this.values();
   }
+
+  /**
+   * An Object whose truthy properties are properties that are excluded from the 'with'
+   * environment bindings of the associated objects.
+   */
+  readonly [Symbol.unscopables] = Object.assign(
+    // Using `Object.assign(Object.create(null), /* ... */)`
+    // rather than `{ __proto__: null, /* ... */ }` due to
+    // TypeScript incompatibilities with using `__proto__`.
+    // https://github.com/microsoft/TypeScript/issues/38385
+
+    // Make the object have `null` prototype to prevent
+    // `Object.prototype` methods from being unscopable.
+    Object.create(null),
+
+    // The default Array properties that are ignored for
+    // `with` statement-binding purposes:
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables#description
+    {
+      at: true,
+      copyWithin: true,
+      entries: true,
+      fill: true,
+      find: true,
+      findIndex: true,
+      findLast: true,
+      findLastIndex: true,
+      flat: true,
+      flatMap: true,
+      includes: true,
+      keys: true,
+      toReversed: true,
+      toSorted: true,
+      toSpliced: true,
+      values: true,
+    },
+  );
 
   // Other methods
 


### PR DESCRIPTION
## What, How & Why?

Makes the `OrderedCollection` TypeScript compatible with `ReadonlyArray`, in turn making Realm query results compatible with types requiring `Symbol.unscopables` to be implemented.

(If needed or if interested, refer to the Background below for a summary of its purpose.)

I initially added a [custom implementation](https://github.com/realm/realm-js/commit/b811a9d83ccaf20bb6ec4cb3da5fa6dc1c757a3c) but realized we could likely piggyback off of the `Array.prototype` implementation. Let me know if you reach a different conclusion. (Manual testing when using `with` confirms this.)

This closes #6106.

## Background

The information below sheds some light on the purpose of `Symbol.unscopables`.

### Introduction

Consider the following:

```js
const myObj = {};

function toString() {
  return "myFunc";
}

with (myObj) {
  // Logs: '[object Object]'
  console.log(toString());
}
```

When the body of JavaScript's `with` statement is evaluated, the members of the provided object (e.g. `myObj` in the above example) are made [available as lexical variables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables#description) (e.g. `toString`) within the body scope.

As seen above, `'[object Object]'` is printed, and not `myFunc`. This is because `toString` is first searched for on the provided object and its prototype chain (in the above example, it exists on the prototype). If not resolved, only then does searching continue up the *scope* chain.

### Problem

Since the prototype chain is searched first, ECMAScript additions to any built-in prototypes will override other variables declared by the user.

ES2015 introduced `Array.prototype.keys()`, which would have made any user-defined variable named `keys` inaccessible within the `with` body scope, as it would have referred to the prototype method instead.

```js
const keys = ["key1", "key2"];

with (Array.prototype) {
  // Logs: 'function keys() { [native code] }'
  console.log(keys.toString());
}
```

### Solution

To exclude certain members from becoming lexical scope variables in the `with` body, `Symbol.unscopables` (aka `@@unscopables`) was introduced.

Properties on the `@@unscopables` object that are set to a truthy value will become *unscopable* and will not be available as variables.

It's important to remember, however, that the properties of the unscopable object's prototype (all the way up the chain) are also checked for a truthy value. So if the unscopable object is set to an empty object (`{}`), all of the properties in its prototype that are truthy will become unscopable.

In order to prevent unintended behavior and to be clear about which properties should be unscopable, [it is recommended](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables#avoid_using_a_non-null-prototype_object_as_unscopables) to set its prototype to `null` and list any other properties explicitly.

```js
const myObj = {
  name: "Bruce",
  [Symbol.unscopables]: {
    __proto__: null,
    name: true,
  },
};

const name = "Wayne";

function toString() {
  return "myFunc";
}

with (myObj) {
  // Logs: Wayne
  console.log(name);

  // Logs: '[object Object]'
  // Would have logged 'myFunc' if [Symbol.unscopables] was {}.
  console.log(toString());
}
```

> Use of `with` is only applicable when `sloppy mode` is used (i.e. not `strict mode`).

## ☑️ ToDos
* [x] 📝 Changelog entry
