### PR TITLE
Unify a prepack command for packages

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -97,8 +97,8 @@ jobs:
     - name: Install node modules
       run: npm ci --ignore-scripts
 
-    - name: Bundle package
-      run: npm run bundle --workspace=${{env.PACKAGE_NAME}}
+    - name: Prepack package
+      run: npm run prepack --workspace=${{env.PACKAGE_NAME}}
 
     - name: Read version
       id: get-version

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -5,11 +5,11 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "bundle": "wireit",
+    "prepack": "wireit",
     "test": "wireit"
   },
   "wireit": {
-    "bundle": {
+    "prepack": {
       "command": "tsc -p tsconfig.build.json",
       "files": [
         "tsconfig.build.json",

--- a/packages/realm-common/package.json
+++ b/packages/realm-common/package.json
@@ -11,6 +11,7 @@
     "./dist/bundle.d.ts": "./dist/bundle.dom.d.ts"
   },
   "scripts": {
+    "prepack": "npm run bundle",
     "bundle": "wireit",
     "lint": "eslint --ext .js,.ts .",
     "test": "mocha 'src/**/*.test.ts'"

--- a/packages/realm-network-transport/package.json
+++ b/packages/realm-network-transport/package.json
@@ -12,12 +12,13 @@
     "./dist/bundle.d.ts": "./dist/bundle.dom.d.ts"
   },
   "scripts": {
+    "prepack": "npm run bundle",
     "bundle": "wireit",
     "lint": "eslint --ext .js,.ts .",
     "test": "mocha 'src/**/*.test.ts'"
   },
   "wireit": {
-    "bundle": {
+    "prepack": {
       "command": "rollup --config",
       "dependencies": [
         "generate-types",

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -9,6 +9,7 @@
   "source": "src/index.tsx",
   "scripts": {
     "bundle": "wireit",
+    "prepack": "npm run bundle",
     "start": "npm run bundle -- --watch",
     "test": "wireit",
     "lint": "eslint --ext .tsx .",
@@ -18,6 +19,7 @@
     "bundle": {
       "command": "rollup --config && tsc -p tsconfig.types.json",
       "dependencies": [
+        "generate-types",
         "../realm:bundle",
         "../realm-common:bundle"
       ],
@@ -28,6 +30,16 @@
       ],
       "output": [
         "dist"
+      ]
+    },
+    "generate-types": {
+      "command": "tsc -p tsconfig.types.json",
+      "files": [
+        "src/**/*.ts"
+      ],
+      "output": [
+        "dist/**/*.d.ts",
+        "dist/**/*.d.ts.map"
       ]
     },
     "test": {

--- a/packages/realm-tools/package.json
+++ b/packages/realm-tools/package.json
@@ -9,12 +9,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "wireit",
+    "prepack": "wireit",
     "lint": "eslint --ext .js,.ts .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "wireit": {
-    "build": {
+    "prepack": {
       "command": "tsc -p tsconfig.build.json",
       "dependencies": [
         "../realm:bundle"

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -11,8 +11,7 @@
     "./dist/bundle.es.js": "./dist/bundle.dom.es.js"
   },
   "scripts": {
-    "prepack": "npm run build",
-    "bundle": "wireit",
+    "prepack": "wireit",
     "start": "npm run build -- --watch",
     "lint": "eslint --ext .js,.ts .",
     "test": "mocha 'src/tests/**/*.test.ts'",
@@ -20,7 +19,7 @@
     "docs": "wireit"
   },
   "wireit": {
-    "bundle": {
+    "prepack": {
       "command": "rollup --config",
       "dependencies": [
         "generate-types"


### PR DESCRIPTION
## What, How & Why?
Packages were using the `bundle` script for preparing for release.  Sometimes it requires more than bundling to prepare a package.  This unifies everything under `prepack`.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
