### PR TITLE
Setter must replace embedded object instead of add a new object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed a crash at a very specific time during a `DiscardLocal` client reset on a FLX Realm could leave subscriptions in an invalid state. ([realm/realm-core#7110](https://github.com/realm/realm-core/pull/7110), since v10.19.4)
 * Fixed an error "Invalid schema change (UPLOAD): cannot process AddColumn instruction for non-existent table" when using automatic client reset with recovery in dev mode to recover schema changes made locally while offline. ([realm/realm-core#7042](https://github.com/realm/realm-core/pull/7042))
 * When place an embedded object would create a new object and keep the original object too. ([#6239](https://github.com/realm/realm-js/issues/6239), since v12.0.0)
+* When setting an embedded object in a `Realm.List` by index, the new object would be inserted at the end rather than replacing the existing object at the given index. ([#6239](https://github.com/realm/realm-js/issues/6239), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed application crash with `KeyNotFound` exception when subscriptions are marked complete after a client reset. ([realm/realm-core#7090](https://github.com/realm/realm-core/issues/7090), since v10.19.0)
 * Fixed a crash at a very specific time during a `DiscardLocal` client reset on a FLX Realm could leave subscriptions in an invalid state. ([realm/realm-core#7110](https://github.com/realm/realm-core/pull/7110), since v10.19.4)
 * Fixed an error "Invalid schema change (UPLOAD): cannot process AddColumn instruction for non-existent table" when using automatic client reset with recovery in dev mode to recover schema changes made locally while offline. ([realm/realm-core#7042](https://github.com/realm/realm-core/pull/7042))
+* When place an embedded object would create a new object and keep the original object too. ([#6239](https://github.com/realm/realm-js/issues/6239), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -2095,6 +2095,7 @@ describe("Lists", () => {
       // check that we have successfully added a Group
       expect(divisions[0]["groups"].length).equals(2);
     });
+
     it("creating standalone embedded object throws", function () {
       // creating standalone embedded object is not allowed
       this.realm.write(() => {
@@ -2103,7 +2104,9 @@ describe("Lists", () => {
         }).throws(Error);
       });
     });
+
     it("supports adding embedded objects", function () {
+      // create a parent object with two embedded child objects
       this.realm.write(() => {
         this.realm.create(HouseOwnerSchema.name, {
           name: "Ib",
@@ -2117,6 +2120,7 @@ describe("Lists", () => {
       const ib = this.realm.objectForPrimaryKey(HouseOwnerSchema.name, "Ib");
       expect(ib.addresses.length).equals(2);
 
+      // add new embedded object
       this.realm.write(() => {
         expect(() => {
           //standalone object throws
@@ -2126,13 +2130,23 @@ describe("Lists", () => {
         ib.addresses.push({ street: "Njalsgade", city: "Islands Brygge" });
         expect(3).equals(ib.addresses.length);
       });
+
+      // update/replace one embedded child object
+      this.realm.write(() => {
+        ib.addresses[0] = { street: "Nørregade", city: "Vesterled" };
+      });
+
+      expect(3).equals(ib.addresses.length);
+      expect("Nørregade").equals(ib.addresses[0].street);
     });
+
     it("querying embedded objects throws", function () {
       expect(() => {
         this.realm.objects(AddressSchema.name);
       }).throws(Error);
     });
   });
+
   describe("objects and classes", () => {
     openRealmBeforeEach({ schema: [TodoList, TodoItem] });
     it("supports constructing objects with lists and pushing objects to it", function () {

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -2128,7 +2128,7 @@ describe("Lists", () => {
         }).throws(Error);
 
         ib.addresses.push({ street: "Njalsgade", city: "Islands Brygge" });
-        expect(3).equals(ib.addresses.length);
+        expect(ib.addresses.length).equals(3);
       });
 
       // update/replace one embedded child object
@@ -2136,8 +2136,8 @@ describe("Lists", () => {
         ib.addresses[0] = { street: "Nørregade", city: "Vesterled" };
       });
 
-      expect(3).equals(ib.addresses.length);
-      expect("Nørregade").equals(ib.addresses[0].street);
+      expect(ib.addresses.length).equals(3);
+      expect(ib.addresses[0].street).equals("Nørregade");
     });
 
     it("querying embedded objects throws", function () {

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -376,6 +376,7 @@ classes:
       - insert_any
       - insert_embedded
       - set_any
+      - set_embedded
 
   Set:
     methods:

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -97,7 +97,7 @@ export class List<T = unknown> extends OrderedCollection<T> implements Partially
     // TODO: Consider a more performant way to determine if the list is embedded
     internal.setAny(
       index,
-      toBinding(value, isEmbedded ? { createObj: () => [internal.insertEmbedded(index), true] } : undefined),
+      toBinding(value, isEmbedded ? { createObj: () => [internal.setEmbedded(index), true] } : undefined),
     );
   }
 


### PR DESCRIPTION
## What, How & Why?

When replacing an element in a list of embedded object, the existing object should be removed. Calling `Obj::set_embedded()` is replacing while `Obj::insert_embedded()` will create a new object and add it to the list without touching the existing element.

This closes #6239 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
