### PR TITLE
Env Driven App Id

### DIFF
--- a/examples/rn-connection-and-error/README.md
+++ b/examples/rn-connection-and-error/README.md
@@ -241,7 +241,7 @@ import Config from 'react-native-config';
 
 export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';
 ```
--  Alternatively you can add a `.env` to your project with the following contents:
+-  Alternatively you can add a `.env` file to your project with the following contents:
    ```bash
    ATLAS_APP_ID=your_app_id
    ```

--- a/examples/rn-connection-and-error/README.md
+++ b/examples/rn-connection-and-error/README.md
@@ -237,8 +237,15 @@ npx pod-install
 1. [Copy your Atlas App ID](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/#std-label-find-your-app-id) from the App Services UI.
 2. Paste the copied ID as the value of the existing variable `ATLAS_APP_ID` in [app/atlas-app-services/config.ts](./frontend/app/atlas-app-services/config.ts):
 ```js
-export const ATLAS_APP_ID = 'YOUR_APP_ID';
+import Config from 'react-native-config';
+
+export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';
 ```
+-  Alternatively you can add a `.env` to your project with the following contents:
+   ```bash
+   ATLAS_APP_ID=your_app_id
+   ```
+   This file is included in the `.gitignore` so that it won't be committed to any code repositories.
 3. Start Metro (the JavaScript bundler) in its own terminal:
 ```sh
 npm start

--- a/examples/rn-connection-and-error/frontend/.gitignore
+++ b/examples/rn-connection-and-error/frontend/.gitignore
@@ -64,3 +64,6 @@ yarn-error.log
 
 # testing
 /coverage
+
+# env
+.env

--- a/examples/rn-connection-and-error/frontend/android/app/build.gradle
+++ b/examples/rn-connection-and-error/frontend/android/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
+// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/examples/rn-connection-and-error/frontend/android/app/build.gradle
+++ b/examples/rn-connection-and-error/frontend/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
-// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+// CUSTOM CODE: This adds support for the `.env` environment variables with react-native-config
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 /**

--- a/examples/rn-connection-and-error/frontend/app/atlas-app-services/config.ts
+++ b/examples/rn-connection-and-error/frontend/app/atlas-app-services/config.ts
@@ -16,7 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import Config from 'react-native-config';
 import {BSON} from 'realm';
 
-export const ATLAS_APP_ID = 'YOUR_APP_ID';
+export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';
 export const SYNC_STORE_ID = new BSON.ObjectId('6426106cb0ad9713140883ed');

--- a/examples/rn-connection-and-error/frontend/ios/Podfile.lock
+++ b/examples/rn-connection-and-error/frontend/ios/Podfile.lock
@@ -375,6 +375,10 @@ PODS:
   - React-jsinspector (0.72.6)
   - React-logger (0.72.6):
     - glog
+  - react-native-config (1.5.1):
+    - react-native-config/App (= 1.5.1)
+  - react-native-config/App (1.5.1):
+    - React-Core
   - react-native-get-random-values (1.9.0):
     - React-Core
   - React-NativeModulesApple (0.72.6):
@@ -540,6 +544,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -622,6 +627,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-get-random-values:
     :path: "../node_modules/react-native-get-random-values"
   React-NativeModulesApple:
@@ -697,6 +704,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 3bf18ff7cb03cd8dfdce08fbbc0d15058c1d71ae
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
+  react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3

--- a/examples/rn-connection-and-error/frontend/package-lock.json
+++ b/examples/rn-connection-and-error/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@realm/react": "^0.6.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
+        "react-native-config": "^1.5.1",
         "react-native-get-random-values": "^1.9.0",
         "realm": "^12.2.0"
       },
@@ -10160,6 +10161,19 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "peerDependencies": {
+        "react-native-windows": ">=0.61"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-get-random-values": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz",
@@ -19011,6 +19025,12 @@
           }
         }
       }
+    },
+    "react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "requires": {}
     },
     "react-native-get-random-values": {
       "version": "1.9.0",

--- a/examples/rn-connection-and-error/frontend/package.json
+++ b/examples/rn-connection-and-error/frontend/package.json
@@ -13,6 +13,7 @@
     "@realm/react": "^0.6.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
+    "react-native-config": "^1.5.1",
     "react-native-get-random-values": "^1.9.0",
     "realm": "^12.2.0"
   },

--- a/examples/rn-multiple-realms/README.md
+++ b/examples/rn-multiple-realms/README.md
@@ -216,8 +216,15 @@ npx pod-install
 1. [Copy your Atlas App ID](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/#std-label-find-your-app-id) from the App Services UI.
 2. Paste the copied ID as the value of the existing variable `ATLAS_APP_ID` in [app/atlas-app-services/config.ts](./frontend/app/atlas-app-services/config.ts):
 ```js
-export const ATLAS_APP_ID = 'YOUR_APP_ID';
+import Config from 'react-native-config';
+
+export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';
 ```
+-  Alternatively you can add a `.env` to your project with the following contents:
+   ```bash
+   ATLAS_APP_ID=your_app_id
+   ```
+   This file is included in the `.gitignore` so that it won't be committed to any code repositories.
 3. Start Metro (the JavaScript bundler) in its own terminal:
 ```sh
 npm start

--- a/examples/rn-multiple-realms/README.md
+++ b/examples/rn-multiple-realms/README.md
@@ -220,7 +220,7 @@ import Config from 'react-native-config';
 
 export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';
 ```
--  Alternatively you can add a `.env` to your project with the following contents:
+-  Alternatively you can add a `.env` file to your project with the following contents:
    ```bash
    ATLAS_APP_ID=your_app_id
    ```

--- a/examples/rn-multiple-realms/frontend/.gitignore
+++ b/examples/rn-multiple-realms/frontend/.gitignore
@@ -64,3 +64,6 @@ yarn-error.log
 
 # testing
 /coverage
+
+# env
+.env

--- a/examples/rn-multiple-realms/frontend/android/app/build.gradle
+++ b/examples/rn-multiple-realms/frontend/android/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
+// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/examples/rn-multiple-realms/frontend/android/app/build.gradle
+++ b/examples/rn-multiple-realms/frontend/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
-// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+// CUSTOM CODE: This adds support for the `.env` environment variables with react-native-config
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 /**

--- a/examples/rn-multiple-realms/frontend/app/atlas-app-services/config.ts
+++ b/examples/rn-multiple-realms/frontend/app/atlas-app-services/config.ts
@@ -16,4 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export const ATLAS_APP_ID = 'YOUR_APP_ID';
+import Config from 'react-native-config';
+
+export const ATLAS_APP_ID = Config.ATLAS_APP_ID || 'YOUR_APP_ID';

--- a/examples/rn-multiple-realms/frontend/ios/ExampleRnMultipleRealms.xcodeproj/project.pbxproj
+++ b/examples/rn-multiple-realms/frontend/ios/ExampleRnMultipleRealms.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -598,6 +599,10 @@
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -640,6 +645,10 @@
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION,
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -663,6 +672,10 @@
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/examples/rn-multiple-realms/frontend/ios/Podfile.lock
+++ b/examples/rn-multiple-realms/frontend/ios/Podfile.lock
@@ -375,6 +375,10 @@ PODS:
   - React-jsinspector (0.72.6)
   - React-logger (0.72.6):
     - glog
+  - react-native-config (1.5.1):
+    - react-native-config/App (= 1.5.1)
+  - react-native-config/App (1.5.1):
+    - React-Core
   - react-native-safe-area-context (4.7.2):
     - React-Core
   - React-NativeModulesApple (0.72.6):
@@ -545,6 +549,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -629,6 +634,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
@@ -708,6 +715,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 3bf18ff7cb03cd8dfdce08fbbc0d15058c1d71ae
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
+  react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3

--- a/examples/rn-multiple-realms/frontend/package-lock.json
+++ b/examples/rn-multiple-realms/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@realm/react": "^0.6.1",
         "react": "18.2.0",
         "react-native": "0.72.6",
+        "react-native-config": "^1.5.1",
         "react-native-safe-area-context": "^4.7.2",
         "react-native-screens": "^3.25.0",
         "react-native-vector-icons": "^10.0.0",
@@ -10289,6 +10290,19 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "peerDependencies": {
+        "react-native-windows": ">=0.61"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.7.2.tgz",
@@ -19327,6 +19341,12 @@
           }
         }
       }
+    },
+    "react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "requires": {}
     },
     "react-native-safe-area-context": {
       "version": "4.7.2",

--- a/examples/rn-multiple-realms/frontend/package.json
+++ b/examples/rn-multiple-realms/frontend/package.json
@@ -16,6 +16,7 @@
     "@realm/react": "^0.6.1",
     "react": "18.2.0",
     "react-native": "0.72.6",
+    "react-native-config": "^1.5.1",
     "react-native-safe-area-context": "^4.7.2",
     "react-native-screens": "^3.25.0",
     "react-native-vector-icons": "^10.0.0",

--- a/examples/rn-todo-list/README.md
+++ b/examples/rn-todo-list/README.md
@@ -160,11 +160,19 @@ npx pod-install
 1. [Copy your Atlas App ID](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/#std-label-find-your-app-id) from the App Services UI.
 2. Set `SYNC_CONFIG.enabled` to `true` and paste the copied ID as the value of the existing variable `SYNC_CONFIG.appId` in [sync.config.js](./frontend/sync.config.js):
 ```js
+import Config from 'react-native-config';
+
 export const SYNC_CONFIG = {
   enabled: true,
-  appId: 'YOUR_APP_ID',
+  appId: Config.ATLAS_APP_ID || 'YOUR_APP_ID',
 };
 ```
+-  Alternatively you can add a `.env` to your project with the following contents:
+   ```bash
+   ATLAS_APP_ID=your_app_id
+   ```
+   This file is included in the `.gitignore` so that it won't be committed to any code repositories.
+
 3. Start Metro (the JavaScript bundler) in its own terminal:
 ```sh
 npm start

--- a/examples/rn-todo-list/README.md
+++ b/examples/rn-todo-list/README.md
@@ -167,7 +167,7 @@ export const SYNC_CONFIG = {
   appId: Config.ATLAS_APP_ID || 'YOUR_APP_ID',
 };
 ```
--  Alternatively you can add a `.env` to your project with the following contents:
+-  Alternatively you can add a `.env` file to your project with the following contents:
    ```bash
    ATLAS_APP_ID=your_app_id
    ```

--- a/examples/rn-todo-list/frontend/.gitignore
+++ b/examples/rn-todo-list/frontend/.gitignore
@@ -64,3 +64,6 @@ yarn-error.log
 
 # testing
 /coverage
+
+# env
+.env

--- a/examples/rn-todo-list/frontend/android/app/build.gradle
+++ b/examples/rn-todo-list/frontend/android/app/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
+// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/examples/rn-todo-list/frontend/android/app/build.gradle
+++ b/examples/rn-todo-list/frontend/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
-// CUSTOM CODE: This adds support for the `.env` environemnt variables with react-native-config
+// CUSTOM CODE: This adds support for the `.env` environment variables with react-native-config
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 

--- a/examples/rn-todo-list/frontend/ios/ExampleRnTodoList.xcodeproj/project.pbxproj
+++ b/examples/rn-todo-list/frontend/ios/ExampleRnTodoList.xcodeproj/project.pbxproj
@@ -600,13 +600,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-					" ",
-					"-Wl -ld_classic ",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -676,13 +670,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-					" ",
-					"-Wl -ld_classic ",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/examples/rn-todo-list/frontend/ios/Podfile.lock
+++ b/examples/rn-todo-list/frontend/ios/Podfile.lock
@@ -375,6 +375,10 @@ PODS:
   - React-jsinspector (0.72.6)
   - React-logger (0.72.6):
     - glog
+  - react-native-config (1.5.1):
+    - react-native-config/App (= 1.5.1)
+  - react-native-config/App (1.5.1):
+    - React-Core
   - react-native-get-random-values (1.9.0):
     - React-Core
   - React-NativeModulesApple (0.72.6):
@@ -540,6 +544,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-config (from `../node_modules/react-native-config`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -622,6 +627,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
   react-native-get-random-values:
     :path: "../node_modules/react-native-get-random-values"
   React-NativeModulesApple:
@@ -697,6 +704,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 3bf18ff7cb03cd8dfdce08fbbc0d15058c1d71ae
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
+  react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   React-NativeModulesApple: 02e35e9a51e10c6422f04f5e4076a7c02243fff2
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3
@@ -722,4 +730,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a7c61b9167a0422bd2f4f87c1f35415b3ddcb971
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.11.3

--- a/examples/rn-todo-list/frontend/package-lock.json
+++ b/examples/rn-todo-list/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@realm/react": "^0.6.1",
         "react": "18.2.0",
         "react-native": "0.72.6",
+        "react-native-config": "^1.5.1",
         "react-native-get-random-values": "^1.9.0",
         "realm": "^12.2.0"
       },
@@ -10247,6 +10248,19 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "peerDependencies": {
+        "react-native-windows": ">=0.61"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-get-random-values": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz",
@@ -19124,6 +19138,12 @@
           }
         }
       }
+    },
+    "react-native-config": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz",
+      "integrity": "sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==",
+      "requires": {}
     },
     "react-native-get-random-values": {
       "version": "1.9.0",

--- a/examples/rn-todo-list/frontend/package.json
+++ b/examples/rn-todo-list/frontend/package.json
@@ -13,6 +13,7 @@
     "@realm/react": "^0.6.1",
     "react": "18.2.0",
     "react-native": "0.72.6",
+    "react-native-config": "^1.5.1",
     "react-native-get-random-values": "^1.9.0",
     "realm": "^12.2.0"
   },

--- a/examples/rn-todo-list/frontend/sync.config.js
+++ b/examples/rn-todo-list/frontend/sync.config.js
@@ -16,9 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import Config from 'react-native-config';
+
 export const SYNC_CONFIG = {
   // Set `enabled` to `true` to enable sync.
   enabled: true,
   // Add your Atlas App ID here if sync is enabled.
-  appId: 'YOUR_APP_ID',
+  appId: Config.ATLAS_APP_ID || 'YOUR_APP_ID',
 };


### PR DESCRIPTION

## What, How & Why?
* add `react-native-config` to React Native examples
* implement using the `.env` file to alternatively access the app id for the app
* add .env to the .gitignore to avoid publish the app id to github
* update README to assist with this methodology


## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
