### PR TITLE
Bug in mapTo on Realm.List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* When mapTo is used on a property of type List, an error like `Property 'test_list' does not exist on 'Task' objects` occurs when trying to access the property. ([#6268](https://github.com/realm/realm-js/issues/6268), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/alias.ts
+++ b/integration-tests/tests/src/tests/alias.ts
@@ -25,6 +25,14 @@ type ObjectA = {
   age?: number;
 };
 
+type Person = {
+  _name: string;
+  address: string;
+  age: number;
+  _married: boolean;
+  _children: Realm.List<Person>;
+};
+
 function addTestObjects(realm: Realm) {
   realm.write(() => {
     realm.create("ObjectA", {
@@ -34,6 +42,20 @@ function addTestObjects(realm: Realm) {
     realm.create("ObjectA", {
       otherName: "Bar",
       age: 42,
+    });
+
+    realm.create("Person", {
+      _name: "Donald",
+      address: "Elm Street",
+      age: 42.0,
+      _married: false,
+      _children: [
+        {
+          _name: "Nancy",
+          age: 14.0,
+          address: "Elm Street",
+        },
+      ],
     });
   });
 }
@@ -93,6 +115,23 @@ describe("Aliasing property names using mapTo", () => {
       // Using the internal name instead of the alias throws an exception.
       expect(() => realm.create("ObjectA", { name: "Boom" })).to.throw();
     });
+
+    // Create objects with links - must use alias
+    realm.write(() => {
+      realm.create("Person", {
+        _name: "Donald",
+        address: "Elm Street",
+        age: 42.0,
+        _married: false,
+        _children: [
+          {
+            _name: "Nancy",
+            age: 14.0,
+            address: "Elm Street",
+          },
+        ],
+      });
+    });
   });
 
   it("supports updating objects", function (this: Mocha.Context & RealmContext) {
@@ -130,6 +169,17 @@ describe("Aliasing property names using mapTo", () => {
     for (const key in obj) {
       expect(key).not.equals("name");
     }
+
+    const donald = realm.objects<Person>("Person")[0] as Person;
+    expect(donald).not.equals(undefined);
+
+    // @ts-expect-error This should be undefined
+    expect(donald.name).equals(undefined);
+    expect(donald._name).equals("Donald");
+
+    // @ts-expect-error This should be undefined
+    expect(donald.children).equals(undefined);
+    expect(donald._children.length).equals(1);
   });
 
   it("supports aliases in queries", function (this: Mocha.Context & RealmContext) {

--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -440,6 +440,16 @@ describe("Babel plugin", () => {
       expect((parsedSchema?.properties.name as PropertySchema).mapTo).toEqual("rename");
     });
 
+    it("handles `@mapTo` decorators on Realm.List", () => {
+      const transformCode = transform({
+        source: `import Realm, { Types, BSON, List, Set, Dictionary, Mixed } from "realm";
+        export class Person extends Realm.Object { @Realm.mapTo('rename') name: Realm.Types.List<Person>; }`,
+      });
+      const parsedSchema = extractSchema(transformCode);
+
+      expect((parsedSchema?.properties.name as PropertySchema).mapTo).toEqual("rename");
+    });
+
     it("ignores `@mapTo` decorators not imported from `realm`", () => {
       const transformCode = transform({
         source: `import Realm, { Types, BSON, List, Set, Dictionary, Mixed } from "realm";

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -334,7 +334,7 @@ export function createPropertyHelpers(property: PropertyContext, options: Helper
   const collectionType = property.type & binding.PropertyType.Collection;
   const typeOptions: TypeOptions = {
     realm: options.realm,
-    name: property.name,
+    name: property.publicName || property.name,
     getClassHelpers: options.getClassHelpers,
     objectType: property.objectType,
     objectSchemaName: property.objectSchemaName,


### PR DESCRIPTION
## What, How & Why?

In #6268, `mapTo` is reported not to work on lists.  We have tests in https://github.com/realm/realm-js/blob/v11/integration-tests/tests/src/tests/alias.ts but they only verify that the schema has been transformed.

Attempts to reproduce bug:

* [x] Add test to babel plugin
* [x] Add test to use alias after schema verification (in `alias.ts`)

The bug seems to hide is the getting but only for list properties.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* ~[ ] 📝 `Compatibility` label is updated or copied from previous entry~
* ~[ ] 📝 Update `COMPATIBILITY.md`~
* [x] 🚦 Tests
* ~[ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* ~[ ] 📱 Check the React Native/other sample apps work if necessary~
* ~[ ] 💥 `Breaking` label has been applied or is not necessary~
