### PR TITLE
Fixed babel plugin add extra name property

### DIFF
--- a/packages/babel-plugin/src/plugin/index.ts
+++ b/packages/babel-plugin/src/plugin/index.ts
@@ -402,11 +402,16 @@ function visitRealmClass(path: NodePath<types.ClassDeclaration>) {
     .map(visitRealmClassStatic)
     .filter((property) => property) as types.ObjectProperty[];
 
-  const schema = types.objectExpression([
-    types.objectProperty(types.identifier("name"), types.stringLiteral(className)),
-    types.objectProperty(types.identifier("properties"), types.objectExpression(schemaProperties)),
+  const hasStaticName = schemaStatics.some(p => p.key.name === "name");
+  const properties = [
+    types.objectProperty(types.identifier("properties"),
+    types.objectExpression(schemaProperties)),
     ...schemaStatics,
-  ]);
+  ];
+  if (!hasStaticName) {
+    properties.unshift(types.objectProperty(types.identifier("name"), types.stringLiteral(className)))
+  }
+  const schema = types.objectExpression(properties);
 
   // Add the schema as a static
   const schemaStatic = types.classProperty(types.identifier("schema"), schema, undefined, undefined, undefined, true);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

When defining class with a static property `name`, the generated js file containes two `name` fields, one is class name and another is the static property 

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
