### PR TITLE
Avoid BigInt literals as JSC/Android doesn't support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * When mapTo is used on a property of type List, an error like `Property 'test_list' does not exist on 'Task' objects` occurs when trying to access the property. ([#6268](https://github.com/realm/realm-js/issues/6268), since v12.0.0)
+* Fixed bug where apps running under JavaScriptCore on Android will terminate with the error message `No identifiers allowed directly after numeric literal`. ([#6194](https://github.com/realm/realm-js/issues/6194), since v12.2.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -380,7 +380,7 @@ export class Realm {
    * @since 0.11.0
    */
   public static schemaVersion(path: string, encryptionKey?: ArrayBuffer | ArrayBufferView): number {
-    const notFound = 18446744073709551615n; // std::numeric_limit<uint64_t>::max() = 0xffffffffffffffff
+    const notFound = "18446744073709551615"; // std::numeric_limit<uint64_t>::max() = 0xffffffffffffffff as string
     const config: Configuration = { path };
     const absolutePath = Realm.determinePath(config);
     const schemaVersion = binding.Realm.getSchemaVersion({
@@ -388,7 +388,7 @@ export class Realm {
       encryptionKey: Realm.determineEncryptionKey(encryptionKey),
     });
     // no easy way to compare uint64_t in TypeScript
-    return notFound.toString() === schemaVersion.toString() ? -1 : binding.Int64.intToNum(schemaVersion);
+    return notFound === schemaVersion.toString() ? -1 : binding.Int64.intToNum(schemaVersion);
   }
 
   /**


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

BigInt literals (integers postfixed with `n`) are not support on JSC/Android.

This closes #6194 

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
