### PR TITLE
Added `skipIf` on missingServer to non-local tests

### DIFF
--- a/integration-tests/tests/src/node/path.ts
+++ b/integration-tests/tests/src/node/path.ts
@@ -123,42 +123,46 @@ describe.skipIf(environment.missingServer, "path configuration (partition based 
   });
 });
 
-describe.skipIf(environment.skipFlexibleSync, "path configuration (flexible sync)", function () {
-  importAppBefore(buildAppConfig("with-flx").anonAuth().flexibleSync());
-  authenticateUserBefore();
+describe.skipIf(
+  environment.skipFlexibleSync || environment.missingServer,
+  "path configuration (flexible sync)",
+  function () {
+    importAppBefore(buildAppConfig("with-flx").anonAuth().flexibleSync());
+    authenticateUserBefore();
 
-  it("absolute path", async function () {
-    this.longTimeout();
-    const filename = getAbsolutePath();
-    const realm = await Realm.open({
-      path: filename,
-      schema: [schema],
-      sync: {
-        flexible: true,
-        user: this.user,
-      },
+    it("absolute path", async function () {
+      this.longTimeout();
+      const filename = getAbsolutePath();
+      const realm = await Realm.open({
+        path: filename,
+        schema: [schema],
+        sync: {
+          flexible: true,
+          user: this.user,
+        },
+      });
+      expect(realm.path).to.equal(filename);
+      expect(Realm.exists({ path: filename })).to.be.true;
+      realm.close();
+      Realm.deleteFile({ path: filename });
     });
-    expect(realm.path).to.equal(filename);
-    expect(Realm.exists({ path: filename })).to.be.true;
-    realm.close();
-    Realm.deleteFile({ path: filename });
-  });
 
-  it("relative path", async function () {
-    this.longTimeout();
-    const filename = getRelativePath();
-    const realm = await Realm.open({
-      path: filename,
-      schema: [schema],
-      sync: {
-        flexible: true,
-        user: this.user,
-      },
+    it("relative path", async function () {
+      this.longTimeout();
+      const filename = getRelativePath();
+      const realm = await Realm.open({
+        path: filename,
+        schema: [schema],
+        sync: {
+          flexible: true,
+          user: this.user,
+        },
+      });
+      // Realm Core will add a ".realm" suffix and url encode the path, if path is relative and sync is configured
+      const realmPath = realm.path;
+      expect(Realm.exists({ path: realmPath })).to.be.true;
+      realm.close();
+      Realm.deleteFile({ path: realmPath });
     });
-    // Realm Core will add a ".realm" suffix and url encode the path, if path is relative and sync is configured
-    const realmPath = realm.path;
-    expect(Realm.exists({ path: realmPath })).to.be.true;
-    realm.close();
-    Realm.deleteFile({ path: realmPath });
-  });
-});
+  },
+);

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -118,7 +118,7 @@ describe("App", () => {
       );
     });
 
-    it("logging in throws on non existing app", async function () {
+    it.skipIf(environment.missingServer, "logging in throws on non existing app", async function () {
       const app = new Realm.App(missingAppConfig);
       const credentials = Realm.Credentials.anonymous();
       await expect(app.logIn(credentials)).to.be.rejectedWith("cannot find app using Client App ID 'smurf'");
@@ -171,7 +171,7 @@ describe("App", () => {
     });
   });
 
-  describe("with valid app", async () => {
+  describe.skipIf(environment.missingServer, "with valid app", async () => {
     importAppBefore(buildAppConfig("with-anon").anonAuth());
 
     it("logins successfully ", async function (this: Mocha.Context & AppContext & RealmContext) {
@@ -264,7 +264,7 @@ describe("App", () => {
     });
   });
 
-  describe("with email-password auth", () => {
+  describe.skipIf(environment.missingServer, "with email-password auth", () => {
     importAppBefore(
       buildAppConfig("with-email-password").emailPasswordAuth({
         autoConfirm: true,
@@ -285,7 +285,7 @@ describe("App", () => {
     });
   });
 
-  describe("with sync", () => {
+  describe.skipIf(environment.missingServer, "with sync", () => {
     importAppBefore(buildAppConfig("with-pbs").anonAuth().partitionBasedSync());
 
     it("migration while sync is enabled throws", async function (this: Mocha.Context & AppContext & RealmContext) {

--- a/integration-tests/tests/src/tests/sync/encryption.ts
+++ b/integration-tests/tests/src/tests/sync/encryption.ts
@@ -83,7 +83,7 @@ describe("Encryption", () => {
     });
   });
 
-  describe("with sync", () => {
+  describe.skipIf(environment.missingServer, "with sync", () => {
     importAppBefore(buildAppConfig("with-pbs").anonAuth().partitionBasedSync());
 
     it("can set property in config", async function (this: AppContext) {

--- a/integration-tests/tests/src/tests/sync/open-behavior.ts
+++ b/integration-tests/tests/src/tests/sync/open-behavior.ts
@@ -46,7 +46,7 @@ async function getRegisteredEmailPassCredentials(app: Realm.App<any, any>) {
   return Realm.Credentials.emailPassword(email, password);
 }
 
-describe("OpenBehaviour", function () {
+describe.skipIf(environment.missingServer, "OpenBehaviour", function () {
   this.longTimeout();
   importAppBefore(buildAppConfig("with-pbs").anonAuth().emailPasswordAuth().partitionBasedSync());
   afterEach(() => Realm.clearTestState());

--- a/integration-tests/tests/src/tests/sync/open.ts
+++ b/integration-tests/tests/src/tests/sync/open.ts
@@ -22,7 +22,7 @@ import Realm from "realm";
 import { authenticateUserBefore, importAppBefore } from "../../hooks";
 import { buildAppConfig } from "../../utils/build-app-config";
 
-describe("Realm.open on a sync Realm", () => {
+describe.skipIf(environment.missingServer, "Realm.open on a sync Realm", () => {
   importAppBefore(buildAppConfig("with-flx").anonAuth().flexibleSync());
   authenticateUserBefore();
 

--- a/integration-tests/tests/src/tests/sync/partition-values.ts
+++ b/integration-tests/tests/src/tests/sync/partition-values.ts
@@ -76,7 +76,7 @@ const createConfig = (schema: Realm.ObjectSchema, user: Realm.User, partitionVal
   },
 });
 
-describe("Partition-values", () => {
+describe.skipIf(environment.missingServer, "Partition-values", () => {
   describe("setting partition value on config", () => {
     importAppBefore(buildAppConfig("with-pbs").anonAuth().partitionBasedSync());
     afterEach(() => Realm.clearTestState());

--- a/integration-tests/tests/src/tests/sync/realm.ts
+++ b/integration-tests/tests/src/tests/sync/realm.ts
@@ -1361,7 +1361,7 @@ describe("Realmtest", () => {
       });
     });
 
-    describe("schemaVersion", () => {
+    describe.skipIf(environment.missingServer, "schemaVersion", () => {
       importAppBefore(buildAppConfig("with-pbs").anonAuth().partitionBasedSync());
 
       [true, false].forEach((encryption) => {
@@ -1380,7 +1380,7 @@ describe("Realmtest", () => {
       });
     });
 
-    describe("exists", () => {
+    describe.skipIf(environment.missingServer, "exists", () => {
       importAppBefore(buildAppConfig("with-pbs").anonAuth().partitionBasedSync());
 
       it("yields correct value on a local realm", () => {

--- a/integration-tests/tests/src/tests/sync/sync-session.ts
+++ b/integration-tests/tests/src/tests/sync/sync-session.ts
@@ -124,7 +124,7 @@ async function seedDataWithExternalUser(app: Realm.App, partition: string) {
   user.logOut();
 }
 
-describe("SessionTest", () => {
+describe.skipIf(environment.missingServer, "SessionTest", () => {
   importAppBefore(buildAppConfig("with-pbs").emailPasswordAuth().partitionBasedSync({ required: true }));
 
   describe("invalid syncsessions", () => {


### PR DESCRIPTION
## What, How & Why?

We're already using `.skipIf(environment.missingServer` a couple of places to be able to run local tests that doesn't require the server. This add a couple more to make the tests pass when the server is stopped and the tests are ran with `MOCHA_REMOTE_CONTEXT=missingServer`.
