### PR TITLE
Fix race condition with useObject

### DIFF
--- a/packages/realm-react/src/cachedObject.ts
+++ b/packages/realm-react/src/cachedObject.ts
@@ -111,6 +111,7 @@ export function createCachedObject({ object, realm, updateCallback, updatedRef }
 
   const cachedObjectResult = new Proxy(object, cachedObjectHandler);
   const listenerCallback: Realm.ObjectChangeCallback<any> = (obj, changes) => {
+    updatedRef.current = true;
     if (changes.deleted) {
       updateCallback();
     } else if (changes.changedProperties.length > 0) {
@@ -125,7 +126,6 @@ export function createCachedObject({ object, realm, updateCallback, updatedRef }
         updateCallback();
       }
     }
-    updatedRef.current = true;
   };
 
   // We cannot add a listener to an invalid object


### PR DESCRIPTION
## What, How & Why?
We had some race condition that re-render was triggered quicker than `updateRef.current` was set to `true`. 
So basically, re-render was happening but the `useObject` was returning old object, so the children component did not see the change and was not re-rendering there. 

We have just tested this fix at `@hernas/realm-js@0.6.5` and this fixed the object not being updated.

## ☑️ ToDos
* [ ] 🚦 Tests


This was caught on:
- React Native with Hermes