### PR TITLE
Fix setting an object with an embedded object property to `null` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * When mapTo is used on a property of type List, an error like `Property 'test_list' does not exist on 'Task' objects` occurs when trying to access the property. ([#6268](https://github.com/realm/realm-js/issues/6268), since v12.0.0)
 * Fixed bug where apps running under JavaScriptCore on Android will terminate with the error message `No identifiers allowed directly after numeric literal`. ([#6194](https://github.com/realm/realm-js/issues/6194), since v12.2.0)
+* When an object had an embedded object as one of its properties, updating that property to `null` or `undefined` did not update the property in the database. ([#6280](https://github.com/realm/realm-js/issues/6280), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -104,8 +104,9 @@ function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions)
     // Asking for the toBinding will create the object and link it to the parent in one operation.
     // Thus, no need to actually set the value on the `obj` unless it's an optional null value.
     const bindingValue = toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
-    // No need to destructure `optional` and check that it's `true` in this condition
-    // as trying to set a non-optional value to null will fail at an earlier stage.
+    // No need to destructure `optional` and check that it's `true` in this condition before setting
+    // it to null as objects are always optional. The condition is placed after the invocation of
+    // `toBinding()` in order to leave the type conversion responsibility to `toBinding()`.
     if (bindingValue === null) {
       obj.setAny(columnKey, bindingValue);
     }

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -101,9 +101,14 @@ const defaultSet =
 
 function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
   return (obj: binding.Obj, value: unknown) => {
-    // Asking for the toBinding will create the object and link it to the parent in one operation
-    // no need to actually set the value on the `obj`
-    toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
+    // Asking for the toBinding will create the object and link it to the parent in one operation.
+    // Thus, no need to actually set the value on the `obj` unless it's an optional null value.
+    const bindingValue = toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
+    // No need to destructure `optional` and check that it's `true` in this condition
+    // as trying to set a non-optional value to null will fail at an earlier stage.
+    if (bindingValue === null) {
+      obj.setAny(columnKey, bindingValue);
+    }
   };
 }
 


### PR DESCRIPTION
## What, How & Why?

Updating an object's property whose value was an embedded object did not call into Core to update the underlying object when the new value was `null` or `undefined`.

This closes #6280 

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
