### PR TITLE
Export `RealmEventName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* None
+* Exporting a `RealmEventName` type. ([#6300](https://github.com/realm/realm-js/pull/6300))
 
 ### Fixed
 * When mapTo is used on a property of type List, an error like `Property 'test_list' does not exist on 'Task' objects` occurs when trying to access the property. ([#6268](https://github.com/realm/realm-js/issues/6268), since v12.0.0)

--- a/integration-tests/tests/src/tests/observable.ts
+++ b/integration-tests/tests/src/tests/observable.ts
@@ -24,9 +24,9 @@
 
 import { expect } from "chai";
 
-import Realm, { CollectionChangeSet, DictionaryChangeSet, ObjectChangeSet } from "realm";
+import Realm, { CollectionChangeSet, DictionaryChangeSet, ObjectChangeSet, RealmEventName } from "realm";
 
-import { openRealmBefore, openRealmBeforeEach } from "../hooks";
+import { openRealmBeforeEach } from "../hooks";
 import { createListenerStub } from "../utils/listener-stub";
 import { createPromiseHandle } from "../utils/promise-handle";
 
@@ -40,7 +40,7 @@ function expectObservableMethods(observable: Observable) {
 
 function expectRealmNotifications(
   realm: Realm,
-  eventName: "change" | "schema" | "beforenotify",
+  eventName: RealmEventName,
   expectedChangeSets: { schema?: Realm.CanonicalObjectSchema[] }[],
 ) {
   const handle = createPromiseHandle();

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1508,6 +1508,7 @@ export declare namespace Realm {
     PropertyTypeName,
     ProviderTypeType as ProviderType,
     ProxyTypeType as ProxyType,
+    RealmEventName,
     RealmObjectConstructor,
     /** @deprecated Will be removed in v13.0.0. Please use {@link RealmObjectConstructor} */
     RealmObjectConstructor as ObjectClass,

--- a/packages/realm/src/index.ts
+++ b/packages/realm/src/index.ts
@@ -144,6 +144,7 @@ export {
   ProviderType,
   ProxyType,
   Realm,
+  RealmEventName,
   RealmObject as Object,
   RealmObjectConstructor,
   RealmSet as Set,


### PR DESCRIPTION
## What, How & Why?

As @elle-j noted in https://github.com/realm/realm-js/pull/6297#discussion_r1415313419 .. we could export and use `RealmEventName` here. 

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
