### PR TITLE
Introduced `expectListenerRemoval`

### DIFF
--- a/integration-tests/tests/src/tests/observable.ts
+++ b/integration-tests/tests/src/tests/observable.ts
@@ -124,8 +124,6 @@ async function expectListenerRemoval({ addListener, removeListener, update }: Li
 }
 
 describe("Observable", () => {
-  // describe("App", () => {});
-
   describe("Realm", () => {
     openRealmBeforeEach({
       schema: [


### PR DESCRIPTION
## What, How & Why?

As per https://github.com/realm/realm-js/pull/6297#discussion_r1415331002, I've introduced a common `expectListenerRemoval` to help test removal of listeners.
