### PR TITLE
Enabling logging after tests (optionally on failure)

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Run tests with coverage
         timeout-minutes: 60
         env:
-          CONTEXT: syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }}
-          # CONTEXT: syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ secrets.ATLAS_QA_DAILY_CLUSTER_NAME }},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
+          CONTEXT: longTimeout=${{ env.LONG_TIMEOUT }}
+          # CONTEXT: longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ secrets.REALM_QA_BASE_URL }},mongodbClusterName=${{ secrets.ATLAS_QA_DAILY_CLUSTER_NAME }},privateKey=${{ secrets.ATLAS_QA_PRIVATE_API_KEY }},publicKey=${{ secrets.ATLAS_QA_PUBLIC_API_KEY }}
         run: npm run ci:coverage --workspace @realm/integration-tests -- --reporter mocha-github-actions-reporter --timeout ${{ env.MOCHA_TIMEOUT }}
 
       - name: Coveralls

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: Create Mocha Remote Context
         id: mocha-env
-        run: echo "context=syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas-config.outputs.url }}" >> $GITHUB_OUTPUT
+        run: echo "context=longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas-config.outputs.url }}" >> $GITHUB_OUTPUT
 
       - name: Wait for the server to start
         run: npx wait-on ${{ steps.baas-config.outputs.url }}

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: Create Mocha Remote Context
         id: mocha-env
-        run: echo "context=longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas-config.outputs.url }}" >> $GITHUB_OUTPUT
+        run: echo "context=printLogAfterTest=on-failure,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas-config.outputs.url }}" >> $GITHUB_OUTPUT
 
       - name: Wait for the server to start
         run: npx wait-on ${{ steps.baas-config.outputs.url }}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -84,6 +84,7 @@ Examples of context variables used:
 - `realmBaseUrl=https://localhost:9090`: Set the base URL used when connecting the the server.
 - `mongodbClusterName=Cluster0`: Set the name of the cluster, used when setting up the "mongodb-atlas" service on imported apps.
 - `mongodbServiceType`: Set the type of mongodb service, used when importing. Defaults to `mongodb` or `mongodb-atlas` if `mongodbClusterName` is set.
+- `printLogAfterTest=on-failure`: Enable printing of the log after every test failure
 
 As an example, to iterate on the performence tests, run the `./tests` (on Node.js) skipping tests that require a server as well as the integration tests and enable performance tests:
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -79,7 +79,6 @@ Examples of context variables used:
 - `integration=false`: Skip the integration test (which performance tests are not considered a part of).
 - `preserveAppAfterRun`: Skip deleting the Realm app after the test run
 - `defaultLogLevel=all`: Set the default log level to help debugging realm core issues.
-- `syncLogLevel=all`: Set the sync client log level to help debugging sync client issues.
 - `reuseApp=true`: Instructs the app importer to reuse and reconfigure a single app. Defaults to `false`.
 - `realmBaseUrl=https://localhost:9090`: Set the base URL used when connecting the the server.
 - `mongodbClusterName=Cluster0`: Set the name of the cluster, used when setting up the "mongodb-atlas" service on imported apps.

--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -93,6 +93,7 @@
 		"@thi.ng/bench": "^3.1.16",
 		"chai": "4.3.6",
 		"chai-as-promised": "^7.1.1",
+		"chalk": "^4.1.2",
 		"concurrently": "^6.0.2",
 		"jsrsasign": "^10.6.1"
 	},

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -17,10 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
+import { AppConfig } from "@realm/app-importer";
 
 import { importApp } from "../utils/import-app";
-import { AppConfig } from "@realm/app-importer";
 import { mongodbServiceType } from "../utils/ExtendedAppConfigBuilder";
+import * as logBuffer from "../utils/buffered-log";
 
 export type AppConfigurationRelaxed = {
   id?: string;
@@ -44,6 +45,8 @@ export function importAppBefore(config: AppConfig | { config: AppConfig }, sdkCo
     } else {
       const { appId, baseUrl } = await importApp(config);
       this.app = new Realm.App({ id: appId, baseUrl, ...sdkConfig });
+      // Un-mute the log to allow log buffer to read from it again
+      Realm.App.Sync.setLogLevel(this.app, logBuffer.defaultLogLevel);
 
       // Extract the sync database name from the config
       const databaseNames: (string | undefined)[] = config.services

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -64,6 +64,11 @@ export function importAppBefore(config: AppConfig | { config: AppConfig }, sdkCo
     }
   });
 
+  after("muteAppLog", function (this: AppContext & Mocha.Context) {
+    // Mute the log to avoid lifetime issues when reading out strings from the logger
+    Realm.App.Sync.setLogLevel(this.app, "off");
+  });
+
   after("removeUsersAfter", async function (this: Partial<AppContext> & Mocha.Context) {
     const { app } = this;
     if (app) {

--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -16,15 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import Realm, { AppConfiguration } from "realm";
+import Realm from "realm";
 
 import { importApp } from "../utils/import-app";
 import { AppConfig } from "@realm/app-importer";
 import { mongodbServiceType } from "../utils/ExtendedAppConfigBuilder";
-
-const REALM_LOG_LEVELS = ["all", "trace", "debug", "detail", "info", "warn", "error", "fatal", "off"];
-
-const { syncLogLevel = "warn" } = environment;
 
 export type AppConfigurationRelaxed = {
   id?: string;
@@ -65,17 +61,6 @@ export function importAppBefore(config: AppConfig | { config: AppConfig }, sdkCo
       } else if (databaseNames.length > 1) {
         throw new Error("Expected at most 1 database name in the config");
       }
-
-      Realm.App.Sync.setLogLevel(this.app, syncLogLevel);
-      // Set a default logger as Android does not forward stdout
-      Realm.App.Sync.setLogger(this.app, (level, message) => {
-        const time = new Date().toISOString().split("T")[1].replace("Z", "");
-        const magentaTime = `\x1b[35m${time}`;
-        const greenLogLevel = `\x1b[32m${REALM_LOG_LEVELS[level].toUpperCase()}`;
-        const whiteMessage = `\x1b[37m${message}}`;
-
-        console.log(`${magentaTime}: ${greenLogLevel}:\t${whiteMessage}`);
-      });
     }
   });
 

--- a/integration-tests/tests/src/hooks/open-realm-before.ts
+++ b/integration-tests/tests/src/hooks/open-realm-before.ts
@@ -20,7 +20,6 @@ import Realm, { User } from "realm";
 
 import { openRealm, OpenRealmConfiguration } from "../utils/open-realm";
 import * as logBuffer from "../utils/buffered-log";
-import { sleep } from "../utils/sleep";
 
 /**
  * Hook for use in before/beforeEach which opens a Realm with the specified config

--- a/integration-tests/tests/src/setup-globals.ts
+++ b/integration-tests/tests/src/setup-globals.ts
@@ -71,10 +71,9 @@ import Realm from "realm";
 import * as logBuffer from "./utils/buffered-log";
 
 // Disable the logger to avoid console flooding
-const { printLogAfterTest = false, defaultLogLevel = printLogAfterTest ? "all" : "off" } = environment;
-Realm.setLogLevel(defaultLogLevel);
+Realm.setLogLevel(logBuffer.defaultLogLevel);
 
-if (printLogAfterTest) {
+if (logBuffer.printLogAfterTest) {
   Realm.setLogger(logBuffer.append);
 }
 
@@ -82,8 +81,13 @@ if (printLogAfterTest) {
 beforeEach("Clear buffered Realm log", logBuffer.clear);
 
 afterEach("Print buffered Realm log", function (this: Mocha.Context) {
-  if (printLogAfterTest === true || (printLogAfterTest === "on-failure" && this.currentTest?.isFailed())) {
+  if (
+    logBuffer.printLogAfterTest === true ||
+    (logBuffer.printLogAfterTest === "on-failure" && this.currentTest && this.currentTest.state === "failed")
+  ) {
+    console.log("=== Printing Realm log since start of test ===");
     logBuffer.printAndClear();
+    console.log("=== End of Realm log ===");
   }
 });
 

--- a/integration-tests/tests/src/setup-globals.ts
+++ b/integration-tests/tests/src/setup-globals.ts
@@ -105,12 +105,10 @@ const logColors: Record<ValidRealmLogLevel, chalk.Chalk> = {
 
 afterEach(function (this: Mocha.Context) {
   if (printLogAfterTest === true || (printLogAfterTest === "on-failure" && this.currentTest?.isFailed())) {
-    console.log();
     for (const { level, message } of log) {
       const color = logColors[level];
       console.log(`[${color(level)}] ${message}`);
     }
-    console.log();
   }
 });
 

--- a/integration-tests/tests/src/typings.d.ts
+++ b/integration-tests/tests/src/typings.d.ts
@@ -44,8 +44,8 @@ type KnownEnvironment = {
   reuseApp?: true;
   /** Set the default log level to help debugging realm core issues */
   defaultLogLevel?: Realm.App.Sync.LogLevel;
-  /** Set the sync client log level to help debugging sync client issues */
-  syncLogLevel?: Realm.App.Sync.LogLevel;
+  /** Enable printing of the log after every test */
+  printLogAfterTest?: boolean | "on-failure";
 
   // BaaS server and Realm App Importer specific variables below
 
@@ -159,6 +159,8 @@ declare namespace Mocha {
 type AppContext = { app: Realm.App; databaseName: string } & Mocha.Context;
 type UserContext = { user: Realm.User } & Mocha.Context;
 type CloseRealmOptions = { deleteFile: boolean; clearTestState: boolean; reopen: boolean };
+
+type ValidRealmLogLevel = Exclude<Realm.App.Sync.LogLevel, "off" | "all">;
 type RealmContext = {
   realm: Realm;
   /**

--- a/integration-tests/tests/src/utils/buffered-log.ts
+++ b/integration-tests/tests/src/utils/buffered-log.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import chalk from "chalk";
+import Realm from "realm";
+
+/**
+ * Contains the Realm log since the test started.
+ */
+let log: { level: ValidRealmLogLevel; message: string }[] = [];
+
+export function append(level: Realm.App.Sync.LogLevel, message: string) {
+  if (level !== "off" && level !== "all") {
+    log.push({ level, message });
+  }
+}
+
+export function clear() {
+  log = [];
+}
+
+const logColors: Record<ValidRealmLogLevel, chalk.Chalk> = {
+  trace: chalk.dim,
+  debug: chalk.dim,
+  detail: chalk.dim,
+  info: chalk.blue,
+  warn: chalk.yellow,
+  error: chalk.red,
+  fatal: chalk.red,
+};
+
+export function printAndClear() {
+  console.log("printAndClearLogBuffer called");
+  for (const { level, message } of log) {
+    const color = logColors[level];
+    console.log(`[${color(level)}] ${message}`);
+  }
+  clear();
+}

--- a/integration-tests/tests/src/utils/buffered-log.ts
+++ b/integration-tests/tests/src/utils/buffered-log.ts
@@ -19,10 +19,11 @@
 import chalk from "chalk";
 import Realm from "realm";
 
-/**
- * Contains the Realm log since the test started.
- */
-let log: { level: ValidRealmLogLevel; message: string }[] = [];
+type LogEntry = { level: ValidRealmLogLevel; message: string };
+
+const log: LogEntry[] = [];
+
+export const { printLogAfterTest = false, defaultLogLevel = printLogAfterTest ? "all" : "off" } = environment;
 
 export function append(level: Realm.App.Sync.LogLevel, message: string) {
   if (level !== "off" && level !== "all") {
@@ -31,7 +32,7 @@ export function append(level: Realm.App.Sync.LogLevel, message: string) {
 }
 
 export function clear() {
-  log = [];
+  log.splice(0, log.length);
 }
 
 const logColors: Record<ValidRealmLogLevel, chalk.Chalk> = {
@@ -45,7 +46,6 @@ const logColors: Record<ValidRealmLogLevel, chalk.Chalk> = {
 };
 
 export function printAndClear() {
-  console.log("printAndClearLogBuffer called");
   for (const { level, message } of log) {
     const color = logColors[level];
     console.log(`[${color(level)}] ${message}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1091,6 +1091,7 @@
         "@thi.ng/bench": "^3.1.16",
         "chai": "4.3.6",
         "chai-as-promised": "^7.1.1",
+        "chalk": "^4.1.2",
         "concurrently": "^6.0.2",
         "jsrsasign": "^10.6.1"
       },
@@ -35820,6 +35821,7 @@
         "@types/node": "^18.15.10",
         "chai": "4.3.6",
         "chai-as-promised": "^7.1.1",
+        "chalk": "^4.1.2",
         "concurrently": "^6.5.1",
         "jsrsasign": "^10.6.1",
         "mocha": "^10.1.0",


### PR DESCRIPTION
## What, How & Why?

I started on this a fix for #6299, to help fix some of the sporadic failures we're seeing in our integration tests.

<!--, but I'm getting weird crashes on React Native:

```
Thread 10 Crashed:: com.facebook.react.JavaScript
0   libsystem_kernel.dylib        	       0x1b17e3fe8 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x1b183812c pthread_kill + 256
2   libsystem_c.dylib             	       0x18012873c abort + 124
3   libsystem_malloc.dylib        	       0x18019a418 malloc_vreport + 912
4   libsystem_malloc.dylib        	       0x18019a698 malloc_zone_error + 100
5   libsystem_malloc.dylib        	       0x180183588 free_small_botch + 36
6   hermes                        	       0x106432d44 0x106320000 + 1125700
7   hermes                        	       0x106436560 0x106320000 + 1140064
8   hermes                        	       0x1063c4d40 0x106320000 + 675136
9   hermes                        	       0x1063c4e24 0x106320000 + 675364
10  hermes                        	       0x106329b4c 0x106320000 + 39756
11  RealmReactNativeTests         	       0x1012b7574 facebook::jsi::RuntimeDecorator<facebook::jsi::Runtime, facebook::jsi::Runtime>::createStringFromUtf8(unsigned char const*, unsigned long) + 60 (decorator.h:219)
12  RealmReactNativeTests         	       0x1012b5600 facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::createStringFromUtf8(unsigned char const*, unsigned long) + 72 (decorator.h:622)
13  RealmReactNativeTests         	       0x1017b5cb0 facebook::jsi::String::createFromUtf8(facebook::jsi::Runtime&, unsigned char const*, unsigned long) + 56 (jsi.h:621)
14  RealmReactNativeTests         	       0x1017c5fb0 auto realm::js::JSI::(anonymous namespace)::Helpers_make_logger(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::$_6::operator()(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const::'lambda'(auto&&)::operator()<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(auto&&) const + 80 (jsi_init.cpp:2727)
15  RealmReactNativeTests         	       0x1017c5d24 realm::js::JSI::(anonymous namespace)::Helpers_make_logger(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::$_6::operator()(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const + 208 (jsi_init.cpp:2726)
16  RealmReactNativeTests         	       0x1017c5bc0 realm::util::UniqueFunction<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::SpecificImpl<realm::js::JSI::(anonymous namespace)::Helpers_make_logger(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::$_6>::call(realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 48 (functional.hpp:154)
17  RealmReactNativeTests         	       0x1017c3b48 realm::util::UniqueFunction<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const + 116 (functional.hpp:94)
18  RealmReactNativeTests         	       0x1017c39c0 realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 80 (event_loop_dispatcher.hpp:54)
19  RealmReactNativeTests         	       0x1017c3964 decltype(std::declval<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&>()(std::declval<realm::util::Logger::Level>(), std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>())) std::__1::__invoke[abi:v15006]<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&, realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&, realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 44 (invoke.h:394)
20  RealmReactNativeTests         	       0x1017c3908 void std::__1::__invoke_void_return_wrapper<void, true>::__call<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&, realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&, realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 40 (invoke.h:479)
21  RealmReactNativeTests         	       0x1017c38d4 std::__1::__function::__alloc_func<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>, std::__1::allocator<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>>, void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()[abi:v15006](realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 44 (function.h:185)
22  RealmReactNativeTests         	       0x1017c25b4 std::__1::__function::__func<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>, std::__1::allocator<realm::util::EventLoopDispatcher<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>>, void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()(realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 44 (function.h:359)
23  RealmReactNativeTests         	       0x1017c0384 std::__1::__function::__value_func<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()[abi:v15006](realm::util::Logger::Level&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const + 84 (function.h:512)
24  RealmReactNativeTests         	       0x1017c0324 std::__1::function<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>::operator()(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const + 44 (function.h:1197)
25  RealmReactNativeTests         	       0x1017bffc4 realm::js::(anonymous namespace)::Helpers::make_logger(std::__1::function<void (realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)>&&)::MyLogger::do_log(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 44 (realm_helpers.h:213)
26  RealmReactNativeTests         	       0x1016e1684 realm::util::Logger::do_log(realm::util::Logger&, realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 48 (logger.hpp:359)
27  RealmReactNativeTests         	       0x1014a6c50 realm::DBLogger::do_log(realm::util::Logger::Level, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 256 (db.cpp:1484)
28  RealmReactNativeTests         	       0x10169aa04 void realm::util::Logger::do_log<unsigned int&>(realm::util::Logger::Level, char const*, unsigned int&) + 88 (logger.hpp:365)
29  RealmReactNativeTests         	       0x101696e5c void realm::util::Logger::log<unsigned int&>(realm::util::Logger::Level, char const*, unsigned int&) + 72 (logger.hpp:347)
30  RealmReactNativeTests         	       0x1016926ac realm::Transaction::do_end_read() + 92 (transaction.cpp:867)
31  RealmReactNativeTests         	       0x101692528 realm::Transaction::close() + 112 (transaction.cpp:143)
32  RealmReactNativeTests         	       0x1014aaf38 (anonymous namespace)::$_3::operator()(realm::Transaction*) const + 28 (db.cpp:299)
33  RealmReactNativeTests         	       0x1014ab174 std::__1::__shared_ptr_pointer<realm::Transaction*, (anonymous namespace)::$_3, std::__1::allocator<realm::Transaction>>::__on_zero_shared() + 72 (shared_ptr.h:263)
34  RealmReactNativeTests         	       0x100fa8f40 std::__1::__shared_count::__release_shared[abi:v15006]() + 64 (shared_ptr.h:174)
35  RealmReactNativeTests         	       0x100fa8ee0 std::__1::__shared_weak_count::__release_shared[abi:v15006]() + 28 (shared_ptr.h:215)
36  RealmReactNativeTests         	       0x101889bd4 std::__1::shared_ptr<realm::Transaction>::~shared_ptr[abi:v15006]() + 64 (shared_ptr.h:702)
37  RealmReactNativeTests         	       0x101889b84 std::__1::shared_ptr<realm::Transaction>::~shared_ptr[abi:v15006]() + 28 (shared_ptr.h:700)
38  RealmReactNativeTests         	       0x101889b50 realm::sync::MutableSubscriptionSet::~MutableSubscriptionSet() + 32 (subscriptions.hpp:217)
39  RealmReactNativeTests         	       0x101888d18 realm::sync::MutableSubscriptionSet::~MutableSubscriptionSet() + 28 (subscriptions.hpp:217)
40  RealmReactNativeTests         	       0x1018897cc realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>::~HostObjClassWrapper() + 48 (realm_js_jsi_helpers.h:56)
41  RealmReactNativeTests         	       0x101889688 realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>::~HostObjClassWrapper() + 28 (realm_js_jsi_helpers.h:56)
42  RealmReactNativeTests         	       0x1018898c4 void std::__1::__destroy_at[abi:v15006]<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>, 0>(realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>*) + 32 (construct_at.h:63)
43  RealmReactNativeTests         	       0x101889898 void std::__1::destroy_at[abi:v15006]<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>, 0>(realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>*) + 24 (construct_at.h:88)
44  RealmReactNativeTests         	       0x101889874 void std::__1::allocator_traits<std::__1::allocator<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>>>::destroy[abi:v15006]<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>, void, void>(std::__1::allocator<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>>&, realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>*) + 28 (allocator_traits.h:317)
45  RealmReactNativeTests         	       0x101889474 std::__1::__shared_ptr_emplace<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>, std::__1::allocator<realm::js::JSI::(anonymous namespace)::HostObjClassWrapper<realm::sync::MutableSubscriptionSet, realm::sync::SubscriptionSet>>>::__on_zero_shared() + 48 (shared_ptr.h:309)
46  RealmReactNativeTests         	       0x100fa8f40 std::__1::__shared_count::__release_shared[abi:v15006]() + 64 (shared_ptr.h:174)
47  RealmReactNativeTests         	       0x100fa8ee0 std::__1::__shared_weak_count::__release_shared[abi:v15006]() + 28 (shared_ptr.h:215)
48  RealmReactNativeTests         	       0x1011ace84 std::__1::shared_ptr<facebook::jsi::HostObject>::~shared_ptr[abi:v15006]() + 64 (shared_ptr.h:702)
49  RealmReactNativeTests         	       0x1011ac410 std::__1::shared_ptr<facebook::jsi::HostObject>::~shared_ptr[abi:v15006]() + 28 (shared_ptr.h:700)
50  RealmReactNativeTests         	       0x1012b8b20 facebook::jsi::DecoratedHostObject::~DecoratedHostObject() + 48 (decorator.h:57)
51  RealmReactNativeTests         	       0x1012b8984 facebook::jsi::DecoratedHostObject::~DecoratedHostObject() + 28 (decorator.h:57)
52  RealmReactNativeTests         	       0x1012b87dc std::__1::__shared_ptr_emplace<facebook::jsi::DecoratedHostObject, std::__1::allocator<facebook::jsi::DecoratedHostObject>>::__on_zero_shared() + 36 (shared_ptr.h:311)
53  hermes                        	       0x106332bfc 0x106320000 + 76796
54  hermes                        	       0x106432d44 0x106320000 + 1125700
55  hermes                        	       0x106436560 0x106320000 + 1140064
56  hermes                        	       0x1063c3f50 0x106320000 + 671568
57  hermes                        	       0x1063c6768 0x106320000 + 681832
58  hermes                        	       0x10639d6ac 0x106320000 + 513708
59  hermes                        	       0x1063694dc 0x106320000 + 300252
60  hermes                        	       0x106365b60 0x106320000 + 285536
61  hermes                        	       0x1063475a0 0x106320000 + 161184
62  hermes                        	       0x106346d34 0x106320000 + 159028
63  hermes                        	       0x106345dd8 0x106320000 + 155096
64  hermes                        	       0x106407f94 0x106320000 + 950164
65  hermes                        	       0x1063472f8 0x106320000 + 160504
66  hermes                        	       0x106366438 0x106320000 + 287800
67  hermes                        	       0x106365b60 0x106320000 + 285536
68  hermes                        	       0x1063475a0 0x106320000 + 161184
69  hermes                        	       0x106345dd8 0x106320000 + 155096
70  hermes                        	       0x106414b98 0x106320000 + 1002392
71  hermes                        	       0x1063472f8 0x106320000 + 160504
72  hermes                        	       0x106366438 0x106320000 + 287800
73  hermes                        	       0x106365b60 0x106320000 + 285536
74  hermes                        	       0x1063475a0 0x106320000 + 161184
75  hermes                        	       0x106346d34 0x106320000 + 159028
76  hermes                        	       0x10632c4b8 0x106320000 + 50360
77  RealmReactNativeTests         	       0x1012b7e70 facebook::jsi::RuntimeDecorator<facebook::jsi::Runtime, facebook::jsi::Runtime>::call(facebook::jsi::Function const&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) + 76 (decorator.h:340)
78  RealmReactNativeTests         	       0x1012b64ec facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::call(facebook::jsi::Function const&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) + 88 (decorator.h:753)
79  RealmReactNativeTests         	       0x10138c808 facebook::jsi::Function::call(facebook::jsi::Runtime&, facebook::jsi::Value const*, unsigned long) const + 100 (jsi-inl.h:259)
80  RealmReactNativeTests         	       0x10117ae20 facebook::jsi::Function::call(facebook::jsi::Runtime&, std::initializer_list<facebook::jsi::Value>) const + 112 (jsi-inl.h:264)
81  RealmReactNativeTests         	       0x1012bd894 facebook::jsi::Value facebook::jsi::Function::call<>(facebook::jsi::Runtime&) const + 76 (jsi-inl.h:272)
82  RealmReactNativeTests         	       0x1013479a8 facebook::react::JSIExecutor::flush() + 104 (JSIExecutor.cpp:423)
83  RealmReactNativeTests         	       0x10121c134 facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3::operator()(facebook::react::JSExecutor*) const + 44 (Instance.cpp:296)
84  RealmReactNativeTests         	       0x10121c0fc decltype(std::declval<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3&>()(std::declval<facebook::react::JSExecutor*>())) std::__1::__invoke[abi:v15006]<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3&, facebook::react::JSExecutor*>(facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3&, facebook::react::JSExecutor*&&) + 36 (invoke.h:394)
85  RealmReactNativeTests         	       0x10121c0a8 void std::__1::__invoke_void_return_wrapper<void, true>::__call<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3&, facebook::react::JSExecutor*>(facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3&, facebook::react::JSExecutor*&&) + 32 (invoke.h:479)
86  RealmReactNativeTests         	       0x10121c07c std::__1::__function::__alloc_func<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3, std::__1::allocator<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3>, void (facebook::react::JSExecutor*)>::operator()[abi:v15006](facebook::react::JSExecutor*&&) + 36 (function.h:185)
87  RealmReactNativeTests         	       0x10121ae50 std::__1::__function::__func<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3, std::__1::allocator<facebook::react::Instance::JSCallInvoker::scheduleAsync(std::__1::function<void ()>&&)::$_3>, void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*&&) + 36 (function.h:359)
88  RealmReactNativeTests         	       0x101245b58 std::__1::__function::__value_func<void (facebook::react::JSExecutor*)>::operator()[abi:v15006](facebook::react::JSExecutor*&&) const + 76 (function.h:512)
89  RealmReactNativeTests         	       0x101245ad8 std::__1::function<void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*) const + 36 (function.h:1197)
90  RealmReactNativeTests         	       0x101245aa4 facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8::operator()() const + 92 (NativeToJsBridge.cpp:310)
91  RealmReactNativeTests         	       0x101245a3c decltype(std::declval<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8&>()()) std::__1::__invoke[abi:v15006]<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8&>(facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8&) + 24 (invoke.h:394)
92  RealmReactNativeTests         	       0x1012459f4 void std::__1::__invoke_void_return_wrapper<void, true>::__call<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8&>(facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8&) + 24 (invoke.h:479)
93  RealmReactNativeTests         	       0x1012459d0 std::__1::__function::__alloc_func<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8, std::__1::allocator<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8>, void ()>::operator()[abi:v15006]() + 28 (function.h:185)
94  RealmReactNativeTests         	       0x101244564 std::__1::__function::__func<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8, std::__1::allocator<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8>, void ()>::operator()() + 28 (function.h:359)
95  RealmReactNativeTests         	       0x100f8a80c std::__1::__function::__value_func<void ()>::operator()[abi:v15006]() const + 68 (function.h:512)
96  RealmReactNativeTests         	       0x100f8a7bc std::__1::function<void ()>::operator()() const + 24 (function.h:1197)
97  RealmReactNativeTests         	       0x101070c98 facebook::react::tryAndReturnError(std::__1::function<void ()> const&) + 24 (RCTCxxUtils.mm:74)
98  RealmReactNativeTests         	       0x101093f0c facebook::react::RCTMessageThread::tryFunc(std::__1::function<void ()> const&) + 36 (RCTMessageThread.mm:69)
99  RealmReactNativeTests         	       0x1010989dc facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1::operator()() const + 80 (RCTMessageThread.mm:82)
100 RealmReactNativeTests         	       0x101098980 decltype(std::declval<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1&>()()) std::__1::__invoke[abi:v15006]<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1&>(facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1&) + 24 (invoke.h:394)
101 RealmReactNativeTests         	       0x101098938 void std::__1::__invoke_void_return_wrapper<void, true>::__call<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1&>(facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1&) + 24 (invoke.h:479)
102 RealmReactNativeTests         	       0x101098914 std::__1::__function::__alloc_func<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1, std::__1::allocator<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1>, void ()>::operator()[abi:v15006]() + 28 (function.h:185)
103 RealmReactNativeTests         	       0x101097624 std::__1::__function::__func<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1, std::__1::allocator<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_1>, void ()>::operator()() + 28 (function.h:359)
104 RealmReactNativeTests         	       0x100f8a80c std::__1::__function::__value_func<void ()>::operator()[abi:v15006]() const + 68 (function.h:512)
105 RealmReactNativeTests         	       0x100f8a7bc std::__1::function<void ()>::operator()() const + 24 (function.h:1197)
106 RealmReactNativeTests         	       0x101093c80 invocation function for block in facebook::react::RCTMessageThread::runAsync(std::__1::function<void ()>) + 48 (RCTMessageThread.mm:45)
107 CoreFoundation                	       0x18039aa34 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 20
108 CoreFoundation                	       0x18039a17c __CFRunLoopDoBlocks + 360
109 CoreFoundation                	       0x18039496c __CFRunLoopRun + 768
110 CoreFoundation                	       0x180394254 CFRunLoopRunSpecific + 584
111 RealmReactNativeTests         	       0x101047840 +[RCTCxxBridge runRunLoop] + 736 (RCTCxxBridge.mm:337)
112 Foundation                    	       0x180bbede0 __NSThread__start__ + 704
113 libsystem_pthread.dylib       	       0x1b1838428 _pthread_start + 116
114 libsystem_pthread.dylib       	       0x1b1833648 thread_start + 8
```
-->