### PR TITLE
Adding `inspect.custom` symbol on RealmObject and Collection on Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Exporting a `RealmEventName` type. ([#6300](https://github.com/realm/realm-js/pull/6300))
 * Automatic client reset recovery now preserves the original division of changesets, rather than combining all unsynchronized changes into a single changeset. ([realm/realm-core#7161](https://github.com/realm/realm-core/pull/7161))
 * Automatic client reset recovery now does a better job of recovering changes when changesets were downloaded from the server after the unuploaded local changes were committed. If the local Realm happened to be fully up to date with the server prior to the client reset, automatic recovery should now always produce exactly the same state as if no client reset was involved. ([realm/realm-core#7161](https://github.com/realm/realm-core/pull/7161))
+* Improved the experience of logging `Realm.Object` and `Realm.Collection` objects on Node.js, by providing a custom "inspect" symbol. ([#2758](https://github.com/realm/realm-js/pull/2758))
 
 ### Fixed
 * When mapTo is used on a property of type List, an error like `Property 'test_list' does not exist on 'Task' objects` occurs when trying to access the property. ([#6268](https://github.com/realm/realm-js/issues/6268), since v12.0.0)

--- a/integration-tests/tests/src/node/custom-inspect.ts
+++ b/integration-tests/tests/src/node/custom-inspect.ts
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Realm from "realm";
+import { inspect } from "node:util";
+
+import { openRealmBefore } from "../hooks";
+import { expect } from "chai";
+
+describe("Custom inspect on Node.js", () => {
+  type Person = {
+    name: string;
+    friends: Realm.List<Person>;
+    bestFriends: Realm.Set<Person>;
+    friendsByName: Realm.Dictionary<Person>;
+  };
+  openRealmBefore({
+    schema: [
+      {
+        name: "Person",
+        properties: {
+          name: "string",
+          friends: "Person[]",
+          bestFriends: { type: "set", objectType: "Person" },
+          friendsByName: { type: "dictionary", objectType: "Person" },
+        },
+      },
+    ],
+  });
+
+  beforeEach(function (this: RealmObjectContext<Person>) {
+    this.object = this.realm.write(() => {
+      const alice = this.realm.create<Person>("Person", { name: "Alice" });
+      const bob = this.realm.create<Person>("Person", { name: "Bob" });
+      const charlie = this.realm.create<Person>("Person", { name: "Charlie" });
+      alice.friends.push(bob, charlie);
+      bob.friends.push(alice, charlie);
+      charlie.friends.push(alice, bob);
+      alice.bestFriends.add(bob);
+      bob.bestFriends.add(alice);
+      return alice;
+    });
+  });
+
+  describe("Realm.Object", () => {
+    it("exposes a custom inspect", function (this: RealmObjectContext<Person>) {
+      const inspected = inspect(this.object, false, 3);
+      expect(inspected).contains("Person");
+      expect(inspected).contains("Alice");
+      expect(inspected).contains("Bob");
+      expect(inspected).contains("Charlie");
+
+      expect(inspected).contains("Realm.List");
+      expect(inspected).contains("Realm.Set");
+      expect(inspected).contains("Realm.Dictionary");
+    });
+  });
+});

--- a/integration-tests/tests/src/node/index.ts
+++ b/integration-tests/tests/src/node/index.ts
@@ -22,3 +22,4 @@ import "./analytics";
 import "./clean-exit";
 import "./path";
 import "./sync-proxy";
+import "./custom-inspect";

--- a/packages/realm/src/platform/node/custom-inspect.ts
+++ b/packages/realm/src/platform/node/custom-inspect.ts
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+import { InspectOptions, inspect } from "node:util";
+
+import { Collection, RealmObject } from "../../internal";
+
+type CustomInspectFunction<T> = (this: T, depth: number, inspectOptions: InspectOptions) => void;
+
+function injectInspect<T extends object>(constructor: { prototype: T }, customInspect: CustomInspectFunction<T>) {
+  Object.assign(constructor.prototype, { [inspect.custom]: customInspect });
+}
+
+injectInspect(RealmObject, function (this, depth: number, inspectOptions: InspectOptions) {
+  const { name } = this.objectSchema();
+  return `${name} ${inspect({ ...this }, inspectOptions.showHidden, depth, inspectOptions.colors)}`;
+});
+
+injectInspect(Collection, function (this, depth: number, inspectOptions: InspectOptions) {
+  const name = this.constructor.name;
+  return `${name} ${inspect({ ...this }, inspectOptions.showHidden, depth, inspectOptions.colors)}`;
+});

--- a/packages/realm/src/platform/node/custom-inspect.ts
+++ b/packages/realm/src/platform/node/custom-inspect.ts
@@ -26,18 +26,6 @@ function injectInspect<T extends object>(constructor: { prototype: T }, customIn
   Object.assign(constructor.prototype, { [inspect.custom]: customInspect });
 }
 
-function possiblyShort(name: string, depth: number, options: InspectOptionsStylized, cb: () => string) {
-  if (depth === -1) {
-    if (options.colors) {
-      return options.stylize(`[${name}]`, "special");
-    } else {
-      return `[${name}]`;
-    }
-  } else {
-    return `${name} ${cb()}`;
-  }
-}
-
 function constructorName(value: object) {
   if (value instanceof RealmObject) {
     return value.objectSchema().name;
@@ -65,9 +53,16 @@ function isIterable<T>(value: object): value is Iterable<T> {
 }
 
 function defaultInspector<T extends object>(this: T, depth: number, options: InspectOptionsStylized) {
-  return possiblyShort(constructorName(this), depth, options, () =>
-    inspect(isIterable(this) ? [...this] : { ...this }, options.showHidden, depth, options.colors),
-  );
+  const name = constructorName(this);
+  if (depth === -1) {
+    if (options.colors) {
+      return options.stylize(`[${name}]`, "special");
+    } else {
+      return `[${name}]`;
+    }
+  } else {
+    return `${name} ${inspect(isIterable(this) ? [...this] : { ...this }, options.showHidden, depth, options.colors)}`;
+  }
 }
 
 injectInspect(RealmObject, defaultInspector);

--- a/packages/realm/src/platform/node/custom-inspect.ts
+++ b/packages/realm/src/platform/node/custom-inspect.ts
@@ -17,8 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 import { InspectOptionsStylized, inspect } from "node:util";
 
-import { Collection, Dictionary, List, RealmObject, RealmSet } from "../../internal";
-import { Results } from "realm/binding";
+import { Collection, Dictionary, List, RealmObject, RealmSet, Results } from "../../internal";
 
 type CustomInspectFunction<T> = (this: T, depth: number, options: InspectOptionsStylized) => void;
 

--- a/packages/realm/src/platform/node/index.ts
+++ b/packages/realm/src/platform/node/index.ts
@@ -19,5 +19,6 @@
 import "./fs";
 import "./device-info";
 import "./sync-proxy-config";
+import "./custom-inspect";
 
 export * from "../../index";


### PR DESCRIPTION
## What, How & Why?

I finally got tired of the lack of property values on objects as they're being logged and implemented a custom inspect function for `Realm.Object` and `Realm.Collection`.

This is the output of logging first a `Realm.Object` with a string, list, set and dictionary properties.

![Screenshot 2023-12-12 at 21 17 31](https://github.com/realm/realm-js/assets/1243959/521e7edd-9a8b-4a3d-80af-0d9de0fcbdc6)

This closes #2758.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
