### PR TITLE
Removing `tsx` from sub-packages

### DIFF
--- a/integration-tests/baas-test-server/package.json
+++ b/integration-tests/baas-test-server/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.0.2",
-    "tsx": "^3.12.2",
     "yargs": "^17.7.2"
   }
 }

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -40,7 +40,6 @@
     "@realm/app-importer": "*",
     "@realm/mocha-reporter": "*",
     "cmake-js": "^6.1.0",
-    "concurrently": "^6.0.2",
-    "tsx": "^3.12.2"
+    "concurrently": "^6.0.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,38 +96,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "dotenv": "^16.0.2",
-        "tsx": "^3.12.2",
         "yargs": "^17.7.2"
-      }
-    },
-    "integration-tests/baas-test-server/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "integration-tests/baas-test-server/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "integration-tests/baas-test-server/node_modules/dotenv": {
@@ -136,58 +105,6 @@
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "integration-tests/baas-test-server/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
-    "integration-tests/baas-test-server/node_modules/tsx": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-      "dependencies": {
-        "esbuild": "~0.18.20",
-        "get-tsconfig": "^4.7.2",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "integration-tests/environments/electron": {
@@ -575,40 +492,7 @@
         "@realm/app-importer": "*",
         "@realm/mocha-reporter": "*",
         "cmake-js": "^6.1.0",
-        "concurrently": "^6.0.2",
-        "tsx": "^3.12.2"
-      }
-    },
-    "integration-tests/environments/node/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "integration-tests/environments/node/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
+        "concurrently": "^6.0.2"
       }
     },
     "integration-tests/environments/node/node_modules/debug": {
@@ -631,43 +515,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "integration-tests/environments/node/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "integration-tests/environments/node/node_modules/glob": {
       "version": "7.1.6",
@@ -784,23 +631,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "integration-tests/environments/node/node_modules/tsx": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "~0.18.20",
-        "get-tsconfig": "^4.7.2",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
     },
     "integration-tests/environments/node/node_modules/yargs": {
       "version": "16.2.0",
@@ -30464,7 +30294,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "mocha": "^10.1.0",
-        "tsx": "^3.12.3"
+        "tsx": "^4.6.2"
       }
     },
     "packages/realm/bindgen/vendor/realm-core/bindgen": {
@@ -30493,97 +30323,11 @@
         "mocha": "^10.1.0"
       }
     },
-    "packages/realm/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/realm/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/realm/node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
-    },
-    "packages/realm/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
-    "packages/realm/node_modules/tsx": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "~0.18.20",
-        "get-tsconfig": "^4.7.2",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
     }
   },
   "dependencies": {
@@ -34273,66 +34017,13 @@
       "requires": {
         "chalk": "^4.1.2",
         "dotenv": "^16.0.2",
-        "tsx": "^3.12.2",
         "yargs": "^17.7.2"
       },
       "dependencies": {
-        "@esbuild/android-arm": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-          "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-          "optional": true
-        },
-        "@esbuild/linux-loong64": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-          "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-          "optional": true
-        },
         "dotenv": {
           "version": "16.0.3",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
           "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
-        },
-        "tsx": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-          "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-          "requires": {
-            "esbuild": "~0.18.20",
-            "fsevents": "~2.3.3",
-            "get-tsconfig": "^4.7.2",
-            "source-map-support": "^0.5.21"
-          }
         }
       }
     },
@@ -35269,7 +34960,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "mocha": "^10.1.0",
-        "tsx": "^3.12.3",
+        "tsx": "^4.6.2",
         "typescript-json-schema": "^0.55.0",
         "yaml": "^2.2.2"
       }
@@ -36070,24 +35761,9 @@
         "mocha-github-actions-reporter": "^0.2.3",
         "mocha-remote-cli": "^1.8.0",
         "mocha-remote-client": "^1.8.0",
-        "realm": "*",
-        "tsx": "^3.12.2"
+        "realm": "*"
       },
       "dependencies": {
-        "@esbuild/android-arm": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-          "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-          "dev": true,
-          "optional": true
-        },
-        "@esbuild/linux-loong64": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-          "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-          "dev": true,
-          "optional": true
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -36101,36 +35777,6 @@
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
             }
-          }
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
           }
         },
         "glob": {
@@ -36214,18 +35860,6 @@
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
             }
-          }
-        },
-        "tsx": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-          "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-          "dev": true,
-          "requires": {
-            "esbuild": "~0.18.20",
-            "fsevents": "~2.3.3",
-            "get-tsconfig": "^4.7.2",
-            "source-map-support": "^0.5.21"
           }
         },
         "yargs": {
@@ -49430,67 +49064,11 @@
         "typedoc-plugin-missing-exports": "^2.0.1"
       },
       "dependencies": {
-        "@esbuild/android-arm": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-          "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-          "dev": true,
-          "optional": true
-        },
-        "@esbuild/linux-loong64": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-          "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-          "dev": true,
-          "optional": true
-        },
         "@types/mocha": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
           "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
-        },
-        "tsx": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-          "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-          "dev": true,
-          "requires": {
-            "esbuild": "~0.18.20",
-            "fsevents": "~2.3.3",
-            "get-tsconfig": "^4.7.2",
-            "source-map-support": "^0.5.21"
-          }
         }
       }
     },


### PR DESCRIPTION
## What, How & Why?

We have this a dependency in the root and we have no need for these to be different versions in the sub-packages of the repo.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
