### PR TITLE
Update PR workflow to ignore unnecessary paths

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -1,9 +1,16 @@
 name: Pull request build and test
 on:
   push:
+    # The workflow will run only when both `branches` and `paths-ignore` are satisfied.
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "**.png"
   pull_request:
+    # Note that the workflow will still run if paths outside of `paths-ignore` have
+    # been modified in the PR, irrespective of an individual commit only modifying
+    # ignored paths. (See: https://github.com/actions/runner/issues/2324)
     paths-ignore:
       - "**.md"
       - "**.png"

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.png"
   workflow_dispatch:
 
 concurrency:

--- a/contrib/working-with-github-actions.md
+++ b/contrib/working-with-github-actions.md
@@ -10,3 +10,5 @@ You find the workflows in the "Actions" menu.
 ## Delete apps and clusters
 
 In most cases our test suites will delete Atlas clusters and apps but not always. If you need to delete them manually, you can use the workflow "Wipe all clusters and apps". The workflow does not distinguish between "active" and "leftover" apps so it can lead to currently running tests to fail.
+
+TEST

--- a/contrib/working-with-github-actions.md
+++ b/contrib/working-with-github-actions.md
@@ -6,9 +6,6 @@ You find the workflows in the "Actions" menu.
 
 ![GithubActions](assets/github-actions-menu.png)
 
-
 ## Delete apps and clusters
 
 In most cases our test suites will delete Atlas clusters and apps but not always. If you need to delete them manually, you can use the workflow "Wipe all clusters and apps". The workflow does not distinguish between "active" and "leftover" apps so it can lead to currently running tests to fail.
-
-TEST


### PR DESCRIPTION
## What, How & Why?

Adds `paths-ignore` to the pr-realm-js workflow for PRs when updating `.md` and `.png` files.
