### PR TITLE
Enable and fix "clean exit" tests

### DIFF
--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -51,6 +51,7 @@ records:
       - initialization_function
       - should_compact_on_launch_function
       - automatically_handle_backlinks_in_migrations
+      - logger
 
   UserIdentity:
     fields:
@@ -127,6 +128,7 @@ records:
       - custom_encryption_key
       - user_agent_binding_info
       - multiplex_sessions
+      - logger
 
   SyncError:
    fields:
@@ -235,8 +237,7 @@ classes:
       - make_network_transport
       - delete_data_for_object
       - base64_decode
-      - make_logger_factory
-      - make_logger
+      - make_callback_logger
       - simulate_sync_error
       - consume_thread_safe_reference_to_shared_realm
       - file_exists
@@ -249,6 +250,8 @@ classes:
     methods:
       - set_default_logger
       - set_default_level_threshold
+      # JS-specific
+      - DOLLAR_resetSharedPtr
 
   ConstTableRef:
     methods:
@@ -463,6 +466,13 @@ classes:
       - unsubscribe
       - call_function
       - make_streaming_request
+      # JS-specific
+      - DOLLAR_resetSharedPtr
+
+  GenericNetworkTransport:
+    methods:
+      # JS-specific
+      - DOLLAR_resetSharedPtr
 
   WatchStream:
     methods:
@@ -501,7 +511,6 @@ classes:
       - immediately_run_file_actions
       - set_session_multiplexing
       - set_log_level
-      - set_logger_factory
       - set_user_agent
       - reconnect
       - path_for_realm

--- a/packages/realm/src/Logger.ts
+++ b/packages/realm/src/Logger.ts
@@ -78,7 +78,7 @@ export function fromBindingLoggerLevelToLogLevel(arg: binding.LoggerLevel): LogL
 
 /** @internal */
 export const defaultLogger: LoggerCallback = function (logLevel: LogLevel, message: string) {
-  const formattedLogMessage = `[${logLevel}] ${message}`;
+  const formattedLogMessage = `(realm)[${logLevel}] ${message}`;
   /* eslint-disable no-console */
   if (logLevel === "error" || logLevel === "fatal") {
     console.error(formattedLogMessage);
@@ -91,4 +91,12 @@ export const defaultLogger: LoggerCallback = function (logLevel: LogLevel, messa
 };
 
 /** @internal */
-export const defaultLoggerLevel: LogLevel = "warn";
+export const defaultLogLevel: LogLevel = "warn";
+
+/** @internal */
+export function toBindingLogger(logger: LoggerCallback, level: LogLevel) {
+  const logLevel = toBindingLoggerLevel(level);
+  return binding.Helpers.makeCallbackLogger((level, message) => {
+    logger(fromBindingLoggerLevelToLogLevel(level), message);
+  }, logLevel);
+}

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -320,6 +320,7 @@ export class Realm {
       }
     }
     Realm.internals.clear();
+    App.resetInternals();
     binding.RealmCoordinator.clearAllCaches();
     binding.App.clearCachedApps();
     ProgressRealmPromise.cancelAll();

--- a/packages/realm/src/app-services/Sync.ts
+++ b/packages/realm/src/app-services/Sync.ts
@@ -20,7 +20,6 @@ import {
   App,
   ConnectionState,
   LogLevel,
-  Logger,
   MutableSubscriptionSet,
   NumericLogLevel,
   OpenRealmBehaviorConfiguration,
@@ -34,8 +33,6 @@ import {
   SyncSession,
   User,
   assert,
-  binding,
-  fromBindingLoggerLevelToNumericLogLevel,
   toBindingLoggerLevel,
   toBindingSyncConfig,
   validateSyncConfiguration,
@@ -59,12 +56,10 @@ export class Sync {
   }
 
   /** @deprecated Will be removed in v13.0.0. Please use {@link Realm.setLogger}. */
-  static setLogger(app: App, logger: Logger) {
-    const factory = binding.Helpers.makeLoggerFactory((level, message) => {
-      logger(fromBindingLoggerLevelToNumericLogLevel(level), message);
-    });
-    app.internal.syncManager.setLoggerFactory(factory);
+  static setLogger() {
+    throw new Error("No longer supported!");
   }
+
   /**
    * Get all sync sessions for a particular user.
    * @since 10.0.0


### PR DESCRIPTION
## What, How & Why?

This closes #4535 if the `Realm.clearTestState` is called.
It relies on https://github.com/realm/realm-core/pull/7231 being merged and released.

To be honest, this doesn't feel like the "right" fix, since we have this problem not only with `App` instances, but any object backed by an "internal" returned from core.
These "internal" objects hold shared pointer references of C++ objects which protects JS values that it gets passed (such as functions passed through configs, etc).
The "internal" shared pointers only get reset when the wrapping JS object gets garbage collected, which in turn allows for the captured JS values to be garbage collected.
All of this introduce delays (JS values being garbage collected → freeing C++ objects → unprotecting JS values → JS values being garbage collected).

The "right" solution would be to find a better way to handle references to objects between JS and C++ that allows earlier garbage collection.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
