### PR TITLE
Less noisy `@realm/react` tests

### DIFF
--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -37,7 +37,9 @@ describe("AppProvider", () => {
   });
 
   it("throws useApp is used without having the AppProvider is rendered", () => {
-    expect(() => renderHook(() => useApp())).toThrow();
+    renderHook(() =>
+      expect(() => useApp()).toThrow("No app found. Did you forget to wrap your component in an <AppProvider>?"),
+    );
   });
 
   it("handle state changes to its configuration", async () => {

--- a/packages/realm-react/src/__tests__/useAuth.test.tsx
+++ b/packages/realm-react/src/__tests__/useAuth.test.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import React from "react";
+import Realm from "realm";
 import { renderHook } from "@testing-library/react-native";
 import { AppConfigBuilder } from "@realm/app-importer";
 
@@ -42,6 +43,16 @@ describe("useAuth", () => {
       const config = new AppConfigBuilder("test-app");
       ({ appId } = await importApp(config.config));
     });
+
+    // Muting the logger to make the failing requests less noisy
+    beforeAll(() => {
+      Realm.setLogLevel("off");
+    });
+
+    afterAll(() => {
+      Realm.setLogLevel("warn");
+    });
+
     it("logIn", async () => {
       const { result } = renderAuth(appId, baseUrl);
       await testAuthOperation({

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -71,8 +71,9 @@ describe("useObject hook", () => {
     });
     realm.close();
   });
+
   afterEach(() => {
-    Realm.clearTestState;
+    Realm.clearTestState();
   });
 
   it("can retrieve a single object using useObject", () => {


### PR DESCRIPTION
## What, How & Why?

This makes the `@realm/react` tests less noisy by muting the logger when failing requests are expected.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
