### PR TITLE
`@realm/react` key-path filtering on `useQuery` and `useObject`

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Enhancements
 * Adding the ability to pass "options" to `useQuery` and `useObject` as an object. ([#6360](https://github.com/realm/realm-js/pull/6360))
-* Adding `keyPaths` option to the `userQuery` and `useObject` hooks, to indicate a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the collection or object. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present. ([#6360](https://github.com/realm/realm-js/pull/6360))
+* Adding `keyPaths` option to the `useQuery` and `useObject` hooks, to indicate a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the collection or object. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present. ([#6360](https://github.com/realm/realm-js/pull/6360))
 
 ### Fixed
 * Removed race condition in `useObject` ([#6291](https://github.com/realm/realm-js/issues/6291)) Thanks [@bimusik](https://github.com/bimusiek)!

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,10 +1,19 @@
 ## vNext (TBD)
 
 ### Deprecations
-* None
+* Deprecated calling `useQuery` with three positional arguments. ([#6360](https://github.com/realm/realm-js/pull/6360))
+
+  Please pass a single "options" object followed by an optional `deps` argument (if your query depends on any local variables):
+  ```tsx
+  const filteredAndSorted = useQuery({
+    type: Object,
+    query: (collection) => collection.filtered('category == $0',category).sorted('name'),
+  }, [category]);
+  ```
 
 ### Enhancements
-* None
+* Adding the ability to pass "options" to `useQuery` and `useObject` as an object. ([#6360](https://github.com/realm/realm-js/pull/6360))
+* Adding `keyPaths` option to the `userQuery` and `useObject` hooks, to indicate a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the collection or object. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present. ([#6360](https://github.com/realm/realm-js/pull/6360))
 
 ### Fixed
 * Removed race condition in `useObject` ([#6291](https://github.com/realm/realm-js/issues/6291)) Thanks [@bimusik](https://github.com/bimusiek)!

--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -155,10 +155,13 @@ import {useQuery} from '@realm/react';
 const Component = () => {
   // ObjectClass is a class extending Realm.Object, which should have been provided in the Realm Config.
   // It is also possible to use the model's name as a string ( ex. "Object" ) if you are not using class based models.
-  const sortedCollection = useQuery(ObjectClass, (collection) => {
-    // The methods `sorted` and `filtered` should be passed as a `query` function.
-    // Any variables that are dependencies of this should be placed in the dependency array.
-    return collection.sorted();
+  const sortedCollection = useQuery({
+    type: ObjectClass,
+    query: (collection) => {
+      // The methods `sorted` and `filtered` should be passed as a `query` function.
+      // Any variables that are dependencies of this should be placed in the dependency array.
+      return collection.sorted();
+    }
   }, []);
 
   return (

--- a/packages/realm-react/src/__tests__/RealmProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/RealmProvider.test.tsx
@@ -23,6 +23,7 @@ import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/re
 
 import { createRealmContext } from "..";
 import { areConfigurationsIdentical, mergeRealmConfiguration } from "../RealmProvider";
+import { randomRealmPath } from "./helpers";
 
 const dogSchema: Realm.ObjectSchema = {
   name: "dog",
@@ -45,7 +46,7 @@ const catSchema: Realm.ObjectSchema = {
 const { RealmProvider, useRealm } = createRealmContext({
   schema: [dogSchema],
   inMemory: true,
-  path: "testArtifacts/realm-provider.realm",
+  path: randomRealmPath(),
 });
 
 const EmptyRealmContext = createRealmContext();

--- a/packages/realm-react/src/__tests__/createRealmTestContext.ts
+++ b/packages/realm-react/src/__tests__/createRealmTestContext.ts
@@ -50,9 +50,9 @@ export function createRealmTestContext(rootConfig: Configuration = {}): RealmTes
     write(callback: () => void) {
       act(() => {
         context.realm.write(callback);
-        context.realm.write(() => {
-          /* Doing an empty write, since beginning a write transaction will force firing of notifications */
-        });
+        // Starting another write transaction will force notifications to fire
+        context.realm.beginTransaction();
+        context.realm.cancelTransaction();
       });
     },
   };

--- a/packages/realm-react/src/__tests__/createRealmTestContext.ts
+++ b/packages/realm-react/src/__tests__/createRealmTestContext.ts
@@ -16,16 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 import Realm, { Configuration } from "realm";
 import { act } from "@testing-library/react-native";
-
-export function randomRealmPath() {
-  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "realm-react-tests-"));
-  return path.join(tempDirPath, "test.realm");
-}
+import { randomRealmPath } from "./helpers";
 
 export type RealmTestContext = {
   realm: Realm;

--- a/packages/realm-react/src/__tests__/createRealmTestContext.ts
+++ b/packages/realm-react/src/__tests__/createRealmTestContext.ts
@@ -62,7 +62,7 @@ export function createRealmTestContext(rootConfig: Configuration = {}): RealmTes
     },
     cleanup() {
       Realm.clearTestState();
-    }
+    },
   };
   return context;
 }

--- a/packages/realm-react/src/__tests__/createRealmTestContext.ts
+++ b/packages/realm-react/src/__tests__/createRealmTestContext.ts
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import Realm, { Configuration } from "realm";
+import { act } from "@testing-library/react-native";
+
+export function randomRealmPath() {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "realm-react-tests-"));
+  return path.join(tempDirPath, "test.realm");
+}
+
+export type RealmTestContext = {
+  realm: Realm;
+  useRealm: () => Realm;
+  write(cb: () => void): void;
+  openRealm(config?: Configuration): void;
+};
+
+/**
+ * Opens a test realm at a random temporary path.
+ * @returns The `realm` and a `write` function, which will wrap `realm.write` with an `act` and prepand a second `realm.write` to force notifications to trigger.
+ */
+export function createRealmTestContext(rootConfig: Configuration = {}): RealmTestContext {
+  let realm: Realm | null = null;
+  const context = {
+    get realm(): Realm {
+      if (realm) {
+        return realm;
+      } else {
+        throw new Error("Call open first");
+      }
+    },
+    useRealm() {
+      return context.realm;
+    },
+    openRealm(config: Configuration = {}) {
+      realm = new Realm({ ...rootConfig, ...config, path: randomRealmPath() });
+    },
+    write(callback: () => void) {
+      act(() => {
+        context.realm.write(callback);
+        context.realm.write(() => {
+          /* Doing an empty write, since beginning a write transaction will force firing of notifications */
+        });
+      });
+    },
+  };
+  return context;
+}

--- a/packages/realm-react/src/__tests__/createRealmTestContext.ts
+++ b/packages/realm-react/src/__tests__/createRealmTestContext.ts
@@ -16,45 +16,53 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import assert from "node:assert";
 import Realm, { Configuration } from "realm";
 import { act } from "@testing-library/react-native";
+
 import { randomRealmPath } from "./helpers";
 
 export type RealmTestContext = {
   realm: Realm;
   useRealm: () => Realm;
   write(cb: () => void): void;
-  openRealm(config?: Configuration): void;
+  openRealm(config?: Configuration): Realm;
+  cleanup(): void;
 };
 
 /**
- * Opens a test realm at a random temporary path.
- * @returns The `realm` and a `write` function, which will wrap `realm.write` with an `act` and prepand a second `realm.write` to force notifications to trigger.
+ * Opens a test realm at a randomized and temporary path.
+ * @returns The `realm` and a `write` function, which will wrap `realm.write` with an `act` and prepand a second `realm.write` to force notifications to trigger synchronously.
  */
 export function createRealmTestContext(rootConfig: Configuration = {}): RealmTestContext {
   let realm: Realm | null = null;
   const context = {
     get realm(): Realm {
-      if (realm) {
-        return realm;
-      } else {
-        throw new Error("Call open first");
-      }
+      assert(realm, "Open the Realm first");
+      return realm;
     },
     useRealm() {
       return context.realm;
     },
     openRealm(config: Configuration = {}) {
+      if (realm) {
+        // Close any realm, previously opened
+        realm.close();
+      }
       realm = new Realm({ ...rootConfig, ...config, path: randomRealmPath() });
+      return realm;
     },
     write(callback: () => void) {
       act(() => {
         context.realm.write(callback);
-        // Starting another write transaction will force notifications to fire
+        // Starting another write transaction will force notifications to fire synchronously
         context.realm.beginTransaction();
         context.realm.cancelTransaction();
       });
     },
+    cleanup() {
+      Realm.clearTestState();
+    }
   };
   return context;
 }

--- a/packages/realm-react/src/__tests__/helpers.ts
+++ b/packages/realm-react/src/__tests__/helpers.ts
@@ -16,6 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { AppConfig, AppImporter, Credentials } from "@realm/app-importer";
 import { act, waitFor } from "@testing-library/react-native";
 
@@ -67,4 +70,9 @@ const importer = new AppImporter({
 
 export async function importApp(config: AppConfig): Promise<{ appId: string }> {
   return importer.importApp(config);
+}
+
+export function randomRealmPath() {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "realm-react-tests-"));
+  return path.join(tempDirPath, "test.realm");
 }

--- a/packages/realm-react/src/__tests__/helpers.ts
+++ b/packages/realm-react/src/__tests__/helpers.ts
@@ -16,9 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 import { AppConfig, AppImporter, Credentials } from "@realm/app-importer";
 import { act, waitFor } from "@testing-library/react-native";
 
@@ -70,9 +67,4 @@ const importer = new AppImporter({
 
 export async function importApp(config: AppConfig): Promise<{ appId: string }> {
   return importer.importApp(config);
-}
-
-export function randomRealmPath() {
-  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "realm-react-tests-"));
-  return path.join(tempDirPath, "test.realm");
 }

--- a/packages/realm-react/src/__tests__/profileHook.tsx
+++ b/packages/realm-react/src/__tests__/profileHook.tsx
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React, { Profiler, ProfilerOnRenderCallback } from "react";
+import { renderHook, RenderHookResult, RenderHookOptions } from "@testing-library/react-native";
+
+function generateProfilerId() {
+  const nonce = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  return `test-${nonce}`;
+}
+
+type RenderEvent = {
+  phase: "mount" | "update";
+  actualDuration: number;
+  baseDuration: number;
+};
+
+type ProfileWrapper = {
+  wrapper: React.ComponentType<React.PropsWithChildren>;
+  renders: RenderEvent[];
+};
+
+function createProfilerWrapper(Parent: undefined | React.ComponentType<React.PropsWithChildren>): ProfileWrapper {
+  const renders: RenderEvent[] = [];
+  const id = generateProfilerId();
+  const handleRender: ProfilerOnRenderCallback = (
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+    interactions,
+  ) => {
+    renders.push({ phase, actualDuration, baseDuration });
+  };
+
+  const Wrapper: React.ComponentType<React.PropsWithChildren> = ({ children }) => (
+    <Profiler id={id} onRender={handleRender} children={children} />
+  );
+
+  return {
+    wrapper: Parent
+      ? ({ children }) => (
+          <Parent>
+            <Wrapper children={children} />
+          </Parent>
+        )
+      : Wrapper,
+    renders,
+  };
+}
+
+export function profileHook<Result, Props>(
+  callback: (props: Props) => Result,
+  options?: RenderHookOptions<Props>,
+): RenderHookResult<Result, Props> & { renders: RenderEvent[] } {
+  const { wrapper, renders } = createProfilerWrapper(options?.wrapper);
+  const result = renderHook<Result, Props>(callback, { ...options, wrapper });
+  return { ...result, renders };
+}

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -16,12 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { useEffect, useState } from "react";
 import Realm from "realm";
 import { renderHook } from "@testing-library/react-native";
 
 import { createUseObject } from "../useObject";
-import { randomRealmPath } from "./helpers";
+import { createRealmTestContext } from "./createRealmTestContext";
 
 const dogSchema: Realm.ObjectSchema = {
   name: "dog",
@@ -37,23 +36,8 @@ interface IDog {
   name: string;
 }
 
-const configuration = {
-  schema: [dogSchema],
-  path: randomRealmPath(),
-};
-
-const useRealm = () => {
-  const [realm, setRealm] = useState(new Realm(configuration));
-  useEffect(() => {
-    return () => {
-      realm.close();
-    };
-  }, [realm, setRealm]);
-
-  return new Realm(configuration);
-};
-
-const useObject = createUseObject(useRealm);
+const context = createRealmTestContext({ schema: [dogSchema] });
+const useObject = createUseObject(context.useRealm);
 
 const testDataSet = [
   { _id: 4, name: "Vincent" },
@@ -63,14 +47,14 @@ const testDataSet = [
 
 describe("useObject hook", () => {
   beforeEach(() => {
-    const realm = new Realm(configuration);
+    context.openRealm();
+    const { realm } = context;
     realm.write(() => {
       realm.deleteAll();
       testDataSet.forEach((data) => {
         realm.create("dog", data);
       });
     });
-    realm.close();
   });
 
   afterEach(() => {

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -50,8 +50,7 @@ const testDataSet = [
 
 describe("useObject", () => {
   beforeEach(() => {
-    context.openRealm();
-    const { realm } = context;
+    const realm = context.openRealm();
     realm.write(() => {
       realm.deleteAll();
       testDataSet.forEach((data) => {
@@ -61,7 +60,7 @@ describe("useObject", () => {
   });
 
   afterEach(() => {
-    Realm.clearTestState();
+    context.cleanup();
   });
 
   it("can retrieve a single object using useObject", () => {

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -21,6 +21,7 @@ import Realm from "realm";
 import { renderHook } from "@testing-library/react-native";
 
 import { createUseObject } from "../useObject";
+import { randomRealmPath } from "./helpers";
 
 const dogSchema: Realm.ObjectSchema = {
   name: "dog",
@@ -38,7 +39,7 @@ interface IDog {
 
 const configuration = {
   schema: [dogSchema],
-  path: "testArtifacts/use-object-hook.realm",
+  path: randomRealmPath(),
 };
 
 const useRealm = () => {

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -96,7 +96,7 @@ describe("useObject", () => {
       const { result, renders } = profileHook(() => useObject<IDog>("dog", vincent._id, ["name"]));
       expect(renders).toHaveLength(1);
       expect(result.current).toMatchObject(vincent);
-      // Update the name and except a re-render
+      // Update the name and expect a re-render
       write(() => {
         if (result.current) {
           result.current.name = "Vince!";
@@ -119,7 +119,7 @@ describe("useObject", () => {
       const { result, renders } = profileHook(() => useObject<IDog>("dog", vincent._id, "age"));
       expect(renders).toHaveLength(1);
       expect(result.current).toMatchObject(vincent);
-      // Update the name and except a re-render
+      // Update the name and expect a re-render
       write(() => {
         if (result.current) {
           result.current.age = 13;

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -133,6 +133,24 @@ describe("useObject", () => {
       expect(renders).toHaveLength(2);
     });
   });
+
+  describe("passing options object as argument", () => {
+    it("rerenders on updates", () => {
+      const { write, realm } = context;
+
+      const vincent = realm.objectForPrimaryKey("dog", 4);
+      assert(vincent);
+
+      const { result, renders } = profileHook(() => useObject<IDog>({ type: "dog", primaryKey: 4, keyPaths: "name" }));
+      expect(renders).toHaveLength(1);
+      write(() => {
+        vincent.name = "Vinnie";
+      });
+      expect(renders).toHaveLength(2);
+      expect(result.current?.name).toEqual("Vinnie");
+      // Expect no renders when updating a property outside key-paths
+      write(() => {
+        vincent.age = 30;
       });
       expect(renders).toHaveLength(2);
     });

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -90,7 +90,7 @@ describe("useObject", () => {
   });
 
   describe("key-path filtering", () => {
-    it("re-renders only if a property in key-paths updates", () => {
+    it("can filter notifications using key-path array", async () => {
       const [vincent] = testDataSet;
       const { write } = context;
       const { result, renders } = profileHook(() => useObject<IDog>("dog", vincent._id, ["name"]));
@@ -108,6 +108,29 @@ describe("useObject", () => {
       write(() => {
         if (result.current) {
           result.current.age = 5;
+        }
+      });
+      expect(renders).toHaveLength(2);
+    });
+
+    it("can filter notifications using key-path string", async () => {
+      const [vincent] = testDataSet;
+      const { write } = context;
+      const { result, renders } = profileHook(() => useObject<IDog>("dog", vincent._id, "age"));
+      expect(renders).toHaveLength(1);
+      expect(result.current).toMatchObject(vincent);
+      // Update the name and except a re-render
+      write(() => {
+        if (result.current) {
+          result.current.age = 13;
+        }
+      });
+      expect(renders).toHaveLength(2);
+      expect(result.current?.age).toEqual(13);
+      // Update the age and don't expect a re-render
+      write(() => {
+        if (result.current) {
+          result.current.name = "Vince!";
         }
       });
       expect(renders).toHaveLength(2);

--- a/packages/realm-react/src/__tests__/useObjectHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectHook.test.tsx
@@ -18,6 +18,7 @@
 
 import Realm from "realm";
 import { renderHook } from "@testing-library/react-native";
+import assert from "node:assert";
 
 import { createUseObject } from "../useObject";
 import { createRealmTestContext } from "./createRealmTestContext";
@@ -98,17 +99,15 @@ describe("useObject", () => {
       expect(result.current).toMatchObject(vincent);
       // Update the name and expect a re-render
       write(() => {
-        if (result.current) {
-          result.current.name = "Vince!";
-        }
+        assert(result.current);
+        result.current.name = "Vince!";
       });
       expect(renders).toHaveLength(2);
       expect(result.current?.name).toEqual("Vince!");
       // Update the age and don't expect a re-render
       write(() => {
-        if (result.current) {
-          result.current.age = 5;
-        }
+        assert(result.current);
+        result.current.age = 5;
       });
       expect(renders).toHaveLength(2);
     });
@@ -121,17 +120,19 @@ describe("useObject", () => {
       expect(result.current).toMatchObject(vincent);
       // Update the name and expect a re-render
       write(() => {
-        if (result.current) {
-          result.current.age = 13;
-        }
+        assert(result.current);
+        result.current.age = 13;
       });
       expect(renders).toHaveLength(2);
       expect(result.current?.age).toEqual(13);
       // Update the age and don't expect a re-render
       write(() => {
-        if (result.current) {
-          result.current.name = "Vince!";
-        }
+        assert(result.current);
+        result.current.name = "Vince!";
+      });
+      expect(renders).toHaveLength(2);
+    });
+  });
       });
       expect(renders).toHaveLength(2);
     });

--- a/packages/realm-react/src/__tests__/useObjectRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useObjectRender.test.tsx
@@ -22,6 +22,7 @@ import { FlatList, ListRenderItem, Text, TextInput, TouchableHighlight, View } f
 import Realm from "realm";
 
 import { createUseObject } from "../useObject";
+import { randomRealmPath } from "./helpers";
 
 export class ListItem extends Realm.Object {
   id!: Realm.BSON.ObjectId;
@@ -66,7 +67,7 @@ export class List extends Realm.Object {
 const configuration: Realm.Configuration = {
   schema: [List, ListItem],
   deleteRealmIfMigrationNeeded: true,
-  path: "testArtifacts/use-object-render.realm",
+  path: randomRealmPath(),
 };
 
 // TODO: It would be better not to have to rely on this, but at the moment I see no other alternatives

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -58,7 +58,6 @@ describe("useQueryHook", () => {
 
   beforeEach(() => {
     context.openRealm();
-
     const { realm } = context;
     realm.write(() => {
       realm.deleteAll();

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -57,8 +57,7 @@ describe("useQuery", () => {
   const useQuery = createUseQuery(context.useRealm);
 
   beforeEach(() => {
-    context.openRealm();
-    const { realm } = context;
+    const realm = context.openRealm();
     realm.write(() => {
       realm.deleteAll();
       testDataSet.forEach((data) => {
@@ -68,7 +67,7 @@ describe("useQuery", () => {
   });
 
   afterEach(() => {
-    Realm.clearTestState();
+    context.cleanup();
   });
 
   it("can retrieve collections using useQuery", () => {
@@ -98,13 +97,13 @@ describe("useQuery", () => {
     expect(collection[99]).toBe(undefined);
   });
 
-  it("can filter objects via a query argument", () => {
+  it("can filter objects via type and callback", () => {
     const { result } = renderHook(() => useQuery<IDog>("dog", (dogs) => dogs.filtered("age > 10")));
     expect(result.current.length).toBe(3);
   });
 
-  describe("passing an options object", () => {
-    it("can filter objects via a query option", () => {
+  describe("passing an object of options as argument", () => {
+    it("can filter objects via a 'query' property", () => {
       const { result, renders } = profileHook(() =>
         useQuery<IDog>({
           type: "dog",
@@ -115,7 +114,7 @@ describe("useQuery", () => {
       expect(renders).toHaveLength(1);
     });
 
-    it("can update filter objects via a query option", () => {
+    it("can update filter objects via a 'query' property", () => {
       const { result, renders, rerender } = profileHook(
         ({ age }) =>
           useQuery<IDog>(
@@ -136,7 +135,7 @@ describe("useQuery", () => {
       expect(renders).toHaveLength(2);
     });
 
-    it("can filter notifications using key-path", async () => {
+    it("can filter notifications using key-path array", async () => {
       const { write } = context;
       const { result, renders } = profileHook(() =>
         useQuery<IDog>({

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -165,5 +165,36 @@ describe("useQuery", () => {
       });
       expect(renders).toHaveLength(2);
     });
+
+    it("can filter notifications using key-path string", async () => {
+      const { write } = context;
+      const { result, renders } = profileHook(() =>
+        useQuery<IDog>({
+          type: "dog",
+          query: (dogs) => dogs.filtered("name != $0", "Vincent"),
+          keyPaths: "age",
+        }),
+      );
+
+      const initialCollection = result.current;
+      expect(initialCollection).toHaveLength(5);
+      expect(renders).toHaveLength(1);
+
+      // Updating an age in the database and expect a render
+      const [firstDog] = result.current;
+      expect(firstDog.name).toEqual("River");
+      write(() => {
+        firstDog.age = 16;
+      });
+      expect(renders).toHaveLength(2);
+      expect(initialCollection).not.toBe(result.current);
+
+      // Updating a name in the database and don't expect a render
+      expect(firstDog.age).toEqual(16);
+      write(() => {
+        firstDog.name = "Rivery!";
+      });
+      expect(renders).toHaveLength(2);
+    });
   });
 });

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -52,7 +52,7 @@ const testDataSet = [
   { _id: 6, name: "Sadie", color: "gold", gender: "female", age: 5 },
 ];
 
-describe("useQueryHook", () => {
+describe("useQuery", () => {
   const context = createRealmTestContext({ schema: [dogSchema] });
   const useQuery = createUseQuery(context.useRealm);
 

--- a/packages/realm-react/src/__tests__/useQueryHook.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryHook.test.tsx
@@ -17,10 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
-import { useEffect, useState } from "react";
-import { renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@testing-library/react-native";
 
 import { createUseQuery } from "../useQuery";
+import { profileHook } from "./profileHook";
+import { randomRealmPath } from "./helpers";
 
 const dogSchema: Realm.ObjectSchema = {
   name: "dog",
@@ -41,24 +42,6 @@ interface IDog {
   age: number;
   gender: string;
 }
-const configuration: Realm.Configuration = {
-  schema: [dogSchema],
-  path: "testArtifacts/use-query-hook.realm",
-  deleteRealmIfMigrationNeeded: true,
-};
-
-const useRealm = () => {
-  const [realm, setRealm] = useState(new Realm(configuration));
-  useEffect(() => {
-    return () => {
-      realm.close();
-    };
-  }, [realm, setRealm]);
-
-  return new Realm(configuration);
-};
-
-const useQuery = createUseQuery(useRealm);
 
 const testDataSet = [
   { _id: 1, name: "Vincent", color: "black and white", gender: "male", age: 4 },
@@ -70,15 +53,21 @@ const testDataSet = [
 ];
 
 describe("useQueryHook", () => {
+  let realm: Realm;
+  const useRealm = () => realm;
+  const useQuery = createUseQuery(useRealm);
+
   beforeEach(() => {
-    const realm = new Realm(configuration);
+    realm = new Realm({
+      schema: [dogSchema],
+      path: randomRealmPath(),
+    });
     realm.write(() => {
       realm.deleteAll();
       testDataSet.forEach((data) => {
         realm.create("dog", data);
       });
     });
-    realm.close();
   });
 
   afterEach(() => {
@@ -110,5 +99,88 @@ describe("useQueryHook", () => {
     const collection = result.current;
 
     expect(collection[99]).toBe(undefined);
+  });
+
+  it("can filter objects via a query argument", () => {
+    const { result } = renderHook(() => useQuery<IDog>("dog", (dogs) => dogs.filtered("age > 10")));
+    expect(result.current.length).toBe(3);
+  });
+
+  describe("passing an options object", () => {
+    it("can filter objects via a query option", () => {
+      const { result, renders } = profileHook(() =>
+        useQuery<IDog>({
+          type: "dog",
+          query: (dogs) => dogs.filtered("age > 10"),
+        }),
+      );
+      expect(result.current.length).toBe(3);
+      expect(renders).toHaveLength(1);
+    });
+
+    it("can update filter objects via a query option", () => {
+      const { result, renders, rerender } = profileHook(
+        ({ age }) =>
+          useQuery<IDog>(
+            {
+              type: "dog",
+              query: (dogs) => dogs.filtered("age > $0", age),
+            },
+            [age],
+          ),
+        { initialProps: { age: 10 } },
+      );
+      expect(result.current.length).toBe(3);
+      expect(renders).toHaveLength(1);
+
+      // Update the query to filter for a different age
+      rerender({ age: 15 });
+      expect(result.current.length).toBe(1);
+      expect(renders).toHaveLength(2);
+    });
+
+    it("can filter notifications using key-path", async () => {
+      const { result, renders } = profileHook(() =>
+        useQuery<IDog>({
+          type: "dog",
+          query: (dogs) => dogs.filtered("age > 10"),
+          keyPaths: ["name"],
+        }),
+      );
+
+      const initialCollection = result.current;
+      expect(initialCollection).toHaveLength(3);
+      expect(renders).toHaveLength(1);
+
+      // Updating a name in the database and expect a render
+      act(() => {
+        const [firstDog] = result.current;
+        expect(firstDog.name).toEqual("River");
+        realm.write(() => {
+          firstDog.name = "Rivery!";
+        });
+        // Force advancing the database to ensure notifications are triggered
+        realm.write(() => {
+          /* ... */
+        });
+      });
+      expect(renders).toHaveLength(2);
+      expect(initialCollection).not.toBe(result.current);
+
+      // Updating an age in the database and don't expect a render
+      act(() => {
+        const [firstDog] = result.current;
+        expect(firstDog.age).toEqual(12);
+        realm.write(() => {
+          firstDog.age = 13;
+        });
+        // Force advancing the database to ensure notifications are triggered
+        realm.write(() => {
+          /* ... */
+        });
+      });
+      expect(renders).toHaveLength(2);
+      expect(initialCollection).toBe(result.current);
+    });
   });
 });

--- a/packages/realm-react/src/__tests__/useQueryRender.test.tsx
+++ b/packages/realm-react/src/__tests__/useQueryRender.test.tsx
@@ -22,6 +22,7 @@ import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 import { FlatList, ListRenderItem, Text, TextInput, TouchableHighlight, View } from "react-native";
 
 import { createRealmContext } from "..";
+import { randomRealmPath } from "./helpers";
 
 class Item extends Realm.Object {
   id!: number;
@@ -66,7 +67,7 @@ const testCollection = [...new Array(30)].map((_, index) => ({ id: index, name: 
 const configuration: Realm.Configuration = {
   schema: [Item, Tag],
   inMemory: true,
-  path: "testArtifacts/use-query-rerender.realm",
+  path: randomRealmPath(),
 };
 
 const itemRenderCounter = jest.fn();

--- a/packages/realm-react/src/cachedObject.ts
+++ b/packages/realm-react/src/cachedObject.ts
@@ -44,6 +44,11 @@ type CachedObjectArgs = {
    * The implementing component should reset this to false when updating its object reference
    */
   updatedRef: React.MutableRefObject<boolean>;
+
+  /**
+   * Optional list of key-paths to limit notifications.
+   */
+  keyPaths?: string[];
 };
 
 export type CachedObject = {
@@ -62,7 +67,13 @@ export type CachedObject = {
  * @param args - {@link CachedObjectArgs} object arguments
  * @returns Proxy object wrapping the {@link Realm.Object}
  */
-export function createCachedObject({ object, realm, updateCallback, updatedRef }: CachedObjectArgs): CachedObject {
+export function createCachedObject({
+  object,
+  realm,
+  updateCallback,
+  updatedRef,
+  keyPaths,
+}: CachedObjectArgs): CachedObject {
   const listCaches = new Map();
   const listTearDowns: Array<() => void> = [];
   // If the object doesn't exist, just return it with an noop tearDown
@@ -135,10 +146,10 @@ export function createCachedObject({ object, realm, updateCallback, updatedRef }
     // see https://github.com/realm/realm-js/issues/4375
     if (realm.isInTransaction) {
       setImmediate(() => {
-        object.addListener(listenerCallback);
+        object.addListener(listenerCallback, keyPaths);
       });
     } else {
-      object.addListener(listenerCallback);
+      object.addListener(listenerCallback, keyPaths);
     }
   }
 

--- a/packages/realm-react/src/helpers.ts
+++ b/packages/realm-react/src/helpers.ts
@@ -42,3 +42,12 @@ export function getObjects<T extends Realm.Object>(
 }
 
 export type CollectionCallback = Parameters<typeof Realm.Results.prototype.addListener>[0];
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export type AnyRealmObject = Realm.Object<any>;
+
+export type RealmClassType<T = any> = { new (...args: any): T };
+
+export function isClassModelConstructor(value: unknown): value is RealmClassType<unknown> {
+  return Object.getPrototypeOf(value) === Realm.Object;
+}

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -65,24 +65,14 @@ type RealmContext = {
   useRealm: ReturnType<typeof createUseRealm>;
 
   /**
-   * @overload
-   * @example
-   * ```tsx
-   * // Return all collection items
-   * const collection = useQuery(Object);
+   * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
+   * The hook will update on any changes to any object in the collection
+   * and return an empty array if the collection is empty.
    *
-   * // Return all collection items sorted by name and filtered by category
-   * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
-   * ```
-   * @param type - The object type, depicted by a string or a class extending Realm.Object
-   * @param query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
-   * This allows for filtering and sorting of the collection, before it is returned.
-   * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
-   * @returns a collection of realm objects or an empty array
-   */
-
-  /**
-   * @overload
+   * The result of this can be consumed directly by the `data` argument of any React Native
+   * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
+   * then only the modified object will re-render.
+   * 
    * @example
    * ```tsx
    * // Return all collection items
@@ -101,22 +91,13 @@ type RealmContext = {
    *   keyPaths: ["name"]
    * }, [category]);
    * ```
+   * 
    * @param options
    * @param options.type - The object type, depicted by a string or a class extending Realm.Object
-   * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
-   * This allows for filtering and sorting of the collection, before it is returned.
+   * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type. This allows for filtering and sorting of the collection, before it is returned.
+   * @param options.keyPaths - Indicates a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the collection. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present.
    * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
    * @returns a collection of realm objects or an empty array
-   */
-
-  /**
-   * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
-   * The hook will update on any changes to any object in the collection
-   * and return an empty array if the collection is empty.
-   *
-   * The result of this can be consumed directly by the `data` argument of any React Native
-   * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
-   * then only the modified object will re-render.
    */
   useQuery: ReturnType<typeof createUseQuery>;
   /**
@@ -210,24 +191,14 @@ export const RealmProvider = defaultContext.RealmProvider;
 export const useRealm = defaultContext.useRealm;
 
 /**
- * @overload
- * @example
- * ```tsx
- * // Return all collection items
- * const collection = useQuery(Object);
+ * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
+ * The hook will update on any changes to any object in the collection
+ * and return an empty array if the collection is empty.
  *
- * // Return all collection items sorted by name and filtered by category
- * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
- * ```
- * @param type - The object type, depicted by a string or a class extending Realm.Object
- * @param query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
- * This allows for filtering and sorting of the collection, before it is returned.
- * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
- * @returns a collection of realm objects or an empty array
- */
-
-/**
- * @overload
+ * The result of this can be consumed directly by the `data` argument of any React Native
+ * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
+ * then only the modified object will re-render.
+ * 
  * @example
  * ```tsx
  * // Return all collection items
@@ -246,22 +217,13 @@ export const useRealm = defaultContext.useRealm;
  *   keyPaths: ["name"]
  * }, [category]);
  * ```
+ * 
  * @param options
  * @param options.type - The object type, depicted by a string or a class extending Realm.Object
- * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
- * This allows for filtering and sorting of the collection, before it is returned.
+ * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type. This allows for filtering and sorting of the collection, before it is returned.
+ * @param options.keyPaths - Indicates a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the collection. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present.
  * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
  * @returns a collection of realm objects or an empty array
- */
-
-/**
- * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
- * The hook will update on any changes to any object in the collection
- * and return an empty array if the collection is empty.
- *
- * The result of this can be consumed directly by the `data` argument of any React Native
- * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
- * then only the modified object will re-render.
  */
 export const useQuery = defaultContext.useQuery;
 

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -24,6 +24,9 @@ import { createUseObject } from "./useObject";
 import { createUseQuery } from "./useQuery";
 import { createUseRealm } from "./useRealm";
 
+export type { UseObjectHook } from "./useObject";
+export type { UseQueryHook, QueryHookOptions, QueryHookClassBasedOptions } from "./useQuery";
+
 type RealmContext = {
   /**
    * The Provider component that is required to wrap any component using

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -72,7 +72,6 @@ type RealmContext = {
    * The result of this can be consumed directly by the `data` argument of any React Native
    * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
    * then only the modified object will re-render.
-   * 
    * @example
    * ```tsx
    * // Return all collection items
@@ -91,7 +90,6 @@ type RealmContext = {
    *   keyPaths: ["name"]
    * }, [category]);
    * ```
-   * 
    * @param options
    * @param options.type - The object type, depicted by a string or a class extending Realm.Object
    * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type. This allows for filtering and sorting of the collection, before it is returned.
@@ -198,7 +196,6 @@ export const useRealm = defaultContext.useRealm;
  * The result of this can be consumed directly by the `data` argument of any React Native
  * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
  * then only the modified object will re-render.
- * 
  * @example
  * ```tsx
  * // Return all collection items
@@ -217,7 +214,6 @@ export const useRealm = defaultContext.useRealm;
  *   keyPaths: ["name"]
  * }, [category]);
  * ```
- * 
  * @param options
  * @param options.type - The object type, depicted by a string or a class extending Realm.Object
  * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type. This allows for filtering and sorting of the collection, before it is returned.

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -63,18 +63,13 @@ type RealmContext = {
    * @returns a realm instance
    */
   useRealm: ReturnType<typeof createUseRealm>;
+
   /**
-   * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
-   * The hook will update on any changes to any object in the collection
-   * and return an empty array if the collection is empty.
-   *
-   * The result of this can be consumed directly by the `data` argument of any React Native
-   * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
-   * then only the modified object will re-render.
+   * @overload
    * @example
    * ```tsx
    * // Return all collection items
-   * const collection = useQuery(Object)
+   * const collection = useQuery(Object);
    *
    * // Return all collection items sorted by name and filtered by category
    * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
@@ -84,6 +79,44 @@ type RealmContext = {
    * This allows for filtering and sorting of the collection, before it is returned.
    * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
    * @returns a collection of realm objects or an empty array
+   */
+
+  /**
+   * @overload
+   * @example
+   * ```tsx
+   * // Return all collection items
+   * const collection = useQuery({ type: Query });
+   *
+   * // Return all collection items sorted by name and filtered by category
+   * const filteredAndSorted = useQuery({
+   *   type: Object,
+   *   query: (collection) => collection.filtered('category == $0',category).sorted('name'),
+   * }, [category]);
+   *
+   * // Return all collection items sorted by name and filtered by category, triggering re-renders only if "name" changes
+   * const filteredAndSorted = useQuery({
+   *   type: Object,
+   *   query: (collection) => collection.filtered('category == $0',category).sorted('name'),
+   *   keyPaths: ["name"]
+   * }, [category]);
+   * ```
+   * @param options
+   * @param options.type - The object type, depicted by a string or a class extending Realm.Object
+   * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
+   * This allows for filtering and sorting of the collection, before it is returned.
+   * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
+   * @returns a collection of realm objects or an empty array
+   */
+
+  /**
+   * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
+   * The hook will update on any changes to any object in the collection
+   * and return an empty array if the collection is empty.
+   *
+   * The result of this can be consumed directly by the `data` argument of any React Native
+   * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
+   * then only the modified object will re-render.
    */
   useQuery: ReturnType<typeof createUseQuery>;
   /**
@@ -177,17 +210,11 @@ export const RealmProvider = defaultContext.RealmProvider;
 export const useRealm = defaultContext.useRealm;
 
 /**
- * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
- * The hook will update on any changes to any object in the collection
- * and return an empty array if the collection is empty.
- *
- * The result of this can be consumed directly by the `data` argument of any React Native
- * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
- * then only the modified object will re-render.
+ * @overload
  * @example
  * ```tsx
  * // Return all collection items
- * const collection = useQuery(Object)
+ * const collection = useQuery(Object);
  *
  * // Return all collection items sorted by name and filtered by category
  * const filteredAndSorted = useQuery(Object, (collection) => collection.filtered('category == $0',category).sorted('name'), [category]);
@@ -197,6 +224,44 @@ export const useRealm = defaultContext.useRealm;
  * This allows for filtering and sorting of the collection, before it is returned.
  * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
  * @returns a collection of realm objects or an empty array
+ */
+
+/**
+ * @overload
+ * @example
+ * ```tsx
+ * // Return all collection items
+ * const collection = useQuery({ type: Query });
+ *
+ * // Return all collection items sorted by name and filtered by category
+ * const filteredAndSorted = useQuery({
+ *   type: Object,
+ *   query: (collection) => collection.filtered('category == $0',category).sorted('name'),
+ * }, [category]);
+ *
+ * // Return all collection items sorted by name and filtered by category, triggering re-renders only if "name" changes
+ * const filteredAndSorted = useQuery({
+ *   type: Object,
+ *   query: (collection) => collection.filtered('category == $0',category).sorted('name'),
+ *   keyPaths: ["name"]
+ * }, [category]);
+ * ```
+ * @param options
+ * @param options.type - The object type, depicted by a string or a class extending Realm.Object
+ * @param options.query - A function that takes a {@link Realm.Collection} and returns a {@link Realm.Collection} of the same type.
+ * This allows for filtering and sorting of the collection, before it is returned.
+ * @param deps - An array of dependencies that will be passed to {@link React.useMemo}
+ * @returns a collection of realm objects or an empty array
+ */
+
+/**
+ * Returns a {@link Realm.Collection} of {@link Realm.Object}s from a given type.
+ * The hook will update on any changes to any object in the collection
+ * and return an empty array if the collection is empty.
+ *
+ * The result of this can be consumed directly by the `data` argument of any React Native
+ * VirtualizedList or FlatList.  If the component used for the list's `renderItem` prop is {@link React.Memo}ized,
+ * then only the modified object will re-render.
  */
 export const useQuery = defaultContext.useQuery;
 
@@ -210,6 +275,7 @@ export const useQuery = defaultContext.useQuery;
  * ```
  * @param type - The object type, depicted by a string or a class extending {@link Realm.Object}
  * @param primaryKey - The primary key of the desired object which will be retrieved using {@link Realm.objectForPrimaryKey}
+ * @param keyPaths - Indicates a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the object. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present.
  * @returns either the desired {@link Realm.Object} or `null` in the case of it being deleted or not existing.
  */
 export const useObject = defaultContext.useObject;

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -75,7 +75,7 @@ type RealmContext = {
    * @example
    * ```tsx
    * // Return all collection items
-   * const collection = useQuery({ type: Query });
+   * const collection = useQuery({ type: Object });
    *
    * // Return all collection items sorted by name and filtered by category
    * const filteredAndSorted = useQuery({
@@ -199,7 +199,7 @@ export const useRealm = defaultContext.useRealm;
  * @example
  * ```tsx
  * // Return all collection items
- * const collection = useQuery({ type: Query });
+ * const collection = useQuery({ type: Object });
  *
  * // Return all collection items sorted by name and filtered by category
  * const filteredAndSorted = useQuery({

--- a/packages/realm-react/src/index.tsx
+++ b/packages/realm-react/src/index.tsx
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm from "realm";
-import { createContext } from "react";
+import React, { createContext } from "react";
 
 import { createRealmProvider } from "./RealmProvider";
 import { createUseObject } from "./useObject";
@@ -93,6 +93,7 @@ type RealmContext = {
    * ```
    * @param type - The object type, depicted by a string or a class extending {@link Realm.Object}
    * @param primaryKey - The primary key of the desired object which will be retrieved using {@link Realm.objectForPrimaryKey}
+   * @param keyPaths - Indicates a lower bound on the changes relevant for the hook. This is a lower bound, since if multiple hooks add listeners (each with their own `keyPaths`) the union of these key-paths will determine the changes that are considered relevant for all listeners registered on the object. In other words: A listener might fire and cause a re-render more than the key-paths specify, if other listeners with different key-paths are present.
    * @returns either the desired {@link Realm.Object} or `null` in the case of it being deleted or not existing.
    */
   useObject: ReturnType<typeof createUseObject>;

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -25,7 +25,11 @@ import { UseRealmHook } from "./useRealm";
 
 export type UseObjectHook = {
   <T>(type: string, primaryKey: T[keyof T], keyPaths?: string | string[]): (T & Realm.Object<T>) | null;
-  <T extends Realm.Object<any>>(type: { new (...args: any): T }, primaryKey: T[keyof T], keyPaths?: string | string[]): T | null;
+  <T extends Realm.Object<any>>(
+    type: { new (...args: any): T },
+    primaryKey: T[keyof T],
+    keyPaths?: string | string[],
+  ): T | null;
 };
 
 /**
@@ -64,7 +68,10 @@ export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
     const cachedObjectRef = useRef<null | CachedObject>(null);
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
-    const memoizedKeyPaths = useMemo(() => typeof keyPaths === "string" ? [keyPaths] : keyPaths, [JSON.stringify(keyPaths)]);
+    const memoizedKeyPaths = useMemo(
+      () => (typeof keyPaths === "string" ? [keyPaths] : keyPaths),
+      [JSON.stringify(keyPaths)],
+    );
 
     if (!cachedObjectRef.current) {
       cachedObjectRef.current = createCachedObject({

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -21,16 +21,20 @@ import Realm from "realm";
 
 import { CachedObject, createCachedObject } from "./cachedObject";
 import { CollectionCallback, getObjectForPrimaryKey, getObjects } from "./helpers";
+import { UseRealmHook } from "./useRealm";
+
+export type UseObjectHook = {
+  <T>(type: string, primaryKey: T[keyof T]): (T & Realm.Object<T>) | null;
+  <T extends Realm.Object<any>>(type: { new (...args: any): T }, primaryKey: T[keyof T]): T | null;
+};
 
 /**
  * Generates the `useObject` hook from a given `useRealm` hook.
  * @param useRealm - Hook that returns an open Realm instance
  * @returns useObject - Hook that is used to gain access to a single Realm object from a primary key
  */
-export function createUseObject(useRealm: () => Realm) {
-  function useObject<T>(type: string, primaryKey: T[keyof T]): (T & Realm.Object<T>) | null;
-  function useObject<T extends Realm.Object<any>>(type: { new (...args: any): T }, primaryKey: T[keyof T]): T | null;
-  function useObject<T extends Realm.Object>(
+export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
+  return function useObject<T extends Realm.Object>(
     type: string | { new (...args: any): T },
     primaryKey: T[keyof T],
   ): T | null {
@@ -151,9 +155,7 @@ export function createUseObject(useRealm: () => Realm) {
     }
     // This will never be undefined, but the type system doesn't know that
     return objectRef.current as T;
-  }
-
-  return useObject;
+  };
 }
 
 // This is a helper function that determines if two primary keys are equal.  It will also handle the case where the primary key is an ObjectId or UUID

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -23,9 +23,12 @@ import { CachedObject, createCachedObject } from "./cachedObject";
 import { CollectionCallback, getObjectForPrimaryKey, getObjects } from "./helpers";
 import { UseRealmHook } from "./useRealm";
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type AnyRealmObject = Realm.Object<any>;
+
 export type UseObjectHook = {
   <T>(type: string, primaryKey: T[keyof T], keyPaths?: string | string[]): (T & Realm.Object<T>) | null;
-  <T extends Realm.Object<any>>(
+  <T extends AnyRealmObject>(
     type: { new (...args: any): T },
     primaryKey: T[keyof T],
     keyPaths?: string | string[],
@@ -38,7 +41,7 @@ export type UseObjectHook = {
  * @returns useObject - Hook that is used to gain access to a single Realm object from a primary key
  */
 export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
-  return function useObject<T extends Realm.Object>(
+  return function useObject<T extends AnyRealmObject>(
     type: string | { new (...args: any): T },
     primaryKey: T[keyof T],
     keyPaths?: string | string[],
@@ -67,9 +70,9 @@ export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
     // Ref: https://github.com/facebook/react/issues/14490
     const cachedObjectRef = useRef<null | CachedObject>(null);
 
-    /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
     const memoizedKeyPaths = useMemo(
       () => (typeof keyPaths === "string" ? [keyPaths] : keyPaths),
+      /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
       [JSON.stringify(keyPaths)],
     );
 

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -20,19 +20,36 @@ import { useEffect, useMemo, useReducer, useRef } from "react";
 import Realm from "realm";
 
 import { CachedObject, createCachedObject } from "./cachedObject";
-import { CollectionCallback, getObjectForPrimaryKey, getObjects } from "./helpers";
+import {
+  AnyRealmObject,
+  CollectionCallback,
+  getObjectForPrimaryKey,
+  getObjects,
+  isClassModelConstructor,
+} from "./helpers";
 import { UseRealmHook } from "./useRealm";
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type AnyRealmObject = Realm.Object<any>;
+type RealmClassType<T = any> = { new (...args: any): T };
+
+export type ObjectHookOptions<T> = {
+  type: string;
+  primaryKey: T[keyof T];
+  keyPaths?: string | string[];
+};
+
+export type ObjectHookClassBasedOptions<T> = {
+  type: RealmClassType<T>;
+  primaryKey: T[keyof T];
+  keyPaths?: string | string[];
+};
 
 export type UseObjectHook = {
+  <T>(options: ObjectHookOptions<T>): (T & Realm.Object<T>) | null;
+  <T extends AnyRealmObject>(options: ObjectHookClassBasedOptions<T>): T | null;
+
   <T>(type: string, primaryKey: T[keyof T], keyPaths?: string | string[]): (T & Realm.Object<T>) | null;
-  <T extends AnyRealmObject>(
-    type: { new (...args: any): T },
-    primaryKey: T[keyof T],
-    keyPaths?: string | string[],
-  ): T | null;
+  <T extends AnyRealmObject>(type: RealmClassType<T>, primaryKey: T[keyof T], keyPaths?: string | string[]): T | null;
 };
 
 /**
@@ -41,8 +58,8 @@ export type UseObjectHook = {
  * @returns useObject - Hook that is used to gain access to a single Realm object from a primary key
  */
 export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
-  return function useObject<T extends AnyRealmObject>(
-    type: string | { new (...args: any): T },
+  function useObject<T extends AnyRealmObject>(
+    type: string | RealmClassType<T>,
     primaryKey: T[keyof T],
     keyPaths?: string | string[],
   ): T | null {
@@ -171,6 +188,24 @@ export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
     }
     // This will never be undefined, but the type system doesn't know that
     return objectRef.current as T;
+  }
+
+  return function useObjectOverload<T extends AnyRealmObject>(
+    typeOrOptions: string | RealmClassType<T> | ObjectHookOptions<T> | ObjectHookClassBasedOptions<T>,
+    primaryKey?: T[keyof T],
+    keyPaths?: string | string[],
+  ): T | null {
+    if (typeof typeOrOptions === "string" || isClassModelConstructor(typeOrOptions)) {
+      if (typeof primaryKey === "undefined") {
+        throw new Error("Expected a primary key");
+      }
+      /* eslint-disable-next-line react-hooks/rules-of-hooks -- We're calling `useQuery` once in any of the brances */
+      return useObject<T>(typeOrOptions, primaryKey, keyPaths);
+    } else {
+      const { type, primaryKey, keyPaths } = typeOrOptions;
+      /* eslint-disable-next-line react-hooks/rules-of-hooks -- We're calling `useQuery` once in any of the brances */
+      return useObject<T>(type, primaryKey, keyPaths);
+    }
   };
 }
 

--- a/packages/realm-react/src/useObject.tsx
+++ b/packages/realm-react/src/useObject.tsx
@@ -24,8 +24,8 @@ import { CollectionCallback, getObjectForPrimaryKey, getObjects } from "./helper
 import { UseRealmHook } from "./useRealm";
 
 export type UseObjectHook = {
-  <T>(type: string, primaryKey: T[keyof T], keyPaths?: string[]): (T & Realm.Object<T>) | null;
-  <T extends Realm.Object<any>>(type: { new (...args: any): T }, primaryKey: T[keyof T], keyPaths?: string[]): T | null;
+  <T>(type: string, primaryKey: T[keyof T], keyPaths?: string | string[]): (T & Realm.Object<T>) | null;
+  <T extends Realm.Object<any>>(type: { new (...args: any): T }, primaryKey: T[keyof T], keyPaths?: string | string[]): T | null;
 };
 
 /**
@@ -37,7 +37,7 @@ export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
   return function useObject<T extends Realm.Object>(
     type: string | { new (...args: any): T },
     primaryKey: T[keyof T],
-    keyPaths?: string[],
+    keyPaths?: string | string[],
   ): T | null {
     const realm = useRealm();
 
@@ -64,7 +64,7 @@ export function createUseObject(useRealm: UseRealmHook): UseObjectHook {
     const cachedObjectRef = useRef<null | CachedObject>(null);
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
-    const memoizedKeyPaths = useMemo(() => keyPaths, [JSON.stringify(keyPaths)]);
+    const memoizedKeyPaths = useMemo(() => typeof keyPaths === "string" ? [keyPaths] : keyPaths, [JSON.stringify(keyPaths)]);
 
     if (!cachedObjectRef.current) {
       cachedObjectRef.current = createCachedObject({

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -26,23 +26,22 @@ type RealmClassType<T = any> = { new (...args: any): T };
 type QueryCallback<T> = (collection: Realm.Results<T>) => Realm.Results<T>;
 type DependencyList = ReadonlyArray<unknown>;
 
+export type UseQueryHook = {
+  <T>(type: string, query?: QueryCallback<T>, deps?: DependencyList): Realm.Results<T & Realm.Object<T>>;
+  <T extends Realm.Object<any>>(
+    type: RealmClassType<T>,
+    query?: QueryCallback<T>,
+    deps?: DependencyList,
+  ): Realm.Results<T>;
+};
+
 /**
  * Generates the `useQuery` hook from a given `useRealm` hook.
  * @param useRealm - Hook that returns an open Realm instance
  * @returns useObject - Hook that is used to gain access to a {@link Realm.Collection}
  */
-export function createUseQuery(useRealm: () => Realm) {
-  function useQuery<T>(
-    type: string,
-    query?: QueryCallback<T>,
-    deps?: DependencyList,
-  ): Realm.Results<T & Realm.Object<T>>;
-  function useQuery<T extends Realm.Object<any>>(
-    type: RealmClassType<T>,
-    query?: QueryCallback<T>,
-    deps?: DependencyList,
-  ): Realm.Results<T>;
-  function useQuery<T extends Realm.Object<any>>(
+export function createUseQuery(useRealm: () => Realm): UseQueryHook {
+  return function useQuery<T extends Realm.Object<any>>(
     type: string | RealmClassType<T>,
     query: QueryCallback<T> = (collection: Realm.Results<T>) => collection,
     deps: DependencyList = [],
@@ -99,6 +98,5 @@ export function createUseQuery(useRealm: () => Realm) {
 
     // This will never not be defined, but the type system doesn't know that
     return collectionRef.current as Realm.Results<T>;
-  }
-  return useQuery;
+  };
 }

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -37,7 +37,7 @@ export type QueryHookOptions<T> = {
 export type QueryHookClassBasedOptions<T> = {
   type: RealmClassType<T>;
   query?: QueryCallback<T>;
-  keyPaths?: string[];
+  keyPaths?: string | string[];
 };
 
 export type UseQueryHook = {

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -20,11 +20,8 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import Realm from "realm";
 
 import { createCachedCollection } from "./cachedCollection";
-import { getObjects } from "./helpers";
+import { AnyRealmObject, RealmClassType, getObjects, isClassModelConstructor } from "./helpers";
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type AnyRealmObject = Realm.Object<any>;
-type RealmClassType<T = any> = { new (...args: any): T };
 type QueryCallback<T> = (collection: Realm.Results<T>) => Realm.Results<T>;
 type DependencyList = ReadonlyArray<unknown>;
 
@@ -55,10 +52,6 @@ export type UseQueryHook = {
     deps?: DependencyList,
   ): Realm.Results<T>;
 };
-
-function isClassModelConstructor(value: unknown): value is RealmClassType<unknown> {
-  return Object.getPrototypeOf(value) === Realm.Object;
-}
 
 /**
  * Maps a value to itself

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -29,7 +29,7 @@ type DependencyList = ReadonlyArray<unknown>;
 type QueryHookOptions<T> = {
   type: string;
   query?: QueryCallback<T>;
-  keyPaths?: string[];
+  keyPaths?: string | string[];
 };
 
 type QueryHookClassBasedOptions<T> = {
@@ -100,7 +100,7 @@ export function createUseQuery(useRealm: () => Realm): UseQueryHook {
     }, [type, realm, queryCallback]);
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
-    const memoizedKeyPaths = useMemo(() => keyPaths, [JSON.stringify(keyPaths)]);
+    const memoizedKeyPaths = useMemo(() => typeof keyPaths === "string" ? [keyPaths] : keyPaths, [JSON.stringify(keyPaths)]);
 
     // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `realm` or `queryResult` change
     const { collection, tearDown } = useMemo(() => {

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -100,7 +100,10 @@ export function createUseQuery(useRealm: () => Realm): UseQueryHook {
     }, [type, realm, queryCallback]);
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps -- Memoizing the keyPaths to avoid renders */
-    const memoizedKeyPaths = useMemo(() => typeof keyPaths === "string" ? [keyPaths] : keyPaths, [JSON.stringify(keyPaths)]);
+    const memoizedKeyPaths = useMemo(
+      () => (typeof keyPaths === "string" ? [keyPaths] : keyPaths),
+      [JSON.stringify(keyPaths)],
+    );
 
     // Wrap the cachedObject in useMemo, so we only replace it with a new instance if `realm` or `queryResult` change
     const { collection, tearDown } = useMemo(() => {

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -59,9 +59,9 @@ export function createUseQuery(useRealm: () => Realm): UseQueryHook {
     const updatedRef = useRef(true);
     const queryCallbackRef = useRef<QueryCallback<T> | null>(null);
 
-    // We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
-    // This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
-    // Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback`
+    /* eslint-disable-next-line react-hooks/exhaustive-deps -- We want the user of this hook to be able pass in the `query` function inline (without the need to `useCallback` on it)
+    This means that the query function is unstable and will be a redefined on each render of the component where `useQuery` is used
+    Therefore we use the `deps` array to memoize the query function internally, and only use the returned `queryCallback` */
     const queryCallback = useCallback(query, [...deps, ...requiredDeps]);
 
     // If the query function changes, we need to update the cachedCollection

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -26,13 +26,13 @@ type RealmClassType<T = any> = { new (...args: any): T };
 type QueryCallback<T> = (collection: Realm.Results<T>) => Realm.Results<T>;
 type DependencyList = ReadonlyArray<unknown>;
 
-type QueryHookOptions<T> = {
+export type QueryHookOptions<T> = {
   type: string;
   query?: QueryCallback<T>;
   keyPaths?: string | string[];
 };
 
-type QueryHookClassBasedOptions<T> = {
+export type QueryHookClassBasedOptions<T> = {
   type: RealmClassType<T>;
   query?: QueryCallback<T>;
   keyPaths?: string[];

--- a/packages/realm-react/src/useQuery.tsx
+++ b/packages/realm-react/src/useQuery.tsx
@@ -43,6 +43,9 @@ export type QueryHookClassBasedOptions<T> = {
 export type UseQueryHook = {
   <T>(options: QueryHookOptions<T>, deps?: DependencyList): Realm.Results<T & Realm.Object<T>>;
   <T extends AnyRealmObject>(options: QueryHookClassBasedOptions<T>, deps?: DependencyList): Realm.Results<T>;
+  <T>(type: string): Realm.Results<T & Realm.Object<T>>;
+  <T extends AnyRealmObject>(type: RealmClassType<T>): Realm.Results<T>;
+
   /** @deprecated To help the `react-hooks/exhaustive-deps` eslint rule detect missing dependencies, we've suggest passing a option object as the first argument */
   <T>(type: string, query?: QueryCallback<T>, deps?: DependencyList): Realm.Results<T & Realm.Object<T>>;
   /** @deprecated To help the `react-hooks/exhaustive-deps` eslint rule detect missing dependencies, we've suggest passing a option object as the first argument */

--- a/packages/realm-react/src/useRealm.tsx
+++ b/packages/realm-react/src/useRealm.tsx
@@ -19,14 +19,18 @@
 import Realm from "realm";
 import { useContext } from "react";
 
+export type UseRealmHook = {
+  (): Realm;
+};
+
 /**
  * Generates a `useRealm` hook given a RealmContext.  This allows access to the {@link Realm}
  * instance anywhere within the RealmProvider.
  * @param RealmContext - The context containing the {@link Realm} instance
  * @returns useRealm - Hook that is used to gain access to the {@link Realm} instance
  */
-export const createUseRealm = (RealmContext: React.Context<Realm | null>) => {
-  return function useRealm(): Realm {
+export const createUseRealm = (RealmContext: React.Context<Realm | null>): UseRealmHook => {
+  return function useRealm() {
     // This is the context setup by `createRealmContext`
     const context = useContext(RealmContext);
     if (context === null) {


### PR DESCRIPTION
## What, How & Why?

This closes #6286

## ☑️ ToDos
* [ ] Figure out a way to document the overload of `useQuery`
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
