### PR TITLE
Removed "build-dependencies" from `@realm/integration-tests` lint

### DIFF
--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -21,8 +21,7 @@
       "command": "eslint --ext .js,.ts . && tsc --noEmit",
       "dependencies": [
         "../../packages/realm-network-transport:bundle",
-				"../../packages/realm:bundle",
-				"build-dependencies"
+				"../../packages/realm:bundle"
       ]
     },
 		"build": {


### PR DESCRIPTION
## What, How & Why?

This speeds up the lint workflow, quite significantly and we can do this because we actually don't need the native modules for linting to work.

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
