### PR TITLE
Migrating from `@react-native-community/eslint-config` to `@react-native/eslint-config`

### DIFF
--- a/install-tests/react-native/.eslintrc.json
+++ b/install-tests/react-native/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@react-native-community",
+    "@react-native",
     "../../.eslintrc"
   ]
 } 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "integration-tests/baas-test-server"
       ],
       "dependencies": {
-        "@react-native-community/eslint-config": "^3.1.0",
+        "@react-native/eslint-config": "0.73.2",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
         "clang-format": "^1.8.0",
@@ -5321,35 +5321,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/@react-native-community/eslint-config": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/eslint-config/-/eslint-config-3.2.0.tgz",
-      "integrity": "sha512-ZjGvoeiBtCbd506hQqwjKmkWPgynGUoJspG8/MuV/EfKnkjCtBmeJvq2n+sWbWEvL9LWXDp2GJmPzmvU5RSvKQ==",
-      "dependencies": {
-        "@babel/core": "^7.14.0",
-        "@babel/eslint-parser": "^7.18.2",
-        "@react-native-community/eslint-plugin": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^5.30.5",
-        "@typescript-eslint/parser": "^5.30.5",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-ft-flow": "^2.0.1",
-        "eslint-plugin-jest": "^26.5.3",
-        "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-react": "^7.30.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-native": "^4.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8",
-        "prettier": ">=2"
-      }
-    },
-    "node_modules/@react-native-community/eslint-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/eslint-plugin/-/eslint-plugin-1.3.0.tgz",
-      "integrity": "sha512-+zDZ20NUnSWghj7Ku5aFphMzuM9JulqCW+aPXT6IfIXFbb8tzYTTOSeRFOtuekJ99ibW2fUCSsjuKNlwDIbHFg=="
-    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.73.1",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.73.1.tgz",
@@ -5555,7 +5526,6 @@
       "version": "0.73.2",
       "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.73.2.tgz",
       "integrity": "sha512-YzMfes19loTfbrkbYNAfHBDXX4oRBzc5wnvHs4h2GIHUj6YKs5ZK5lldqSrBJCdZAI3nuaO9Qj+t5JRwou571w==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/eslint-parser": "^7.20.0",
@@ -5583,7 +5553,6 @@
       "version": "0.73.1",
       "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.73.1.tgz",
       "integrity": "sha512-8BNMFE8CAI7JLWLOs3u33wcwcJ821LYs5g53Xyx9GhSg0h8AygTwDrwmYb/pp04FkCNCPjKPBoaYRthQZmxgwA==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "integration-tests/baas-test-server"
   ],
   "dependencies": {
-    "@react-native-community/eslint-config": "^3.1.0",
+    "@react-native/eslint-config": "0.73.2",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "clang-format": "^1.8.0",


### PR DESCRIPTION
## What, How & Why?

The latter has taken over as the package used by the template.
I also moved the dependency into the install tests package.json, to prevent a stale version of this from conflicting when updating the React Native apps in the repository.