### PR TITLE
Using BaaSaaS in the Realm JS PR workflow

### DIFF
--- a/.github/actions/baas-test-server/.eslintrc.json
+++ b/.github/actions/baas-test-server/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/.github/actions/baas-test-server/action.yml
+++ b/.github/actions/baas-test-server/action.yml
@@ -1,9 +1,6 @@
 name: Start BaaS test server
 description: Uses
 inputs:
-  baasaas-key:
-    description: SDK specific API key for BaaSaaS
-    required: true
   branch:
     description: BaaS branch to use when starting the server
     default: master

--- a/.github/actions/baas-test-server/action.yml
+++ b/.github/actions/baas-test-server/action.yml
@@ -9,40 +9,15 @@ inputs:
     default: master
   githash:
     description: Specific githash to use when starting the server (this is used instead of branch if provided)
-# outputs:
-#   container-id:
-#     description: The id of the container created
-#     value: ${{ steps.baasaas-start.outputs.container-id }}
-#   baas-url:
-#     description: The url of the BaaS server created
-#     value: ${{ steps.baasaas-start.outputs.baas-url }}
-#   mongo-url:
-#     description: The url of the MongoDB instance backing the server created
-#     value: ${{ steps.baasaas-start.outputs.mongo-url }}
+outputs:
+  container-id:
+    description: The id of the container created
+  baas-url:
+    description: The url of the BaaS server created
+  mongo-url:
+    description: The url of the MongoDB instance backing the server created
 
 runs:
   using: node20
   main: start-server.js
-# runs:
-#   using: composite
-#   steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/setup-node@v3
-#       with:
-#         node-version: 20
-#         cache: npm
-#     - shell: bash
-#       run: npm ci --ignore-scripts
-#     - shell: bash
-#       run: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
-#       id: baasaas-start
-#       env:
-#         BAASAAS_KEY: ${{ inputs.baasaas-key }}
-#     # Using another action to create a post step, since "composite" actions doesn't support those
-#     # See https://github.com/actions/runner/issues/1478
-#     - name: Stop server
-#       uses: TLizer/action-with-post-step@v1
-#       with:
-#         main: echo 'Nothing to do right now'
-#         post: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
-
+  post: stop-server.js

--- a/.github/actions/baas-test-server/action.yml
+++ b/.github/actions/baas-test-server/action.yml
@@ -1,0 +1,44 @@
+name: Start BaaS test server
+description: Uses
+inputs:
+  baasaas-key:
+    description: SDK specific API key for BaaSaaS
+    required: true
+  branch:
+    description: BaaS branch to use when starting the server
+    default: master
+  githash:
+    description: Specific githash to use when starting the server (this is used instead of branch if provided)
+outputs:
+  container-id:
+    description: The id of the container created
+    value: ${{ steps.baasaas-start.outputs.container-id }}
+  baas-url:
+    description: The url of the BaaS server created
+    value: ${{ steps.baasaas-start.outputs.baas-url }}
+  mongo-url:
+    description: The url of the MongoDB instance backing the server created
+    value: ${{ steps.baasaas-start.outputs.mongo-url }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+        cache: npm
+    - shell: bash
+      run: npm ci --ignore-scripts
+    - shell: bash
+      run: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
+      id: baasaas-start
+      env:
+        BAASAAS_KEY: ${{ inputs.baasaas-key }}
+    # Using another action to create a post step, since "composite" actions doesn't support those
+    # See https://github.com/actions/runner/issues/1478
+    - name: Stop server
+      uses: TLizer/action-with-post-step@v1
+      with:
+        main: echo 'Nothing to do right now'
+        post: npx baas-test-server baasaas stop ${{ steps.baasaas-start.outputs.container-id }}

--- a/.github/actions/baas-test-server/action.yml
+++ b/.github/actions/baas-test-server/action.yml
@@ -9,36 +9,40 @@ inputs:
     default: master
   githash:
     description: Specific githash to use when starting the server (this is used instead of branch if provided)
-outputs:
-  container-id:
-    description: The id of the container created
-    value: ${{ steps.baasaas-start.outputs.container-id }}
-  baas-url:
-    description: The url of the BaaS server created
-    value: ${{ steps.baasaas-start.outputs.baas-url }}
-  mongo-url:
-    description: The url of the MongoDB instance backing the server created
-    value: ${{ steps.baasaas-start.outputs.mongo-url }}
+# outputs:
+#   container-id:
+#     description: The id of the container created
+#     value: ${{ steps.baasaas-start.outputs.container-id }}
+#   baas-url:
+#     description: The url of the BaaS server created
+#     value: ${{ steps.baasaas-start.outputs.baas-url }}
+#   mongo-url:
+#     description: The url of the MongoDB instance backing the server created
+#     value: ${{ steps.baasaas-start.outputs.mongo-url }}
 
 runs:
-  using: composite
-  steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 20
-        cache: npm
-    - shell: bash
-      run: npm ci --ignore-scripts
-    - shell: bash
-      run: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
-      id: baasaas-start
-      env:
-        BAASAAS_KEY: ${{ inputs.baasaas-key }}
-    # Using another action to create a post step, since "composite" actions doesn't support those
-    # See https://github.com/actions/runner/issues/1478
-    - name: Stop server
-      uses: TLizer/action-with-post-step@v1
-      with:
-        main: echo 'Nothing to do right now'
-        post: npx baas-test-server baasaas stop ${{ steps.baasaas-start.outputs.container-id }}
+  using: node20
+  main: start-server.js
+# runs:
+#   using: composite
+#   steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/setup-node@v3
+#       with:
+#         node-version: 20
+#         cache: npm
+#     - shell: bash
+#       run: npm ci --ignore-scripts
+#     - shell: bash
+#       run: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
+#       id: baasaas-start
+#       env:
+#         BAASAAS_KEY: ${{ inputs.baasaas-key }}
+#     # Using another action to create a post step, since "composite" actions doesn't support those
+#     # See https://github.com/actions/runner/issues/1478
+#     - name: Stop server
+#       uses: TLizer/action-with-post-step@v1
+#       with:
+#         main: echo 'Nothing to do right now'
+#         post: npx baas-test-server baasaas start ${{ inputs.githash }} --branch ${{ inputs.branch }}
+

--- a/.github/actions/baas-test-server/action.yml
+++ b/.github/actions/baas-test-server/action.yml
@@ -15,6 +15,8 @@ outputs:
     description: The url of the MongoDB instance backing the server created
 
 runs:
+  # Using "composite" here would be ideal,
+  # but it doesn't support a "stop" step, which we need to shutdown the server.
   using: node20
   main: start-server.js
   post: stop-server.js

--- a/.github/actions/baas-test-server/package.json
+++ b/.github/actions/baas-test-server/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@realm/baas-test-server-action",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true
+}

--- a/.github/actions/baas-test-server/start-server.js
+++ b/.github/actions/baas-test-server/start-server.js
@@ -18,5 +18,4 @@
 
 import cp from "node:child_process";
 
-console.log(process.env);
 cp.execSync("npx baas-test-server baasaas start", { stdio: "inherit" });

--- a/.github/actions/baas-test-server/start-server.js
+++ b/.github/actions/baas-test-server/start-server.js
@@ -18,4 +18,5 @@
 
 import cp from "node:child_process";
 
+console.log(process.env);
 cp.execSync("npx baas-test-server baasaas start", { stdio: "inherit" });

--- a/.github/actions/baas-test-server/start-server.js
+++ b/.github/actions/baas-test-server/start-server.js
@@ -1,0 +1,3 @@
+import cp from "child_process";
+
+cp.execSync("ls");

--- a/.github/actions/baas-test-server/stop-server.js
+++ b/.github/actions/baas-test-server/stop-server.js
@@ -18,4 +18,4 @@
 
 import cp from "node:child_process";
 
-cp.execSync("npx baas-test-server baasaas start", { stdio: "inherit" });
+cp.execSync("npx baas-test-server baasaas stop", { stdio: "inherit" });

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -252,7 +252,7 @@ jobs:
       MOCHA_REMOTE_REPORTER: mocha-github-actions-reporter
       MOCHA_REMOTE_EXIT_ON_ERROR: true
       SPAWN_LOGCAT: true
-      BAAS_TAG: latest
+      BAAS_BRANCH: master
       # Pin the Xcode version
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app
     runs-on: ${{ matrix.variant.runner }}
@@ -284,19 +284,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
-
-      - name: Generate server configuration
-        id: baas-config
-        run:
-          suffix=$(node -p 'Math.floor(Math.random()*Number.MAX_SAFE_INTEGER)');
-          subdomain="realm-js-test-server-${{ github.run_id }}-${{ github.run_attempt }}-${suffix}";
-          echo "subdomain=${subdomain}" >> $GITHUB_OUTPUT;
-          echo "url=https://${subdomain}.ngrok.io" >> $GITHUB_OUTPUT;
-
-      - name: Trigger the test server workflow to start the server
-        run: gh workflow run test-server.yml -f ngrok_subdomain=${{ steps.baas-config.outputs.subdomain }} -f run_id=${{ github.run_id }} -f server_tag=${{ env.BAAS_TAG }}
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Get NPM cache directory
         id: npm-cache-dir
@@ -372,12 +359,17 @@ jobs:
         if: ${{ (matrix.variant.os == 'ios') }}
         run: open -a ${{ env.DEVELOPER_DIR }}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator
 
+      - name: Start BaaS test server
+        id: baas
+        uses: ./.github/actions/baas-test-server
+        with:
+          branch: ${{ env.BAAS_BRANCH }}
+        env:
+          BAASAAS_KEY: ${{ secrets.BAASAAS_KEY }}
+
       - name: Create Mocha Remote Context
         id: mocha-env
-        run: echo "context=syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas-config.outputs.url }}" >> $GITHUB_OUTPUT
-
-      - name: Wait for the server to start
-        run: npx wait-on ${{ steps.baas-config.outputs.url }}
+        run: echo "context=syncLogLevel=warn,longTimeout=${{ env.LONG_TIMEOUT }},realmBaseUrl=${{ steps.baas.outputs.baas-url }}" >> $GITHUB_OUTPUT
 
       - name: Run ${{matrix.variant.target}} (${{ matrix.variant.os}} / ${{ matrix.variant.environment }})
         if: ${{ (matrix.variant.os != 'android') && (matrix.variant.os != 'ios') }}

--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -255,6 +255,7 @@ jobs:
       BAAS_BRANCH: master
       # Pin the Xcode version
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app
+      IOS_DEVICE_NAME: iPhone 14
     runs-on: ${{ matrix.variant.runner }}
     strategy:
       fail-fast: false
@@ -355,9 +356,14 @@ jobs:
           # Ensure we install the prebuild built in the previous job
           npm_config_realm_local_prebuilds: ${{github.workspace}}/packages/realm/prebuilds
 
-      - name: Invoke the simulator (making subsequent "open -a Simulator" calls work)
-        if: ${{ (matrix.variant.os == 'ios') }}
-        run: open -a ${{ env.DEVELOPER_DIR }}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator
+      # The following makes subsequent "open -a Simulator" calls work
+      - name: Invoke the simulator
+        if: ${{ matrix.variant.os == 'ios' }}
+        run: open -a ${{ env.DEVELOPER_DIR }}/Contents/Developer/Applications/Simulator.app
+
+      - name: Boot the simulator
+        if: ${{ matrix.variant.os == 'ios' }}
+        run: xcrun simctl boot '${{ env.IOS_DEVICE_NAME }}'
 
       - name: Start BaaS test server
         id: baas

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -28,8 +28,9 @@ jobs:
         id: baas
         uses: ./.github/actions/baas-test-server
         with:
-          baasaas-key: ${{ secrets.BAASAAS_KEY }}
           branch: ${{ inputs.branch }}
           githash: ${{ inputs.githash }}
+        env:
+          BAASAAS_KEY: ${{ secrets.BAASAAS_KEY }}
       - name: Perform a request to the server
         run: curl ${{ steps.baas.outputs.baas-url }}/api/private/v1.0/version

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,19 +1,15 @@
-name: Run test server
+name: Start BaaS test server (test)
 
 on:
   workflow_dispatch:
     inputs:
-      ngrok_subdomain:
-        description: A subdomain to prefix ".ngrok.io" used for the server.
+      branch:
         type: string
-      run_id:
-        description: The GitHub Actions run id of the triggering action, which will be used to await completion.
-        type: number
-      server_tag:
-        description: The docker tag to use when pulling the server
+        description: BaaS branch to use when starting the server
+        default: master
+      githash:
         type: string
-        # Consider updating this in the calling workflow: https://github.com/realm/realm-js/blob/1a1a0edc354059122f1d9800c66a4a0860120fcb/.github/workflows/pr-realm-js.yml#L245
-        default: latest
+        description: Specific githash to use when starting the server (this is used instead of branch if provided)
 
 jobs:
   server:
@@ -21,44 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Determine Ngrok subdomain
-        id: ngrok-config
-        run:
-          subdomain="${{ inputs.ngrok_subdomain || format('realm-js-test-server-{0}-{1}', github.run_id, github.run_attempt) }}";
-          echo "subdomain=${subdomain}" >> $GITHUB_OUTPUT;
-          echo "hostname=${subdomain}.ngrok.io" >> $GITHUB_OUTPUT;
-      - name: Start Ngrok
-        run: docker run --detach --network host --env NGROK_AUTHTOKEN ngrok/ngrok http --subdomain ${{ steps.ngrok-config.outputs.subdomain }} 9090
-        env:
-          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-      - name: Preparing server entrypoint
-        # Writes an entrypoint script, which will patch the test-config to use the right hostnames, before it starts the server
-        run: |
-          echo '#!/bin/bash' >> patch-and-run.sh
-          echo 'NGROK_HOSTNAME=${{ steps.ngrok-config.outputs.hostname }}' >> patch-and-run.sh
-          # Replace localhost:9090 with the Ngrok hostname, "http" with "https" and "ws" with "wss"
-          echo 'sed -i -e "s/http:\/\/localhost:9090/https:\/\/${{ steps.ngrok-config.outputs.hostname }}/g" -e "s/ws:\/\/localhost:9090/wss:\/\/${{ steps.ngrok-config.outputs.hostname }}/g" /stitch/test_config.json' >> patch-and-run.sh
-          echo 'cat /stitch/test_config.json' >> patch-and-run.sh
-          # Start the server
-          echo '/run.sh' >> patch-and-run.sh
-          chmod u+x patch-and-run.sh
-      - name: Docker Login
-        uses: azure/docker-login@v1
-        with:
-          login-server: ghcr.io
-          username: realm-ci
-          password: ${{ secrets.REALM_CI_GITHUB_API_KEY }}
-      - name: Start server
-        run: docker run ${{ env.MODE }} --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --publish 9090:9090 --volume `pwd`/patch-and-run.sh:/patch-and-run.sh --entrypoint /patch-and-run.sh ghcr.io/realm/ci/mongodb-realm-test-server:${{ inputs.server_tag }}
-        env:
-          # Use --detach if a run_id is provided to watch for completion, --interactive otherwise
-          MODE: ${{ inputs.run_id && '--detach' || '--interactive' }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.BAAS_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.BAAS_AWS_SECRET_ACCESS_KEY }}
-      - name: Wait for triggering run to complete
-        if:  ${{ inputs.run_id }}
-        # Using " > /dev/null" because this will print the status of all jobs and steps every second
-        # Using "--interval 60" because we don't want to hit the GitHub actions requests limit
-        run: gh run watch --interval 60 ${{ inputs.run_id }} > /dev/null
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Start BaaS test server
+        id: baas
+        uses: ./.github/actions/baas-test-server
+      - run: curl ${{ steps.baas.outputs.baas-url }}/api/private/v1.0/version

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -17,7 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup node version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
       - name: Start BaaS test server
         id: baas
         uses: ./.github/actions/baas-test-server
-      - run: curl ${{ steps.baas.outputs.baas-url }}/api/private/v1.0/version
+        with:
+          baasaas-key: ${{ secrets.BAASAAS_KEY }}
+          branch: ${{ inputs.branch }}
+          githash: ${{ inputs.githash }}
+      - name: Perform a request to the server
+        run: curl ${{ steps.baas.outputs.baas-url }}/api/private/v1.0/version

--- a/integration-tests/baas-test-server/README.md
+++ b/integration-tests/baas-test-server/README.md
@@ -1,22 +1,19 @@
 # Run BaaS from source
 
-Run the Lerna bootstrap from the root of this repository.
+We're using an NPM workspace mono-repository, so first you need to install dependencies from the package root:
 
 ```shell
-npx lerna bootstrap --scope @realm/baas-test-server
+npm install
 ```
 
 Create a `.env` file with your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets.
+Ask your team how to get these.
 
 ```shell
 # .env
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
-
-A file called `assisted_agg` will be downloaded if it does not already exist in order for MongoDB aggregation tests to run.
-* When running the tests, Mac may block execution of the file. If so, go
-   to `System Settings > Privacy & Security` (for Mac), find blocked files, then allow `assisted_agg`.
 
 Run the `start` script, sit back and relax as a mongo server is started, BaaS is pulled, built and started with a proper configuration 🤞
 

--- a/integration-tests/baas-test-server/README.md
+++ b/integration-tests/baas-test-server/README.md
@@ -21,7 +21,7 @@ AWS_SECRET_ACCESS_KEY=...
 Run the `start` script, sit back and relax as BaaS is pulled and started.
 
 ```shell
-npm start docker
+npx baas-test-server docker
 ```
 
 Visit the administrative UI in your browser, if you need to.
@@ -43,5 +43,5 @@ BAASAAS_KEY=...
 Run the `start` script, sit back and relax as BaaS is started remotely.
 
 ```shell
-npm start baasaas
+npx baas-test-server baasaas start
 ```

--- a/integration-tests/baas-test-server/README.md
+++ b/integration-tests/baas-test-server/README.md
@@ -1,4 +1,4 @@
-# Run BaaS from source
+# Run a BaaS test server
 
 We're using an NPM workspace mono-repository, so first you need to install dependencies from the package root:
 
@@ -6,23 +6,42 @@ We're using an NPM workspace mono-repository, so first you need to install depen
 npm install
 ```
 
-Create a `.env` file with your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets.
+## Run BaaS locally using docker
+
+Create a `.env` file with your `AWS_PROFILE`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets.
 Ask your team how to get these.
 
 ```shell
 # .env
+AWS_PROFILE=...
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-Run the `start` script, sit back and relax as a mongo server is started, BaaS is pulled, built and started with a proper configuration 🤞
+Run the `start` script, sit back and relax as BaaS is pulled and started.
 
 ```shell
-npm start
+npm start docker
 ```
 
 Visit the administrative UI in your browser, if you need to.
 
 ```shell
 open http://localhost:9090
+```
+
+## Run BaaS via the BaaSaaS infrastructure
+
+Create a `.env` file with your `BAASAAS_KEY` secrets.
+Ask your team how to get these.
+
+```shell
+# .env
+BAASAAS_KEY=...
+```
+
+Run the `start` script, sit back and relax as BaaS is started remotely.
+
+```shell
+npm start baasaas
 ```

--- a/integration-tests/baas-test-server/README.md
+++ b/integration-tests/baas-test-server/README.md
@@ -18,9 +18,11 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-Run the `start` script, sit back and relax as BaaS is pulled and started.
+Run the `start` script (calls the CLI's `docker` command), sit back and relax as BaaS is pulled and started.
 
 ```shell
+npm start
+# or
 npx baas-test-server docker
 ```
 
@@ -40,8 +42,10 @@ Ask your team how to get these.
 BAASAAS_KEY=...
 ```
 
-Run the `start` script, sit back and relax as BaaS is started remotely.
+Run the `baasaas:start` script (calls the CLI's `baasaas start` command), sit back and relax as BaaS is started remotely.
 
 ```shell
+npm run baasaas:start
+# or
 npx baas-test-server baasaas start
 ```

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import assert from "node:assert";
-import gha from "@actions/core";
 
 const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb/endpoint/";
 
@@ -39,7 +38,8 @@ type StartedContainer = {
 
 function assertStartedContainer(value: unknown): asserts value is StartedContainer {
   assert(typeof value === "object" && value !== null);
-  assert("id" in value && typeof value.id === "string");
+  assert("id" in value);
+  assert.equal(typeof value.id, "string");
 }
 
 type StartContainerOptions =
@@ -84,7 +84,7 @@ export async function stopContainer(id: string) {
 type ContainerStatus = {
   id: string;
   lastStatus: "RUNNING" | "PENDING" | string;
-  startedAt: string | Record<never, never>;
+  startedAt?: string;
   createdAt: string;
   creatorId: string;
   creatorName: string;
@@ -97,10 +97,13 @@ function assertContainerStatus(value: unknown): asserts value is ContainerStatus
   assert(typeof value === "object" && value !== null);
   assert("id" in value && typeof value.id === "string");
   assert("lastStatus" in value && typeof value.lastStatus === "string");
-  assert("startedAt" in value && (typeof value.startedAt === "string" || typeof value.startedAt === "object"));
   assert("createdAt" in value && typeof value.createdAt === "string");
   assert("creatorId" in value && typeof value.creatorId === "string");
   assert("creatorName" in value && typeof value.creatorName === "string");
+  if ("startedAt" in value && typeof value.startedAt !== "string") {
+    // The service will sometimes respond with an empty object in `startedAt`
+    delete value.startedAt;
+  }
   if ("httpUrl" in value) {
     assert(typeof value.httpUrl === "string");
   }

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -18,7 +18,138 @@
 
 import assert from "node:assert";
 
-const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb";
+const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb/endpoint/";
+
+function createHeaders(appendKey = false) {
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  if (appendKey) {
+    const { BAASAAS_KEY } = process.env;
+    assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
+    headers["apiKey"] = BAASAAS_KEY;
+  }
+  return headers;
+}
+
+type StartedContainer = {
+  id: string;
+};
+
+function assertStartedContainer(value: unknown): asserts value is StartedContainer {
+  assert(typeof value === "object" && value !== null);
+  assert("id" in value && typeof value.id === "string");
+}
+
+type StartContainerOptions =
+  | {
+      githash: string;
+    }
+  | {
+      branch: string;
+    };
+
+export async function startContainer(options: StartContainerOptions) {
+  const url = new URL("startContainer", BAASAAS_BASE_URL);
+  if ("githash" in options) {
+    url.searchParams.append("branch", options.githash);
+  } else if ("branch" in options) {
+    url.searchParams.append("branch", options.branch);
+  }
+  const response = await fetch(url, { method: "POST", headers: createHeaders(true) });
+  assert(response.ok);
+  const json = await response.json();
+  assertStartedContainer(json);
+  return json;
+}
+
+type StopContainerResponse = {
+  /* TODO: Fill in */
+};
+
+function assertStopContainerResponse(value: unknown): asserts value is StopContainerResponse {
+  /* TODO: Fill in */
+}
+
+export async function stopContainer(id: string) {
+  const url = new URL("stopContainer", BAASAAS_BASE_URL);
+  url.searchParams.append("id", id);
+  const response = await fetch(url, { method: "POST", headers: createHeaders(true) });
+  assert(response.ok);
+  const json = await response.json();
+  assertStopContainerResponse(json);
+}
+
+type ContainerStatus = {
+  id: string;
+  lastStatus: "RUNNING" | "PENDING" | string;
+  startedAt: string | Record<never, never>;
+  createdAt: string;
+  creatorId: string;
+  creatorName: string;
+  httpUrl?: string;
+  mongoUrl?: string;
+  tags: unknown[];
+};
+
+function assertContainerStatus(value: unknown): asserts value is ContainerStatus {
+  assert(typeof value === "object" && value !== null);
+  assert("id" in value && typeof value.id === "string");
+  assert("lastStatus" in value && typeof value.lastStatus === "string");
+  assert("startedAt" in value && (typeof value.startedAt === "string" || typeof value.startedAt === "object"));
+  assert("createdAt" in value && typeof value.createdAt === "string");
+  assert("creatorId" in value && typeof value.creatorId === "string");
+  assert("creatorName" in value && typeof value.creatorName === "string");
+  if ("httpUrl" in value) {
+    assert(typeof value.httpUrl === "string");
+  }
+  if ("mongoUrl" in value) {
+    assert(typeof value.mongoUrl === "string");
+  }
+  assert("tags" in value && Array.isArray(value.tags));
+}
+
+export async function containerStatus(id: string) {
+  const url = new URL("containerStatus", BAASAAS_BASE_URL);
+  url.searchParams.append("id", id);
+  const response = await fetch(url, { headers: createHeaders(true) });
+  assert(response.ok);
+  const json = await response.json();
+  assertContainerStatus(json);
+  return json;
+}
+
+type Userinfo = {
+  id: string;
+  type: string;
+  custom_data: Record<string, unknown>;
+  data: Record<string, unknown>;
+  identities: [{ id: string; provider_type: string }];
+};
+
+function assertUserinfo(value: unknown): asserts value is Userinfo {
+  assert(typeof value === "object" && value !== null);
+  assert("id" in value && typeof value.id === "string");
+  assert("type" in value && typeof value.type === "string");
+  assert("custom_data" in value && typeof value.custom_data === "object");
+  assert("data" in value && typeof value.data === "object");
+  assert("identities" in value && Array.isArray(value.identities));
+  for (const identity of value.identities) {
+    assert(typeof identity === "object");
+    assert("id" in identity && typeof identity.id === "string");
+    assert("provider_type" in identity && typeof identity.provider_type === "string");
+  }
+}
+
+export async function userinfo() {
+  const url = new URL("userinfo", BAASAAS_BASE_URL);
+  const headers = createHeaders(true);
+  const response = await fetch(url, { headers });
+  assert(response.ok);
+  const json = await response.json();
+  assertUserinfo(json);
+  return json;
+}
 
 type Image = {
   buildVariant: string;
@@ -43,12 +174,12 @@ function assertImage(value: unknown): asserts value is Image {
   assert(typeof object.imageTag === "string");
 }
 
-type ImagesResponse = {
+type Images = {
   allBranches: string[];
   images: Record<string, undefined | Image[]>;
 };
 
-function assertImagesResponse(value: unknown): asserts value is ImagesResponse {
+function assertImages(value: unknown): asserts value is Images {
   assert(typeof value === "object" && value !== null);
   const object = value as Record<string, unknown>;
   assert(Array.isArray(object.allBranches));
@@ -62,19 +193,32 @@ function assertImagesResponse(value: unknown): asserts value is ImagesResponse {
   }
 }
 
-export async function listImages(): Promise<ImagesResponse> {
-  const response = await fetch(`${BAASAAS_BASE_URL}/endpoint/images`);
+export async function listImages() {
+  const url = new URL("images", BAASAAS_BASE_URL);
+  const response = await fetch(url, { headers: createHeaders(false) });
   assert(response.ok);
   const json = await response.json();
-  assertImagesResponse(json);
+  assertImages(json);
   return json;
 }
 
-export type BaaSaaSCommandArgv = {
-  branch: string;
-};
+type ListContainers = ContainerStatus[];
 
-export async function runBaaSaaS(argv: BaaSaaSCommandArgv) {
-  const { BAASAAS_KEY } = process.env;
-  assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
+function assertListContainers(value: unknown): asserts value is ListContainers {
+  assert(Array.isArray(value));
+  for (const element of value) {
+    assertContainerStatus(element);
+  }
+}
+
+export async function listContainers(mine = false) {
+  const url = new URL("listContainers", BAASAAS_BASE_URL);
+  if (mine) {
+    url.searchParams.append("mine", "true");
+  }
+  const response = await fetch(url, { headers: createHeaders(true) });
+  assert(response.ok, response.statusText);
+  const json = await response.json();
+  assertListContainers(json);
+  return json;
 }

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import assert from "node:assert";
+
+const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb";
+
+type Image = {
+  buildVariant: string;
+  imageTag: string;
+  /*
+  _id: string;
+  project: string;
+  order: number;
+  versionId: string;
+  taskId: string;
+  execution: number;
+  timestamp: string;
+  branch: string;
+  revision: string;
+  */
+};
+
+function assertImage(value: unknown): asserts value is Image {
+  assert(typeof value === "object" && value !== null);
+  const object = value as Record<string, unknown>;
+  assert(typeof object.buildVariant === "string");
+  assert(typeof object.imageTag === "string");
+}
+
+type ImagesResponse = {
+  allBranches: string[];
+  images: Record<string, undefined | Image[]>;
+};
+
+function assertImagesResponse(value: unknown): asserts value is ImagesResponse {
+  assert(typeof value === "object" && value !== null);
+  const object = value as Record<string, unknown>;
+  assert(Array.isArray(object.allBranches));
+  const { images } = object;
+  assert(typeof images === "object" && images !== null);
+  for (const available of Object.values(images)) {
+    assert(Array.isArray(available));
+    for (const image of available) {
+      assertImage(image);
+    }
+  }
+}
+
+export async function listImages(): Promise<ImagesResponse> {
+  const response = await fetch(`${BAASAAS_BASE_URL}/endpoint/images`);
+  assert(response.ok);
+  const json = await response.json();
+  assertImagesResponse(json);
+  return json;
+}
+
+export type BaaSaaSCommandArgv = {
+  branch: string;
+};
+
+export async function runBaaSaaS(argv: BaaSaaSCommandArgv) {
+  const { BAASAAS_KEY } = process.env;
+  assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
+}

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -27,6 +27,7 @@ function createHeaders(appendKey = false) {
   };
   if (appendKey) {
     const { BAASAAS_KEY = gha.getInput("baasaas-key") } = process.env;
+    console.log(process.env);
     assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
     headers["apiKey"] = BAASAAS_KEY;
   }

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -26,7 +26,7 @@ function createHeaders(appendKey = false) {
     "Content-Type": "application/json",
   };
   if (appendKey) {
-    const { BAASAAS_KEY = gha.getInput("baasaas-key") } = process.env;
+    const { BAASAAS_KEY } = process.env;
     console.log(process.env);
     assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
     headers["apiKey"] = BAASAAS_KEY;

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -27,7 +27,6 @@ function createHeaders(appendKey = false) {
   };
   if (appendKey) {
     const { BAASAAS_KEY } = process.env;
-    console.log(process.env);
     assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
     headers["apiKey"] = BAASAAS_KEY;
   }

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -153,26 +153,32 @@ export async function userinfo() {
 }
 
 type Image = {
-  buildVariant: string;
-  imageTag: string;
-  /*
   _id: string;
   project: string;
   order: number;
   versionId: string;
+  buildVariant: string;
   taskId: string;
+  revision: string;
   execution: number;
   timestamp: string;
   branch: string;
-  revision: string;
-  */
+  imageTag: string;
 };
 
 function assertImage(value: unknown): asserts value is Image {
   assert(typeof value === "object" && value !== null);
-  const object = value as Record<string, unknown>;
-  assert(typeof object.buildVariant === "string");
-  assert(typeof object.imageTag === "string");
+  assert("_id" in value && typeof value._id === "string");
+  assert("project" in value && typeof value.project === "string");
+  assert("order" in value && typeof value.order === "number");
+  assert("versionId" in value && typeof value.versionId === "string");
+  assert("buildVariant" in value && typeof value.buildVariant === "string");
+  assert("taskId" in value && typeof value.taskId === "string");
+  assert("revision" in value && typeof value.revision === "string");
+  assert("execution" in value && typeof value.execution === "number");
+  assert("timestamp" in value && typeof value.timestamp === "string");
+  assert("branch" in value && typeof value.branch === "string");
+  assert("imageTag" in value && typeof value.imageTag === "string");
 }
 
 type Images = {
@@ -182,11 +188,9 @@ type Images = {
 
 function assertImages(value: unknown): asserts value is Images {
   assert(typeof value === "object" && value !== null);
-  const object = value as Record<string, unknown>;
-  assert(Array.isArray(object.allBranches));
-  const { images } = object;
-  assert(typeof images === "object" && images !== null);
-  for (const available of Object.values(images)) {
+  assert("allBranches" in value && Array.isArray(value.allBranches));
+  assert("images" in value && typeof value.images === "object" && value.images !== null);
+  for (const available of Object.values(value.images)) {
     assert(Array.isArray(available));
     for (const image of available) {
       assertImage(image);

--- a/integration-tests/baas-test-server/baasaas.ts
+++ b/integration-tests/baas-test-server/baasaas.ts
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import assert from "node:assert";
+import gha from "@actions/core";
 
 const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb/endpoint/";
 
@@ -25,7 +26,7 @@ function createHeaders(appendKey = false) {
     "Content-Type": "application/json",
   };
   if (appendKey) {
-    const { BAASAAS_KEY } = process.env;
+    const { BAASAAS_KEY = gha.getInput("baasaas-key") } = process.env;
     assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
     headers["apiKey"] = BAASAAS_KEY;
   }

--- a/integration-tests/baas-test-server/baasaas/client.ts
+++ b/integration-tests/baas-test-server/baasaas/client.ts
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import {
+  assertContainer,
+  assertContainerList,
+  assertImages,
+  assertStartedContainer,
+  assertStopContainerResponse,
+  assertUserinfo,
+} from "./assertions";
+import { request } from "./request";
+
+const BAASAAS_BASE_URL = "https://us-east-1.aws.data.mongodb-api.com/app/baas-container-service-autzb/endpoint/";
+
+type StartContainerOptions =
+  | {
+      githash: string;
+    }
+  | {
+      branch: string;
+    };
+
+export async function startContainer(options: StartContainerOptions) {
+  const url = new URL("startContainer", BAASAAS_BASE_URL);
+  if ("githash" in options) {
+    url.searchParams.append("branch", options.githash);
+  } else if ("branch" in options) {
+    url.searchParams.append("branch", options.branch);
+  }
+  return request({ url, method: "POST", authenticated: true }, assertStartedContainer);
+}
+
+export async function stopContainer(id: string) {
+  const url = new URL("stopContainer", BAASAAS_BASE_URL);
+  url.searchParams.append("id", id);
+  return request({ url, method: "POST", authenticated: true }, assertStopContainerResponse);
+}
+
+export async function containerStatus(id: string) {
+  const url = new URL("containerStatus", BAASAAS_BASE_URL);
+  url.searchParams.append("id", id);
+  return request({ url, method: "GET", authenticated: true }, assertContainer);
+}
+
+export async function userinfo() {
+  const url = new URL("userinfo", BAASAAS_BASE_URL);
+  return request({ url, method: "GET", authenticated: true }, assertUserinfo);
+}
+
+export async function listImages() {
+  const url = new URL("images", BAASAAS_BASE_URL);
+  return request({ url, method: "GET", authenticated: false }, assertImages);
+}
+
+export async function listContainers(mine = false) {
+  const url = new URL("listContainers", BAASAAS_BASE_URL);
+  if (mine) {
+    url.searchParams.append("mine", "true");
+  }
+  return request({ url, method: "GET", authenticated: true }, assertContainerList);
+}

--- a/integration-tests/baas-test-server/baasaas/request.ts
+++ b/integration-tests/baas-test-server/baasaas/request.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import assert from "node:assert";
+
+function createHeaders(authenticated = false) {
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  if (authenticated) {
+    const { BAASAAS_KEY } = process.env;
+    assert(BAASAAS_KEY, "Missing BAASAAS_KEY env");
+    headers["apiKey"] = BAASAAS_KEY;
+  }
+  return headers;
+}
+
+type RequestOptions = {
+  url: URL;
+  method: string;
+  authenticated: boolean;
+};
+
+export async function request<R>(
+  { url, method, authenticated }: RequestOptions,
+  assertion: (response: unknown) => asserts response is R,
+): Promise<R> {
+  const response = await fetch(url, { method, headers: createHeaders(authenticated) });
+  if (response.ok) {
+    const json = await response.json();
+    assertion(json);
+    return json;
+  } else if (response.headers.get("content-type") === "application/json") {
+    const json = await response.json();
+    throw new Error(`Request failed (${response.status} / ${response.statusText}): ${JSON.stringify(json)}`);
+  } else {
+    throw new Error(`Request failed (${response.status} / ${response.statusText})`);
+  }
+}

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -28,14 +28,8 @@ dotenv.config({
 // Loading a .env from cwd too
 dotenv.config();
 
-const COMMON_ID_PREFIX = "arn:aws:ecs:us-east-1:969505754201:task/baas-container-service2/";
-
 function abbreviateId(id: string) {
-  return id.replace(COMMON_ID_PREFIX, "");
-}
-
-function expandId(id: string) {
-  return id.startsWith(COMMON_ID_PREFIX) ? id : COMMON_ID_PREFIX + id;
+  return id.split("/").pop();
 }
 
 export function wrapCommand<Argv>(command: (argv: Argv) => Promise<void>): (argv: Argv) => void {
@@ -180,7 +174,7 @@ yargs(hideBin(process.argv))
               }
             } else {
               console.log(`Stopping container '${abbreviateId(id)}'`);
-              await baasaas.stopContainer(expandId(id));
+              await baasaas.stopContainer(id);
             }
           } else {
             const containers = await baasaas.listContainers(true);

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -167,21 +167,20 @@ yargs(hideBin(process.argv))
       .command(
         ["stop [id]"],
         "Stop a container running on the BaaSaaS service",
-        (yargs) => yargs.positional("id", { type: "string", default: gha.getState("container-id") }),
-        wrapCommand(async (argv) => {
+        (yargs) => yargs.positional("id", { type: "string" }),
+        wrapCommand(async ({ id = gha.getState("container-id") }) => {
           await printUserInfo();
-          if (argv.id) {
-            if (argv.id === "all" || argv.id === "*") {
+          if (id) {
+            if (id === "all" || id === "*") {
               console.log(`Stopping all containers:`);
               const containers = await baasaas.listContainers(true);
               for (const container of containers) {
                 console.log(`→ Stopping container '${abbreviateId(container.id)}'`);
-                // TODO: Re-enable once listing "mine" works as expected
-                // await baasaas.stopContainer(container.id);
+                await baasaas.stopContainer(container.id);
               }
             } else {
-              console.log(`Stopping container '${abbreviateId(argv.id)}'`);
-              await baasaas.stopContainer(expandId(argv.id));
+              console.log(`Stopping container '${abbreviateId(id)}'`);
+              await baasaas.stopContainer(expandId(id));
             }
           } else {
             const containers = await baasaas.listContainers(true);

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -13,7 +13,7 @@ import waitFor from "p-wait-for";
 import gha from "@actions/core";
 
 import * as docker from "./docker";
-import * as baasaas from "./baasaas";
+import * as baasaas from "./baasaas/client";
 import { UsageError } from "./helpers";
 
 const GITHUB_ACTIONS = process.env.GITHUB_ACTIONS === "true";

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -171,8 +171,8 @@ yargs(hideBin(process.argv))
         wrapCommand(async ({ id = gha.getState("CONTAINER_ID") }) => {
           await printUserInfo();
           if (id) {
-            if (id === "all" || id === "*") {
-              console.log(`Stopping all containers:`);
+            if (id === "all" || id === "mine" || id === "*") {
+              console.log(`Stopping all your containers:`);
               const containers = await baasaas.listContainers(true);
               for (const container of containers) {
                 console.log(`→ Stopping container '${abbreviateId(container.id)}'`);

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -164,6 +164,11 @@ yargs(hideBin(process.argv))
         (yargs) => yargs.positional("id", { type: "string" }),
         wrapCommand(async ({ id = gha.getState("CONTAINER_ID") }) => {
           await printUserInfo();
+          if (GITHUB_ACTIONS && !id) {
+            console.log("Skipped stopping container, since an id could not be determined.");
+            return;
+          }
+
           if (id) {
             if (id === "all" || id === "mine" || id === "*") {
               console.log(`Stopping all your containers:`);

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -5,8 +5,9 @@
 import dotenv from "dotenv";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { DockerCommandArgv, dockerCommand } from "./docker";
+import { DockerCommandArgv, runDocker } from "./docker";
 import { wrapCommand } from "./helpers";
+import { runBaaSaaS } from "./baasaas";
 
 dotenv.config();
 
@@ -15,7 +16,13 @@ yargs(hideBin(process.argv))
     ["docker [tag]"],
     "Runs the BaaS test image using Docker",
     (yargs) => yargs.positional("tag", { type: "string" }).option("branch", { default: "master" }),
-    wrapCommand(dockerCommand),
+    wrapCommand(runDocker),
+  )
+  .command<DockerCommandArgv>(
+    ["baasaas"],
+    "Runs the BaaS test image using the BaaSaaS service",
+    (yargs) => yargs.option("branch", { default: "master" }),
+    wrapCommand(runBaaSaaS),
   )
   .demandCommand(1)
   .parse();

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -131,7 +131,10 @@ yargs(hideBin(process.argv))
       .command(
         ["start [githash]"],
         "Start a container on the BaaSaaS service",
-        (yargs) => yargs.positional("githash", { type: "string" }).option("branch", { default: "master" }),
+        (yargs) =>
+          yargs
+            .positional("githash", { type: "string", default: gha.getInput("githash") ?? undefined })
+            .option("branch", { default: gha.getInput("branch") || "master" }),
         wrapCommand(async (argv) => {
           await printUserInfo();
           const container = await baasaas.startContainer(
@@ -158,7 +161,7 @@ yargs(hideBin(process.argv))
       .command(
         ["stop [id]"],
         "Stop a container running on the BaaSaaS service",
-        (yargs) => yargs.positional("id", { type: "string" }),
+        (yargs) => yargs.positional("id", { type: "string", default: gha.getState("container-id") }),
         wrapCommand(async (argv) => {
           await printUserInfo();
           if (argv.id) {

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env tsx
+
+/* eslint header/header: 0 */
+
+import dotenv from "dotenv";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { DockerCommandArgv, dockerCommand } from "./docker";
+import { wrapCommand } from "./helpers";
+
+dotenv.config();
+
+yargs(hideBin(process.argv))
+  .command<DockerCommandArgv>(
+    ["docker [tag]"],
+    "Runs the BaaS test image using Docker",
+    (yargs) => yargs.positional("tag", { type: "string" }).option("branch", { default: "master" }),
+    wrapCommand(dockerCommand),
+  )
+  .demandCommand(1)
+  .parse();

--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -155,11 +155,11 @@ yargs(hideBin(process.argv))
 
           if (GITHUB_ACTIONS) {
             gha.notice(`Server listening on ${httpUrl}`, { title: "Started BaaS server" });
+            // Useful when called from a wrapper action
+            gha.saveState("CONTAINER_ID", container.id);
             gha.setOutput("container-id", container.id);
             gha.setOutput("baas-url", httpUrl);
             gha.setOutput("mongo-url", mongoUrl);
-            // Useful when called from a wrapper action
-            gha.saveState("container-id", container.id);
           }
           // TODO: On GitHub poll the triggering workflow run
         }),
@@ -168,7 +168,7 @@ yargs(hideBin(process.argv))
         ["stop [id]"],
         "Stop a container running on the BaaSaaS service",
         (yargs) => yargs.positional("id", { type: "string" }),
-        wrapCommand(async ({ id = gha.getState("container-id") }) => {
+        wrapCommand(async ({ id = gha.getState("CONTAINER_ID") }) => {
           await printUserInfo();
           if (id) {
             if (id === "all" || id === "*") {

--- a/integration-tests/baas-test-server/docker.ts
+++ b/integration-tests/baas-test-server/docker.ts
@@ -20,7 +20,7 @@ import cp, { execSync } from "node:child_process";
 import assert from "node:assert";
 import chalk from "chalk";
 import { ExecError, UsageError } from "./helpers";
-import { listImages } from "./baasaas";
+import { listImages } from "./baasaas/client";
 
 const BAAS_CONTAINER_NAME = "baas-test-server";
 const BAAS_PORT = 9090;

--- a/integration-tests/baas-test-server/helpers.ts
+++ b/integration-tests/baas-test-server/helpers.ts
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import chalk from "chalk";
+
+export class UsageError extends Error {}
+
+export type ExecError = {
+  stdout: string;
+  stderr: string;
+} & Error;
+
+export function wrapCommand<Argv>(command: (argv: Argv) => Promise<void>): (argv: Argv) => void {
+  return function (argv: Argv) {
+    command(argv).catch((err) => {
+      console.error();
+      if (err instanceof UsageError) {
+        console.error(chalk.red(err.message));
+      } else if (err instanceof Error) {
+        console.error(chalk.red(err.stack));
+      } else {
+        throw err;
+      }
+    });
+  };
+}

--- a/integration-tests/baas-test-server/helpers.ts
+++ b/integration-tests/baas-test-server/helpers.ts
@@ -16,26 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import chalk from "chalk";
-
 export class UsageError extends Error {}
 
 export type ExecError = {
   stdout: string;
   stderr: string;
 } & Error;
-
-export function wrapCommand<Argv>(command: (argv: Argv) => Promise<void>): (argv: Argv) => void {
-  return function (argv: Argv) {
-    command(argv).catch((err) => {
-      console.error();
-      if (err instanceof UsageError) {
-        console.error(chalk.red(err.message));
-      } else if (err instanceof Error) {
-        console.error(chalk.red(err.stack));
-      } else {
-        throw err;
-      }
-    });
-  };
-}

--- a/integration-tests/baas-test-server/package.json
+++ b/integration-tests/baas-test-server/package.json
@@ -4,6 +4,9 @@
   "private": false,
   "type": "module",
   "main": "index.js",
+  "bin": {
+    "baas-test-server": "./cli.ts"
+  },
   "scripts": {
     "start": "tsx index.ts"
   },

--- a/integration-tests/baas-test-server/package.json
+++ b/integration-tests/baas-test-server/package.json
@@ -8,7 +8,7 @@
     "baas-test-server": "./cli.ts"
   },
   "scripts": {
-    "start": "tsx index.ts"
+    "start": "baas-test-server"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/integration-tests/baas-test-server/package.json
+++ b/integration-tests/baas-test-server/package.json
@@ -8,7 +8,11 @@
     "baas-test-server": "./cli.ts"
   },
   "scripts": {
-    "start": "baas-test-server"
+    "start": "baas-test-server docker",
+    "baasaas": "baas-test-server baasaas",
+    "baasaas:start": "baas-test-server baasaas start",
+    "baasaas:stop": "baas-test-server baasaas stop",
+    "baasaas:list": "baas-test-server baasaas list"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/integration-tests/baas-test-server/package.json
+++ b/integration-tests/baas-test-server/package.json
@@ -11,8 +11,10 @@
     "start": "baas-test-server"
   },
   "dependencies": {
+    "@actions/core": "^1.10.1",
     "chalk": "^4.1.2",
     "dotenv": "^16.0.2",
+    "p-wait-for": "^5.0.2",
     "yargs": "^17.7.2"
   }
 }

--- a/integration-tests/environments/react-native/harness/runner.js
+++ b/integration-tests/environments/react-native/harness/runner.js
@@ -21,8 +21,8 @@ const android = require("./android-cli");
 const xcode = require("./xcode-cli");
 const logcat = require("./logcat");
 
-const IOS_DEVICE_NAME = "realm-js-integration-tests";
-const IOS_DEVICE_TYPE_ID = "com.apple.CoreSimulator.SimDeviceType.iPhone-13";
+const { IOS_DEVICE_NAME = "iPhone 14", IOS_DEVICE_TYPE_ID = "com.apple.CoreSimulator.SimDeviceType.iPhone-14" } =
+  process.env;
 
 const { MOCHA_REMOTE_PORT, PLATFORM, SPAWN_LOGCAT, SKIP_RUNNER, RETRY_DELAY, RETRIES } = process.env;
 

--- a/integration-tests/environments/react-native/package.json
+++ b/integration-tests/environments/react-native/package.json
@@ -8,8 +8,8 @@
     "test:android": "wireit",
     "test:ios": "wireit",
     "test:catalyst": "wireit",
-    "test:ci:android": "PLATFORM=android npm run common:ci",
-    "test:ci:ios": "pod-install && PLATFORM=ios npm run common:ci",
+    "test:ci:android": "wireit",
+    "test:ci:ios": "wireit",
     "watch:ios": "wireit",
     "watch:catalyst": "wireit",
     "watch:android": "wireit",
@@ -80,6 +80,17 @@
         }
       }
     },
+    "pod-install:ci": {
+      "command": "pod-install",
+      "env": {
+        "USE_HERMES": {
+          "external": true
+        },
+        "RCT_NEW_ARCH_ENABLED": {
+          "external": true
+        }
+      }
+    },
     "common": {
       "command": "mocha-remote --reporter @realm/mocha-reporter --watch $WATCH -- concurrently --kill-others-on-fail npm:metro npm:runner"
     },
@@ -126,6 +137,21 @@
       "env": {
         "PLATFORM": "catalyst",
         "WATCH": "false"
+      }
+    },
+    "test:ci:android": {
+      "command": "npm run common:ci",
+      "env": {
+        "PLATFORM": "android"
+      }
+    },
+    "test:ci:ios": {
+      "command": "npm run common:ci",
+      "dependencies": [
+        "pod-install:ci"
+      ],
+      "env": {
+        "PLATFORM": "ios"
       }
     },
     "watch:android": {

--- a/integration-tests/tests/src/node/ssl.ts
+++ b/integration-tests/tests/src/node/ssl.ts
@@ -39,10 +39,13 @@ import { buildAppConfig } from "../utils/build-app-config";
 import { closeRealm } from "../utils/close-realm";
 import { createPromiseHandle } from "../utils/promise-handle";
 import { importAppBefore } from "../hooks";
+import { baseUrl } from "../utils/import-app";
 
 // IMPORTANT:
 // * Can only run on non-Apple machines, otherwise tests will await forever.
-describe.skipIf(platform() === "darwin" || environment.missingServer, "SSL Configuration", function () {
+// * Can only run if the baseUrl points to a server using TLS / HTTPs.
+const missingTLS = baseUrl.startsWith("http://");
+describe.skipIf(platform() === "darwin" || environment.missingServer || missingTLS, "SSL Configuration", function () {
   this.longTimeout();
   importAppBefore(buildAppConfig("with-flx").anonAuth().flexibleSync());
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,9 @@
         "chalk": "^4.1.2",
         "dotenv": "^16.0.2",
         "yargs": "^17.7.2"
+      },
+      "bin": {
+        "baas-test-server": "cli.ts"
       }
     },
     "integration-tests/baas-test-server/node_modules/dotenv": {
@@ -2778,7 +2781,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
       "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "dev": true,
       "dependencies": {
         "@chevrotain/gast": "10.5.0",
         "@chevrotain/types": "10.5.0",
@@ -2789,7 +2791,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
       "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "dev": true,
       "dependencies": {
         "@chevrotain/types": "10.5.0",
         "lodash": "4.17.21"
@@ -2798,20 +2799,17 @@
     "node_modules/@chevrotain/types": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "dev": true
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
     },
     "node_modules/@chevrotain/utils": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "dev": true
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
     },
     "node_modules/@commander-js/extra-typings": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-10.0.3.tgz",
       "integrity": "sha512-OIw28QV/GlP8k0B5CJTRsl8IyNvd0R8C8rfo54Yz9P388vCNDgdNrFlKxZTGqps+5j6lSw3Ss9JTQwcur1w1oA==",
-      "dev": true,
       "peerDependencies": {
         "commander": "10.0.x"
       }
@@ -2820,7 +2818,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2832,7 +2829,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -6331,26 +6327,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8015,8 +8007,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9149,7 +9140,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -9186,7 +9176,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -9269,7 +9258,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "dependencies": {
         "camel-case": "^4.1.2",
         "capital-case": "^1.0.4",
@@ -9317,7 +9305,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
       "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "dev": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "10.5.0",
         "@chevrotain/gast": "10.5.0",
@@ -9950,7 +9937,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -10275,7 +10261,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -11174,8 +11159,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -11954,7 +11938,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -14581,7 +14564,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
@@ -18659,7 +18641,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -18724,8 +18705,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -20026,7 +20006,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -21446,7 +21425,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -21511,7 +21489,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -21535,7 +21512,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -21544,8 +21520,7 @@
     "node_modules/path-equal": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
-      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
-      "dev": true
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g=="
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -23252,8 +23227,7 @@
     "node_modules/regexp-to-ast": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "dev": true
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -23874,7 +23848,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -24046,7 +24019,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -24435,7 +24407,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -25602,7 +25573,6 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -25645,7 +25615,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -25654,7 +25623,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -25919,7 +25887,6 @@
       "version": "0.55.0",
       "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.55.0.tgz",
       "integrity": "sha512-BXaivYecUdiXWWNiUqXgY6A9cMWerwmhtO+lQE7tDZGs7Mf38sORDeQZugfYOZOHPZ9ulsD+w0LWjFDOQoXcwg==",
-      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/node": "^16.9.2",
@@ -25937,14 +25904,12 @@
     "node_modules/typescript-json-schema/node_modules/@types/node": {
       "version": "16.18.70",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-      "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg==",
-      "dev": true
+      "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
     },
     "node_modules/typescript-json-schema/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -25964,7 +25929,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -25976,7 +25940,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26177,7 +26140,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -26186,7 +26148,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -26268,8 +26229,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -27276,7 +27236,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -28039,7 +27998,7 @@
         "@types/lodash-es": "^4.17.6",
         "@types/react": "^18.2.6",
         "babel-jest": "^29.6.3",
-        "babel-plugin-module-resolver": "5.0.0",
+        "babel-plugin-module-resolver": "^5.0.0",
         "fb-watchman": "^2.0.1",
         "jest": "^29.6.3",
         "prettier": "2.8.8",
@@ -29648,7 +29607,6 @@
     "packages/realm/bindgen/vendor/realm-core": {
       "name": "@realm/bindgen",
       "version": "0.1.0",
-      "dev": true,
       "dependencies": {
         "@commander-js/extra-typings": "^10.0.2",
         "@types/node": "^18.15.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,12 +67,23 @@
       "name": "@realm/baas-test-server",
       "version": "0.1.0",
       "dependencies": {
+        "@actions/core": "^1.10.1",
         "chalk": "^4.1.2",
         "dotenv": "^16.0.2",
+        "p-wait-for": "^5.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
         "baas-test-server": "cli.ts"
+      }
+    },
+    "integration-tests/baas-test-server/node_modules/@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "integration-tests/baas-test-server/node_modules/dotenv": {
@@ -595,7 +606,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
       "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
-      "dev": true,
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -3566,7 +3576,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
       "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -21398,12 +21407,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-wait-for": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-5.0.2.tgz",
+      "integrity": "sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==",
+      "dependencies": {
+        "p-timeout": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-hash": {
@@ -25678,7 +25712,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -25983,7 +26016,6 @@
       "version": "5.28.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
       "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
-      "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },


### PR DESCRIPTION
## What, How & Why?

This updates the private `@realm/baas-test-server` with `baasaas` sub-commands to start, stop and list containers. The existing docker-based server is moved to a new `docker` command. Invoking the two commands are documented in the README.md of the package.

This PR also creates a JavaScript -based action, invoking the `baas-test-server` CLI (provided by our `@realm/baas-test-server` package) to start and stop the server. I had to use a "node20" action, instead of a "composite", because the latter doesn't support a "post" step, which we need to stop the server as the job ends.

I also wrote a type-safe TypeScript client for the BaaSaaS service, for good measure.