### PR TITLE
Remove `fs-extra`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * File format: generates Realms with format v23 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
 
 ### Internal
+* Removed any use of `fs-extra`.
 <!-- * Either mention core version or upgrade -->
 <!-- * Using Realm Core vX.Y.Z -->
 <!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -141,7 +141,7 @@ Because of limitations (see below), we need to explicitly require in the files d
 Because we want our tests to run in many environments, we've a limited runtime available. Tests have access to the following globals:
 
 - [the Mocha hook globals](https://mochajs.org/#hooks) (describe, it, after, before, etc.).
-- `fs` the lowest common denominator of the [`fs-extra`](https://www.npmjs.com/package/fs-extra) and [`react-native-fs`](https://www.npmjs.com/package/react-native-fs) APIs.
+- `fs` the lowest common denominator of the [`node:fs`](https://nodejs.org/api/fs.html) and [`react-native-fs`](https://www.npmjs.com/package/react-native-fs) APIs.
 - `path` the lowest common denominator of the Node.js path interface and a [node-independent implementation of Node's path](https://www.npmjs.com/package/path-browserify) module.
 - `it.skipIf` and `describe.skipIf` skips tests based on the environment, see `tests/src/utils/skip-if.ts` for a detailed explanation.
 

--- a/integration-tests/environments/electron/app/mocha.js
+++ b/integration-tests/environments/electron/app/mocha.js
@@ -29,8 +29,8 @@ const client = new Client({
   tests(context) {
     console.log("Loading tests!");
     // Set the Realm global for the tests to use
-    global.fs = require("fs-extra");
-    global.path = require("path");
+    global.fs = require("node:fs");
+    global.path = require("node:path");
     global.environment = {
       ...context,
       electron: processType,

--- a/integration-tests/environments/electron/package.json
+++ b/integration-tests/environments/electron/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@electron/remote": "^2.0.9",
     "@realm/integration-tests": "*",
-    "fs-extra": "^9.1.0",
     "mocha-remote-client": "^1.8.0",
     "@realm/app-importer": "*"
   },

--- a/integration-tests/environments/node/index.cjs
+++ b/integration-tests/environments/node/index.cjs
@@ -16,10 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+const fs = require("node:fs");
 const os = require("node:os");
+const path = require("node:path");
 const { Client } = require("mocha-remote-client");
-const fs = require("fs-extra");
-const path = require("path");
 const v8 = require("v8");
 const vm = require("vm");
 

--- a/integration-tests/environments/node/index.mjs
+++ b/integration-tests/environments/node/index.mjs
@@ -16,10 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 import { Client } from "mocha-remote-client";
-import fs from "fs-extra";
-import path from "path";
 
 import v8 from "node:v8";
 import vm from "node:vm";

--- a/integration-tests/environments/react-native/README.md
+++ b/integration-tests/environments/react-native/README.md
@@ -204,7 +204,7 @@ Install additional dependencies:
 ```bash
 cd react-native
 npm install mocha mocha-junit-reporter mocha-remote-client react-native-fs path-browserify @react-native-community/art react-native-progress
-npm install mocha-remote-server fs-extra promise-timeout --save-dev
+npm install mocha-remote-server promise-timeout --save-dev
 ```
 
 Open the `package.json` of both `react-native` and `react-native-backup`:

--- a/integration-tests/tests/src/node/analytics.ts
+++ b/integration-tests/tests/src/node/analytics.ts
@@ -24,7 +24,7 @@ import { fileURLToPath } from "url";
 import { expect } from "chai";
 import { collectPlatformData } from "realm/scripts/submit-analytics";
 
-import fse from "fs-extra";
+import fs from "fs";
 
 // emulate old __dirname: https://flaviocopes.com/fix-dirname-not-defined-es-module-scope/
 const __filename = fileURLToPath(import.meta.url);
@@ -39,7 +39,7 @@ describe("Analytics", () => {
 
   function getRealmVersion() {
     const packageJsonPath = path.resolve(__dirname, "../../../../packages/realm/package.json");
-    const packageJson = fse.readJsonSync(packageJsonPath);
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
     return packageJson["version"];
   }
 

--- a/packages/realm-app-importer/package.json
+++ b/packages/realm-app-importer/package.json
@@ -48,13 +48,11 @@
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "deepmerge": "^4.2.2",
-    "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
     "yargs": "^17.6.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.2",
-    "@types/fs-extra": "^9.0.13",
     "@types/glob": "^8.0.0",
     "@types/yargs": "^17.0.13"
   }

--- a/packages/realm-web-integration-tests/package.json
+++ b/packages/realm-web-integration-tests/package.json
@@ -46,12 +46,10 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
-    "@types/fs-extra": "^9.0.13",
     "@types/mocha": "^8",
     "@types/puppeteer": "^5.4.6",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.17.0",
-    "fs-extra": "^10.1.0",
     "html-webpack-plugin": "^5.5.0",
     "mongodb-realm-cli": "^1.3.2",
     "source-map-loader": "^4.0.2",

--- a/packages/realm-web-integration-tests/tsconfig.json
+++ b/packages/realm-web-integration-tests/tsconfig.json
@@ -12,7 +12,6 @@
 			"mocha",
 			"puppeteer",
 			"realm-web",
-			"fs-extra",
 			"mocha-remote-client",
 			"jwt-encode"
 		],

--- a/packages/realm-web/package.json
+++ b/packages/realm-web/package.json
@@ -91,11 +91,9 @@
   "devDependencies": {
     "@realm/fetch": "^0.1.0",
     "@types/chai": "^4.2.9",
-    "@types/fs-extra": "^8.1.0",
     "@types/js-base64": "^3.3.1",
     "@types/mocha": "^10.0.6",
     "chai": "4.3.6",
-    "fs-extra": "^10.0.0",
     "mocha": "^10.2.0"
   },
   "engines": {

--- a/packages/realm-web/scripts/postversion.ts
+++ b/packages/realm-web/scripts/postversion.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import fs from "fs-extra";
+import fs from "node:fs";
 import path from "path";
 import cp from "child_process";
 


### PR DESCRIPTION
## What, How & Why?

As an alternative to #6373, this removes all use of the `fs-extra` package.
We weren't actually using it in ways that couldn't easily be replaced by `node:fs`, so I think we should just avoid it to simplify things and get one less dependency.

## In draft

It turns out that since `exists` doesn't return a `Promise` when called from `node:fs`, the libraries cannot be easily replaced, I think we should rethink the way we provide `fs` and `path` implementations to the tests: https://github.com/realm/realm-js/issues/6408

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
