### PR TITLE
Removing `concurrently` as dependency from a few packages

### DIFF
--- a/integration-tests/environments/electron/package.json
+++ b/integration-tests/environments/electron/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@realm/mocha-reporter": "*",
     "command-line-args": "^5.2.1",
-    "concurrently": "^8.0.1",
     "electron": "^24.1.2",
     "electron-builder": "^24.9.1",
     "mocha-github-actions-reporter": "^0.3.0",

--- a/integration-tests/environments/node/package.json
+++ b/integration-tests/environments/node/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@realm/app-importer": "*",
     "@realm/mocha-reporter": "*",
-    "cmake-js": "^6.1.0",
-    "concurrently": "^6.0.2"
+    "cmake-js": "^6.1.0"
   }
 }

--- a/integration-tests/tests/package.json
+++ b/integration-tests/tests/package.json
@@ -77,7 +77,6 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/jsrsasign": "^10.5.4",
     "@types/mocha": "^10.0.0",
-    "concurrently": "^6.5.1",
     "mocha": "^10.1.0",
     "nyc": "^15.1.0",
     "platform": "^1.3.6",
@@ -87,7 +86,6 @@
     "@thi.ng/bench": "^3.1.16",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.1",
-    "concurrently": "^6.0.2",
     "jsrsasign": "^11.0.0",
     "node-fetch": "^3.3.2"
   },


### PR DESCRIPTION
## What, How & Why?

Now that the app importer is no longer a CLI, we had unused dependencies on `concurrently`.
