### PR TITLE
Update `pr-coverage.yml` to run only on changes to sourcefiles on PRs

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,5 +1,12 @@
 name: Test Coverage
-on: ["push", "pull_request"]
+on:
+  pull_request:
+    paths:
+      # Trigger only when files affecting coverage has changed
+      - "**.ts"
+      - "**.js"
+      # Or the workflow itself
+      - ".github/workflows/pr-coverage.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What, How & Why?

I believe it's only interesting to run this when PRs are opened/updated targeting source-files, instead of any push to any branch.
