### PR TITLE
revert arguments when call callFunctionOnService to spread variable

### DIFF
--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -289,7 +289,7 @@ export class User<
    * await doThing(a2);
    */
   callFunction(name: string, ...args: unknown[]): Promise<unknown> {
-    return this.callFunctionOnService(name, undefined, args);
+    return this.callFunctionOnService(name, undefined, ...args);
   }
 
   /** @internal */


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->
in version 12+, the User function called from the client always sends arguments wrapped in Array,
I compare the code with version 11+ and found out that function `callFunction` pass the `args` to next function `callFunctionOnService` as a single array argument instead of spread arguments

This should resolve [#6447 <!-- link to an existing issue -->](https://github.com/realm/realm-js/issues/6447)

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
