### PR TITLE
Fixed `User#callFunction` arguments, passing them correctly to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fixed `User#callFunction` to correctly pass arguments to the server. Previously they would be sent as an array, so if your server-side function used to handle the unwrapping of arguments, it would need an update too. The "functions factory" pattern of calling `user.functions.sum(1, 2, 3)` wasn't affected by this bug. Thanks to @deckyfx for finding this and suggesting the fix! ([#6447](https://github.com/realm/realm-js/issues/6447), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/sync/user.ts
+++ b/integration-tests/tests/src/tests/sync/user.ts
@@ -643,7 +643,7 @@ describe.skipIf(environment.missingServer, "User", () => {
           private: false,
           source: `
             exports = function (...args) {
-              return parseInt(args.reduce((a, b) => a + b, 0));
+              return args.reduce((a, b) => a + b, 0);
             };
           `,
         }),

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -289,13 +289,12 @@ export class User<
    * await doThing(a2);
    */
   callFunction(name: string, ...args: unknown[]): Promise<unknown> {
-    return this.callFunctionOnService(name, undefined, args);
+    return this.callFunctionOnService(name, undefined, ...args);
   }
 
   /** @internal */
-  callFunctionOnService(name: string, serviceName: string | undefined, ...args: unknown[]): Promise<unknown> {
-    const cleanedArgs = cleanArguments(args);
-    return this.app.internal.callFunction(this.internal, name, cleanedArgs as binding.EJson[], serviceName);
+  async callFunctionOnService(name: string, serviceName: string | undefined, ...args: unknown[]): Promise<unknown> {
+    return this.app.internal.callFunction(this.internal, name, cleanArguments(args), serviceName);
   }
 
   /** @internal */
@@ -307,7 +306,7 @@ export class User<
     const request = this.app.internal.makeStreamingRequest(
       this.internal,
       functionName,
-      cleanArguments(functionArgs) as binding.EJson[],
+      cleanArguments(functionArgs),
       serviceName,
     );
 

--- a/packages/realm/src/app-services/utils.ts
+++ b/packages/realm/src/app-services/utils.ts
@@ -16,11 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { binding } from "src/internal";
+
 /**
  * Remove entries for undefined property values.
  * @internal
  */
-export function cleanArguments(args: unknown[] | unknown): unknown[] | unknown {
+export function cleanArguments(args: unknown[]): binding.EJson[];
+export function cleanArguments(args: unknown): binding.EJson;
+export function cleanArguments(args: unknown[] | unknown) {
   if (Array.isArray(args)) {
     // Note: `undefined` elements in the array is not removed.
     return args.map(cleanArguments);


### PR DESCRIPTION
## What, How & Why?

This closes #6447 by correctly spreading in the `args` when calling `callFunctionOnService`.

I also fixed the test that was passing, because we had wrapped the function being tested in a `parseInt`, which sadly coerced the `[123]` into `123`, making the test pass although the code was broken.

Credit for discovering and proposing a fix for the bug goes to @deckyfx - thanks again!

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
