### PR TITLE
Update README.md by moving tiers into our "SUPPORT.md"

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,35 @@ The Realm team is here to help you with your Realm-related issues!
 
 ## Documentation
 
-Before asking questions, please familiarize yourself with our [Node.js](https://www.mongodb.com/docs/realm/sdk/node/) and [React Native](https://www.mongodb.com/docs/realm/sdk/react-native/) documentation. 
+Before asking questions, please familiarize yourself with our [Node.js](https://www.mongodb.com/docs/realm/sdk/node/) and [React Native](https://www.mongodb.com/docs/realm/sdk/react-native/) documentation.
+
+## Tiers
+
+It is exciting to have users, and we want to support you as good as possible. Our community support (Github issues in this and our related repositories) is divided into three tiers, and below you can see which packages, versions and platforms we consider for the different tiers.
+
+If you want to contribute to any of our packages, you are welcome to do so. We will take the time to review your pull request for any package.
+
+### Tier 1 - fully supported
+
+In tier 1 we will respond to issues in a timely manner during workdays from CET timezone, and we will work on bug fixing and adding new features.
+
+* [`realm`](https://www.npmjs.com/package/realm) (NPM tag: `latest`) on node.js (active LTS) and Electron on Windows, MacOS, and Linux
+* [`realm`](https://www.npmjs.com/package/realm) (NPM tag: `latest`) with the latest React Native version 0.71.0 on Android and iOS
+* [`@realm/react`](https://www.npmjs.com/package/@realm/react) (NPM tag: `latest`) in conjunction with the latest [`realm`](https://www.npmjs.com/package/realm) release
+
+### Tier 2 - best effort
+
+Some packages are considered to be mature and stable, and we will support them as good as we can when time permits.
+
+* [`realm-web`](https://www.npmjs.com/package/realm-web) (NPM tag: `latest`)
+* [Realm Studio](https://github.com/realm/realm-studio) ([latest](https://github.com/realm/realm-studio/releases/latest) release) on Windows, MacOS, and Linux
+* Any other release of [`realm`](https://www.npmjs.com/package/realm) not covered by tier 1
+
+### Tier 3 - experimental
+
+The third tier covers our experimental packages. We work on them occasionally, and they are likely to change radically when we do.
+
+* [`@realm/babel-plugin`](https://www.npmjs.com/package/@realm/babel-plugin)
 
 ## MongoDB Developer Community
 

--- a/packages/realm/README.md
+++ b/packages/realm/README.md
@@ -30,34 +30,6 @@ It might help to think of the Realm database as the persistance layer of the Atl
 
 Please see the detailed instructions in our docs to use [Atlas Device SDK for Node.js](https://www.mongodb.com/docs/realm/sdk/node/) and [Atlas Device SDK for React Native](https://www.mongodb.com/docs/realm/sdk/react-native/). Please notice that currently only Node.js version 18 or later is supported. For React Native users, we have a [compatibility matrix](https://github.com/realm/realm-js/blob/HEAD/COMPATIBILITY.md) showing which versions are supported.
 
-## Tiers
-
-It is exciting to have users, and we want to support you as good as possible. Our community support (Github issues in this and our related repositories) is divided into three tiers, and below you can see which packages, versions and platforms we consider for the different tiers.
-
-If you want to contribute to any of our packages, you are welcome to do so. We will take the time to review your pull request for any package.
-
-### Tier 1 - fully supported
-
-In tier 1 we will respond to issues in a timely manner during workdays from CET timezone, and we will work on bug fixing and adding new features.
-
-* [`realm`](https://www.npmjs.com/package/realm) (NPM tag: `latest`) on node.js (active LTS) and Electron on Windows, MacOS, and Linux
-* [`realm`](https://www.npmjs.com/package/realm) (NPM tag: `latest`) with the latest React Native version 0.71.0 on Android and iOS
-* [`@realm/react`](https://www.npmjs.com/package/@realm/react) (NPM tag: `latest`) in conjunction with the latest [`realm`](https://www.npmjs.com/package/realm) release
-
-### Tier 2 - best effort
-
-Some packages are considered to be mature and stable, and we will support them as good as we can when time permits.
-
-* [`realm-web`](https://www.npmjs.com/package/realm-web) (NPM tag: `latest`)
-* [Realm Studio](https://github.com/realm/realm-studio) ([latest](https://github.com/realm/realm-studio/releases/latest) release) on Windows, MacOS, and Linux
-* Any other release of [`realm`](https://www.npmjs.com/package/realm) not covered by tier 1
-
-### Tier 3 - experimental
-
-The third tier covers our experimental packages. We work on them occasionally, and they are likely to change radically when we do.
-
-* [`@realm/babel-plugin`](https://www.npmjs.com/package/@realm/babel-plugin)
-
 ## Documentation
 
 ### Atlas Device SDKs for React Native and Node.js


### PR DESCRIPTION
## What, How & Why?

In conversation with @otso we wanted to clean up the README a bit and one suggestion was to move the support tiers into the SUPPORT.md to make it possible to show code ealier.
