### PR TITLE
Expose configuring BAAS via the CLI

### DIFF
--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -84,7 +84,11 @@ yargs(hideBin(process.argv))
   .command(
     ["docker [githash]"],
     "Runs the BaaS test image using Docker",
-    (yargs) => yargs.positional("githash", { type: "string" }).option("branch", { default: "master" }),
+    (yargs) =>
+      yargs
+        .positional("githash", { type: "string" })
+        .option("branch", { default: "master" })
+        .option("config", { type: "string", coerce: path.resolve }),
     wrapCommand(async (argv) => {
       const { AWS_PROFILE, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = process.env;
       assert(AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY, "Missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY env");
@@ -95,12 +99,22 @@ yargs(hideBin(process.argv))
       docker.ensureNoBaas();
 
       if (argv.githash) {
-        docker.spawnBaaS({ tag: argv.githash, accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY });
+        docker.spawnBaaS({
+          tag: argv.githash,
+          accessKeyId: AWS_ACCESS_KEY_ID,
+          secretAccessKey: AWS_SECRET_ACCESS_KEY,
+          configPath: argv.config,
+        });
       } else {
         const tag = await docker.fetchBaasTag(argv.branch);
         assert(AWS_PROFILE, "Missing AWS_PROFILE env");
         docker.pullBaas({ profile: AWS_PROFILE, tag });
-        docker.spawnBaaS({ tag, accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY });
+        docker.spawnBaaS({
+          tag,
+          accessKeyId: AWS_ACCESS_KEY_ID,
+          secretAccessKey: AWS_SECRET_ACCESS_KEY,
+          configPath: argv.config,
+        });
       }
     }),
   )

--- a/integration-tests/baas-test-server/docker.ts
+++ b/integration-tests/baas-test-server/docker.ts
@@ -118,12 +118,17 @@ export function spawnBaaS({
   tag,
   accessKeyId,
   secretAccessKey,
+  configPath,
 }: {
   tag: string;
   accessKeyId: string;
   secretAccessKey: string;
+  configPath: string | undefined;
 }) {
   console.log("Starting server from tag", chalk.dim(tag));
+  const configOptions = configPath
+    ? ["--mount", `type=bind,source=${configPath},target=/app/test_overwritable_config.json`]
+    : [];
   spawn(chalk.blueBright("baas"), "docker", [
     "run",
     "--name",
@@ -136,6 +141,7 @@ export function spawnBaaS({
     `AWS_SECRET_ACCESS_KEY=${secretAccessKey}`,
     "--publish",
     `${BAAS_PORT}:${BAAS_PORT}`,
+    ...configOptions,
     tag,
   ]);
 }


### PR DESCRIPTION
## What, How & Why?

Once https://github.com/10gen/baas/pull/12773 merge, with this PR we can configure BaaS from the `baas-test-server` CLI.
