### PR TITLE
Disable eslint plugin (no-duplicate-values-in-enum) as Core's PropertyType make use of it.

### DIFF
--- a/packages/realm/.eslintrc.json
+++ b/packages/realm/.eslintrc.json
@@ -6,6 +6,7 @@
   ],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-duplicate-enum-values": "off",
     "no-console": "error",
     "sort-imports": ["warn", { "ignoreDeclarationSort": true }],
     "jsdoc/check-tag-names": "off",


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

A recent upgrade of ESLint is preventing us from building. The root cause is an [enum in Realm Core with a duplicate value](https://github.com/realm/realm-core/blob/master/src/realm/object-store/property.hpp#L42-L67), and the ESLint plugin was enabled in [5.22.0](https://github.com/typescript-eslint/typescript-eslint/blob/v6.0.0/CHANGELOG.md#5220-2022-05-02)

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
