### PR TITLE
Adding more precise detection of Expo Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Added support for using aggregate operations on Mixed properties in queries. ([realm/realm-core#7398](https://github.com/realm/realm-core/pull/7398))
 * Improved file compaction performance on platforms with page sizes greater than 4k (for example arm64 Apple platforms) for files less than 256 pages in size. ([realm/realm-core#7492](https://github.com/realm/realm-core/pull/7492))
 * Added the ability to set the log level for one or more categories via `Realm.setLogLevel`. ([#6560](https://github.com/realm/realm-js/issues/6560))
+* Added detection and better instructions when imported from the Expo Go app. ([#6523](https://github.com/realm/realm-js/pull/6523))
 
 ### Fixed
 * Aligned Dictionaries to Lists and Sets when they get cleared. ([#6205](https://github.com/realm/realm-core/issues/6205), since v10.3.0-rc.1)

--- a/packages/realm/src/platform/react-native/expo-go-detection.ts
+++ b/packages/realm/src/platform/react-native/expo-go-detection.ts
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Platform } from "react-native";
+
+export function isExpoGo() {
+  try {
+    // @ts-expect-error - This depends on unstable Expo implementation details
+    return typeof expo === "object" && expo.modules?.ExponentConstants?.executionEnvironment === "storeClient";
+  } catch {
+    return false;
+  }
+}
+
+export class RealmInExpoGoError extends Error {
+  constructor() {
+    const runCommand = `npx expo run:${Platform.OS}`;
+    super(
+      `'realm' was imported from the Expo Go app, but unfortunately Expo Go doesn't contain the native module for the 'realm' package - consider using an Expo development build instead:\n\nnpm install expo-dev-client\n${runCommand}\n\nRead more: https://docs.expo.dev/develop/development-builds/introduction/`,
+    );
+  }
+}
+
+if (isExpoGo()) {
+  throw new RealmInExpoGoError();
+}

--- a/packages/realm/src/platform/react-native/index.ts
+++ b/packages/realm/src/platform/react-native/index.ts
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import "./expo-go-detection";
 import "./binding";
 import "./fs";
 import "./device-info";


### PR DESCRIPTION
## What, How & Why?

Many newcomers to Realm and Expo gets confused about the fact that Expo Go doesn't ship with native modules.
Instead of showing a generic error when failing to load our native module, I suggest adding an attempt to detect Expo Go and showing a more direct message, with actionable steps:

<img width="516" alt="Screenshot 2024-03-01 at 21 57 20" src="https://github.com/realm/realm-js/assets/1243959/d867abfb-1176-4c63-b976-d2a21f5b1770">


## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests (manually)
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
