### PR TITLE
RJS-2673: Prevent flickering behavior in `RealmProvider`

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 * Removed race condition in `useObject` ([#6291](https://github.com/realm/realm-js/issues/6291)) Thanks [@bimusik](https://github.com/bimusiek)!
+* Fixed flickering of the `RealmProvider`'s `fallback` component and its `children` when offline. ([#6333](https://github.com/realm/realm-js/issues/6333))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useReducer, useState } from "react";
 import type Realm from "realm";
 
 import { useApp } from "./AppProvider";
@@ -35,6 +35,21 @@ type UserProviderProps = {
   children: React.ReactNode;
 };
 
+function userWasUpdated(userA: Realm.User | null, userB: Realm.User | null) {
+  if (!userA && !userB) {
+    return false;
+  } else if (userA && userB) {
+    return (
+      userA.id !== userB.id ||
+      userA.state !== userB.state ||
+      userA.accessToken !== userB.accessToken ||
+      userA.refreshToken !== userB.refreshToken
+    );
+  } else {
+    return true;
+  }
+}
+
 /**
  * React component providing a Realm user on the context for the sync hooks
  * to use. A `UserProvider` is required for an app to use the hooks.
@@ -42,37 +57,30 @@ type UserProviderProps = {
 export const UserProvider: React.FC<UserProviderProps> = ({ fallback: Fallback, children }) => {
   const app = useApp();
   const [user, setUser] = useState<Realm.User | null>(() => app.currentUser);
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
   // Support for a possible change in configuration
-  if (app.currentUser?.id != user?.id) {
-    setUser(app.currentUser);
+  const currentUser = app.currentUser;
+  if (userWasUpdated(user, currentUser)) {
+    setUser(currentUser);
   }
 
   useEffect(() => {
-    const event = () => {
-      let userHasChanged = false;
-      const currentUser = app.currentUser;
-      if (currentUser && user) {
-        userHasChanged =
-          currentUser.id !== user.id ||
-          currentUser.state !== user.state ||
-          currentUser.accessToken !== user.accessToken ||
-          currentUser.refreshToken !== currentUser.refreshToken;
-      } else if (currentUser || user) {
-        userHasChanged = true;
-      }
+    app.addListener(forceUpdate);
 
-      if (userHasChanged) {
-        setUser(app.currentUser);
-      }
-    };
-    user?.addListener(event);
-    app?.addListener(event);
-    return () => {
-      user?.removeListener(event);
-      app?.removeListener(event);
-    };
-  }, [user, app]);
+    return () => app.removeListener(forceUpdate);
+  }, [app]);
+
+  useEffect(() => {
+    user?.addListener(forceUpdate);
+
+    return () => user?.removeListener(forceUpdate);
+
+    /*
+      eslint-disable-next-line react-hooks/exhaustive-deps
+      -- We should depend on `user.id` rather than `user` as the ID will indicate a new user in this case.
+    */
+  }, [user?.id]);
 
   if (!user) {
     if (typeof Fallback === "function") {

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -59,7 +59,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ fallback: Fallback, 
   const [user, setUser] = useState<Realm.User | null>(() => app.currentUser);
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
-  // Support for a possible change in configuration
+  // Support for a possible change in configuration.
+  // Do the check here rather than in a `useEffect()` so as to not render stale state. This allows
+  // for the rerender to restart without also having to rerender the children using the stale state.
   const currentUser = app.currentUser;
   if (userWasUpdated(user, currentUser)) {
     setUser(currentUser);

--- a/packages/realm-react/src/UserProvider.tsx
+++ b/packages/realm-react/src/UserProvider.tsx
@@ -50,7 +50,21 @@ export const UserProvider: React.FC<UserProviderProps> = ({ fallback: Fallback, 
 
   useEffect(() => {
     const event = () => {
-      setUser(app.currentUser);
+      let userHasChanged = false;
+      const currentUser = app.currentUser;
+      if (currentUser && user) {
+        userHasChanged =
+          currentUser.id !== user.id ||
+          currentUser.state !== user.state ||
+          currentUser.accessToken !== user.accessToken ||
+          currentUser.refreshToken !== currentUser.refreshToken;
+      } else if (currentUser || user) {
+        userHasChanged = true;
+      }
+
+      if (userHasChanged) {
+        setUser(app.currentUser);
+      }
     };
     user?.addListener(event);
     app?.addListener(event);

--- a/packages/realm/src/Listeners.ts
+++ b/packages/realm/src/Listeners.ts
@@ -32,7 +32,7 @@ export type ListenersOptions<CallbackType, TokenType, Args extends unknown[]> = 
 
 /** @internal */
 export class Listeners<CallbackType, TokenType, Args extends unknown[] = []> {
-  constructor(private options: ListenersOptions<CallbackType, TokenType, Args>) {}
+  constructor(private readonly options: ListenersOptions<CallbackType, TokenType, Args>) {}
   /**
    * Mapping of registered listener callbacks onto the their token in the bindings ObjectNotifier.
    */

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -87,15 +87,16 @@ export class User<
   UserProfileDataType extends DefaultUserProfileData = DefaultUserProfileData,
 > {
   /** @internal */
-  public app: App;
+  public readonly app: App;
 
   /** @internal */
-  public internal: binding.SyncUser;
+  public readonly internal: binding.SyncUser;
 
-  // cached version of profile
+  /** @internal */
   private cachedProfile: UserProfileDataType | undefined;
 
-  private listeners = new Listeners<UserChangeCallback, UserListenerToken>({
+  /** @internal */
+  private readonly listeners = new Listeners<UserChangeCallback, UserListenerToken>({
     add: (callback: () => void): UserListenerToken => {
       return this.internal.subscribe(callback);
     },
@@ -123,6 +124,27 @@ export class User<
     this.internal = internal;
     this.app = app;
     this.cachedProfile = undefined;
+
+    Object.defineProperty(this, "listeners", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+    Object.defineProperty(this, "internal", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+    Object.defineProperty(this, "app", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+    Object.defineProperty(this, "cachedProfile", {
+      enumerable: false,
+      configurable: false,
+      writable: true,
+    });
   }
 
   /**


### PR DESCRIPTION
## What, How & Why?

This PR makes the internal fields of `User` non-enumerable in order to hide them during deep comparisons. It also updates the `UserProvider` to only `setUser()` when specific fields change.

A plausible reason for the flickering behavior described in #6333 is:
1. The `user` in `UserProvider` would continuously have its listener added (and removed) (in `v0.6.2`), setting the `user` to a new reference in its listener callback each time.
2. ..causing `RealmProvider` to rerender whenever the `user` is a new reference.
3. ..causing `RealmProvider` to check if the configuration has changed (`!areConfigurationsIdentical()`) and force a rerender if it has. In cases where it should not have changed, the function indicated that it had. The function uses Lodash's `isEqual()` which does a deep comparison that included the `User`'s internal fields as they were still enumerable. For objects with properties being set to functions (e.g. `User.listeners.options`), those will be different references if the user itself is a different reference.
4. ...causing the `useEffect` callback where the Realm is opened and closed in `RealmProvider` to run (setting the `realm` to the opened realm, then to `null` when unmounted). The switch between `realm` and `null` renders either the `children` or the `fallback` respectively. The repeated behavior causes the flickering.

This closes #6333

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
