### PR TITLE
Use `no-jira-ticket` label on PRs created by workflows

### DIFF
--- a/.github/workflows/prepare-package-release.yml
+++ b/.github/workflows/prepare-package-release.yml
@@ -87,3 +87,4 @@ jobs:
           body: An automated PR for next release.
           commit-message: "[${{env.VERSION_PREFIX}}${{ steps.update-changelog.outputs.new-version }}] Bump version"
           token: ${{ secrets.REALM_CI_PAT }}
+          labels: no-jira-ticket

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -43,6 +43,7 @@ jobs:
           commit-message: "[${{ steps.update-changelog.outputs.new-version }}] Bump version"
           token: ${{ secrets.REALM_CI_PAT }}
           assignees: ${{ github.event.sender.login }}
+          labels: no-jira-ticket
 
       - name: Update summary
         run: echo "Created [PR for v${{ steps.update-changelog.outputs.new-version }}](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prepare-templates-release.yml
+++ b/.github/workflows/prepare-templates-release.yml
@@ -37,3 +37,4 @@ jobs:
         draft: false
         body: An automated PR for next react native templates release.
         commit-message: "[${{ steps.update-version.outputs.version }}] Bump version"
+        labels: no-jira-ticket

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -174,6 +174,7 @@ jobs:
         delete-branch: true
         commit-message: Prepare for vNext
         base: ${{ steps.find-pull-request.outputs.base-ref }}
+        labels: no-jira-ticket
 
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -150,6 +150,7 @@ jobs:
         delete-branch: true
         commit-message: Prepare for vNext
         base: ${{ steps.find-pull-request.outputs.base-ref }}
+        labels: no-jira-ticket
 
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@8a13f2645ad8b6ada32f829b2fae9c0955a5265d


### PR DESCRIPTION
## What, How & Why?

This adds `no-jira-ticket` label on PRs created by workflows.
