### PR TITLE
RJS-2764: Replacing "object" overload on `Realm.setLogLevel` with a second optional `category` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Improved performance of RQL queries on a non-linked string property using `>`, `>=`, `<`, `<=` operators and fixed behavior that a null string should be evaluated as less than everything, previously nulls were not matched. ([realm/realm-core#3939](https://github.com/realm/realm-core/issues/3939))
 * Added support for using aggregate operations on Mixed properties in queries. ([realm/realm-core#7398](https://github.com/realm/realm-core/pull/7398))
 * Improved file compaction performance on platforms with page sizes greater than 4k (for example arm64 Apple platforms) for files less than 256 pages in size. ([realm/realm-core#7492](https://github.com/realm/realm-core/pull/7492))
+* Added the ability to pass a category as the second argument to `setLogLevel`. ([#6560](https://github.com/realm/realm-js/issues/6560))
 
 ### Fixed
 * Aligned Dictionaries to Lists and Sets when they get cleared. ([#6205](https://github.com/realm/realm-core/issues/6205), since v10.3.0-rc.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Improved performance of RQL queries on a non-linked string property using `>`, `>=`, `<`, `<=` operators and fixed behavior that a null string should be evaluated as less than everything, previously nulls were not matched. ([realm/realm-core#3939](https://github.com/realm/realm-core/issues/3939))
 * Added support for using aggregate operations on Mixed properties in queries. ([realm/realm-core#7398](https://github.com/realm/realm-core/pull/7398))
 * Improved file compaction performance on platforms with page sizes greater than 4k (for example arm64 Apple platforms) for files less than 256 pages in size. ([realm/realm-core#7492](https://github.com/realm/realm-core/pull/7492))
-* Added the ability to pass a category as the second argument to `setLogLevel`. ([#6560](https://github.com/realm/realm-js/issues/6560))
+* Added the ability to set the log level for one or more categories via `Realm.setLogLevel`. ([#6560](https://github.com/realm/realm-js/issues/6560))
 
 ### Fixed
 * Aligned Dictionaries to Lists and Sets when they get cleared. ([#6205](https://github.com/realm/realm-core/issues/6205), since v10.3.0-rc.1)

--- a/packages/realm/src/Logger.ts
+++ b/packages/realm/src/Logger.ts
@@ -140,22 +140,6 @@ export const LOG_CATEGORIES = [
 export type LogCategory = (typeof LOG_CATEGORIES)[number];
 
 /**
- * Log options to use when setting the log level.
- */
-export type LogOptions = {
-  /**
-   * The log level to be used by the logger.
-   * @default "info"
-   */
-  level: LogLevel;
-  /**
-   * The category to set the log level for. If omitted, the log level
-   * is set for all categories (`"Realm"`).
-   */
-  category?: LogCategory;
-};
-
-/**
  * A callback passed to `Realm.App.Sync.setLogger` when instrumenting the Atlas Device Sync client with a custom logger.
  * @param level - The level of the log entry between 0 and 8 inclusively.
  * Use this as an index into `['all', 'trace', 'debug', 'detail', 'info', 'warn', 'error', 'fatal', 'off']` to get the name of the level.

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -32,7 +32,6 @@ import {
   List,
   LogCategory,
   LogLevel,
-  LogOptions,
   LoggerCallback,
   LoggerCallback1,
   LoggerCallback2,
@@ -112,36 +111,18 @@ export class Realm {
   private static internals = new Set<binding.WeakRef<binding.Realm>>();
 
   /**
-   * Sets the log level across all levels.
+   * Sets the log level.
    * @param level - The log level to be used by the logger. The default value is `info`.
+   * @param category - The category to set the log level for. If omitted, the log level is set for all categories (`"Realm"`).
    * @note The log level can be changed during the lifetime of the application.
    * @since 12.0.0
    * @example
    * Realm.setLogLevel("all");
    */
-  static setLogLevel(level: LogLevel): void;
-
-  /**
-   * Sets the log level for a specific category.
-   * @param options - The log options to use.
-   * @note The log level can be changed during the lifetime of the application.
-   * @since 12.7.0
-   * @example
-   * Realm.setLogLevel({ category: "Realm", level: "all" });
-   */
-  static setLogLevel(options: LogOptions): void;
-  static setLogLevel(arg: LogLevel | LogOptions) {
-    const setLevel = (level: LogLevel, category = "Realm") => {
-      assert(LOG_CATEGORIES.includes(category as LogCategory), `Unexpected log category: '${category}'`);
-      const categoryRef = binding.LogCategoryRef.getCategory(category);
-      categoryRef.setDefaultLevelThreshold(toBindingLoggerLevel(level));
-    };
-
-    if (typeof arg === "string") {
-      setLevel(arg);
-    } else {
-      setLevel(arg.level, arg.category);
-    }
+  static setLogLevel(level: LogLevel, category: LogCategory = "Realm"): void {
+    assert(LOG_CATEGORIES.includes(category as LogCategory), `Unexpected log category: '${category}'`);
+    const categoryRef = binding.LogCategoryRef.getCategory(category);
+    categoryRef.setDefaultLevelThreshold(toBindingLoggerLevel(level));
   }
 
   /**


### PR DESCRIPTION
## What, How & Why?

This closes #6560.

Although this breaks the API of the method, this as only ever been released in an `rc` release (namely [v12.7.0-rc.0](https://github.com/realm/realm-js/releases/tag/v12.7.0-rc.0)), which are exempted from semantic versioning.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
