### PR TITLE
Replacing `changelog-header.sh` with a TypeScript equivalent

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -161,7 +161,6 @@ jobs:
       continue-on-error: true
 
     - name: Update Changelog
-      working-directory: 
       run: npm run prepend-changelog-header -- ${{ github.workspace }}/${{ env.PACKAGE_PATH }}/CHANGELOG.md
 
     - name: Create vNext PR

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -161,8 +161,8 @@ jobs:
       continue-on-error: true
 
     - name: Update Changelog
-      working-directory: ${{ github.workspace }}/${{ env.PACKAGE_PATH }}
-      run: ${{ github.workspace }}/scripts/changelog-header.sh
+      working-directory: 
+      run: npm run prepend-changelog-header -- ${{ github.workspace }}/${{ env.PACKAGE_PATH }}/CHANGELOG.md
 
     - name: Create vNext PR
       id: vnext-pr

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -138,7 +138,7 @@ jobs:
       continue-on-error: true
 
     - name: Update Changelog
-      run: ${{ github.workspace }}/scripts/changelog-header.sh
+      run: npm run prepend-changelog-header
 
     - name: Create vNext PR
       id: vnext-pr

--- a/CHANGELOG.header.md
+++ b/CHANGELOG.header.md
@@ -1,9 +1,3 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-CHANGELOG=$(cat <<EOF
 ## vNext (TBD)
 
 ### Deprecations
@@ -25,9 +19,3 @@ CHANGELOG=$(cat <<EOF
 <!-- * Either mention core version or upgrade -->
 <!-- * Using Realm Core vX.Y.Z -->
 <!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
-
-$(cat CHANGELOG.md)
-EOF
-)
-
-echo "$CHANGELOG" > CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "wireit",
     "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
     "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
-    "clean": "git clean -fdx -e node_modules -e .env"
+    "clean": "git clean -fdx -e node_modules -e .env",
+    "prepend-changelog-header": "tsx scripts/prepend-changelog-header.ts"
   },
   "wireit": {
     "build": {

--- a/scripts/prepend-changelog-header.ts
+++ b/scripts/prepend-changelog-header.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const headerPath = path.resolve(__dirname, "../CHANGELOG.header.md");
+const header = fs.readFileSync(headerPath, "utf8").trim();
+
+const changelogPathInput = process.argv[2] || path.resolve(__dirname, "../CHANGELOG.md");
+const changelogPath = path.resolve(changelogPathInput);
+
+console.log(`Prepending header to ${changelogPath}`);
+const changelog = fs.readFileSync(changelogPath, "utf8");
+const prependedChangelog = header + "\n\n" + changelog;
+fs.writeFileSync(changelogPath, prependedChangelog, "utf8");


### PR DESCRIPTION
## What, How & Why?

Running the bash script locally errored with:

```
❯ ./scripts/changelog-header.sh
./scripts/changelog-header.sh: line 6: unexpected EOF while looking for matching `)'
```

Instead of spending time debugging it, I rewrote it in TypeScript.
