### PR TITLE
RJS-2727: Re-using anonymous users by default in `realm-web`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "rollup-plugin-dts": "^6.1.0",
         "rollup-plugin-istanbul": "^5.0.0",
         "rollup-plugin-node-builtins": "^2.1.2",
-        "tsx": "^4.7.0",
+        "tsx": "^4.7.2",
         "typedoc": "^0.25.7",
         "typescript": "5.0.4",
         "wireit": "^0.14.4"
@@ -236,9 +236,6 @@
         "react-native-test-app": "^3.2.16",
         "react-test-renderer": "18.2.0",
         "typescript": "5.0.4"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "integration-tests/environments/react-native-test-app/node_modules/mkdirp": {
@@ -24046,9 +24043,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsx": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.0.tgz",
-      "integrity": "sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.2.tgz",
+      "integrity": "sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==",
       "dependencies": {
         "esbuild": "~0.19.10",
         "get-tsconfig": "^4.7.2"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-istanbul": "^5.0.0",
     "rollup-plugin-node-builtins": "^2.1.2",
-    "tsx": "^4.7.0",
+    "tsx": "^4.7.2",
     "typedoc": "^0.25.7",
     "typescript": "5.0.4",
     "wireit": "^0.14.4"

--- a/packages/realm-web-integration-tests/src/app.test.ts
+++ b/packages/realm-web-integration-tests/src/app.test.ts
@@ -55,7 +55,7 @@ describe("App#constructor", () => {
 
   it("can log in two users, switch between them and log out", async () => {
     const app = createApp();
-    const credentials = Credentials.anonymous();
+    const credentials = Credentials.anonymous(false);
     // Authenticate the first user
     const user1 = await app.logIn(credentials);
     expect(app.currentUser).equals(user1);

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## vNext (TBD)
 
+### Breaking Changes
+* Logging in with `Credentials.anonymous()` credentials will reuse any existing anonymous user which is already authenticated with the app. This will result in less users being created. Use `Credentials.anonymous(false)` to disable this behaviour and achieve the old behaviour of creating new anonymous users on every login. ([#6592](https://github.com/realm/realm-js/pull/6592))
+
 ### Deprecations
 * None
 

--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## vNext (TBD)
 
-### Breaking Changes
-* Logging in with `Credentials.anonymous()` credentials will reuse any existing anonymous user which is already authenticated with the app. This will result in less users being created. Use `Credentials.anonymous(false)` to disable this behaviour and achieve the old behaviour of creating new anonymous users on every login. ([#6592](https://github.com/realm/realm-js/pull/6592))
-
 ### Deprecations
 * None
 
@@ -11,6 +8,7 @@
 
 ### Fixed
 * Fixed an endless loop of requests that would happen if linking credentials failed due to an authentication failure. ([#6588](https://github.com/realm/realm-js/pull/6588), since v0.6.0)
+* Logging in with `Credentials.anonymous()` credentials will now reuse any existing anonymous user which is already authenticated with the app. This aligns with the behaviour of the `realm` package and will result in less users being created. Use `Credentials.anonymous(false)` to disable this behaviour and achieve the old behaviour of creating new anonymous users on every login. ([#6592](https://github.com/realm/realm-js/pull/6592))
 
 ### Internal
 * None

--- a/packages/realm-web/src/App.ts
+++ b/packages/realm-web/src/App.ts
@@ -202,6 +202,18 @@ export class App<
     credentials: Credentials,
     fetchProfile = true,
   ): Promise<User<FunctionsFactoryType, CustomDataType>> {
+    if (credentials.reuse) {
+      // TODO: Consider exposing providerName on "User" and match against that instead?
+      const existingUser = this.users.find((user) => user.providerType === credentials.providerType);
+      if (existingUser) {
+        this.switchUser(existingUser);
+        // If needed, fetch and set the profile on the user
+        if (fetchProfile) {
+          await existingUser.refreshProfile();
+        }
+        return existingUser;
+      }
+    }
     const response = await this.authenticator.authenticate(credentials);
     const user = this.createOrUpdateUser(response, credentials.providerType);
     // Let's ensure this will be the current user, in case the user object was reused.

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -961,4 +961,34 @@ describe("App", () => {
       expect(refreshToken).equals("gilfoyles-forth-refresh-token");
     }
   });
+
+  it("will reuse anonymous users by default and avoid it when asked not to", async () => {
+    const fetch = createMockFetch([
+      LOCATION_RESPONSE,
+      {
+        user_id: "alices-id",
+        access_token: "alices-access-token",
+        refresh_token: "alices-refresh-token",
+        device_id: "000000000000000000000000",
+      },
+      {
+        user_id: "bobs-id",
+        access_token: "bobs-access-token",
+        refresh_token: "bobs-refresh-token",
+        device_id: "000000000000000000000000",
+      },
+    ]);
+    const app = new App({
+      id: "my-mocked-app",
+      storage: new MemoryStorage(),
+      fetch,
+      baseUrl: "http://localhost:1337",
+    });
+    const user1 = await app.logIn(Credentials.anonymous(), false);
+    const user2 = await app.logIn(Credentials.anonymous(), false);
+    expect(user2).equals(user1);
+    const user3 = await app.logIn(Credentials.anonymous(false), false);
+    expect(user3).not.equals(user1);
+    expect(user3.id).not.equals(user1.id);
+  });
 });

--- a/packages/realm-web/src/tests/App.test.ts
+++ b/packages/realm-web/src/tests/App.test.ts
@@ -814,7 +814,7 @@ describe("App", () => {
       baseUrl: "http://localhost:1337",
     });
 
-    const credentials = App.Credentials.anonymous();
+    const credentials = App.Credentials.anonymous(false);
     await app1.logIn(credentials, false); // Alice
     await app2.logIn(credentials, false); // Charlie
     const bob = await app1.logIn(credentials, true);


### PR DESCRIPTION
## What, How & Why?

This closes RJS-2727 by adding the optional `reuse` argument to the anonymous credentials.
I've marked this as breaking, since this would previously default to creation of new users on subsequent logins with anonymous credentials.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
