### PR TITLE
RJS-2792: Upgrade to Realm Core v14.5.0

### DIFF
--- a/.github/workflows/pr-linting.yml
+++ b/.github/workflows/pr-linting.yml
@@ -20,5 +20,3 @@ jobs:
         run: npm ci
       - name: Run linting of subpackages
         run: npm run lint
-      - name: Run trunk to lint C++ code
-        run: npm run trunk:check-all

--- a/.github/workflows/pr-linting.yml
+++ b/.github/workflows/pr-linting.yml
@@ -16,10 +16,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      # Install the root package (--ignore-scripts to avoid downloading or building the native module)
       - name: Install root package dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Run linting of subpackages
         run: npm run lint
-      - name: Run linting of C++ code
-        run: npm run lint:cpp
+      - name: Run trunk to lint C++ code
+        run: npm run trunk:check-all

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,25 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.21.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.4.5
+      uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - clang-format@16.0.3
+actions:
+  disabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+  enabled:
+    - trunk-upgrade-available

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,8 +10,8 @@ plugins:
       ref: v1.4.5
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
-runtimes:
-  enabled:
+# runtimes:
+#   enabled:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 > This version bumps the Realm file format to version 24. It is not possible to downgrade to earlier versions. Older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v6.0.0, might not be upgradeable. **Only Realm Studio 15.0.0 or later** will be able to open the new file format.
 
 ### Enhancements
+* The base URL used to communicate with the Atlas App Services was updated changed from "https://realm.mongodb.com" to "https://services.cloud.mongodb.com". ([realm/realm-core#7534](https://github.com/realm/realm-core/pull/7534)).
 * Updated bundled OpenSSL version to 3.2.0. ([realm/realm-core#7303](https://github.com/realm/realm-core/pull/7303))
 * Improved performance of object notifiers with complex schemas by ~20%. ([realm/realm-core#7424](https://github.com/realm/realm-core/pull/7424))
 * Improved performance with very large number of notifiers by ~75%. ([realm/realm-core#7424](https://github.com/realm/realm-core/pull/7424))
@@ -31,6 +32,9 @@
 * Fixed opening a Realm with cached user while offline results in fatal error and session does not retry connection. ([#6554](https://github.com/realm/realm-js/issues/6554) and [#6558](https://github.com/realm/realm-js/issues/6558), since v12.6.0)
 * Fixed sorting order of strings to use standard unicode codepoint order instead of grouping similar English letters together. A noticeable change will be from "aAbBzZ" to "ABZabz". ([realm/realm-core#2573](https://github.com/realm/realm-core/issues/2573))
 * `data` and `string` are now strongly typed for comparisons and queries. This change is especially relevant when querying for a string constant on a Mixed property, as now only strings will be returned. If searching for `data` is desired, then that type must be specified by the constant. In RQL the new way to specify a binary constant is to use `mixed = bin('xyz')` or `mixed = binary('xyz')`. ([realm/realm-core#6407](https://github.com/realm/realm-core/issues/6407))
+
+* Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included) ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536)).
+* Null pointer exception may be triggered when logging out and async commits callbacks not executed ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 > This version bumps the Realm file format to version 24. It is not possible to downgrade to earlier versions. Older files will automatically be upgraded to the new file format. Files created by Realm JavaScript prior to v6.0.0, might not be upgradeable. **Only Realm Studio 15.0.0 or later** will be able to open the new file format.
 
 ### Enhancements
-* The base URL used to communicate with the Atlas App Services was updated changed from "https://realm.mongodb.com" to "https://services.cloud.mongodb.com". ([realm/realm-core#7534](https://github.com/realm/realm-core/pull/7534)).
 * Updated bundled OpenSSL version to 3.2.0. ([realm/realm-core#7303](https://github.com/realm/realm-core/pull/7303))
 * Improved performance of object notifiers with complex schemas by ~20%. ([realm/realm-core#7424](https://github.com/realm/realm-core/pull/7424))
 * Improved performance with very large number of notifiers by ~75%. ([realm/realm-core#7424](https://github.com/realm/realm-core/pull/7424))
@@ -32,7 +31,6 @@
 * Fixed opening a Realm with cached user while offline results in fatal error and session does not retry connection. ([#6554](https://github.com/realm/realm-js/issues/6554) and [#6558](https://github.com/realm/realm-js/issues/6558), since v12.6.0)
 * Fixed sorting order of strings to use standard unicode codepoint order instead of grouping similar English letters together. A noticeable change will be from "aAbBzZ" to "ABZabz". ([realm/realm-core#2573](https://github.com/realm/realm-core/issues/2573))
 * `data` and `string` are now strongly typed for comparisons and queries. This change is especially relevant when querying for a string constant on a Mixed property, as now only strings will be returned. If searching for `data` is desired, then that type must be specified by the constant. In RQL the new way to specify a binary constant is to use `mixed = bin('xyz')` or `mixed = binary('xyz')`. ([realm/realm-core#6407](https://github.com/realm/realm-core/issues/6407))
-
 * Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included). ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536))
 * Null pointer exception may be triggered when logging out and async commits callbacks not executed. ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
 
@@ -42,7 +40,8 @@
 * File format: generates Realms with format v24 (reads and upgrades file format v10 or later).
 
 ### Internal
-* Upgraded Realm Core from v13.26.0 to v14.4.1. ([#6499](https://github.com/realm/realm-js/issues/6499), [#6541](https://github.com/realm/realm-js/issues/6541), [#6568](https://github.com/realm/realm-js/issues/6568), and [#6572](https://github.com/realm/realm-js/issues/6572))
+* The base URL used to communicate with the Atlas App Services was changed from "https://realm.mongodb.com" to "https://services.cloud.mongodb.com". ([realm/realm-core#7534](https://github.com/realm/realm-core/pull/7534)).
+* Upgraded Realm Core from v13.26.0 to v14.5.0. ([#6499](https://github.com/realm/realm-js/issues/6499), [#6541](https://github.com/realm/realm-js/issues/6541), [#6568](https://github.com/realm/realm-js/issues/6568), [#6572](https://github.com/realm/realm-js/issues/6572), and [#6599](https://github.com/realm/realm-js/issues/6599))
 
 ## 12.7.0-rc.0 (2024-03-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@
 * Fixed sorting order of strings to use standard unicode codepoint order instead of grouping similar English letters together. A noticeable change will be from "aAbBzZ" to "ABZabz". ([realm/realm-core#2573](https://github.com/realm/realm-core/issues/2573))
 * `data` and `string` are now strongly typed for comparisons and queries. This change is especially relevant when querying for a string constant on a Mixed property, as now only strings will be returned. If searching for `data` is desired, then that type must be specified by the constant. In RQL the new way to specify a binary constant is to use `mixed = bin('xyz')` or `mixed = binary('xyz')`. ([realm/realm-core#6407](https://github.com/realm/realm-core/issues/6407))
 
-* Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included) ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536)).
-* Null pointer exception may be triggered when logging out and async commits callbacks not executed ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
+* Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included). ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536))
+* Null pointer exception may be triggered when logging out and async commits callbacks not executed. ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@tsconfig/node-lts": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
-        "clang-format": "^1.8.0",
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-flowtype": "^8.0.3",
@@ -121,7 +120,7 @@
       "devDependencies": {
         "@realm/mocha-reporter": "*",
         "command-line-args": "^5.2.1",
-        "electron": "29.1.6",
+        "electron": "^29.1.6",
         "electron-builder": "^24.9.1",
         "mocha-github-actions-reporter": "^0.3.0",
         "mocha-junit-reporter": "^2.2.0",
@@ -7142,7 +7141,8 @@
     "node_modules/async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
@@ -8517,51 +8517,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
-    },
-    "node_modules/clang-format": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
-      "integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
-      "dependencies": {
-        "async": "^3.2.3",
-        "glob": "^7.0.0",
-        "resolve": "^1.1.6"
-      },
-      "bin": {
-        "check-clang-format": "bin/check-clang-format.js",
-        "clang-format": "index.js",
-        "git-clang-format": "bin/git-clang-format"
-      }
-    },
-    "node_modules/clang-format/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/clang-format/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -26480,7 +26435,6 @@
         "chalk": "^4.1.2",
         "change-case": "^4.1.2",
         "chevrotain": "^10.4.0",
-        "clang-format": "^1.8.0",
         "commander": "^11.1.0",
         "debug": "^4.3.4",
         "typescript-json-schema": "^0.55.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-typescript": "^11.1.6",
+        "@trunkio/launcher": "^1.3.0",
         "@tsconfig/node-lts": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
@@ -5275,6 +5276,141 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+    },
+    "node_modules/@trunkio/launcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trunkio/launcher/-/launcher-1.3.0.tgz",
+      "integrity": "sha512-CIehTfjiB905y9SuSMIRKkMv7qV+2jOALau7f1w0kjD14aHZIerT+eSeIzfrp2CTgRTTPAz2MZh+euNmh2Goxg==",
+      "dependencies": {
+        "semver": "^7.5.4",
+        "tar": "^6.2.0",
+        "yaml": "^2.2.0"
+      },
+      "bin": {
+        "trunk": "trunk.js",
+        "trunk_bash": "trunk"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trunkio/launcher/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@tsconfig/node-lts": {
       "version": "20.1.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-typescript": "^11.1.6",
+    "@trunkio/launcher": "^1.3.0",
     "@tsconfig/node-lts": "^20.1.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "bundle": "wireit",
     "lint": "wireit",
     "lint:fix": "wireit",
-    "trunk:check": "trunk check",
-    "trunk:check-all": "trunk check --all",
-    "trunk:fmt": "trunk fmt",
     "clean": "git clean -fdx -e node_modules -e .env",
     "prepend-changelog-header": "tsx scripts/prepend-changelog-header.ts"
   },
@@ -33,13 +30,13 @@
       ]
     },
     "lint": {
-      "command": "npm run lint --workspaces --if-present",
+      "command": "npm run lint --workspaces --if-present && trunk check --all",
       "dependencies": [
         "./packages/babel-plugin:bundle"
       ]
     },
     "lint:fix": {
-      "command": "npm run lint --workspaces --if-present -- --fix",
+      "command": "npm run lint --workspaces --if-present -- --fix && trunk fmt",
       "dependencies": [
         "./packages/babel-plugin:bundle"
       ]

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "bundle": "wireit",
     "lint": "wireit",
     "lint:fix": "wireit",
-    "lint:cpp": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format --dry-run --Werror",
-    "lint:cpp:fix": "find src packages/realm/bindgen/src -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs clang-format -i",
+    "trunk:check": "trunk check",
+    "trunk:check-all": "trunk check --all",
+    "trunk:fmt": "trunk fmt",
     "clean": "git clean -fdx -e node_modules -e .env",
     "prepend-changelog-header": "tsx scripts/prepend-changelog-header.ts"
   },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@tsconfig/node-lts": "^20.1.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
-    "clang-format": "^1.8.0",
     "eslint": "^8.43.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-flowtype": "^8.0.3",

--- a/packages/realm/bindgen/src/eslint-formatter.ts
+++ b/packages/realm/bindgen/src/eslint-formatter.ts
@@ -1,3 +1,0 @@
-import { createCommandFormatter } from "@realm/bindgen/formatter";
-
-export const eslint = createCommandFormatter("eslint", ["npx", "eslint", "--fix", "--format=stylish"]);

--- a/packages/realm/bindgen/src/formatters.ts
+++ b/packages/realm/bindgen/src/formatters.ts
@@ -1,0 +1,4 @@
+import { createCommandFormatter } from "@realm/bindgen/formatter";
+
+export const eslintFormatter = createCommandFormatter("eslint", ["npx", "eslint", "--fix", "--format=stylish"]);
+export const trunkFormatter = createCommandFormatter("trunk", ["npx", "trunk", "fmt", "--force"]);

--- a/packages/realm/bindgen/src/templates/jsi.ts
+++ b/packages/realm/bindgen/src/templates/jsi.ts
@@ -32,7 +32,7 @@ import {
 } from "@realm/bindgen/bound-model";
 
 import { doJsPasses } from "../js-passes";
-import { trunk } from "../trunk-formatter";
+import { trunkFormatter } from "../formatters";
 
 // Code assumes this is a unique name that is always in scope to refer to the jsi::Runtime.
 // Callbacks need to ensure this is in scope. Functions taking Runtime arguments must use this name.
@@ -1058,7 +1058,7 @@ class JsiCppDecls extends CppDecls {
 }
 
 export function generate({ rawSpec, spec, file: makeFile }: TemplateContext): void {
-  const out = makeFile("jsi_init.cpp", trunk);
+  const out = makeFile("jsi_init.cpp", trunkFormatter);
 
   // HEADER
   out(`// This file is generated: Update the spec instead of editing this file directly`);

--- a/packages/realm/bindgen/src/templates/jsi.ts
+++ b/packages/realm/bindgen/src/templates/jsi.ts
@@ -485,8 +485,7 @@ function convertToJsi(addon: JsiAddon, type: Type, expr: string): string {
         case "AsyncResult":
           assert.fail("Should never see AsyncResult here");
       }
-      assert.fail(`unknown template ${type.name}`);
-      break;
+      return assert.fail(`unknown template ${type.name}`);
 
     case "Class":
       assert(!type.sharedPtrWrapped, `should not directly convert from ${type.name} without shared_ptr wrapper`);
@@ -617,8 +616,7 @@ function convertFromJsi(addon: JsiAddon, type: Type, expr: string): string {
         case "std::function":
           return `${type.toCpp()}(${c(inner, expr)})`;
       }
-      assert.fail(`unknown template ${type.name}`);
-      break;
+      return assert.fail(`unknown template ${type.name}`);
 
     case "Class":
       if (type.sharedPtrWrapped) return `*JS_TO_SHARED_${type.name}(_env, ${expr})`;

--- a/packages/realm/bindgen/src/templates/jsi.ts
+++ b/packages/realm/bindgen/src/templates/jsi.ts
@@ -32,7 +32,7 @@ import {
 } from "@realm/bindgen/bound-model";
 
 import { doJsPasses } from "../js-passes";
-import { clangFormat } from "@realm/bindgen/formatter";
+import { trunk } from "../trunk-formatter";
 
 // Code assumes this is a unique name that is always in scope to refer to the jsi::Runtime.
 // Callbacks need to ensure this is in scope. Functions taking Runtime arguments must use this name.
@@ -1060,7 +1060,7 @@ class JsiCppDecls extends CppDecls {
 }
 
 export function generate({ rawSpec, spec, file: makeFile }: TemplateContext): void {
-  const out = makeFile("jsi_init.cpp", clangFormat);
+  const out = makeFile("jsi_init.cpp", trunk);
 
   // HEADER
   out(`// This file is generated: Update the spec instead of editing this file directly`);

--- a/packages/realm/bindgen/src/templates/node-wrapper.ts
+++ b/packages/realm/bindgen/src/templates/node-wrapper.ts
@@ -17,11 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////
 import { TemplateContext } from "@realm/bindgen/context";
 
-import { eslint } from "../eslint-formatter";
+import { eslintFormatter } from "../formatters";
 import { generate as generateBase, generateNativeBigIntSupport } from "./base-wrapper";
 
 export function generate(context: TemplateContext): void {
-  const out = context.file("native.node.mjs", eslint);
+  const out = context.file("native.node.mjs", eslintFormatter);
 
   out("// This file is generated: Update the spec instead of editing this file directly");
 
@@ -46,6 +46,6 @@ export function generate(context: TemplateContext): void {
 
   generateBase(context, out);
 
-  context.file("native.node.d.mts", eslint)("export * from './native'");
-  context.file("native.node.d.cts", eslint)("import * as binding from './native'; export = binding;");
+  context.file("native.node.d.mts", eslintFormatter)("export * from './native'");
+  context.file("native.node.d.cts", eslintFormatter)("import * as binding from './native'; export = binding;");
 }

--- a/packages/realm/bindgen/src/templates/node.ts
+++ b/packages/realm/bindgen/src/templates/node.ts
@@ -417,8 +417,7 @@ function convertToNode(addon: NodeAddon, type: Type, expr: string): string {
         case "AsyncResult":
           assert.fail("Should never see AsyncResult here");
       }
-      assert.fail(`unknown template ${type.name}`);
-      break;
+      return assert.fail(`unknown template ${type.name}`);
 
     case "Class":
       assert(!type.sharedPtrWrapped, `should not directly convert from ${type.name} without shared_ptr wrapper`);
@@ -537,8 +536,7 @@ function convertFromNode(addon: NodeAddon, type: Type, expr: string): string {
         case "std::function":
           return `${type.toCpp()}(${c(inner, expr)})`;
       }
-      assert.fail(`unknown template ${type.name}`);
-      break;
+      return assert.fail(`unknown template ${type.name}`);
 
     case "Class":
       if (type.sharedPtrWrapped) return `*NODE_TO_SHARED_${type.name}(${expr})`;

--- a/packages/realm/bindgen/src/templates/node.ts
+++ b/packages/realm/bindgen/src/templates/node.ts
@@ -32,7 +32,7 @@ import {
 } from "@realm/bindgen/bound-model";
 
 import { doJsPasses } from "../js-passes";
-import { trunk } from "../trunk-formatter";
+import { trunkFormatter } from "../formatters";
 
 // Code assumes this is a unique name that is always in scope to refer to the Napi::Env.
 // Callbacks need to ensure this is in scope. Functions taking Env arguments must use this name.
@@ -917,7 +917,7 @@ class NodeCppDecls extends CppDecls {
 }
 
 export function generate({ rawSpec, spec, file: makeFile }: TemplateContext): void {
-  const out = makeFile("node_init.cpp", trunk);
+  const out = makeFile("node_init.cpp", trunkFormatter);
 
   // HEADER
   out(`// This file is generated: Update the spec instead of editing this file directly`);

--- a/packages/realm/bindgen/src/templates/node.ts
+++ b/packages/realm/bindgen/src/templates/node.ts
@@ -30,9 +30,9 @@ import {
   Pointer,
   Template,
 } from "@realm/bindgen/bound-model";
-import { clangFormat } from "@realm/bindgen/formatter";
 
 import { doJsPasses } from "../js-passes";
+import { trunk } from "../trunk-formatter";
 
 // Code assumes this is a unique name that is always in scope to refer to the Napi::Env.
 // Callbacks need to ensure this is in scope. Functions taking Env arguments must use this name.
@@ -919,7 +919,7 @@ class NodeCppDecls extends CppDecls {
 }
 
 export function generate({ rawSpec, spec, file: makeFile }: TemplateContext): void {
-  const out = makeFile("node_init.cpp", clangFormat);
+  const out = makeFile("node_init.cpp", trunk);
 
   // HEADER
   out(`// This file is generated: Update the spec instead of editing this file directly`);

--- a/packages/realm/bindgen/src/templates/react-native-wrapper.ts
+++ b/packages/realm/bindgen/src/templates/react-native-wrapper.ts
@@ -17,11 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////
 import { TemplateContext } from "@realm/bindgen/context";
 
-import { eslint } from "../eslint-formatter";
+import { eslintFormatter } from "../formatters";
 import { generate as generateBase, generateNativeBigIntSupport } from "./base-wrapper";
 
 export function generate(context: TemplateContext): void {
-  const out = context.file("native.react-native.mjs", eslint);
+  const out = context.file("native.react-native.mjs", eslintFormatter);
 
   out("// This file is generated: Update the spec instead of editing this file directly");
 
@@ -62,6 +62,6 @@ export function generate(context: TemplateContext): void {
 
   generateBase(context, out);
 
-  context.file("native.react-native.d.mts", eslint)("export * from './native'");
-  context.file("native.react-native.d.cts", eslint)("import * as binding from './native'; export = binding;");
+  context.file("native.react-native.d.mts", eslintFormatter)("export * from './native'");
+  context.file("native.react-native.d.cts", eslintFormatter)("import * as binding from './native'; export = binding;");
 }

--- a/packages/realm/bindgen/src/templates/typescript.ts
+++ b/packages/realm/bindgen/src/templates/typescript.ts
@@ -22,7 +22,7 @@ import { TemplateContext } from "@realm/bindgen/context";
 import { Arg, BoundSpec, NamedType, Property, Type } from "@realm/bindgen/bound-model";
 
 import { doJsPasses } from "../js-passes";
-import { eslint } from "../eslint-formatter";
+import { eslintFormatter } from "../formatters";
 
 const PRIMITIVES_MAPPING: Record<string, string> = {
   void: "void",
@@ -151,7 +151,7 @@ export function generate({ rawSpec, spec: boundSpec, file }: TemplateContext): v
 
   const spec = doJsPasses(boundSpec);
 
-  const coreOut = file("core.ts", eslint);
+  const coreOut = file("core.ts", eslintFormatter);
   coreOut("// This file is generated: Update the spec instead of editing this file directly");
 
   coreOut("// Enums");
@@ -175,7 +175,7 @@ export function generate({ rawSpec, spec: boundSpec, file }: TemplateContext): v
     }
   `);
 
-  const out = file("native.d.ts", eslint);
+  const out = file("native.d.ts", eslintFormatter);
   out("// This file is generated: Update the spec instead of editing this file directly");
   out('import { ObjectId, UUID, Decimal128 } from "bson";');
   out("import { Float, Status, ", spec.enums.map((e) => e.name).join(", "), '} from "../dist/core";');

--- a/packages/realm/bindgen/src/trunk-formatter.ts
+++ b/packages/realm/bindgen/src/trunk-formatter.ts
@@ -1,3 +1,0 @@
-import { createCommandFormatter } from "@realm/bindgen/formatter";
-
-export const trunk = createCommandFormatter("trunk", ["npx", "trunk", "fmt", "--force"]);

--- a/packages/realm/bindgen/src/trunk-formatter.ts
+++ b/packages/realm/bindgen/src/trunk-formatter.ts
@@ -1,0 +1,3 @@
+import { createCommandFormatter } from "@realm/bindgen/formatter";
+
+export const trunk = createCommandFormatter("trunk", ["npx", "trunk", "fmt", "--force"]);


### PR DESCRIPTION
## What, How & Why?

This upgrades to Realm Core v14.5.0.

In alignment with https://github.com/realm/realm-core/pull/7554 this removes the root package's dependency on `clang-format`.

Fixes https://github.com/realm/realm-js/issues/6544

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
