### PR TITLE
RJS-2784: Clear internal state to avoid crashes when React Native app is reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * `data` and `string` are now strongly typed for comparisons and queries. This change is especially relevant when querying for a string constant on a Mixed property, as now only strings will be returned. If searching for `data` is desired, then that type must be specified by the constant. In RQL the new way to specify a binary constant is to use `mixed = bin('xyz')` or `mixed = binary('xyz')`. ([realm/realm-core#6407](https://github.com/realm/realm-core/issues/6407))
 * Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included). ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536))
 * Null pointer exception may be triggered when logging out and async commits callbacks not executed. ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
-* Fixed a bug when caused crashes when reloading React Native apps. ([#6579](https://github.com/realm/realm-js/issues/6579), since v12.0.0)
+* Fixed a bug which caused crashes when reloading React Native apps. ([#6579](https://github.com/realm/realm-js/issues/6579), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * `data` and `string` are now strongly typed for comparisons and queries. This change is especially relevant when querying for a string constant on a Mixed property, as now only strings will be returned. If searching for `data` is desired, then that type must be specified by the constant. In RQL the new way to specify a binary constant is to use `mixed = bin('xyz')` or `mixed = binary('xyz')`. ([realm/realm-core#6407](https://github.com/realm/realm-core/issues/6407))
 * Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included). ([realm/realm-core#7536](https://github.com/realm/realm-core/issues/7536))
 * Null pointer exception may be triggered when logging out and async commits callbacks not executed. ([realm/realm-core#7434](https://github.com/realm/realm-core/issues/7434), since v12.6.0)
+* Fixed a bug when caused crashes when reloading React Native apps. ([#6579](https://github.com/realm/realm-js/issues/6579), since v12.0.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1360,6 +1360,10 @@ export namespace Realm {
   export import PushClient = internal.PushClient;
 }
 
-//Set default logger and log level.
+// Clear the internal state to prevent crashes when reloading on React Native
+binding.RealmCoordinator.clearAllCaches();
+binding.App.clearCachedApps();
+
+// Set default logger and log level.
 Realm.setLogger(defaultLogger);
 Realm.setLogLevel(defaultLoggerLevel);

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1360,10 +1360,6 @@ export namespace Realm {
   export import PushClient = internal.PushClient;
 }
 
-// Clear the internal state to prevent crashes when reloading on React Native
-binding.RealmCoordinator.clearAllCaches();
-binding.App.clearCachedApps();
-
 // Set default logger and log level.
 Realm.setLogger(defaultLogger);
 Realm.setLogLevel(defaultLoggerLevel);

--- a/packages/realm/src/platform/react-native/index.ts
+++ b/packages/realm/src/platform/react-native/index.ts
@@ -22,9 +22,11 @@ import "./fs";
 import "./device-info";
 import "./sync-proxy-config";
 
+import { Realm } from "../../Realm";
+import { binding } from "../binding";
+
 // Clear the internal state to prevent crashes when reloading the app
 binding.RealmCoordinator.clearAllCaches();
 binding.App.clearCachedApps();
 
-import { Realm } from "../../Realm";
 export = Realm;

--- a/packages/realm/src/platform/react-native/index.ts
+++ b/packages/realm/src/platform/react-native/index.ts
@@ -22,5 +22,9 @@ import "./fs";
 import "./device-info";
 import "./sync-proxy-config";
 
+// Clear the internal state to prevent crashes when reloading the app
+binding.RealmCoordinator.clearAllCaches();
+binding.App.clearCachedApps();
+
 import { Realm } from "../../Realm";
 export = Realm;


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes #6579 

During development it is common to reload a React Native app. As it is a rough process, it is important to clear the previous state - including listeners. Realm Core provides some low-level method to clear many internal data structures, and by invoking these when the SDK is initialized (loaded in the app), any state from the previous app instance is removed.

Testing is difficult, and I have only tried it manually in a app running locally on my computer.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
