### PR TITLE
Combined: Support `Mixed` data type with collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* A `mixed` value can now hold a `Realm.List` and `Realm.Dictionary` with nested collections. Note that `Realm.Set` is not supported as a `mixed` value. ([#6513](https://github.com/realm/realm-js/pull/6513))
+* A `mixed` value can now hold a `Realm.List` and `Realm.Dictionary` with nested collections. Note that `Realm.Set` is not supported as a `mixed` value. ([#6613](https://github.com/realm/realm-js/pull/6613))
 ```typescript
 class CustomObject extends Realm.Object {
   value!: Realm.Types.Mixed;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@
 
 ### Enhancements
 * A `mixed` value can now hold a `Realm.List` and `Realm.Dictionary` with nested collections. Note that `Realm.Set` is not supported as a `mixed` value. ([#6513](https://github.com/realm/realm-js/pull/6513))
-
 ```typescript
 class CustomObject extends Realm.Object {
-  value!: Realm.Mixed;
+  value!: Realm.Types.Mixed;
 
   static schema: ObjectSchema = {
     name: "CustomObject",
@@ -20,8 +19,8 @@ class CustomObject extends Realm.Object {
 
 const realm = await Realm.open({ schema: [CustomObject] });
 
-// Create an object with a dictionary value as the Mixed property,
-// containing primitives and a list.
+// Create an object with a dictionary value as the Mixed
+// property, containing primitives and a list.
 const realmObject = realm.write(() => {
   return realm.create(CustomObject, {
     value: {
@@ -30,9 +29,7 @@ const realmObject = realm.write(() => {
       bool: true,
       list: [
         {
-          dict: {
-            string: "world",
-          },
+          string: "world",
         },
       ],
     },
@@ -40,16 +37,30 @@ const realmObject = realm.write(() => {
 });
 
 // Accessing the collection value returns the managed collection.
-// The default generic type argument is `unknown` (mixed).
-const dictionary = realmObject.value as Realm.Dictionary;
-const list = dictionary.list as Realm.List;
-const leafDictionary = (list[0] as Realm.Dictionary).dict as Realm.Dictionary;
+const dictionary = realmObject.value;
+expectDictionary(dictionary);
+const list = dictionary.list;
+expectList(list);
+const leafDictionary = list[0];
+expectDictionary(leafDictionary);
 console.log(leafDictionary.string); // "world"
 
 // Update the Mixed property to a list.
 realm.write(() => {
   realmObject.value = [1, "hello", { newKey: "new value" }];
 });
+
+// Useful custom helper functions. (Will be provided in a future release.)
+function expectList(value: unknown): asserts value is Realm.List {
+  if (!(value instanceof Realm.List)) {
+    throw new Error("Expected a 'Realm.List'.");
+  }
+}
+function expectDictionary(value: unknown): asserts value is Realm.Dictionary {
+  if (!(value instanceof Realm.Dictionary)) {
+    throw new Error("Expected a 'Realm.Dictionary'.");
+  }
+}
 ```
 
 ### Fixed

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -794,7 +794,7 @@ describe("Lists", () => {
         obj.arrayCol = [this.realm.create<ITestObjectSchema>(TestObjectSchema.name, { doubleCol: 1.0 })];
         expect(obj.arrayCol[0].doubleCol).equals(1.0);
 
-        // TODO: Solve the "removeAll()" case for self-assignment.
+        // TODO: Enable when self-assignment is solved (https://github.com/realm/realm-core/issues/7422).
         // obj.arrayCol = obj.arrayCol; // eslint-disable-line no-self-assign
         // expect(obj.arrayCol[0].doubleCol).equals(1.0);
 

--- a/integration-tests/tests/src/tests/list.ts
+++ b/integration-tests/tests/src/tests/list.ts
@@ -711,7 +711,7 @@ describe("Lists", () => {
           Error,
           "Requested index 2 calling set() on list 'LinkTypesObject.arrayCol' when max is 1",
         );
-        expect(() => (array[-1] = { doubleCol: 1 })).throws(Error, "Index -1 cannot be less than zero.");
+        expect(() => (array[-1] = { doubleCol: 1 })).throws(Error, "Cannot set item at negative index -1");
 
         //@ts-expect-error TYPEBUG: our List type-definition expects index accesses to be done with a number , should probably be extended.
         array["foo"] = "bar";
@@ -772,6 +772,7 @@ describe("Lists", () => {
     openRealmBeforeEach({
       schema: [LinkTypeSchema, TestObjectSchema, PersonListSchema, PersonSchema, PrimitiveArraysSchema],
     });
+
     it("are typesafe", function (this: RealmContext) {
       let obj: ILinkTypeSchema;
       let prim: IPrimitiveArraysSchema;
@@ -792,8 +793,10 @@ describe("Lists", () => {
         //@ts-expect-error TYPEBUG: type missmatch, forcecasting shouldn't be done
         obj.arrayCol = [this.realm.create<ITestObjectSchema>(TestObjectSchema.name, { doubleCol: 1.0 })];
         expect(obj.arrayCol[0].doubleCol).equals(1.0);
-        obj.arrayCol = obj.arrayCol; // eslint-disable-line no-self-assign
-        expect(obj.arrayCol[0].doubleCol).equals(1.0);
+
+        // TODO: Solve the "removeAll()" case for self-assignment.
+        // obj.arrayCol = obj.arrayCol; // eslint-disable-line no-self-assign
+        // expect(obj.arrayCol[0].doubleCol).equals(1.0);
 
         //@ts-expect-error Person is not assignable to boolean.
         expect(() => (prim.bool = [person])).throws(
@@ -868,21 +871,6 @@ describe("Lists", () => {
         testAssign("data", DATA1);
         testAssign("date", DATE1);
 
-        function testAssignNull(name: string, expected: string) {
-          //@ts-expect-error TYPEBUG: our List type-definition expects index accesses to be done with a number , should probably be extended.
-          expect(() => (prim[name] = [null])).throws(Error, `Expected '${name}[0]' to be ${expected}, got null`);
-          //@ts-expect-error TYPEBUG: our List type-definition expects index accesses to be done with a number , should probably be extended.
-          expect(prim[name].length).equals(1);
-        }
-
-        testAssignNull("bool", "a boolean");
-        testAssignNull("int", "a number or bigint");
-        testAssignNull("float", "a number");
-        testAssignNull("double", "a number");
-        testAssignNull("string", "a string");
-        testAssignNull("data", "an instance of ArrayBuffer");
-        testAssignNull("date", "an instance of Date");
-
         testAssign("optBool", true);
         testAssign("optInt", 1);
         testAssign("optFloat", 1.1);
@@ -905,7 +893,33 @@ describe("Lists", () => {
       //@ts-expect-error throws on modification outside of transaction.
       expect(() => (prim.bool = [])).throws("Cannot modify managed objects outside of a write transaction.");
     });
+
+    it("throws when assigning null to non-nullable", function (this: RealmContext) {
+      const realm = this.realm;
+      const prim = realm.write(() => realm.create<IPrimitiveArraysSchema>(PrimitiveArraysSchema.name, {}));
+
+      function testAssignNull(name: string, expected: string) {
+        expect(() => {
+          realm.write(() => {
+            // @ts-expect-error TYPEBUG: our List type-definition expects index accesses to be done with a number , should probably be extended.
+            prim[name] = [null];
+          });
+        }).throws(Error, `Expected '${name}[0]' to be ${expected}, got null`);
+
+        // @ts-expect-error TYPEBUG: our List type-definition expects index accesses to be done with a number , should probably be extended.
+        expect(prim[name].length).equals(0);
+      }
+
+      testAssignNull("bool", "a boolean");
+      testAssignNull("int", "a number or bigint");
+      testAssignNull("float", "a number");
+      testAssignNull("double", "a number");
+      testAssignNull("string", "a string");
+      testAssignNull("data", "an instance of ArrayBuffer");
+      testAssignNull("date", "an instance of Date");
+    });
   });
+
   describe("operations", () => {
     openRealmBeforeEach({ schema: [LinkTypeSchema, TestObjectSchema, PersonSchema, PersonListSchema] });
     it("supports enumeration", function (this: RealmContext) {

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -2146,9 +2146,8 @@ describe("Mixed", () => {
           filtered = objects.filtered(`mixed[*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed[${nonExistentIndex}][*] == $0`, itemToMatch);
-          // expect(filtered.length).equals(0);
+          filtered = objects.filtered(`mixed[${nonExistentIndex}][*] == $0`, itemToMatch);
+          expect(filtered.length).equals(0);
 
           index++;
         }
@@ -2247,29 +2246,25 @@ describe("Mixed", () => {
         for (const itemToMatch of nestedList) {
           // Objects with a nested list item that matches the `itemToMatch` at the GIVEN index.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed[0][0][${index}] == $0`, itemToMatch);
-          // expect(filtered.length).equals(expectedFilteredCount);
+          expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][${index}] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns 2 objects -- the objects whose mixed fields are strings.)
-          // filtered = objects.filtered(`mixed[0][0][${nonExistentIndex}] == $0`, itemToMatch);
-          // expect(filtered.length).equals(0);
+          filtered = objects.filtered(`mixed[0][0][${nonExistentIndex}] == $0`, itemToMatch);
+          expect(filtered.length).equals(0);
 
           // Objects with a nested list item that matches the `itemToMatch` at ANY index.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed[0][0][*] == $0`, itemToMatch);
-          // expect(filtered.length).equals(expectedFilteredCount);
+          filtered = objects.filtered(`mixed[0][0][*] == $0`, itemToMatch);
+          expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed[0][${nonExistentIndex}][*] == $0`, itemToMatch);
-          // expect(filtered.length).equals(0);
+          filtered = objects.filtered(`mixed[0][${nonExistentIndex}][*] == $0`, itemToMatch);
+          expect(filtered.length).equals(0);
 
           index++;
         }
@@ -2301,9 +2296,8 @@ describe("Mixed", () => {
 
         // Objects with a nested list containing an item of the given type.
 
-        // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (This returns all objects.)
-        // filtered = objects.filtered(`mixed[0][0][*].@type == 'null'`);
-        // expect(filtered.length).equals(expectedFilteredCount);
+        filtered = objects.filtered(`mixed[0][0][*].@type == 'null'`);
+        expect(filtered.length).equals(expectedFilteredCount);
 
         filtered = objects.filtered(`mixed[0][0][*].@type == 'bool'`);
         expect(filtered.length).equals(expectedFilteredCount);
@@ -2409,7 +2403,9 @@ describe("Mixed", () => {
 
           // Objects with a dictionary value at the given key matching any of the values inserted.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (For all keys, this returns 0 objects.)
+          // TODO: Bug or feature in Core? (For all keys, this returns 0 objects.)
+          //       Was reported as part of https://github.com/realm/realm-core/issues/7587,
+          //       but the issue remains for `IN`. They could be treating argument lists special.
           // filtered = objects.filtered(`mixed.${key} IN $0`, insertedValues);
           // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2514,35 +2510,30 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at the GIVEN key.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, valueToMatch);
-          // expect(filtered.length).equals(expectedFilteredCount);
+          expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed['depth1']['depth2']['${nonExistentKey}'] == $0`, valueToMatch);
+          filtered = objects.filtered(`mixed['depth1']['depth2']['${nonExistentKey}'] == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
-          // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
+          expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, valueToMatch);
-          // expect(filtered.length).equals(expectedFilteredCount);
+          filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, valueToMatch);
+          expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed.depth1.depth2.${nonExistentKey} == $0`, valueToMatch);
+          filtered = objects.filtered(`mixed.depth1.depth2.${nonExistentKey} == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
-          // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
+          expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at ANY key.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
-          // filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, valueToMatch);
-          // expect(filtered.length).equals(expectedFilteredCount);
+          filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, valueToMatch);
+          expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
@@ -2557,7 +2548,9 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value at the given key matching any of the values inserted.
 
-          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (For all keys, this returns 2 objects -- the objects whose mixed fields are strings.)
+          // TODO: Bug or feature in Core? (For all keys, this returns 0 objects.)
+          //       Was reported as part of https://github.com/realm/realm-core/issues/7587,
+          //       but the issue remains for `IN`. They could be treating argument lists special.
           // filtered = objects.filtered(`mixed.depth1.depth2.${key} IN $0`, insertedValues);
           // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2592,9 +2585,8 @@ describe("Mixed", () => {
 
         // Objects with a nested dictionary containing a property of the given type.
 
-        // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (This returns all objects.)
-        // filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'null'`);
-        // expect(filtered.length).equals(expectedFilteredCount);
+        filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'null'`);
+        expect(filtered.length).equals(expectedFilteredCount);
 
         filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'bool'`);
         expect(filtered.length).equals(expectedFilteredCount);

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -2146,7 +2146,7 @@ describe("Mixed", () => {
           filtered = objects.filtered(`mixed[*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed[${nonExistentIndex}][*] == $0`, itemToMatch);
           // expect(filtered.length).equals(0);
 
@@ -2247,27 +2247,27 @@ describe("Mixed", () => {
         for (const itemToMatch of nestedList) {
           // Objects with a nested list item that matches the `itemToMatch` at the GIVEN index.
 
-          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed[0][0][${index}] == $0`, itemToMatch);
           // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][${index}] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Core bug? (When `itemToMatch` is `null`, this returns 2 objects -- the objects whose mixed fields are strings.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns 2 objects -- the objects whose mixed fields are strings.)
           // filtered = objects.filtered(`mixed[0][0][${nonExistentIndex}] == $0`, itemToMatch);
           // expect(filtered.length).equals(0);
 
           // Objects with a nested list item that matches the `itemToMatch` at ANY index.
 
-          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed[0][0][*] == $0`, itemToMatch);
           // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `itemToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed[0][${nonExistentIndex}][*] == $0`, itemToMatch);
           // expect(filtered.length).equals(0);
 
@@ -2301,7 +2301,7 @@ describe("Mixed", () => {
 
         // Objects with a nested list containing an item of the given type.
 
-        // TODO: Core bug? (This returns all objects.)
+        // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (This returns all objects.)
         // filtered = objects.filtered(`mixed[0][0][*].@type == 'null'`);
         // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2409,7 +2409,7 @@ describe("Mixed", () => {
 
           // Objects with a dictionary value at the given key matching any of the values inserted.
 
-          // TODO: Core bug? (For all keys, this returns 0 objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (For all keys, this returns 0 objects.)
           // filtered = objects.filtered(`mixed.${key} IN $0`, insertedValues);
           // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2514,33 +2514,33 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at the GIVEN key.
 
-          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, valueToMatch);
           // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed['depth1']['depth2']['${nonExistentKey}'] == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
           // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
-          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, valueToMatch);
           // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed.depth1.depth2.${nonExistentKey} == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
           // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at ANY key.
 
-          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (When `valueToMatch` is `null`, this returns all objects.)
           // filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, valueToMatch);
           // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2557,7 +2557,7 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value at the given key matching any of the values inserted.
 
-          // TODO: Core bug? (For all keys, this returns 2 objects -- the objects whose mixed fields are strings.)
+          // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (For all keys, this returns 2 objects -- the objects whose mixed fields are strings.)
           // filtered = objects.filtered(`mixed.depth1.depth2.${key} IN $0`, insertedValues);
           // expect(filtered.length).equals(expectedFilteredCount);
 
@@ -2592,7 +2592,7 @@ describe("Mixed", () => {
 
         // Objects with a nested dictionary containing a property of the given type.
 
-        // TODO: Core bug? (This returns all objects.)
+        // TODO: Enable after https://github.com/realm/realm-core/issues/7587. (This returns all objects.)
         // filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'null'`);
         // expect(filtered.length).equals(expectedFilteredCount);
 

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -2146,8 +2146,9 @@ describe("Mixed", () => {
           filtered = objects.filtered(`mixed[*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          filtered = objects.filtered(`mixed[${nonExistentIndex}][*] == $0`, itemToMatch);
-          expect(filtered.length).equals(0);
+          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed[${nonExistentIndex}][*] == $0`, itemToMatch);
+          // expect(filtered.length).equals(0);
 
           index++;
         }
@@ -2246,25 +2247,29 @@ describe("Mixed", () => {
         for (const itemToMatch of nestedList) {
           // Objects with a nested list item that matches the `itemToMatch` at the GIVEN index.
 
+          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed[0][0][${index}] == $0`, itemToMatch);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][${index}] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          filtered = objects.filtered(`mixed[0][0][${nonExistentIndex}] == $0`, itemToMatch);
-          expect(filtered.length).equals(0);
+          // TODO: Core bug? (When `itemToMatch` is `null`, this returns 2 objects -- the objects whose mixed fields are strings.)
+          // filtered = objects.filtered(`mixed[0][0][${nonExistentIndex}] == $0`, itemToMatch);
+          // expect(filtered.length).equals(0);
 
           // Objects with a nested list item that matches the `itemToMatch` at ANY index.
 
-          filtered = objects.filtered(`mixed[0][0][*] == $0`, itemToMatch);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed[0][0][*] == $0`, itemToMatch);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed[0][0][*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          filtered = objects.filtered(`mixed[0][${nonExistentIndex}][*] == $0`, itemToMatch);
-          expect(filtered.length).equals(0);
+          // TODO: Core bug? (When `itemToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed[0][${nonExistentIndex}][*] == $0`, itemToMatch);
+          // expect(filtered.length).equals(0);
 
           index++;
         }
@@ -2296,8 +2301,9 @@ describe("Mixed", () => {
 
         // Objects with a nested list containing an item of the given type.
 
-        filtered = objects.filtered(`mixed[0][0][*].@type == 'null'`);
-        expect(filtered.length).equals(expectedFilteredCount);
+        // TODO: Core bug? (This returns all objects.)
+        // filtered = objects.filtered(`mixed[0][0][*].@type == 'null'`);
+        // expect(filtered.length).equals(expectedFilteredCount);
 
         filtered = objects.filtered(`mixed[0][0][*].@type == 'bool'`);
         expect(filtered.length).equals(expectedFilteredCount);
@@ -2403,8 +2409,9 @@ describe("Mixed", () => {
 
           // Objects with a dictionary value at the given key matching any of the values inserted.
 
-          filtered = objects.filtered(`mixed.${key} IN $0`, insertedValues);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // TODO: Core bug? (For all keys, this returns 0 objects.)
+          // filtered = objects.filtered(`mixed.${key} IN $0`, insertedValues);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.${key} IN $0`, [nonExistentValue]);
           expect(filtered.length).equals(0);
@@ -2507,30 +2514,35 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at the GIVEN key.
 
+          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
           let filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, valueToMatch);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed['depth1']['depth2']['${key}'] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          filtered = objects.filtered(`mixed['depth1']['depth2']['${nonExistentKey}'] == $0`, valueToMatch);
+          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed['depth1']['depth2']['${nonExistentKey}'] == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
-          expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
+          // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
-          filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, valueToMatch);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, valueToMatch);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2.${key} == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
 
-          filtered = objects.filtered(`mixed.depth1.depth2.${nonExistentKey} == $0`, valueToMatch);
+          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed.depth1.depth2.${nonExistentKey} == $0`, valueToMatch);
           // Core treats missing keys as `null` in queries.
-          expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
+          // expect(filtered.length).equals(valueToMatch === null ? expectedFilteredCount : 0);
 
           // Objects with a nested dictionary value that matches the `valueToMatch` at ANY key.
 
-          filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, valueToMatch);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // TODO: Core bug? (When `valueToMatch` is `null`, this returns all objects.)
+          // filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, valueToMatch);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2[*] == $0`, nonExistentValue);
           expect(filtered.length).equals(0);
@@ -2545,8 +2557,9 @@ describe("Mixed", () => {
 
           // Objects with a nested dictionary value at the given key matching any of the values inserted.
 
-          filtered = objects.filtered(`mixed.depth1.depth2.${key} IN $0`, insertedValues);
-          expect(filtered.length).equals(expectedFilteredCount);
+          // TODO: Core bug? (For all keys, this returns 2 objects -- the objects whose mixed fields are strings.)
+          // filtered = objects.filtered(`mixed.depth1.depth2.${key} IN $0`, insertedValues);
+          // expect(filtered.length).equals(expectedFilteredCount);
 
           filtered = objects.filtered(`mixed.depth1.depth2.${key} IN $0`, [nonExistentValue]);
           expect(filtered.length).equals(0);
@@ -2579,8 +2592,9 @@ describe("Mixed", () => {
 
         // Objects with a nested dictionary containing a property of the given type.
 
-        filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'null'`);
-        expect(filtered.length).equals(expectedFilteredCount);
+        // TODO: Core bug? (This returns all objects.)
+        // filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'null'`);
+        // expect(filtered.length).equals(expectedFilteredCount);
 
         filtered = objects.filtered(`mixed.depth1.depth2[*].@type == 'bool'`);
         expect(filtered.length).equals(expectedFilteredCount);

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -1417,7 +1417,7 @@ describe("Mixed", () => {
             expect(list[0]).equals("updated");
           });
 
-          // TODO: Solve the "removeAll()" case for self-assignment.
+          // TODO: Enable when self-assignment is solved (https://github.com/realm/realm-core/issues/7422).
           it.skip("self assigns", function (this: RealmContext) {
             const created = this.realm.write(() => {
               return this.realm.create<IMixedSchema>(MixedSchema.name, { mixed: ["original1", "original2"] });
@@ -1439,7 +1439,7 @@ describe("Mixed", () => {
             expect(list[1]).equals("original2");
           });
 
-          // TODO: Solve the "removeAll()" case for self-assignment.
+          // TODO: Enable when self-assignment is solved (https://github.com/realm/realm-core/issues/7422).
           it.skip("self assigns nested list", function (this: RealmContext) {
             const { mixed: list } = this.realm.write(() => {
               return this.realm.create<IMixedSchema>(MixedSchema.name, {
@@ -1603,7 +1603,7 @@ describe("Mixed", () => {
             expect(dictionary.newKey).equals("updated");
           });
 
-          // TODO: Solve the "removeAll()" case for self-assignment.
+          // TODO: Enable when self-assignment is solved (https://github.com/realm/realm-core/issues/7422).
           it.skip("self assigns", function (this: RealmContext) {
             const created = this.realm.write(() => {
               return this.realm.create<IMixedSchema>(MixedSchema.name, {
@@ -1627,7 +1627,7 @@ describe("Mixed", () => {
             expect(dictionary.key2).equals("original2");
           });
 
-          // TODO: Solve the "removeAll()" case for self-assignment.
+          // TODO: Enable when self-assignment is solved (https://github.com/realm/realm-core/issues/7422).
           it.skip("self assigns nested dictionary", function (this: RealmContext) {
             const { mixed: dictionary } = this.realm.write(() => {
               return this.realm.create<IMixedSchema>(MixedSchema.name, {

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -16,9 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import Realm, { BSON } from "realm";
+import Realm, { BSON, ObjectSchema } from "realm";
 import { expect } from "chai";
-import { openRealmBefore } from "../hooks";
+
+import { openRealmBefore, openRealmBeforeEach } from "../hooks";
 
 interface ISingle {
   a: Realm.Mixed;
@@ -49,7 +50,23 @@ interface IMixedSchema {
   value: Realm.Mixed;
 }
 
-const SingleSchema: Realm.ObjectSchema = {
+interface IMixedAndEmbedded {
+  mixedValue: Realm.Mixed;
+  embeddedObject: { value: Realm.Mixed };
+}
+
+interface IMixedWithDefaultCollections {
+  mixedWithDefaultList: Realm.Mixed;
+  mixedWithDefaultDictionary: Realm.Mixed;
+}
+
+interface ICollectionsOfMixed {
+  list: Realm.List<Realm.Mixed>;
+  dictionary: Realm.Dictionary<Realm.Mixed>;
+  set: Realm.Set<Realm.Mixed>;
+}
+
+const SingleSchema: ObjectSchema = {
   name: "mixed",
   properties: {
     a: "mixed",
@@ -59,7 +76,7 @@ const SingleSchema: Realm.ObjectSchema = {
   },
 };
 
-const VertexSchema: Realm.ObjectSchema = {
+const VertexSchema: ObjectSchema = {
   name: "Vertex",
   properties: {
     a: "int",
@@ -68,7 +85,7 @@ const VertexSchema: Realm.ObjectSchema = {
   },
 };
 
-const MixNestedSchema: Realm.ObjectSchema = {
+const MixNestedSchema: ObjectSchema = {
   name: "Nested",
   properties: {
     a: "mixed",
@@ -77,7 +94,7 @@ const MixNestedSchema: Realm.ObjectSchema = {
   },
 };
 
-const MixedNullableSchema: Realm.ObjectSchema = {
+const MixedNullableSchema: ObjectSchema = {
   name: "mixed",
   properties: {
     nullable: "mixed",
@@ -85,9 +102,73 @@ const MixedNullableSchema: Realm.ObjectSchema = {
   },
 };
 
-const MixedSchema: Realm.ObjectSchema = {
+const MixedSchema: ObjectSchema = {
   name: "MixedClass",
-  properties: { value: "mixed" },
+  properties: {
+    value: "mixed",
+  },
+};
+
+const MixedAndEmbeddedSchema: ObjectSchema = {
+  name: "MixedAndEmbedded",
+  properties: {
+    mixedValue: "mixed",
+    embeddedObject: "EmbeddedObject?",
+  },
+};
+
+const EmbeddedObjectSchema: ObjectSchema = {
+  name: "EmbeddedObject",
+  embedded: true,
+  properties: {
+    value: "mixed",
+  },
+};
+
+const CollectionsOfMixedSchema: ObjectSchema = {
+  name: "CollectionsOfMixed",
+  properties: {
+    list: "mixed[]",
+    dictionary: "mixed{}",
+    set: "mixed<>",
+  },
+};
+
+const bool = true;
+const int = 123;
+const double = 123.456;
+const d128 = BSON.Decimal128.fromString("6.022e23");
+const string = "hello";
+const date = new Date();
+const oid = new BSON.ObjectId();
+const uuid = new BSON.UUID();
+const nullValue = null;
+const uint8Values = [0, 1, 2, 4, 8];
+const uint8Buffer = new Uint8Array(uint8Values).buffer;
+const unmanagedRealmObject: IMixedSchema = { value: 1 };
+
+// The `unmanagedRealmObject` is not added to these collections since a managed
+// Realm object will be added by the individual tests after one has been created.
+const flatListAllTypes: unknown[] = [bool, int, double, d128, string, date, oid, uuid, nullValue, uint8Buffer];
+const flatDictionaryAllTypes: Record<string, unknown> = {
+  bool,
+  int,
+  double,
+  d128,
+  string,
+  date,
+  oid,
+  uuid,
+  nullValue,
+  uint8Buffer,
+};
+
+const MixedWithDefaultCollectionsSchema: ObjectSchema = {
+  name: "MixedWithDefaultCollections",
+  properties: {
+    mixedWithDefaultList: { type: "mixed", default: [...flatListAllTypes] },
+    mixedWithDefaultDictionary: { type: "mixed", default: { ...flatDictionaryAllTypes } },
+  },
 };
 
 describe("Mixed", () => {
@@ -136,6 +217,8 @@ describe("Mixed", () => {
       const oid = new BSON.ObjectId();
       const uuid = new BSON.UUID();
       const date = new Date();
+      const list = [1, "two"];
+      const dictionary = { number: 1, string: "two" };
 
       const data = this.realm.write(() => this.realm.create<ISingle>(SingleSchema.name, { a: oid }));
       expect(typeof data.a === typeof oid, "should be the same type BSON.ObjectId");
@@ -145,27 +228,37 @@ describe("Mixed", () => {
       expect(typeof data.a === typeof uuid, "should be the same type BSON.UUID");
       expect(String(data.a)).equals(uuid.toString(), "should have the same content BSON.UUID");
 
+      this.realm.write(() => (data.a = date));
+      expect(typeof data.a === typeof date, "should be the same type Date");
+      expect(String(data.a)).equals(date.toString(), "should have the same content Date");
+
       this.realm.write(() => (data.a = d128));
       expect(String(data.a)).equals(d128.toString(), "Should be the same BSON.Decimal128");
 
       this.realm.write(() => (data.a = 12345678));
       expect(data.a).equals(12345678, "Should be the same 12345678");
 
-      this.realm.write(() => ((data.a = null), "Should be the same null"));
+      this.realm.write(() => (data.a = null));
       expect(data.a).equals(null);
 
-      this.realm.write(() => ((data.a = undefined), "Should be the same null"));
+      this.realm.write(() => (data.a = undefined));
       expect(data.a).equals(null);
-    });
-    it("wrong type throws", function (this: RealmContext) {
-      expect(() => {
-        this.realm.write(() => this.realm.create(SingleSchema.name, { a: Object.create({}) }));
-      }).throws(Error, "Unable to convert an object with ctor 'Object' to a Mixed");
+
+      this.realm.write(() => (data.a = list));
+      expect(data.a).to.be.instanceOf(Realm.List);
+      expect((data.a as Realm.List<any>)[0]).equals(1);
+
+      this.realm.write(() => (data.a = dictionary));
+      expect(data.a).to.be.instanceOf(Realm.Dictionary);
+      expect((data.a as Realm.Dictionary<any>).number).equals(1);
     });
   });
 
   describe("Nested types", () => {
-    openRealmBefore({ schema: [SingleSchema, VertexSchema, MixNestedSchema] });
+    openRealmBefore({
+      schema: [SingleSchema, VertexSchema, MixNestedSchema, MixedAndEmbeddedSchema, EmbeddedObjectSchema],
+    });
+
     it("support nested types", function (this: RealmContext) {
       const obj1 = this.realm.write(() => {
         const r = this.realm.create<IVertex>(VertexSchema.name, { a: 1, b: 0, c: 0 });
@@ -199,6 +292,27 @@ describe("Mixed", () => {
       expect((obj2.b as IVertex).a).equals(1, "Should be equal 1");
       expect((obj2.b as IVertex).b).equals(0, "Should be equal 0");
     });
+
+    it("throws if nested type is an embedded object", function (this: RealmContext) {
+      this.realm.write(() => {
+        // Create an object with an embedded object property.
+        const { embeddedObject } = this.realm.create(MixedAndEmbeddedSchema.name, {
+          mixedValue: null,
+          embeddedObject: { value: 1 },
+        });
+        expect(embeddedObject).instanceOf(Realm.Object);
+
+        // Create an object with the Mixed property being the embedded object.
+        expect(() => this.realm.create(MixedAndEmbeddedSchema.name, { mixedValue: embeddedObject })).to.throw(
+          "Using an embedded object (EmbeddedObject) as a Mixed value is not supported",
+        );
+      });
+      const objects = this.realm.objects<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name);
+      // TODO: Length should equal 1 when this PR is merged: https://github.com/realm/realm-js/pull/6356
+      // expect(objects.length).equals(1);
+      expect(objects.length).equals(2);
+      expect(objects[0].mixedValue).to.be.null;
+    });
   });
 
   describe("Nullable types", () => {
@@ -220,23 +334,589 @@ describe("Mixed", () => {
       expect(value.nullable_list[4]).equals(5, "Should be equal 5");
     });
   });
-  describe("Mixed arrays", () => {
-    openRealmBefore({ schema: [MixedSchema] });
-    it("throws when creating an array of multiple values", function (this: RealmContext) {
-      const objectsBefore = this.realm.objects(MixedSchema.name);
-      expect(objectsBefore.length).equals(0);
 
-      // check if the understandable error message is thrown
-      expect(() => {
-        this.realm.write(() => {
-          this.realm.create("MixedClass", { value: [123, false, "hello"] });
-        });
-      }).throws(Error, "A mixed property cannot contain an array of values.");
-
-      //  verify that the transaction has been rolled back
-      const objectsAfter = this.realm.objects(MixedSchema.name);
-      expect(objectsAfter.length).equals(0);
+  describe("Collection types", () => {
+    openRealmBeforeEach({
+      schema: [
+        MixedSchema,
+        MixedAndEmbeddedSchema,
+        MixedWithDefaultCollectionsSchema,
+        CollectionsOfMixedSchema,
+        EmbeddedObjectSchema,
+      ],
     });
+
+    function expectRealmList(value: unknown): asserts value is Realm.List<any> {
+      expect(value).instanceOf(Realm.List);
+    }
+
+    function expectRealmDictionary(value: unknown): asserts value is Realm.Dictionary<any> {
+      expect(value).instanceOf(Realm.Dictionary);
+    }
+
+    function expectMatchingFlatList(list: unknown) {
+      expectRealmList(list);
+      expect(list.length).to.be.greaterThanOrEqual(flatListAllTypes.length);
+
+      let index = 0;
+      for (const item of list) {
+        if (item instanceof Realm.Object) {
+          // @ts-expect-error Property `value` does exist.
+          expect(item.value).equals(unmanagedRealmObject.value);
+        } else if (item instanceof ArrayBuffer) {
+          expectMatchingUint8Buffer(item);
+        } else {
+          expect(String(item)).equals(String(flatListAllTypes[index]));
+        }
+        index++;
+      }
+    }
+
+    function expectMatchingFlatDictionary(dictionary: unknown) {
+      expectRealmDictionary(dictionary);
+      expect(Object.keys(dictionary).length).to.be.greaterThanOrEqual(Object.keys(flatDictionaryAllTypes).length);
+
+      for (const key in dictionary) {
+        const value = dictionary[key];
+        if (key === "realmObject") {
+          expect(value).instanceOf(Realm.Object);
+          expect(value.value).equals(unmanagedRealmObject.value);
+        } else if (key === "uint8Buffer") {
+          expectMatchingUint8Buffer(value);
+        } else {
+          expect(String(value)).equals(String(flatDictionaryAllTypes[key]));
+        }
+      }
+    }
+
+    function expectMatchingUint8Buffer(value: unknown) {
+      expect(value).instanceOf(ArrayBuffer);
+      expect([...new Uint8Array(value as ArrayBuffer)]).eql(uint8Values);
+    }
+
+    describe("Flat collections", () => {
+      describe("CRUD operations", () => {
+        describe("Create and access", () => {
+          it("a list with different types (input: JS Array)", function (this: RealmContext) {
+            const { value: list } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, unmanagedRealmObject);
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: [...flatListAllTypes, realmObject],
+              });
+            });
+
+            expect(this.realm.objects(MixedSchema.name).length).equals(2);
+            expectMatchingFlatList(list);
+          });
+
+          it("a list with different types (input: Realm List)", function (this: RealmContext) {
+            const { value: list } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, unmanagedRealmObject);
+              // Create an object with a Realm List property type (i.e. not a Mixed type).
+              const realmObjectWithList = this.realm.create<ICollectionsOfMixed>(CollectionsOfMixedSchema.name, {
+                list: [...flatListAllTypes, realmObject],
+              });
+              expectRealmList(realmObjectWithList.list);
+              // Use the Realm List as the value for the Mixed property on a different object.
+              return this.realm.create<IMixedSchema>(MixedSchema.name, { value: realmObjectWithList.list });
+            });
+
+            expect(this.realm.objects(MixedSchema.name).length).equals(2);
+            expectMatchingFlatList(list);
+          });
+
+          it("a list with different types (input: Default value)", function (this: RealmContext) {
+            const { mixedWithDefaultList } = this.realm.write(() => {
+              // Pass an empty object in order to use the default value from the schema.
+              return this.realm.create<IMixedWithDefaultCollections>(MixedWithDefaultCollectionsSchema.name, {});
+            });
+
+            expect(this.realm.objects(MixedWithDefaultCollectionsSchema.name).length).equals(1);
+            expectMatchingFlatList(mixedWithDefaultList);
+          });
+
+          it("a dictionary with different types (input: JS Object)", function (this: RealmContext) {
+            const { createdWithProto, createdWithoutProto } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, unmanagedRealmObject);
+              const createdWithProto = this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: { ...flatDictionaryAllTypes, realmObject },
+              });
+              const createdWithoutProto = this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: Object.assign(Object.create(null), {
+                  ...flatDictionaryAllTypes,
+                  realmObject,
+                }),
+              });
+              return { createdWithProto, createdWithoutProto };
+            });
+
+            expect(this.realm.objects(MixedSchema.name).length).equals(3);
+            expectMatchingFlatDictionary(createdWithProto.value);
+            expectMatchingFlatDictionary(createdWithoutProto.value);
+          });
+
+          it("a dictionary with different types (input: Realm Dictionary)", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, unmanagedRealmObject);
+              // Create an object with a Realm Dictionary property type (i.e. not a Mixed type).
+              const realmObjectWithDictionary = this.realm.create<ICollectionsOfMixed>(CollectionsOfMixedSchema.name, {
+                dictionary: { ...flatDictionaryAllTypes, realmObject },
+              });
+              expectRealmDictionary(realmObjectWithDictionary.dictionary);
+              // Use the Realm Dictionary as the value for the Mixed property on a different object.
+              return this.realm.create<IMixedSchema>(MixedSchema.name, { value: realmObjectWithDictionary.dictionary });
+            });
+
+            expect(this.realm.objects(MixedSchema.name).length).equals(2);
+            expectMatchingFlatDictionary(dictionary);
+          });
+
+          it("a dictionary with different types (input: Default value)", function (this: RealmContext) {
+            const { mixedWithDefaultDictionary } = this.realm.write(() => {
+              // Pass an empty object in order to use the default value from the schema.
+              return this.realm.create<IMixedWithDefaultCollections>(MixedWithDefaultCollectionsSchema.name, {});
+            });
+
+            expect(this.realm.objects(MixedWithDefaultCollectionsSchema.name).length).equals(1);
+            expectMatchingFlatDictionary(mixedWithDefaultDictionary);
+          });
+
+          it("a dictionary (input: Spread embedded Realm object)", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              const { embeddedObject } = this.realm.create<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name, {
+                embeddedObject: { value: 1 },
+              });
+              expect(embeddedObject).instanceOf(Realm.Object);
+
+              // Spread the embedded object in order to use its entries as a dictionary in Mixed.
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: { ...embeddedObject },
+              });
+            });
+
+            expectRealmDictionary(dictionary);
+            expect(dictionary).deep.equals({ value: 1 });
+          });
+
+          it("a dictionary (input: Spread custom non-Realm object)", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              class CustomClass {
+                constructor(public value: number) {}
+              }
+              const customObject = new CustomClass(1);
+
+              // Spread the embedded object in order to use its entries as a dictionary in Mixed.
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: { ...customObject },
+              });
+            });
+
+            expectRealmDictionary(dictionary);
+            expect(dictionary).deep.equals({ value: 1 });
+          });
+
+          it("inserts list items via `push()`", function (this: RealmContext) {
+            const { value: list } = this.realm.write(() => {
+              return this.realm.create<IMixedSchema>(MixedSchema.name, { value: [] });
+            });
+            expectRealmList(list);
+            expect(list.length).equals(0);
+
+            this.realm.write(() => {
+              list.push(...flatListAllTypes);
+              list.push(this.realm.create(MixedSchema.name, unmanagedRealmObject));
+            });
+            expectMatchingFlatList(list);
+          });
+
+          it("inserts dictionary entries", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              return this.realm.create<IMixedSchema>(MixedSchema.name, { value: {} });
+            });
+            expectRealmDictionary(dictionary);
+            expect(Object.keys(dictionary).length).equals(0);
+
+            this.realm.write(() => {
+              for (const key in flatDictionaryAllTypes) {
+                dictionary[key] = flatDictionaryAllTypes[key];
+              }
+              dictionary.realmObject = this.realm.create(MixedSchema.name, unmanagedRealmObject);
+            });
+            expectMatchingFlatDictionary(dictionary);
+          });
+        });
+
+        describe("Update", () => {
+          it("updates list items via property setters", function (this: RealmContext) {
+            const { value: list } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, { value: "original" });
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: ["original", realmObject],
+              });
+            });
+            expectRealmList(list);
+            expect(list.length).equals(2);
+            expect(list[0]).equals("original");
+            expect(list[1].value).equals("original");
+
+            this.realm.write(() => {
+              list[0] = "updated";
+              list[1].value = "updated";
+            });
+            expect(list[0]).equals("updated");
+            expect(list[1].value).equals("updated");
+
+            this.realm.write(() => {
+              list[0] = null;
+              list[1] = null;
+            });
+            expect(list.length).equals(2);
+            expect(list[0]).to.be.null;
+            expect(list[1]).to.be.null;
+          });
+
+          it("updates dictionary entries via property setters", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, { value: "original" });
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: { string: "original", realmObject },
+              });
+            });
+            expectRealmDictionary(dictionary);
+            expect(Object.keys(dictionary).length).equals(2);
+            expect(dictionary.string).equals("original");
+            expect(dictionary.realmObject.value).equals("original");
+
+            this.realm.write(() => {
+              dictionary.string = "updated";
+              dictionary.realmObject.value = "updated";
+            });
+            expect(dictionary.string).equals("updated");
+            expect(dictionary.realmObject.value).equals("updated");
+
+            this.realm.write(() => {
+              dictionary.string = null;
+              dictionary.realmObject = null;
+            });
+            expect(Object.keys(dictionary).length).equals(2);
+            expect(dictionary.string).to.be.null;
+            expect(dictionary.realmObject).to.be.null;
+          });
+        });
+
+        describe("Remove", () => {
+          it("removes list items via `remove()`", function (this: RealmContext) {
+            const { value: list } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, { value: "original" });
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: ["original", realmObject],
+              });
+            });
+            expectRealmList(list);
+            expect(list.length).equals(2);
+
+            this.realm.write(() => {
+              list.remove(1);
+            });
+            expect(list.length).equals(1);
+            expect(list[0]).equals("original");
+          });
+
+          it("removes dictionary entries via `remove()`", function (this: RealmContext) {
+            const { value: dictionary } = this.realm.write(() => {
+              const realmObject = this.realm.create(MixedSchema.name, { value: "original" });
+              return this.realm.create<IMixedSchema>(MixedSchema.name, {
+                value: { string: "original", realmObject },
+              });
+            });
+            expectRealmDictionary(dictionary);
+            expect(Object.keys(dictionary).length).equals(2);
+
+            this.realm.write(() => {
+              dictionary.remove("realmObject");
+            });
+            expect(Object.keys(dictionary).length).equals(1);
+            expect(dictionary.string).equals("original");
+            expect(dictionary.realmObject).to.be.undefined;
+          });
+        });
+      });
+
+      describe("Filtering", () => {
+        it("filters by query path on list with different types", function (this: RealmContext) {
+          const expectedFilteredCount = 5;
+          const mixedList = [...flatListAllTypes];
+          const nonExistentValue = "nonExistentValue";
+
+          this.realm.write(() => {
+            // Create 2 objects that should not pass the query string filter.
+            this.realm.create(MixedSchema.name, { value: "not a list" });
+            mixedList.push(this.realm.create(MixedSchema.name, { value: "not a list" }));
+
+            // Create the objects that should pass the query string filter.
+            for (let count = 0; count < expectedFilteredCount; count++) {
+              this.realm.create(MixedSchema.name, { value: mixedList });
+            }
+          });
+          const objects = this.realm.objects(MixedSchema.name);
+          expect(objects.length).equals(expectedFilteredCount + 2);
+
+          let index = 0;
+          for (const itemToMatch of mixedList) {
+            // Objects with a list item that matches the `itemToMatch` at the GIVEN index.
+            let filtered = objects.filtered(`value[${index}] == $0`, itemToMatch);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value[${index}] == $0`, nonExistentValue);
+            expect(filtered.length).equals(0);
+
+            // Objects with a list item that matches the `itemToMatch` at ANY index.
+            filtered = objects.filtered(`value[*] == $0`, itemToMatch);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value[*] == $0`, nonExistentValue);
+            expect(filtered.length).equals(0);
+
+            index++;
+          }
+        });
+
+        it("filters by query path on dictionary with different types", function (this: RealmContext) {
+          const expectedFilteredCount = 5;
+          const mixedDictionary = { ...flatDictionaryAllTypes };
+          const nonExistentValue = "nonExistentValue";
+          const nonExistentKey = "nonExistentKey";
+
+          this.realm.write(() => {
+            // Create 2 objects that should not pass the query string filter.
+            this.realm.create(MixedSchema.name, { value: "not a dictionary" });
+            mixedDictionary.realmObject = this.realm.create(MixedSchema.name, { value: "not a dictionary" });
+
+            // Create the objects that should pass the query string filter.
+            for (let count = 0; count < expectedFilteredCount; count++) {
+              this.realm.create(MixedSchema.name, { value: mixedDictionary });
+            }
+          });
+          const objects = this.realm.objects(MixedSchema.name);
+          expect(objects.length).equals(expectedFilteredCount + 2);
+
+          const insertedValues = Object.values(mixedDictionary);
+
+          for (const key in mixedDictionary) {
+            const valueToMatch = mixedDictionary[key];
+
+            // Objects with a dictionary value that matches the `valueToMatch` at the GIVEN key.
+            let filtered = objects.filtered(`value['${key}'] == $0`, valueToMatch);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value['${key}'] == $0`, nonExistentValue);
+            expect(filtered.length).equals(0);
+
+            filtered = objects.filtered(`value['${nonExistentKey}'] == $0`, valueToMatch);
+            expect(filtered.length).equals(0);
+
+            filtered = objects.filtered(`value.${key} == $0`, valueToMatch);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value.${key} == $0`, nonExistentValue);
+            expect(filtered.length).equals(0);
+
+            filtered = objects.filtered(`value.${nonExistentKey} == $0`, valueToMatch);
+            expect(filtered.length).equals(0);
+
+            // Objects with a dictionary value that matches the `valueToMatch` at ANY key.
+            filtered = objects.filtered(`value[*] == $0`, valueToMatch);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value[*] == $0`, nonExistentValue);
+            expect(filtered.length).equals(0);
+
+            // Objects with a dictionary containing a key that matches `key`.
+            filtered = objects.filtered(`value.@keys == $0`, key);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value.@keys == $0`, nonExistentKey);
+            expect(filtered.length).equals(0);
+
+            // Objects with a dictionary with the key `key` matching any of the values inserted.
+            filtered = objects.filtered(`value.${key} IN $0`, insertedValues);
+            expect(filtered.length).equals(expectedFilteredCount);
+
+            filtered = objects.filtered(`value.${key} IN $0`, [nonExistentValue]);
+            expect(filtered.length).equals(0);
+          }
+        });
+      });
+    });
+
+    describe("Invalid operations", () => {
+      it("throws when creating a set (input: JS Set)", function (this: RealmContext) {
+        this.realm.write(() => {
+          expect(() => this.realm.create(MixedSchema.name, { value: new Set() })).to.throw(
+            "Using a Set as a Mixed value is not supported",
+          );
+        });
+
+        const objects = this.realm.objects(MixedSchema.name);
+        // TODO: Length should equal 0 when this PR is merged: https://github.com/realm/realm-js/pull/6356
+        // expect(objects.length).equals(0);
+        expect(objects.length).equals(1);
+      });
+
+      it("throws when creating a set (input: Realm Set)", function (this: RealmContext) {
+        this.realm.write(() => {
+          const { set } = this.realm.create(CollectionsOfMixedSchema.name, { set: [int] });
+          expect(set).instanceOf(Realm.Set);
+          expect(() => this.realm.create(MixedSchema.name, { value: set })).to.throw(
+            "Using a RealmSet as a Mixed value is not supported",
+          );
+        });
+
+        const objects = this.realm.objects(MixedSchema.name);
+        // TODO: Length should equal 0 when this PR is merged: https://github.com/realm/realm-js/pull/6356
+        // expect(objects.length).equals(0);
+        expect(objects.length).equals(1);
+      });
+
+      it("throws when updating a list item to a set", function (this: RealmContext) {
+        const { set, list } = this.realm.write(() => {
+          const realmObjectWithSet = this.realm.create(CollectionsOfMixedSchema.name, { set: [int] });
+          const realmObjectWithMixed = this.realm.create<IMixedSchema>(MixedSchema.name, { value: ["original"] });
+          return { set: realmObjectWithSet.set, list: realmObjectWithMixed.value };
+        });
+        expectRealmList(list);
+        expect(list[0]).equals("original");
+
+        this.realm.write(() => {
+          expect(() => (list[0] = new Set())).to.throw("Using a Set as a Mixed value is not supported");
+          expect(() => (list[0] = set)).to.throw("Using a RealmSet as a Mixed value is not supported");
+        });
+        expect(list[0]).equals("original");
+      });
+
+      it("throws when updating a dictionary entry to a set", function (this: RealmContext) {
+        const { set, dictionary } = this.realm.write(() => {
+          const realmObjectWithSet = this.realm.create(CollectionsOfMixedSchema.name, { set: [int] });
+          const realmObjectWithMixed = this.realm.create<IMixedSchema>(MixedSchema.name, {
+            value: { string: "original" },
+          });
+          return { set: realmObjectWithSet.set, dictionary: realmObjectWithMixed.value };
+        });
+        expectRealmDictionary(dictionary);
+        expect(dictionary.string).equals("original");
+
+        this.realm.write(() => {
+          expect(() => (dictionary.string = new Set())).to.throw("Using a Set as a Mixed value is not supported");
+          expect(() => (dictionary.string = set)).to.throw("Using a RealmSet as a Mixed value is not supported");
+        });
+        expect(dictionary.string).equals("original");
+      });
+
+      it("throws when creating a list or dictionary with an embedded object", function (this: RealmContext) {
+        this.realm.write(() => {
+          // Create an object with an embedded object property.
+          const { embeddedObject } = this.realm.create(MixedAndEmbeddedSchema.name, {
+            embeddedObject: { value: 1 },
+          });
+          expect(embeddedObject).instanceOf(Realm.Object);
+
+          // Create two objects with the Mixed property (`value`) being a list and
+          // dictionary (respectively) containing the reference to the embedded object.
+          expect(() => this.realm.create(MixedAndEmbeddedSchema.name, { mixedValue: [embeddedObject] })).to.throw(
+            "Using an embedded object (EmbeddedObject) as a Mixed value is not supported",
+          );
+          expect(() => this.realm.create(MixedAndEmbeddedSchema.name, { mixedValue: { embeddedObject } })).to.throw(
+            "Using an embedded object (EmbeddedObject) as a Mixed value is not supported",
+          );
+        });
+        const objects = this.realm.objects<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name);
+        // TODO: Length should equal 1 when this PR is merged: https://github.com/realm/realm-js/pull/6356
+        // expect(objects.length).equals(1);
+        expect(objects.length).equals(3);
+      });
+
+      it("throws when setting a list or dictionary item to an embedded object", function (this: RealmContext) {
+        this.realm.write(() => {
+          // Create an object with an embedded object property.
+          const { embeddedObject } = this.realm.create(MixedAndEmbeddedSchema.name, {
+            embeddedObject: { value: 1 },
+          });
+          expect(embeddedObject).instanceOf(Realm.Object);
+
+          // Create two objects with the Mixed property (`value`)
+          // being an empty list and dictionary (respectively).
+          const { mixedValue: list } = this.realm.create<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name, {
+            mixedValue: [],
+          });
+          expectRealmList(list);
+
+          const { mixedValue: dictionary } = this.realm.create<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name, {
+            mixedValue: {},
+          });
+          expectRealmDictionary(dictionary);
+
+          expect(() => (list[0] = embeddedObject)).to.throw(
+            "Using an embedded object (EmbeddedObject) as a Mixed value is not supported",
+          );
+          expect(
+            () => (dictionary.prop = embeddedObject),
+            "Using an embedded object (EmbeddedObject) as a Mixed value is not supported",
+          );
+        });
+        const objects = this.realm.objects<IMixedAndEmbedded>(MixedAndEmbeddedSchema.name);
+        expect(objects.length).equals(3);
+        // Check that the list and dictionary are still empty.
+        expect((objects[1].mixedValue as Realm.List<any>).length).equals(0);
+        expect(Object.keys(objects[2].mixedValue as Realm.Dictionary<any>).length).equals(0);
+      });
+
+      it("throws when setting a list or dictionary outside a transaction", function (this: RealmContext) {
+        const created = this.realm.write(() => {
+          return this.realm.create<IMixedSchema>(MixedSchema.name, { value: "original" });
+        });
+        expect(created.value).equals("original");
+        expect(() => (created.value = ["a list item"])).to.throw(
+          "Cannot modify managed objects outside of a write transaction",
+        );
+        expect(() => (created.value = { key: "a dictionary value" })).to.throw(
+          "Cannot modify managed objects outside of a write transaction",
+        );
+        expect(created.value).equals("original");
+      });
+
+      it("invalidates the list when removed", function (this: RealmContext) {
+        const created = this.realm.write(() => {
+          return this.realm.create<IMixedSchema>(MixedSchema.name, { value: [1] });
+        });
+        const list = created.value;
+        expectRealmList(list);
+
+        this.realm.write(() => {
+          created.value = null;
+        });
+        expect(created.value).to.be.null;
+        expect(() => list[0]).to.throw("List is no longer valid");
+      });
+
+      it("invalidates the dictionary when removed", function (this: RealmContext) {
+        const created = this.realm.write(() => {
+          return this.realm.create<IMixedSchema>(MixedSchema.name, { value: { prop: 1 } });
+        });
+        const dictionary = created.value;
+        expectRealmDictionary(dictionary);
+
+        this.realm.write(() => {
+          created.value = null;
+        });
+        expect(created.value).to.be.null;
+        expect(() => dictionary.prop).to.throw("This collection is no more");
+      });
+    });
+  });
+
+  describe("Typed arrays in Mixed", () => {
+    openRealmBeforeEach({ schema: [MixedSchema] });
+
     it("supports datatypes with binary data contents", function (this: RealmContext) {
       const uint8Values1 = [0, 1, 2, 4, 8];
       const uint8Values2 = [255, 128, 64, 32, 16, 8];

--- a/integration-tests/tests/src/tests/results.ts
+++ b/integration-tests/tests/src/tests/results.ts
@@ -186,15 +186,15 @@ describe("Results", () => {
       expect(() => {
         //@ts-expect-error Should be an invalid write to read-only object.
         objects[-1] = { doubleCol: 0 };
-      }).throws("Index -1 cannot be less than zero.");
+      }).throws("Modifying a Results collection is not supported");
       expect(() => {
         //@ts-expect-error Should be an invalid write to read-only object.
         objects[0] = { doubleCol: 0 };
-      }).throws("Assigning into a Results is not supported");
+      }).throws("Modifying a Results collection is not supported");
       expect(() => {
         //@ts-expect-error Should be an invalid write to read-only object.
         objects[1] = { doubleCol: 0 };
-      }).throws("Assigning into a Results is not supported");
+      }).throws("Modifying a Results collection is not supported");
       expect(() => {
         objects.length = 0;
       }).throws("Cannot assign to read only property 'length'");

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -266,6 +266,7 @@ classes:
       - needs_file_format_upgrade
       - sync_user_as_app_user
       - app_user_as_sync_user
+      - get_mixed_type
 
   LogCategoryRef:
     methods:
@@ -301,6 +302,7 @@ classes:
       - get_key
       - get_any
       - set_any
+      - set_collection
       - get_linked_object
       - get_backlink_count
       - get_backlink_view

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -7,10 +7,10 @@
 # * `classes` and their `methods`
 #   * Methods, static methods, constructors, and properties in the general `spec.yml`
 #     should all be listed in this opt-in list as `methods`.
-# * `records` and their `fields``
+# * `records` and their `fields`
 #
-# If all methods in a class, or all fields of a property, are opted out of,
-# the entire class/property should be removed.
+# If all methods in a class, or all fields of a record, are opted out of,
+# the entire class/record should be removed.
 
 records:
   Property:
@@ -266,7 +266,6 @@ classes:
       - needs_file_format_upgrade
       - sync_user_as_app_user
       - app_user_as_sync_user
-      - get_mixed_type
 
   LogCategoryRef:
     methods:
@@ -337,6 +336,8 @@ classes:
       - index_of_obj
       - get_obj
       - get_any
+      - get_list
+      - get_dictionary
       - sort_by_names
       - snapshot
       - max
@@ -389,27 +390,35 @@ classes:
   Collection:
     methods:
       - get_object_schema
+      - get_type
       - size
       - is_valid
       - get_any
       - as_results
+      - snapshot
 
   List:
     methods:
       - make
+      - get_obj
+      - get_list
+      - get_dictionary
       - move
       - remove
       - remove_all
       - swap
       - delete_all
       - insert_any
+      - insert_collection
       - insert_embedded
       - set_any
       - set_embedded
+      - set_collection
 
   Set:
     methods:
       - make
+      - get_obj
       - insert_any
       - remove_any
       - remove_all
@@ -420,10 +429,13 @@ classes:
       - make
       - get_keys
       - get_values
+      - get_list
+      - get_dictionary
       - contains
       - add_key_based_notification_callback
       - insert_any
       - insert_embedded
+      - insert_collection
       - try_get_any
       - remove_all
       - try_erase

--- a/packages/realm/bindgen/js_spec.yml
+++ b/packages/realm/bindgen/js_spec.yml
@@ -25,4 +25,3 @@ classes:
       raw_dereference:
         sig: '() const -> Nullable<SharedSyncSession>'
         cppName: lock
-

--- a/packages/realm/bindgen/src/templates/base-wrapper.ts
+++ b/packages/realm/bindgen/src/templates/base-wrapper.ts
@@ -84,6 +84,7 @@ export function generate({ spec: boundSpec }: TemplateContext, out: Outputter): 
     "Decimal128",
     "EJSON_parse: EJSON.parse",
     "EJSON_stringify: EJSON.stringify",
+    "Symbol_for: Symbol.for",
   ];
 
   for (const cls of spec.classes) {

--- a/packages/realm/bindgen/src/templates/jsi.ts
+++ b/packages/realm/bindgen/src/templates/jsi.ts
@@ -79,7 +79,17 @@ function pushRet<T, U extends T>(arr: T[], elem: U) {
 class JsiAddon extends CppClass {
   exports: string[] = [];
   classes: string[] = [];
-  injectables = ["Long", "ArrayBuffer", "Float", "UUID", "ObjectId", "Decimal128", "EJSON_parse", "EJSON_stringify"];
+  injectables = [
+    "Long",
+    "ArrayBuffer",
+    "Float",
+    "UUID",
+    "ObjectId",
+    "Decimal128",
+    "EJSON_parse",
+    "EJSON_stringify",
+    "Symbol_for",
+  ];
   mem_inits: CppMemInit[] = [];
 
   props = new Set<string>();
@@ -901,6 +911,16 @@ class JsiCppDecls extends CppDecls {
               `,
             )
             .join("\n")}
+
+          // We are returning sentinel values for lists and dictionaries in the
+          // form of Symbol singletons. This is due to not being able to construct
+          // the actual list or dictionary in the current context.
+          case realm::type_List:
+            return ${this.addon.accessCtor("Symbol_for")}.call(_env, "Realm.List");
+
+          case realm::type_Dictionary:
+            return ${this.addon.accessCtor("Symbol_for")}.call(_env, "Realm.Dictionary");
+
           // The remaining cases are never stored in a Mixed.
           ${spec.mixedInfo.unusedDataTypes.map((t) => `case DataType::Type::${t}: break;`).join("\n")}
           }

--- a/packages/realm/bindgen/src/templates/node.ts
+++ b/packages/realm/bindgen/src/templates/node.ts
@@ -839,6 +839,16 @@ class NodeCppDecls extends CppDecls {
               `,
             )
             .join("\n")}
+
+          // We are returning sentinel values for lists and dictionaries in the
+          // form of Symbol singletons. This is due to not being able to construct
+          // the actual list or dictionary in the current context.
+          case realm::type_List:
+            return Napi::Symbol::For(napi_env_var_ForBindGen, "Realm.List");
+
+          case realm::type_Dictionary:
+            return Napi::Symbol::For(napi_env_var_ForBindGen, "Realm.Dictionary");
+
           // The remaining cases are never stored in a Mixed.
           ${spec.mixedInfo.unusedDataTypes.map((t) => `case DataType::Type::${t}: break;`).join("\n")}
           }

--- a/packages/realm/bindgen/src/templates/typescript.ts
+++ b/packages/realm/bindgen/src/templates/typescript.ts
@@ -124,7 +124,7 @@ function generateArguments(spec: BoundSpec, args: Arg[]) {
 
 function generateMixedTypes(spec: BoundSpec) {
   return `
-    export type Mixed = null | ${spec.mixedInfo.getters
+    export type Mixed = null | symbol | ${spec.mixedInfo.getters
       .map(({ type }) => generateType(spec, type, Kind.Ret))
       .join(" | ")};
     export type MixedArg = null | ${spec.mixedInfo.ctors.map((type) => generateType(spec, type, Kind.Arg)).join(" | ")};
@@ -173,6 +173,8 @@ export function generate({ rawSpec, spec: boundSpec, file }: TemplateContext): v
       public reason?: string;
       constructor(isOk: boolean) { this.isOk = isOk; }
     }
+    export const ListSentinel = Symbol.for("Realm.List");
+    export const DictionarySentinel = Symbol.for("Realm.Dictionary");
   `);
 
   const out = file("native.d.ts", eslintFormatter);

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -421,7 +421,7 @@ export function insertIntoDictionaryOfMixed(
   internal: binding.Dictionary,
   toBinding: TypeHelpers["toBinding"],
 ) {
-  // TODO: Solve the "removeAll()" case for self-assignment.
+  // TODO: Solve the "removeAll()" case for self-assignment (https://github.com/realm/realm-core/issues/7422).
   internal.removeAll();
 
   for (const key in dictionary) {

--- a/packages/realm/src/Dictionary.ts
+++ b/packages/realm/src/Dictionary.ts
@@ -15,49 +15,55 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
+
 import {
+  COLLECTION_ACCESSOR as ACCESSOR,
   AssertionError,
   Collection,
   DefaultObject,
   IllegalConstructorError,
   JSONCacheMap,
+  List,
   Realm,
   RealmObject,
+  Results,
+  COLLECTION_TYPE_HELPERS as TYPE_HELPERS,
   TypeHelpers,
   assert,
   binding,
+  createListAccessor,
+  createResultsAccessor,
+  insertIntoListOfMixed,
+  isJsOrRealmList,
+  toItemType,
 } from "./internal";
 
 /* eslint-disable jsdoc/multiline-blocks -- We need this to have @ts-expect-error located correctly in the .d.ts bundle */
 
 const REALM = Symbol("Dictionary#realm");
 const INTERNAL = Symbol("Dictionary#internal");
-const HELPERS = Symbol("Dictionary#helpers");
 
 export type DictionaryChangeSet = {
   deletions: string[];
   modifications: string[];
   insertions: string[];
 };
-export type DictionaryChangeCallback = (dictionary: Dictionary, changes: DictionaryChangeSet) => void;
+
+export type DictionaryChangeCallback<T = unknown> = (dictionary: Dictionary<T>, changes: DictionaryChangeSet) => void;
 
 const DEFAULT_PROPERTY_DESCRIPTOR: PropertyDescriptor = { configurable: true, enumerable: true };
 const PROXY_HANDLER: ProxyHandler<Dictionary> = {
   get(target, prop, receiver) {
     const value = Reflect.get(target, prop, receiver);
     if (typeof value === "undefined" && typeof prop === "string") {
-      const internal = target[INTERNAL];
-      const fromBinding = target[HELPERS].fromBinding;
-      return fromBinding(internal.tryGetAny(prop));
+      return target[ACCESSOR].get(target[INTERNAL], prop);
     } else {
       return value;
     }
   },
   set(target, prop, value) {
     if (typeof prop === "string") {
-      const internal = target[INTERNAL];
-      const toBinding = target[HELPERS].toBinding;
-      internal.insertAny(prop, toBinding(value));
+      target[ACCESSOR].set(target[INTERNAL], prop, value);
       return true;
     } else {
       assert(typeof prop !== "symbol", "Symbols cannot be used as keys of a dictionary");
@@ -106,16 +112,38 @@ const PROXY_HANDLER: ProxyHandler<Dictionary> = {
  * Dictionaries behave mostly like a JavaScript object i.e., as a key/value pair
  * where the key is a string.
  */
-export class Dictionary<T = unknown> extends Collection<string, T, [string, T], [string, T], DictionaryChangeCallback> {
+export class Dictionary<T = unknown> extends Collection<
+  string,
+  T,
+  [string, T],
+  [string, T],
+  DictionaryChangeCallback<T>,
+  /** @internal */
+  DictionaryAccessor<T>
+> {
+  /** @internal */
+  private declare [REALM]: Realm;
+
+  /**
+   * The representation in the binding.
+   * @internal
+   */
+  private readonly [INTERNAL]: binding.Dictionary;
+
   /**
    * Create a `Results` wrapping a set of query `Results` from the binding.
    * @internal
    */
-  constructor(realm: Realm, internal: binding.Dictionary, helpers: TypeHelpers) {
+  constructor(
+    realm: Realm,
+    internal: binding.Dictionary,
+    accessor: DictionaryAccessor<T>,
+    typeHelpers: TypeHelpers<T>,
+  ) {
     if (arguments.length === 0 || !(internal instanceof binding.Dictionary)) {
       throw new IllegalConstructorError("Dictionary");
     }
-    super((listener, keyPaths) => {
+    super(accessor, typeHelpers, (listener, keyPaths) => {
       return this[INTERNAL].addKeyBasedNotificationCallback(
         ({ deletions, insertions, modifications }) => {
           try {
@@ -145,7 +173,7 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
       );
     });
 
-    const proxied = new Proxy(this, PROXY_HANDLER) as Dictionary<T>;
+    const proxied = new Proxy(this, PROXY_HANDLER as ProxyHandler<this>);
 
     Object.defineProperty(this, REALM, {
       enumerable: false,
@@ -153,36 +181,11 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
       writable: false,
       value: realm,
     });
-    Object.defineProperty(this, INTERNAL, {
-      enumerable: false,
-      configurable: false,
-      writable: false,
-      value: internal,
-    });
-    Object.defineProperty(this, HELPERS, {
-      enumerable: false,
-      configurable: false,
-      writable: false,
-      value: helpers,
-    });
+
+    this[INTERNAL] = internal;
 
     return proxied;
   }
-
-  /**
-   * The representation in the binding.
-   * @internal
-   */
-  private declare [REALM]: Realm;
-
-  /**
-   * The representation in the binding.
-   * @internal
-   */
-  private declare [INTERNAL]: binding.Dictionary;
-
-  /** @internal */
-  private declare [HELPERS]: TypeHelpers;
 
   /** @ts-expect-error We're exposing methods in the end-users namespace of keys */
   [key: string]: T;
@@ -216,12 +219,15 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * @since 10.5.0
    * @ts-expect-error We're exposing methods in the end-users namespace of values */
   *values(): Generator<T> {
-    const { fromBinding } = this[HELPERS];
-    const snapshot = this[INTERNAL].values.snapshot();
-    const size = snapshot.size();
-    for (let i = 0; i < size; i++) {
-      const value = snapshot.getAny(i);
-      yield fromBinding(value) as T;
+    const realm = this[REALM];
+    const values = this[INTERNAL].values;
+    const itemType = toItemType(values.type);
+    const typeHelpers = this[TYPE_HELPERS];
+    const accessor = createResultsAccessor({ realm, typeHelpers, itemType });
+    const results = new Results<T>(realm, values, accessor, typeHelpers);
+
+    for (const value of results.values()) {
+      yield value;
     }
   }
 
@@ -231,15 +237,21 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * @since 10.5.0
    * @ts-expect-error We're exposing methods in the end-users namespace of entries */
   *entries(): Generator<[string, T]> {
-    const { fromBinding } = this[HELPERS];
     const keys = this[INTERNAL].keys.snapshot();
-    const values = this[INTERNAL].values.snapshot();
+    const snapshot = this[INTERNAL].values.snapshot();
     const size = keys.size();
-    assert(size === values.size(), "Expected keys and values to equal in size");
+    assert(size === snapshot.size(), "Expected keys and values to equal in size");
+
+    const realm = this[REALM];
+    const itemType = toItemType(snapshot.type);
+    const typeHelpers = this[TYPE_HELPERS];
+    const accessor = createResultsAccessor({ realm, typeHelpers, itemType });
+    const results = new Results<T>(realm, snapshot, accessor, typeHelpers);
+
     for (let i = 0; i < size; i++) {
       const key = keys.getAny(i);
-      const value = values.getAny(i);
-      yield [key, fromBinding(value)] as [string, T];
+      const value = results[i];
+      yield [key, value] as [string, T];
     }
   }
 
@@ -278,14 +290,12 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
    * @since 10.6.0
    */
   set(elementsOrKey: string | { [key: string]: T }, value?: T): this {
-    const elements = typeof elementsOrKey === "object" ? elementsOrKey : { [elementsOrKey]: value };
-    assert(Object.getOwnPropertySymbols(elements).length === 0, "Symbols cannot be used as keys of a dictionary");
     assert.inTransaction(this[REALM]);
-    const internal = this[INTERNAL];
-    const toBinding = this[HELPERS].toBinding;
+    const elements = typeof elementsOrKey === "object" ? elementsOrKey : { [elementsOrKey]: value as T };
+    assert(Object.getOwnPropertySymbols(elements).length === 0, "Symbols cannot be used as keys of a dictionary");
 
-    for (const [key, val] of Object.entries(elements)) {
-      internal.insertAny(key, toBinding(val));
+    for (const [key, value] of Object.entries(elements)) {
+      this[key] = value;
     }
     return this;
   }
@@ -321,4 +331,125 @@ export class Dictionary<T = unknown> extends Collection<string, T, [string, T], 
       Object.entries(this).map(([k, v]) => [k, v instanceof RealmObject ? v.toJSON(k, cache) : v]),
     );
   }
+}
+
+/**
+ * Accessor for getting and setting items in the binding collection.
+ * @internal
+ */
+export type DictionaryAccessor<T = unknown> = {
+  get: (dictionary: binding.Dictionary, key: string) => T;
+  set: (dictionary: binding.Dictionary, key: string, value: T) => void;
+};
+
+type DictionaryAccessorFactoryOptions<T> = {
+  realm: Realm;
+  typeHelpers: TypeHelpers<T>;
+  itemType: binding.PropertyType;
+  isEmbedded?: boolean;
+};
+
+/** @internal */
+export function createDictionaryAccessor<T>(options: DictionaryAccessorFactoryOptions<T>): DictionaryAccessor<T> {
+  return options.itemType === binding.PropertyType.Mixed
+    ? createDictionaryAccessorForMixed<T>(options)
+    : createDictionaryAccessorForKnownType<T>(options);
+}
+
+function createDictionaryAccessorForMixed<T>({
+  realm,
+  typeHelpers,
+}: Pick<DictionaryAccessorFactoryOptions<T>, "realm" | "typeHelpers">): DictionaryAccessor<T> {
+  const { toBinding, fromBinding } = typeHelpers;
+  return {
+    get(dictionary, key) {
+      const value = dictionary.tryGetAny(key);
+      switch (value) {
+        case binding.ListSentinel: {
+          const accessor = createListAccessor<T>({ realm, itemType: binding.PropertyType.Mixed, typeHelpers });
+          return new List<T>(realm, dictionary.getList(key), accessor, typeHelpers) as T;
+        }
+        case binding.DictionarySentinel: {
+          const accessor = createDictionaryAccessor<T>({ realm, itemType: binding.PropertyType.Mixed, typeHelpers });
+          return new Dictionary<T>(realm, dictionary.getDictionary(key), accessor, typeHelpers) as T;
+        }
+        default:
+          return fromBinding(value) as T;
+      }
+    },
+    set(dictionary, key, value) {
+      assert.inTransaction(realm);
+
+      if (isJsOrRealmList(value)) {
+        dictionary.insertCollection(key, binding.CollectionType.List);
+        insertIntoListOfMixed(value, dictionary.getList(key), toBinding);
+      } else if (isJsOrRealmDictionary(value)) {
+        dictionary.insertCollection(key, binding.CollectionType.Dictionary);
+        insertIntoDictionaryOfMixed(value, dictionary.getDictionary(key), toBinding);
+      } else {
+        dictionary.insertAny(key, toBinding(value));
+      }
+    },
+  };
+}
+
+function createDictionaryAccessorForKnownType<T>({
+  realm,
+  typeHelpers,
+  isEmbedded,
+}: Omit<DictionaryAccessorFactoryOptions<T>, "itemType">): DictionaryAccessor<T> {
+  const { fromBinding, toBinding } = typeHelpers;
+  return {
+    get(dictionary, key) {
+      return fromBinding(dictionary.tryGetAny(key));
+    },
+    set(dictionary, key, value) {
+      assert.inTransaction(realm);
+
+      if (isEmbedded) {
+        toBinding(value, { createObj: () => [dictionary.insertEmbedded(key), true] });
+      } else {
+        dictionary.insertAny(key, toBinding(value));
+      }
+    },
+  };
+}
+
+/** @internal */
+export function insertIntoDictionaryOfMixed(
+  dictionary: Dictionary | Record<string, unknown>,
+  internal: binding.Dictionary,
+  toBinding: TypeHelpers["toBinding"],
+) {
+  // TODO: Solve the "removeAll()" case for self-assignment.
+  internal.removeAll();
+
+  for (const key in dictionary) {
+    const value = dictionary[key];
+    if (isJsOrRealmList(value)) {
+      internal.insertCollection(key, binding.CollectionType.List);
+      insertIntoListOfMixed(value, internal.getList(key), toBinding);
+    } else if (isJsOrRealmDictionary(value)) {
+      internal.insertCollection(key, binding.CollectionType.Dictionary);
+      insertIntoDictionaryOfMixed(value, internal.getDictionary(key), toBinding);
+    } else {
+      internal.insertAny(key, toBinding(value));
+    }
+  }
+}
+
+/** @internal */
+export function isJsOrRealmDictionary(value: unknown): value is Dictionary | Record<string, unknown> {
+  return isPOJO(value) || value instanceof Dictionary;
+}
+
+/** @internal */
+export function isPOJO(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    // Lastly check for the absence of a prototype as POJOs
+    // can still be created using `Object.create(null)`.
+    (value.constructor === Object || !Object.getPrototypeOf(value))
+  );
 }

--- a/packages/realm/src/GeoSpatial.ts
+++ b/packages/realm/src/GeoSpatial.ts
@@ -124,6 +124,24 @@ export type GeoBox = {
 };
 
 /** @internal */
+export function isGeoCircle(value: object): value is GeoCircle {
+  return "center" in value && "distance" in value && typeof value.distance === "number";
+}
+
+/** @internal */
+export function isGeoBox(value: object): value is GeoBox {
+  return "bottomLeft" in value && "topRight" in value;
+}
+
+/** @internal */
+export function isGeoPolygon(value: object): value is GeoPolygon {
+  return (
+    ("type" in value && value.type === "Polygon" && "coordinates" in value && Array.isArray(value.coordinates)) ||
+    ("outerRing" in value && Array.isArray(value.outerRing))
+  );
+}
+
+/** @internal */
 export function circleToBindingGeospatial(circle: GeoCircle): binding.Geospatial {
   return binding.Geospatial.makeFromCircle({
     center: toBindingGeoPoint(circle.center),

--- a/packages/realm/src/List.ts
+++ b/packages/realm/src/List.ts
@@ -426,7 +426,7 @@ export function insertIntoListOfMixed(
   internal: binding.List,
   toBinding: TypeHelpers["toBinding"],
 ) {
-  // TODO: Solve the "removeAll()" case for self-assignment.
+  // TODO: Solve the "removeAll()" case for self-assignment (https://github.com/realm/realm-core/issues/7422).
   internal.removeAll();
 
   for (const [index, item] of list.entries()) {

--- a/packages/realm/src/OrderedCollection.ts
+++ b/packages/realm/src/OrderedCollection.ts
@@ -20,24 +20,40 @@ import {
   ClassHelpers,
   Collection,
   DefaultObject,
-  INTERNAL,
   IllegalConstructorError,
   JSONCacheMap,
+  ListAccessor,
+  INTERNAL as OBJ_INTERNAL,
   Realm,
   RealmObject,
   Results,
+  ResultsAccessor,
+  SetAccessor,
+  COLLECTION_TYPE_HELPERS as TYPE_HELPERS,
   TypeAssertionError,
   TypeHelpers,
   assert,
   binding,
+  createResultsAccessor,
   getTypeName,
+  isJsOrRealmDictionary,
+  isJsOrRealmList,
   mixedToBinding,
+  toItemType,
   unwind,
 } from "./internal";
 
 const DEFAULT_COLUMN_KEY = binding.Int64.numToInt(0) as unknown as binding.ColKey;
 
+type OrderedCollectionInternal = binding.List | binding.Results | binding.Set;
 type PropertyType = string;
+
+/**
+ * Accessor for getting and setting items in the binding collection, as
+ * well as converting the values to and from their binding representations.
+ * @internal
+ */
+export type OrderedCollectionAccessor<T = unknown> = ListAccessor<T> | ResultsAccessor<T> | SetAccessor<T>;
 
 /**
  * A sort descriptor is either a string containing one or more property names
@@ -75,11 +91,6 @@ export type CollectionChangeCallback<T = unknown, EntryType extends [unknown, un
   changes: CollectionChangeSet,
 ) => void;
 
-/** @internal */
-export type OrderedCollectionHelpers = TypeHelpers & {
-  get(results: binding.Results, index: number): unknown;
-};
-
 const DEFAULT_PROPERTY_DESCRIPTOR: PropertyDescriptor = { configurable: true, enumerable: true, writable: true };
 const PROXY_HANDLER: ProxyHandler<OrderedCollection> = {
   // TODO: Consider executing the `parseInt` first to optimize for index access over accessing a member on the list
@@ -97,13 +108,19 @@ const PROXY_HANDLER: ProxyHandler<OrderedCollection> = {
   set(target, prop, value, receiver) {
     if (typeof prop === "string") {
       const index = Number.parseInt(prop, 10);
-      // TODO: Consider catching an error from access out of bounds, instead of checking the length, to optimize for the hot path
-      // TODO: Do we expect an upper bound check on the index when setting?
       if (Number.isInteger(index)) {
-        if (index < 0) {
-          throw new Error(`Index ${index} cannot be less than zero.`);
+        // Optimize for the hot-path by catching a potential out of bounds access from Core, rather
+        // than checking the length upfront. Thus, our List differs from the behavior of a JS array.
+        try {
+          target.set(index, value);
+        } catch (err) {
+          // Let the custom errors from Results take precedence over out of bounds errors. This will
+          // let users know that they cannot modify Results, rather than erroring on incorrect index.
+          if (index < 0 && !(target instanceof Results)) {
+            throw new Error(`Cannot set item at negative index ${index}.`);
+          }
+          throw err;
         }
-        target.set(index, value);
         return true;
       }
     }
@@ -131,19 +148,39 @@ const PROXY_HANDLER: ProxyHandler<OrderedCollection> = {
  * subscripting, enumerating with `for-of` and so on.
  * @see {@link https://mdn.io/Array | Array}
  */
-export abstract class OrderedCollection<T = unknown, EntryType extends [unknown, unknown] = [number, T]>
-  extends Collection<number, T, EntryType, T, CollectionChangeCallback<T, EntryType>>
+export abstract class OrderedCollection<
+    T = unknown,
+    EntryType extends [unknown, unknown] = [number, T],
+    /** @internal */
+    Accessor extends OrderedCollectionAccessor<T> = OrderedCollectionAccessor<T>,
+  >
+  extends Collection<
+    number,
+    T,
+    EntryType,
+    T,
+    CollectionChangeCallback<T, EntryType>,
+    /** @internal */
+    Accessor
+  >
   implements Omit<ReadonlyArray<T>, "entries">
 {
   /** @internal */ protected declare realm: Realm;
+
+  /**
+   * The representation in the binding of the underlying collection.
+   * @internal
+   */
+  public abstract readonly internal: OrderedCollectionInternal;
+
   /** @internal */ protected declare results: binding.Results;
-  /** @internal */ protected declare helpers: OrderedCollectionHelpers;
+
   /** @internal */
-  constructor(realm: Realm, results: binding.Results, helpers: OrderedCollectionHelpers) {
+  constructor(realm: Realm, results: binding.Results, accessor: Accessor, typeHelpers: TypeHelpers<T>) {
     if (arguments.length === 0) {
       throw new IllegalConstructorError("OrderedCollection");
     }
-    super((callback, keyPaths) => {
+    super(accessor, typeHelpers, (callback, keyPaths) => {
       return results.addNotificationCallback(
         (changes) => {
           try {
@@ -166,6 +203,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
     });
     // Wrap in a proxy to trap ownKeys and get, enabling the spread operator
     const proxied = new Proxy(this, PROXY_HANDLER as ProxyHandler<this>);
+
     // Get the class helpers for later use, if available
     const { objectType } = results;
     const classHelpers = typeof objectType === "string" && objectType !== "" ? realm.getClassHelpers(objectType) : null;
@@ -181,12 +219,6 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       configurable: false,
       writable: false,
       value: results,
-    });
-    Object.defineProperty(this, "helpers", {
-      enumerable: false,
-      configurable: false,
-      writable: false,
-      value: helpers,
     });
     Object.defineProperty(this, "classHelpers", {
       enumerable: false,
@@ -206,6 +238,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       configurable: true,
       writable: false,
     });
+
     return proxied;
   }
 
@@ -215,25 +248,16 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   private declare mixedToBinding: (value: unknown, options: { isQueryArg: boolean }) => binding.MixedArg;
 
   /**
-   * Get an element of the ordered collection by index.
-   * @param index - The index.
-   * @returns The element.
+   * Get an element of the collection.
    * @internal
    */
-  public get(index: number): T {
-    return this.helpers.fromBinding(this.helpers.get(this.results, index)) as T;
-  }
+  public abstract get(index: number): T;
 
   /**
-   * Set an element of the ordered collection by index.
-   * @param index - The index.
-   * @param value - The value.
+   * Set an element in the collection.
    * @internal
    */
-  public set(index: number, value: T): void;
-  public set() {
-    throw new Error(`Assigning into a ${this.constructor.name} is not supported`);
-  }
+  public abstract set(index: number, value: T): void;
 
   /**
    * The plain object representation for JSON serialization.
@@ -269,10 +293,9 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * @returns An iterator with all values in the collection.
    */
   *values(): Generator<T> {
-    const snapshot = this.results.snapshot();
-    const { get, fromBinding } = this.helpers;
+    const snapshot = this.snapshot();
     for (const i of this.keys()) {
-      yield fromBinding(get(snapshot, i)) as T;
+      yield snapshot[i];
     }
   }
 
@@ -281,11 +304,10 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * @returns An iterator with all key/value pairs in the collection.
    */
   *entries(): Generator<EntryType> {
-    const { get, fromBinding } = this.helpers;
-    const snapshot = this.results.snapshot();
-    const size = snapshot.size();
+    const snapshot = this.snapshot();
+    const size = snapshot.length;
     for (let i = 0; i < size; i++) {
-      yield [i, fromBinding(get(snapshot, i))] as EntryType;
+      yield [i, snapshot[i]] as EntryType;
     }
   }
 
@@ -310,7 +332,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * @returns The name of the type of values.
    */
   get type(): PropertyType {
-    return getTypeName(this.results.type & ~binding.PropertyType.Flags, undefined);
+    return getTypeName(toItemType(this.results.type), undefined);
   }
 
   /**
@@ -379,11 +401,17 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    */
   indexOf(searchElement: T, fromIndex?: number): number {
     assert(typeof fromIndex === "undefined", "The second fromIndex argument is not yet supported");
+
     if (this.type === "object") {
       assert.instanceOf(searchElement, RealmObject);
-      return this.results.indexOfObj(searchElement[INTERNAL]);
+      return this.results.indexOfObj(searchElement[OBJ_INTERNAL]);
+    } else if (isJsOrRealmList(searchElement) || isJsOrRealmDictionary(searchElement)) {
+      // Collections are always treated as not equal since their
+      // references will always be different for each access.
+      const NOT_FOUND = -1;
+      return NOT_FOUND;
     } else {
-      return this.results.indexOf(this.helpers.toBinding(searchElement));
+      return this.results.indexOf(this[TYPE_HELPERS].toBinding(searchElement));
     }
   }
   /**
@@ -795,12 +823,16 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * let merlots = wines.filtered('variety == "Merlot" && vintage <= $0', maxYear);
    */
   filtered(queryString: string, ...args: unknown[]): Results<T> {
-    const { results: parent, realm, helpers } = this;
+    const { results: parent, realm } = this;
     const kpMapping = binding.Helpers.getKeypathMapping(realm.internal);
     const bindingArgs = args.map((arg) => this.queryArgToBinding(arg));
     const newQuery = parent.query.table.query(queryString, bindingArgs, kpMapping);
     const results = binding.Helpers.resultsAppendQuery(parent, newQuery);
-    return new Results(realm, results, helpers);
+
+    const itemType = toItemType(results.type);
+    const typeHelpers = this[TYPE_HELPERS];
+    const accessor = createResultsAccessor({ realm, typeHelpers, itemType });
+    return new Results(realm, results, accessor, typeHelpers);
   }
 
   /** @internal */
@@ -871,7 +903,7 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   sorted(arg0: boolean | SortDescriptor[] | string = "self", arg1?: boolean): Results<T> {
     if (Array.isArray(arg0)) {
       assert.undefined(arg1, "second 'argument'");
-      const { results: parent, realm, helpers } = this;
+      const { results: parent, realm } = this;
       // Map optional "reversed" to "ascending" (expected by the binding)
       const descriptors = arg0.map<[string, boolean]>((arg, i) => {
         if (typeof arg === "string") {
@@ -887,7 +919,10 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
       });
       // TODO: Call `parent.sort`, avoiding property name to column key conversion to speed up performance here.
       const results = parent.sortByNames(descriptors);
-      return new Results(realm, results, helpers);
+      const itemType = toItemType(results.type);
+      const typeHelpers = this[TYPE_HELPERS];
+      const accessor = createResultsAccessor({ realm, typeHelpers, itemType });
+      return new Results(realm, results, accessor, typeHelpers);
     } else if (typeof arg0 === "string") {
       return this.sorted([[arg0, arg1 === true]]);
     } else if (typeof arg0 === "boolean") {
@@ -912,7 +947,12 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
    * @returns Results which will **not** live update.
    */
   snapshot(): Results<T> {
-    return new Results(this.realm, this.results.snapshot(), this.helpers);
+    const { realm, internal } = this;
+    const snapshot = internal.snapshot();
+    const itemType = toItemType(snapshot.type);
+    const typeHelpers = this[TYPE_HELPERS];
+    const accessor = createResultsAccessor({ realm, typeHelpers, itemType });
+    return new Results(realm, snapshot, accessor, typeHelpers);
   }
 
   /** @internal */
@@ -931,4 +971,36 @@ export abstract class OrderedCollection<T = unknown, EntryType extends [unknown,
   private mapKeyPaths(keyPaths: string[]) {
     return this.realm.internal.createKeyPathArray(this.results.objectType, keyPaths);
   }
+}
+
+type Getter<CollectionType, T> = (collection: CollectionType, index: number) => T;
+
+type GetterFactoryOptions<T> = {
+  fromBinding: TypeHelpers<T>["fromBinding"];
+  itemType: binding.PropertyType;
+};
+
+/** @internal */
+export function createDefaultGetter<CollectionType extends OrderedCollectionInternal, T>({
+  fromBinding,
+  itemType,
+}: GetterFactoryOptions<T>): Getter<CollectionType, T> {
+  const isObjectItem = itemType === binding.PropertyType.Object || itemType === binding.PropertyType.LinkingObjects;
+  return isObjectItem ? (...args) => getObject(fromBinding, ...args) : (...args) => getKnownType(fromBinding, ...args);
+}
+
+function getObject<T>(
+  fromBinding: TypeHelpers<T>["fromBinding"],
+  collection: OrderedCollectionInternal,
+  index: number,
+): T {
+  return fromBinding(collection.getObj(index));
+}
+
+function getKnownType<T>(
+  fromBinding: TypeHelpers<T>["fromBinding"],
+  collection: OrderedCollectionInternal,
+  index: number,
+): T {
+  return fromBinding(collection.getAny(index));
 }

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -20,7 +20,7 @@ import {
   ClassHelpers,
   Dictionary,
   List,
-  OrderedCollectionHelpers,
+  ListAccessor,
   Realm,
   RealmSet,
   Results,
@@ -29,7 +29,16 @@ import {
   TypeOptions,
   assert,
   binding,
+  createDictionaryAccessor,
+  createListAccessor,
+  createResultsAccessor,
+  createSetAccessor,
   getTypeHelpers,
+  insertIntoDictionaryOfMixed,
+  insertIntoListOfMixed,
+  isJsOrRealmDictionary,
+  isJsOrRealmList,
+  toItemType,
 } from "./internal";
 
 type PropertyContext = binding.Property & {
@@ -38,13 +47,6 @@ type PropertyContext = binding.Property & {
   embedded: boolean;
   default?: unknown;
 };
-
-function getObj(results: binding.Results, index: number) {
-  return results.getObj(index);
-}
-function getAny(results: binding.Results, index: number) {
-  return results.getAny(index);
-}
 
 /** @internal */
 export type HelperOptions = {
@@ -60,15 +62,15 @@ type PropertyOptions = {
 } & HelperOptions &
   binding.Property_Relaxed;
 
-type PropertyAccessors = {
+type PropertyAccessor = {
   get(obj: binding.Obj): unknown;
   set(obj: binding.Obj, value: unknown): unknown;
-  collectionHelpers?: OrderedCollectionHelpers;
+  listAccessor?: ListAccessor;
 };
 
 /** @internal */
 export type PropertyHelpers = TypeHelpers &
-  PropertyAccessors & {
+  PropertyAccessor & {
     type: binding.PropertyType;
     columnKey: binding.ColKey;
     embedded: boolean;
@@ -116,7 +118,7 @@ function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions)
   };
 }
 
-type AccessorFactory = (options: PropertyOptions) => PropertyAccessors;
+type AccessorFactory = (options: PropertyOptions) => PropertyAccessor;
 
 const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>> = {
   [binding.PropertyType.Object](options) {
@@ -153,11 +155,9 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
     linkOriginPropertyName,
     getClassHelpers,
     optional,
-    typeHelpers: { fromBinding },
   }) {
     const realmInternal = realm.internal;
-    const itemType = type & ~binding.PropertyType.Flags;
-
+    const itemType = toItemType(type);
     const itemHelpers = getTypeHelpers(itemType, {
       realm,
       name: `element of ${name}`,
@@ -166,13 +166,6 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
       objectType,
       objectSchemaName: undefined,
     });
-
-    // Properties of items are only available on lists of objects
-    const isObjectItem = itemType === binding.PropertyType.Object || itemType === binding.PropertyType.LinkingObjects;
-    const collectionHelpers: OrderedCollectionHelpers = {
-      ...itemHelpers,
-      get: isObjectItem ? getObj : getAny,
-    };
 
     if (itemType === binding.PropertyType.LinkingObjects) {
       // Locate the table of the targeted object
@@ -186,71 +179,51 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
       const targetProperty = persistedProperties.find((p) => p.name === linkOriginPropertyName);
       assert(targetProperty, `Expected a '${linkOriginPropertyName}' property on ${objectType}`);
       const tableRef = binding.Helpers.getTable(realmInternal, tableKey);
+      const resultsAccessor = createResultsAccessor({ realm, typeHelpers: itemHelpers, itemType });
 
       return {
         get(obj: binding.Obj) {
           const tableView = obj.getBacklinkView(tableRef, targetProperty.columnKey);
           const results = binding.Results.fromTableView(realmInternal, tableView);
-          return new Results(realm, results, collectionHelpers);
+          return new Results(realm, results, resultsAccessor, itemHelpers);
         },
         set() {
           throw new Error("Not supported");
         },
       };
     } else {
-      const { toBinding: itemToBinding } = itemHelpers;
+      const listAccessor = createListAccessor({ realm, typeHelpers: itemHelpers, itemType, isEmbedded: embedded });
+
       return {
-        collectionHelpers,
+        listAccessor,
         get(obj: binding.Obj) {
           const internal = binding.List.make(realm.internal, obj, columnKey);
           assert.instanceOf(internal, binding.List);
-          return fromBinding(internal);
+          return new List(realm, internal, listAccessor, itemHelpers);
         },
         set(obj, values) {
           assert.inTransaction(realm);
-          // Implements https://github.com/realm/realm-core/blob/v12.0.0/src/realm/object-store/list.hpp#L258-L286
           assert.iterable(values);
-          const bindingValues = [];
-          const internal = binding.List.make(realm.internal, obj, columnKey);
 
-          // In case of embedded objects, they're added as they're transformed
-          // So we need to ensure an empty list before
-          if (embedded) {
-            internal.removeAll();
-          }
-          // Transform all values to mixed before inserting into the list
-          {
-            let index = 0;
+          const internal = binding.List.make(realm.internal, obj, columnKey);
+          internal.removeAll();
+          let index = 0;
+          try {
             for (const value of values) {
-              try {
-                if (embedded) {
-                  itemToBinding(value, { createObj: () => [internal.insertEmbedded(index), true] });
-                } else {
-                  bindingValues.push(itemToBinding(value));
-                }
-              } catch (err) {
-                if (err instanceof TypeAssertionError) {
-                  err.rename(`${name}[${index}]`);
-                }
-                throw err;
-              }
-              index++;
+              listAccessor.insert(internal, index++, value);
             }
-          }
-          // Move values into the internal list - embedded objects are added as they're transformed
-          if (!embedded) {
-            internal.removeAll();
-            let index = 0;
-            for (const value of bindingValues) {
-              internal.insertAny(index++, value);
+          } catch (err) {
+            if (err instanceof TypeAssertionError) {
+              err.rename(`${name}[${index - 1}]`);
             }
+            throw err;
           }
         },
       };
     }
   },
   [binding.PropertyType.Dictionary]({ columnKey, realm, name, type, optional, objectType, getClassHelpers, embedded }) {
-    const itemType = type & ~binding.PropertyType.Flags;
+    const itemType = toItemType(type);
     const itemHelpers = getTypeHelpers(itemType, {
       realm,
       name: `value in ${name}`,
@@ -259,23 +232,28 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
       optional,
       objectSchemaName: undefined,
     });
+    const dictionaryAccessor = createDictionaryAccessor({
+      realm,
+      typeHelpers: itemHelpers,
+      itemType,
+      isEmbedded: embedded,
+    });
+
     return {
       get(obj) {
         const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-        return new Dictionary(realm, internal, itemHelpers);
+        return new Dictionary(realm, internal, dictionaryAccessor, itemHelpers);
       },
       set(obj, value) {
+        assert.inTransaction(realm);
+
         const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
         // Clear the dictionary before adding new values
         internal.removeAll();
-        assert.object(value, `values of ${name}`);
+        assert.object(value, `values of ${name}`, { allowArrays: false });
         for (const [k, v] of Object.entries(value)) {
           try {
-            if (embedded) {
-              itemHelpers.toBinding(v, { createObj: () => [internal.insertEmbedded(k), true] });
-            } else {
-              internal.insertAny(k, itemHelpers.toBinding(v));
-            }
+            dictionaryAccessor.set(internal, k, v);
           } catch (err) {
             if (err instanceof TypeAssertionError) {
               err.rename(`${name}["${k}"]`);
@@ -287,7 +265,7 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
     };
   },
   [binding.PropertyType.Set]({ columnKey, realm, name, type, optional, objectType, getClassHelpers }) {
-    const itemType = type & ~binding.PropertyType.Flags;
+    const itemType = toItemType(type);
     const itemHelpers = getTypeHelpers(itemType, {
       realm,
       name: `value in ${name}`,
@@ -297,76 +275,64 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
       objectSchemaName: undefined,
     });
     assert.string(objectType);
-    const collectionHelpers: OrderedCollectionHelpers = {
-      get: itemType === binding.PropertyType.Object ? getObj : getAny,
-      fromBinding: itemHelpers.fromBinding,
-      toBinding: itemHelpers.toBinding,
-    };
+    const setAccessor = createSetAccessor({ realm, typeHelpers: itemHelpers, itemType });
+
     return {
       get(obj) {
         const internal = binding.Set.make(realm.internal, obj, columnKey);
-        return new RealmSet(realm, internal, collectionHelpers);
+        return new RealmSet(realm, internal, setAccessor, itemHelpers);
       },
       set(obj, value) {
+        assert.inTransaction(realm);
+
         const internal = binding.Set.make(realm.internal, obj, columnKey);
         // Clear the set before adding new values
         internal.removeAll();
         assert.array(value, "values");
         for (const v of value) {
-          internal.insertAny(itemHelpers.toBinding(v));
+          setAccessor.insert(internal, v);
         }
       },
     };
   },
   [binding.PropertyType.Mixed](options) {
-    const {
-      realm,
-      columnKey,
-      typeHelpers: { fromBinding, toBinding },
-    } = options;
+    const { realm, columnKey, typeHelpers } = options;
+    const { fromBinding, toBinding } = typeHelpers;
+    const listAccessor = createListAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
+    const dictionaryAccessor = createDictionaryAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
 
     return {
-      get: (obj) => {
+      get(obj) {
         try {
-          // We currently rely on the Core helper `get_mixed_type()` for calling `obj.get_any()`
-          // since doing it here in the SDK layer will cause the binding layer to throw for
-          // collections. It's non-trivial to do in the bindgen templates as a `binding.List`
-          // would have to be constructed using the `realm` and `obj`. Going via the helpers
-          // bypasses that as we will return a primitive (the data type). If possible, revisiting
-          // this for a more performant solution would be ideal as we now make an extra call into
-          // Core for each Mixed access, not only for collections.
-          const mixedType = binding.Helpers.getMixedType(obj, columnKey);
-          if (mixedType === binding.MixedDataType.List) {
-            return fromBinding(binding.List.make(realm.internal, obj, columnKey));
+          const value = obj.getAny(columnKey);
+          switch (value) {
+            case binding.ListSentinel: {
+              const internal = binding.List.make(realm.internal, obj, columnKey);
+              return new List(realm, internal, listAccessor, typeHelpers);
+            }
+            case binding.DictionarySentinel: {
+              const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
+              return new Dictionary(realm, internal, dictionaryAccessor, typeHelpers);
+            }
+            default:
+              return fromBinding(value);
           }
-          if (mixedType === binding.MixedDataType.Dictionary) {
-            return fromBinding(binding.Dictionary.make(realm.internal, obj, columnKey));
-          }
-          return defaultGet(options)(obj);
         } catch (err) {
           assert.isValid(obj);
           throw err;
         }
       },
-      set: (obj: binding.Obj, value: unknown) => {
+      set(obj: binding.Obj, value: unknown) {
         assert.inTransaction(realm);
 
-        if (value instanceof List || Array.isArray(value)) {
+        if (isJsOrRealmList(value)) {
           obj.setCollection(columnKey, binding.CollectionType.List);
           const internal = binding.List.make(realm.internal, obj, columnKey);
-          let index = 0;
-          for (const item of value) {
-            internal.insertAny(index++, toBinding(item));
-          }
-        } else if (value instanceof Dictionary || isPOJO(value)) {
+          insertIntoListOfMixed(value, internal, toBinding);
+        } else if (isJsOrRealmDictionary(value)) {
           obj.setCollection(columnKey, binding.CollectionType.Dictionary);
           const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-          internal.removeAll();
-          for (const key in value) {
-            internal.insertAny(key, toBinding(value[key]));
-          }
-        } else if (value instanceof RealmSet || value instanceof Set) {
-          throw new Error(`Using a ${value.constructor.name} as a Mixed value is not supported.`);
+          insertIntoDictionaryOfMixed(value, internal, toBinding);
         } else {
           defaultSet(options)(obj, value);
         }
@@ -413,23 +379,12 @@ export function createPropertyHelpers(property: PropertyContext, options: Helper
       typeHelpers: getTypeHelpers(collectionType, typeOptions),
     });
   } else {
-    const baseType = property.type & ~binding.PropertyType.Flags;
-    return getPropertyHelpers(baseType, {
+    const itemType = toItemType(property.type);
+    return getPropertyHelpers(itemType, {
       ...property,
       ...options,
       ...typeOptions,
-      typeHelpers: getTypeHelpers(baseType, typeOptions),
+      typeHelpers: getTypeHelpers(itemType, typeOptions),
     });
   }
-}
-
-/** @internal */
-export function isPOJO(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    // Lastly check for the absence of a prototype as POJOs
-    // can still be created using `Object.create(null)`.
-    (value.constructor === Object || !Object.getPrototypeOf(value))
-  );
 }

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -48,10 +48,12 @@ import {
   SubscriptionSet,
   SyncSession,
   TypeAssertionError,
+  TypeHelpers,
   Unmanaged,
   UpdateMode,
   assert,
   binding,
+  createResultsAccessor,
   defaultLogger,
   defaultLoggerLevel,
   extendDebug,
@@ -938,25 +940,27 @@ export class Realm {
   objects<T = DefaultObject>(type: string): Results<RealmObject<T> & T>;
   objects<T extends AnyRealmObject = RealmObject & DefaultObject>(type: Constructor<T>): Results<T>;
   objects<T extends AnyRealmObject>(type: string | Constructor<T>): Results<T> {
-    const { objectSchema, wrapObject } = this.classes.getHelpers(type);
+    const { internal, classes } = this;
+    const { objectSchema, wrapObject } = classes.getHelpers(type);
     if (isEmbedded(objectSchema)) {
       throw new Error("You cannot query an embedded object.");
     } else if (isAsymmetric(objectSchema)) {
       throw new Error("You cannot query an asymmetric object.");
     }
 
-    const table = binding.Helpers.getTable(this.internal, objectSchema.tableKey);
-    const results = binding.Results.fromTable(this.internal, table);
-    return new Results<T>(this, results, {
-      get(results: binding.Results, index: number) {
-        return results.getObj(index);
+    const table = binding.Helpers.getTable(internal, objectSchema.tableKey);
+    const results = binding.Results.fromTable(internal, table);
+    const typeHelpers: TypeHelpers<T> = {
+      fromBinding(value) {
+        return wrapObject(value as binding.Obj) as T;
       },
-      fromBinding: wrapObject,
-      toBinding(value: unknown) {
+      toBinding(value) {
         assert.instanceOf(value, RealmObject);
         return value[INTERNAL];
       },
-    });
+    };
+    const accessor = createResultsAccessor<T>({ realm: this, typeHelpers, itemType: binding.PropertyType.Object });
+    return new Results<T>(this, results, accessor, typeHelpers);
   }
 
   /**

--- a/packages/realm/src/tests/PropertyHelpers.test.ts
+++ b/packages/realm/src/tests/PropertyHelpers.test.ts
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+
+import { isPOJO } from "../PropertyHelpers";
+
+describe("PropertyHelpers", () => {
+  describe("isPOJO()", () => {
+    it("returns true for object literal", () => {
+      const object = {};
+      expect(object.constructor).to.equal(Object);
+      expect(isPOJO(object)).to.be.true;
+    });
+
+    it("returns true for Object constructor", () => {
+      const object = new Object();
+      expect(object.constructor).to.equal(Object);
+      expect(isPOJO(object)).to.be.true;
+    });
+
+    it("returns true for Object without prototype", () => {
+      let object = Object.assign(Object.create(null), {});
+      expect(object.constructor).to.be.undefined;
+      expect(Object.getPrototypeOf(object)).to.be.null;
+      expect(isPOJO(object)).to.be.true;
+
+      object = Object.create(null);
+      expect(object.constructor).to.be.undefined;
+      expect(Object.getPrototypeOf(object)).to.be.null;
+      expect(isPOJO(object)).to.be.true;
+    });
+
+    it("returns false for user-defined class", () => {
+      class CustomClass {}
+      const object = new CustomClass();
+      expect(object.constructor).to.equal(CustomClass);
+      expect(isPOJO(object)).to.be.false;
+    });
+
+    it("returns false for user-defined class called Object", () => {
+      class Object {}
+      const object = new Object();
+      expect(object.constructor).to.equal(Object);
+      expect(isPOJO(object)).to.be.false;
+    });
+
+    it("returns false for Arrays", () => {
+      expect(isPOJO([])).to.be.false;
+      expect(isPOJO(new Array(1))).to.be.false;
+    });
+
+    it("returns false for null", () => {
+      expect(isPOJO(null)).to.be.false;
+    });
+  });
+});

--- a/packages/realm/src/tests/collection-helpers.test.ts
+++ b/packages/realm/src/tests/collection-helpers.test.ts
@@ -18,9 +18,9 @@
 
 import { expect } from "chai";
 
-import { isPOJO } from "../PropertyHelpers";
+import { isPOJO } from "../Dictionary";
 
-describe("PropertyHelpers", () => {
+describe("Collection helpers", () => {
   describe("isPOJO()", () => {
     it("returns true for object literal", () => {
       const object = {};
@@ -53,12 +53,13 @@ describe("PropertyHelpers", () => {
       expect(isPOJO(object)).to.be.false;
     });
 
-    it("returns false for user-defined class called Object", () => {
-      class Object {}
-      const object = new Object();
-      expect(object.constructor).to.equal(Object);
-      expect(isPOJO(object)).to.be.false;
-    });
+    // TS2725 compile error: "Class name cannot be 'Object' when targeting ES5 with module Node16"
+    // it("returns false for user-defined class called Object", () => {
+    //   class Object {}
+    //   const object = new Object();
+    //   expect(object.constructor).to.equal(Object);
+    //   expect(isPOJO(object)).to.be.false;
+    // });
 
     it("returns false for Arrays", () => {
       expect(isPOJO([])).to.be.false;


### PR DESCRIPTION
## What, How & Why?

> [!NOTE]
> This feature has **already been reviewed**. New updates to review: `CHANGELOG.md`.
> The branch can be merged whenever we want to make a release with this new feature.

Adds support for storing lists and dictionaries (with nested collections) as the underlying value of a `Mixed` property.

Sets are not supported as a Mixed value.


### Test overview

<details>
<summary>Click to expand</summary>

```
  Mixed
    Collection types
      CRUD operations
        Create and access
          List
            ✓ has all primitive types (input: JS Array)
            ✓ has all primitive types (input: Realm List)
            ✓ has all primitive types (input: Default value)
            ✓ has nested lists of all primitive types
            ✓ has nested dictionaries of all primitive types
            ✓ has mix of nested collections of all types
            ✓ inserts all primitive types via `push()`
            ✓ inserts nested lists of all primitive types via `push()`
            ✓ inserts nested dictionaries of all primitive types via `push()`
            ✓ inserts mix of nested collections of all types via `push()`
            ✓ returns different reference for each access
          Dictionary
            ✓ has all primitive types (input: JS Object)
            ✓ has all primitive types (input: JS Object w/o proto)
            ✓ has all primitive types (input: Realm Dictionary)
            ✓ has all primitive types (input: Default value)
            ✓ can use the spread of embedded Realm object
            ✓ can use the spread of custom non-Realm object
            ✓ has nested lists of all primitive types
            ✓ has nested dictionaries of all primitive types
            ✓ has mix of nested collections of all types
            ✓ inserts all primitive types via setter
            ✓ inserts nested lists of all primitive types via setter
            ✓ inserts nested dictionaries of all primitive types via setter
            ✓ inserts mix of nested collections of all types via setter
            ✓ inserts mix of nested collections of all types via `set()` overloads
            ✓ returns different reference for each access
          Results
            from List
              snapshot()
                ✓ has all primitive types
                ✓ has mix of nested collections of all types
              objects().filtered()
                ✓ has all primitive types
                ✓ has mix of nested collections of all types
            from Dictionary
              objects().filtered()
                ✓ has all primitive types
                ✓ has mix of nested collections of all types
        Update
          List
            ✓ updates top-level item via setter
            ✓ updates nested item via setter
            ✓ updates itself to a new list
            ✓ updates nested list to a new list
            ✓ does not become invalidated when updated to a new list
            - self assigns
            - self assigns nested list
          Dictionary
            ✓ updates top-level entry via setter
            ✓ updates nested entry via setter
            ✓ updates itself to a new dictionary
            ✓ updates nested dictionary to a new dictionary
            ✓ does not become invalidated when updated to a new dictionary
            - self assigns
            - self assigns nested dictionary
        Remove
          List
            ✓ removes top-level item via `remove()`
            ✓ removes nested item via `remove()`
          Dictionary
            ✓ removes top-level entry via `remove()`
            ✓ removes nested entry via `remove()`
        JS collection methods
          List
            ✓ pop()
            ✓ shift()
            ✓ unshift()
            ✓ splice()
            ✓ indexOf()
          Iterators
            ✓ values() - list
            ✓ values() - dictionary
            ✓ entries() - list
            ✓ entries() - dictionary
      Filtering
        ✓ filters by query path on list of all primitive types
        ✓ filters by query path on nested list of all primitive types
        ✓ filters by query path on dictionary of all primitive types
        ✓ filters by query path on nested dictionary of all primitive types
      Invalid operations
        ✓ throws when creating a Mixed with a set
        ✓ throws when creating a set with a list
        ✓ throws when creating a set with a dictionary
        ✓ throws when updating a list item to a set
        ✓ throws when updating a dictionary entry to a set
        ✓ throws when creating a list or dictionary with an embedded object
        ✓ throws when setting a list or dictionary item to an embedded object
        ✓ throws when setting a list or dictionary outside a transaction
        ✓ throws when setting a list item out of bounds
        ✓ throws when setting a nested list item out of bounds
        ✓ throws when assigning to list snapshot (Results)
        ✓ invalidates the list when removed
        ✓ invalidates the dictionary when removed

  Observable
    Collections in Mixed
      Collection notifications
        List
          ✓ fires when inserting, updating, and deleting at top-level
          ✓ fires when inserting, updating, and deleting in nested list
          ✓ fires when inserting, updating, and deleting in nested dictionary
          ✓ does not fire when updating object at top-level
        Dictionary
          ✓ fires when inserting, updating, and deleting at top-level
          ✓ fires when inserting, updating, and deleting in nested list
          ✓ fires when inserting, updating, and deleting in nested dictionary
          ✓ does not fire when updating object at top-level
      Object notifications
        ✓ fires when inserting, updating, and deleting in top-level list
        ✓ fires when inserting, updating, and deleting in nested list
        ✓ fires when inserting, updating, and deleting in top-level dictionary
        ✓ fires when inserting, updating, and deleting in nested dictionary
        ✓ fires when inserting, updating, and deleting in nested dictionary (using key-path)
```
</details>

### Brief overview of usage

```typescript
class CustomObject extends Realm.Object {
  value!: Realm.Types.Mixed;

  static schema: ObjectSchema = {
    name: "CustomObject",
    properties: {
      value: "mixed",
    },
  };
}

const realm = await Realm.open({ schema: [CustomObject] });

// Create an object with a dictionary value as the Mixed
// property, containing primitives and a list.
const realmObject = realm.write(() => {
  return realm.create(CustomObject, {
    value: {
      num: 1,
      string: "hello",
      bool: true,
      list: [
        {
          string: "world",
        },
      ],
    },
  });
});

// Accessing the collection value returns the managed collection.
const dictionary = realmObject.value;
expectDictionary(dictionary);
const list = dictionary.list;
expectList(list);
const leafDictionary = list[0];
expectDictionary(leafDictionary);
console.log(leafDictionary.string); // "world"

// Update the Mixed property to a list.
realm.write(() => {
  realmObject.value = [1, "hello", { newKey: "new value" }];
});

// Useful custom helper functions. (Will be provided in a future release.)
function expectList(value: unknown): asserts value is Realm.List {
  if (!(value instanceof Realm.List)) {
    throw new Error("Expected a 'Realm.List'.");
  }
}
function expectDictionary(value: unknown): asserts value is Realm.Dictionary {
  if (!(value instanceof Realm.Dictionary)) {
    throw new Error("Expected a 'Realm.Dictionary'.");
  }
}
```

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests