### PR TITLE
Suggestions to the "BSON v6 upgrade"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       ],
       "dependencies": {
         "@react-native/eslint-config": "0.73.2",
+        "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -4870,6 +4871,36 @@
       },
       "engines": {
         "node": ">=14.15"
+      }
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+      "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+      "dependencies": {
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-alias/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26270,7 +26270,7 @@
         "html-webpack-plugin": "^5.5.0",
         "mongodb-realm-cli": "^1.3.2",
         "source-map-loader": "^5.0.0",
-        "ts-loader": "^9.3.0",
+        "ts-loader": "^9.5.1",
         "webpack-cli": "^5.1.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   ],
   "dependencies": {
     "@react-native/eslint-config": "0.73.2",
+    "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/realm-web-integration-tests/package.json
+++ b/packages/realm-web-integration-tests/package.json
@@ -54,7 +54,7 @@
     "html-webpack-plugin": "^5.5.0",
     "mongodb-realm-cli": "^1.3.2",
     "source-map-loader": "^5.0.0",
-    "ts-loader": "^9.3.0",
+    "ts-loader": "^9.5.1",
     "webpack-cli": "^5.1.4"
   }
 }

--- a/packages/realm-web-integration-tests/src/index.ts
+++ b/packages/realm-web-integration-tests/src/index.ts
@@ -24,25 +24,25 @@ if (location.pathname.endsWith("-callback")) {
   Realm.handleAuthRedirect();
 } else if (location.pathname.endsWith("/google-login")) {
   console.log("Hello to Google Login ...");
-  require("./google-login");
+  await import("./google-login");
 } else {
   new MochaRemoteClient({
-    tests: () => {
+    async tests() {
       beforeEach(function () {
         this.slow(1000);
         this.timeout(10000);
       });
 
-      require("./environment.test");
-      require("./app.test");
-      require("./credentials.test");
-      require("./user.test");
-      require("./functions.test");
-      require("./services.test");
-      require("./api-key-auth.test");
-      require("./email-password-auth.test");
-      require("./iife.test");
-      require("./bson.test");
+      await import("./environment.test");
+      await import("./app.test");
+      await import("./credentials.test");
+      await import("./user.test");
+      await import("./functions.test");
+      await import("./services.test");
+      await import("./api-key-auth.test");
+      await import("./email-password-auth.test");
+      await import("./iife.test");
+      await import("./bson.test");
     },
   });
 }

--- a/packages/realm-web-integration-tests/src/services.test.ts
+++ b/packages/realm-web-integration-tests/src/services.test.ts
@@ -16,7 +16,5 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-describe("App services", () => {
-  require("./remote-mongodb-service.test");
-  require("./http-service.test");
-});
+import "./remote-mongodb-service.test";
+import "./http-service.test";

--- a/packages/realm-web-integration-tests/tsconfig.json
+++ b/packages/realm-web-integration-tests/tsconfig.json
@@ -2,10 +2,11 @@
 	"compilerOptions": {
 		"strict": true,
 		"sourceMap": true,
-		"module": "commonjs",
-		"target": "ES2019",
+		"module": "ES2022",
+		"target": "ES2022",
+		"moduleResolution": "Bundler",
 		"lib": [
-			"ES2019",
+			"ES2022",
 			"DOM"
 		],
 		"types": [

--- a/packages/realm-web-integration-tests/tsconfig.web.json
+++ b/packages/realm-web-integration-tests/tsconfig.web.json
@@ -9,7 +9,7 @@
 			"mocha-remote-client"
 		],
 		"lib": [
-			"ES2020",
+			"ES2022",
 			"DOM"
 		]
 	},

--- a/packages/realm-web/rollup.config.mjs
+++ b/packages/realm-web/rollup.config.mjs
@@ -25,7 +25,10 @@ import dts from "rollup-plugin-dts";
 import pkg from "./package.json" assert { type: "json" };
 
 const replacer = replace({
+  preventAssignment: true,
+  values: {
   __SDK_VERSION__: JSON.stringify(pkg.version),
+  },
 });
 
 export default [

--- a/packages/realm-web/rollup.config.mjs
+++ b/packages/realm-web/rollup.config.mjs
@@ -16,11 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import alias from "@rollup/plugin-alias";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import replace from "@rollup/plugin-replace";
 import dts from "rollup-plugin-dts";
+
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 
 import pkg from "./package.json" assert { type: "json" };
 
@@ -100,6 +104,16 @@ export default [
       },
     ],
     plugins: [
+      // Providing an alias for the "bson" package
+      // See https://github.com/mongodb/js-bson/pull/669#pullrequestreview-1994786536 for more context
+      alias({
+        entries: [
+          {
+            find: "bson",
+            replacement: require.resolve("bson"),
+          },
+        ],
+      }),
       nodeResolve({
         mainFields: ["browser", "module", "main"],
         exportConditions: ["browser", "module", "main"],

--- a/packages/realm-web/rollup.config.mjs
+++ b/packages/realm-web/rollup.config.mjs
@@ -27,7 +27,7 @@ import pkg from "./package.json" assert { type: "json" };
 const replacer = replace({
   preventAssignment: true,
   values: {
-  __SDK_VERSION__: JSON.stringify(pkg.version),
+    __SDK_VERSION__: JSON.stringify(pkg.version),
   },
 });
 
@@ -100,15 +100,16 @@ export default [
       },
     ],
     plugins: [
-      commonjs(),
-      typescript({
-        tsconfig: "src/dom/tsconfig.json",
-      }),
       nodeResolve({
         mainFields: ["browser", "module", "main"],
         exportConditions: ["browser", "module", "main"],
         modulesOnly: true,
         preferBuiltins: false,
+      }),
+      commonjs(),
+      typescript({
+        tsconfig: "src/dom/tsconfig.json",
+        removeComments: true,
       }),
       replacer,
     ],


### PR DESCRIPTION
## What, How & Why?

- Uses the rollup alias plugin to provide an exact path for the "bson" package, to avoiding a top-level await when bundling "bson" into the "realm-web" IIFE bundle.
- Updates the `realm-web-integration-tests` to consume the "realm-web" ESM bundle.
