### PR TITLE
RJS-2717: Replaced lodash with lodash.isequal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5737,10 +5737,10 @@
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -15859,6 +15859,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -26119,7 +26124,7 @@
       "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash.isequal": "^4.5.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -26130,7 +26135,7 @@
         "@realm/app-importer": "*",
         "@testing-library/react-native": "^12.4.3",
         "@types/jest": "^29.5.12",
-        "@types/lodash-es": "^4.17.6",
+        "@types/lodash.isequal": "^4.5.8",
         "@types/react": "^18.2.6",
         "babel-jest": "^29.7.0",
         "babel-plugin-module-resolver": "^5.0.0",

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -46,9 +46,6 @@
       ]
     }
   },
-  "dependencies": {
-    "lodash": "^4.17.21"
-  },
   "devDependencies": {
     "@babel/core": "^7.23.9",
     "@babel/preset-env": "^7.23.9",
@@ -58,7 +55,6 @@
     "@realm/app-importer": "*",
     "@testing-library/react-native": "^12.4.3",
     "@types/jest": "^29.5.12",
-    "@types/lodash-es": "^4.17.6",
     "@types/react": "^18.2.6",
     "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^5.0.0",
@@ -106,5 +102,9 @@
   "bugs": {
     "url": "https://github.com/realm/realm-js/issues"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@types/lodash.isequal": "^4.5.8",
+    "lodash.isequal": "^4.5.0"
+  }
 }

--- a/packages/realm-react/package.json
+++ b/packages/realm-react/package.json
@@ -56,6 +56,7 @@
     "@testing-library/react-native": "^12.4.3",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.6",
+    "@types/lodash.isequal": "^4.5.8",
     "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "fb-watchman": "^2.0.1",
@@ -104,7 +105,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/lodash.isequal": "^4.5.8",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -18,7 +18,7 @@
 
 import React, { createContext, useContext, useLayoutEffect, useRef, useState } from "react";
 import Realm from "realm";
-import { isEqual } from "lodash";
+import { isEqual } from "lodash.isequal";
 
 import { AuthResult, OperationState } from "./types";
 

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -18,7 +18,7 @@
 
 import React, { useContext, useEffect, useRef, useState } from "react";
 import Realm from "realm";
-import { isEqual } from "lodash";
+import { isEqual } from "lodash.isequal";
 
 import { UserContext } from "./UserProvider";
 


### PR DESCRIPTION
## What, How & Why?

Since we're only using `isEqual` from `lodash` we should avoid requiring in the entire library as it'll be difficult for end-users to shake off. Instead we could depend on the more limited `lodash.isequal` package.

This closes #6458 .