### PR TITLE
RJS-2810: Add privacy manifest for Apple App Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-## vNext (TBD)
-
-### Deprecations
-* None
-
-### Enhancements
-* None
+## 12.8.1-alpha.0 (2024-05-03)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Internal
 * Using Realm Core v14.6.1.
-* Added privacy manifest for Apple App Store. ([#6638](https://github.com/realm/realm-js/issues/6638))
+* Added [privacy manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files)  for Apple App Store. ([#6638](https://github.com/realm/realm-js/issues/6638))
 
 ## 12.8.0 (2024-05-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## vNext (TBD)
+
+### Deprecations
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* None
+
+### Compatibility
+* React Native >= v0.71.4
+* Realm Studio v15.0.0.
+* File format: generates Realms with format v24 (reads and upgrades file format v10.
+
+### Internal
+<!-- * Either mention core version or upgrade -->
+<!-- * Using Realm Core vX.Y.Z -->
+<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+
 ## 12.8.1-alpha.0 (2024-05-03)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 <!-- * Either mention core version or upgrade -->
 <!-- * Using Realm Core vX.Y.Z -->
 <!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Added privacy manifest for Apple App Store. ([#6638](https://github.com/realm/realm-js/issues/6638))
 
 ## 12.8.0 (2024-05-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@
 * File format: generates Realms with format v24 (reads and upgrades file format v10.
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Using Realm Core v14.6.1.
 * Added privacy manifest for Apple App Store. ([#6638](https://github.com/realm/realm-js/issues/6638))
 
 ## 12.8.0 (2024-05-01)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25901,7 +25901,7 @@
       }
     },
     "packages/realm": {
-      "version": "12.8.0",
+      "version": "12.8.1-alpha.0",
       "hasInstallScript": true,
       "license": "apache-2.0",
       "dependencies": {

--- a/packages/realm/PrivacyInfo.xcprivacy
+++ b/packages/realm/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+        <dict>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+        </dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/realm/RealmJS.podspec
+++ b/packages/realm/RealmJS.podspec
@@ -43,18 +43,12 @@ Pod::Spec.new do |s|
 
   s.source_files           = 'react-native/ios/RealmReact/*.mm'
   s.public_header_files    = 'react-native/ios/RealmReact/*.h'
-
+  s.resource_bundles       = { 'RealmJS' => ['PrivacyInfo.xcprivacy'] }
+  
   s.frameworks             = uses_frameworks ? ['React'] : []
-
   s.library                = 'c++', 'z', 'compression'
 
   s.pod_target_xcconfig    = {
-                                # Setting up clang
-                                'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-                                'CLANG_CXX_LIBRARY' => 'libc++',
-                                # Setting the current project version and versioning system to get a symbol for analytics
-                                'CURRENT_PROJECT_VERSION' => s.version,
-                                'VERSIONING_SYSTEM' => 'apple-generic',
                                 # Header search paths are prefixes to the path specified in #include macros
                                 'HEADER_SEARCH_PATHS' => [
                                   '"$(PODS_TARGET_SRCROOT)/react-native/ios/RealmReact/"',

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -68,13 +68,13 @@
     "types.d.cts",
     "react-native/android",
     "react-native/ios/realm-js-ios.xcframework",
-    "react-native/ios/realm-js-ios.xcframework/PrivacyInfo.xcprivacy",
     "react-native/ios/realm-js-ios.xcframework/**/*.a",
     "react-native/ios/RealmReact",
     "bindgen/vendor/realm-core/dependencies.list",
     "scripts/submit-analytics.mjs",
     "react-native.config.js",
     "RealmJS.podspec",
+    "PrivacyInfo.xcprivacy",
     "binding.gyp"
   ],
   "scripts": {

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -68,6 +68,7 @@
     "types.d.cts",
     "react-native/android",
     "react-native/ios/realm-js-ios.xcframework",
+    "react-native/ios/realm-js-ios.xcframework/PrivacyInfo.xcprivacy",
     "react-native/ios/realm-js-ios.xcframework/**/*.a",
     "react-native/ios/RealmReact",
     "bindgen/vendor/realm-core/dependencies.list",

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm",
-  "version": "12.8.0",
+  "version": "12.8.1-alpha.0",
   "description": "Realm by MongoDB is an offline-first mobile database: an alternative to SQLite and key-value stores",
   "license": "apache-2.0",
   "homepage": "https://www.mongodb.com/docs/realm/",

--- a/packages/realm/scripts/build-ios.sh
+++ b/packages/realm/scripts/build-ios.sh
@@ -123,3 +123,6 @@ rm -rf ../realm-js-ios.xcframework
 xcodebuild -create-xcframework \
     "${LIBRARIES[@]}" \
     -output ../realm-js-ios.xcframework
+
+# Add the privacy manifest to the generated framework
+cp "${PROJECT_ROOT}/PrivacyInfo.xcprivacy" ../realm-js-ios.xcframework

--- a/packages/realm/scripts/build-ios.sh
+++ b/packages/realm/scripts/build-ios.sh
@@ -123,6 +123,3 @@ rm -rf ../realm-js-ios.xcframework
 xcodebuild -create-xcframework \
     "${LIBRARIES[@]}" \
     -output ../realm-js-ios.xcframework
-
-# Add the privacy manifest to the generated framework
-cp "${PROJECT_ROOT}/PrivacyInfo.xcprivacy" ../realm-js-ios.xcframework


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

This closes #6638

### The manifest
The actual privacy manifest is based on our current understanding of what is needed.

### Testing
1. `npm pack` is used to create a `tgz` file
2. In a simple app, the "release" is added: `npm install realm-x.y.z.tgz`
3. The xcode project is generated: `cd ios && pod install`
4. The code project is opened with XCode: build and archive the app
5. The archived app is validated in XCode, and no errors (e.g. 'invalid bundle structure' or 'the “.../RealmJS” binary file is not permitted') are reported

### Unknowns
I am a bit uncertain if the proposed privacy manifest (in particular the location of it) is compatible with Catalyst.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
