### PR TITLE
Fix unresolvable links in API reference docs and remove re-exports

### DIFF
--- a/packages/realm-react/src/__tests__/useEmailPasswordAuth.test.tsx
+++ b/packages/realm-react/src/__tests__/useEmailPasswordAuth.test.tsx
@@ -27,7 +27,6 @@ import { useEmailPasswordAuth } from "../useEmailPasswordAuth";
 import { baseUrl, importApp, testAuthOperation } from "./helpers";
 
 function renderEmailPasswordAuth(appId: string, baseUrl: string) {
-  console.log({ appId, baseUrl });
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <AppProvider id={appId} baseUrl={baseUrl}>
       {children}

--- a/packages/realm/src/Logger.ts
+++ b/packages/realm/src/Logger.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { assert, binding } from "./internal";
+import { type App, assert, binding } from "./internal";
 
 export type LogLevel = "all" | "trace" | "debug" | "detail" | "info" | "warn" | "error" | "fatal" | "off";
 
@@ -140,7 +140,7 @@ export const LOG_CATEGORIES = [
 export type LogCategory = (typeof LOG_CATEGORIES)[number];
 
 /**
- * A callback passed to `Realm.App.Sync.setLogger` when instrumenting the Atlas Device Sync client with a custom logger.
+ * A callback passed to {@link App.Sync.setLogger} when instrumenting the Atlas Device Sync client with a custom logger.
  * @param level - The level of the log entry between 0 and 8 inclusively.
  * Use this as an index into `['all', 'trace', 'debug', 'detail', 'info', 'warn', 'error', 'fatal', 'off']` to get the name of the level.
  * @param message - The message of the log entry.

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1276,9 +1276,12 @@ export namespace Realm {
   export import InitialSubscriptions = internal.InitialSubscriptions;
   export import List = internal.List;
   export import LocalAppConfiguration = internal.LocalAppConfiguration;
+  export import LogCategory = internal.LogCategory;
   export import LogEntry = internal.LogEntry;
   export import Logger = internal.Logger;
   export import LoggerCallback = internal.LoggerCallback;
+  export import LoggerCallback1 = internal.LoggerCallback1;
+  export import LoggerCallback2 = internal.LoggerCallback2;
   export import MapToDecorator = internal.MapToDecorator;
   export import Metadata = internal.Metadata;
   export import MetadataMode = internal.MetadataMode;
@@ -1305,6 +1308,7 @@ export namespace Realm {
   export import ProgressRealmPromise = internal.ProgressRealmPromise;
   export import PropertiesTypes = internal.PropertiesTypes;
   export import PropertySchema = internal.PropertySchema;
+  export import PropertySchemaCommon = internal.PropertySchemaCommon;
   export import PropertySchemaParseError = internal.PropertySchemaParseError;
   export import PropertySchemaShorthand = internal.PropertySchemaShorthand;
   export import PropertySchemaStrict = internal.PropertySchemaStrict;
@@ -1337,6 +1341,7 @@ export namespace Realm {
   export import UserChangeCallback = internal.UserChangeCallback;
   export import UserIdentity = internal.UserIdentity;
   export import UserState = internal.UserState;
+  export import UserTypeName = internal.UserTypeName;
   export import WaitForSync = internal.WaitForSync;
   export import WatchOptionsFilter = internal.WatchOptionsFilter;
   export import WatchOptionsIds = internal.WatchOptionsIds;

--- a/packages/realm/src/app-services/User.ts
+++ b/packages/realm/src/app-services/User.ts
@@ -360,7 +360,7 @@ export class User<
 
   /**
    * @param serviceName - The name of the MongoDB service to connect to.
-   * @returns A client enabling access to a {@link MongoDB} service.
+   * @returns A client enabling access to a MongoDB service.
    * @example
    * let blueWidgets = user.mongoClient("myService")
    *                       .db("myDb")

--- a/packages/realm/typedoc.json
+++ b/packages/realm/typedoc.json
@@ -3,6 +3,7 @@
   "tsconfig": "./tsconfig.docs.json",
   "excludeInternal": true,
   "excludePrivate": true,
+  "excludeReferences": true,
   "customCss": "../../typedoc/style.css",
   "media": "../../media",
   "name": "Realm JavaScript",


### PR DESCRIPTION
## What, How & Why?

* Fixes Typedoc link resolution for some of our `{@link}`s.
* [Removes](https://typedoc.org/options/input/#excludereferences) re-exports of already included symbols from the API reference page as each reference was only showing `re-exports X` (see below).

Previously showed the following:
<img width="556" alt="realm-js-api-references" src="https://github.com/realm/realm-js/assets/81748770/64f03901-8347-4dde-ac52-eba808a619c6">
