### PR TITLE
Adding tests accessing `app.currentUser` from `App` and `User` listeners

### DIFF
--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -245,7 +245,7 @@ describe("App", () => {
 
       const handle = createPromiseHandle();
       const listener = () => {
-        expect(this.app.currentUser).to.not.be.null;
+        expect(this.app.currentUser).instanceOf(Realm.User);
         this.app.removeListener(listener);
         handle.resolve();
       };
@@ -269,6 +269,7 @@ describe("App", () => {
 
       const handle = createPromiseHandle();
       const listener = () => {
+        expect(this.app.currentUser).instanceOf(Realm.User);
         expect(this.app.currentUser?.id).equals(user.id);
         user.removeListener(listener);
         handle.resolve();

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -236,7 +236,9 @@ describe("App", () => {
       expect(this.app.currentUser).to.be.null;
     });
 
-    it("currentUser is available from an App listener", async function (this: Mocha.Context & AppContext & RealmContext) {
+    it("currentUser is available from an App listener", async function (this: Mocha.Context &
+      AppContext &
+      RealmContext) {
       expect(this.app.currentUser).to.be.null;
 
       const credentials = Realm.Credentials.anonymous();
@@ -257,7 +259,9 @@ describe("App", () => {
       await handle;
     });
 
-    it.only("currentUser is available from a User listener", async function (this: Mocha.Context & AppContext & RealmContext) {
+    it.only("currentUser is available from a User listener", async function (this: Mocha.Context &
+      AppContext &
+      RealmContext) {
       expect(this.app.currentUser).to.be.null;
 
       const credentials = Realm.Credentials.anonymous(false);

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -24,6 +24,7 @@ import { generatePartition } from "../../utils/generators";
 import { baseUrl } from "../../hooks/import-app-before";
 import { select } from "../../utils/select";
 import { buildAppConfig } from "../../utils/build-app-config";
+import { createPromiseHandle } from "../../utils/promise-handle";
 
 const TestObjectSchema: Realm.ObjectSchema = {
   primaryKey: "_id",
@@ -233,6 +234,50 @@ describe("App", () => {
 
       await user1.logOut();
       expect(this.app.currentUser).to.be.null;
+    });
+
+    it("currentUser is available from an App listener", async function (this: Mocha.Context & AppContext & RealmContext) {
+      expect(this.app.currentUser).to.be.null;
+
+      const credentials = Realm.Credentials.anonymous();
+
+      const handle = createPromiseHandle();
+      const listener = () => {
+        expect(this.app.currentUser).to.not.be.null;
+        this.app.removeListener(listener);
+        handle.resolve();
+      };
+
+      this.app.addListener(listener);
+      await this.app.logIn(credentials);
+
+      await this.app.currentUser?.logOut();
+      expect(this.app.currentUser).to.be.null;
+
+      await handle;
+    });
+
+    it.only("currentUser is available from a User listener", async function (this: Mocha.Context & AppContext & RealmContext) {
+      expect(this.app.currentUser).to.be.null;
+
+      const credentials = Realm.Credentials.anonymous(false);
+      const user = await this.app.logIn(credentials);
+
+      const handle = createPromiseHandle();
+      const listener = () => {
+        expect(this.app.currentUser?.id).equals(user.id);
+        user.removeListener(listener);
+        handle.resolve();
+      };
+      user.addListener(listener);
+
+      // Refresh custom data to fire the listener
+      await user.refreshCustomData();
+
+      await user.logOut();
+      expect(this.app.currentUser).to.be.null;
+
+      await handle;
     });
 
     it("changeListeners works", async function (this: Mocha.Context & AppContext & RealmContext) {

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -264,7 +264,7 @@ describe("App", () => {
       RealmContext) {
       expect(this.app.currentUser).to.be.null;
 
-      const credentials = Realm.Credentials.anonymous(false);
+      const credentials = Realm.Credentials.anonymous();
       const user = await this.app.logIn(credentials);
 
       const handle = createPromiseHandle();

--- a/integration-tests/tests/src/tests/sync/app.ts
+++ b/integration-tests/tests/src/tests/sync/app.ts
@@ -259,7 +259,7 @@ describe("App", () => {
       await handle;
     });
 
-    it.only("currentUser is available from a User listener", async function (this: Mocha.Context &
+    it("currentUser is available from a User listener", async function (this: Mocha.Context &
       AppContext &
       RealmContext) {
       expect(this.app.currentUser).to.be.null;


### PR DESCRIPTION
## What, How & Why?

This exercise https://github.com/realm/realm-core/issues/7670 and https://github.com/realm/realm-core/issues/7183 to ensure future regressions will be easier to debug.

We should hold back on merging this, until https://github.com/realm/realm-core/issues/7670 is fixed and we've upgraded Core to include the fix.
