### PR TITLE
Update OAuth2Helper to remove accessing the stitch prefix

### DIFF
--- a/packages/realm-web/CHANGELOG.md
+++ b/packages/realm-web/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Internal
 * The base URL used to communicate with the Atlas App Services was changed from "https://realm.mongodb.com" to "https://services.cloud.mongodb.com". ([#6591](https://github.com/realm/realm-js/pull/6591))
+* Avoid falling back to `_stitch_` prefixed values when parsing the querystring response from an OAuth2 redirection. ([#6659](https://github.com/realm/realm-js/pull/6659))
 
 2.0.0 Release notes (2022-10-18)
 =============================================================

--- a/packages/realm-web/src/OAuth2Helper.ts
+++ b/packages/realm-web/src/OAuth2Helper.ts
@@ -69,15 +69,10 @@ type RedirectResult = {
 };
 
 const REDIRECT_HASH_TO_RESULT: { [k: string]: keyof RedirectResult } = {
-  _stitch_client_app_id: "appId",
   _baas_client_app_id: "appId",
-  _stitch_ua: "userAuth",
   _baas_ua: "userAuth",
-  _stitch_link: "link",
   _baas_link: "link",
-  _stitch_error: "error",
   _baas_error: "error",
-  _stitch_state: "state",
   _baas_state: "state",
 };
 


### PR DESCRIPTION
## What, How & Why?

This removes fallback of reading values from the `_stitch_` prefix of the OAuth 2 redirect response query string.
Related to #6657 but not exactly the same (since this doesn't relate to the access token).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
