### PR TITLE
Fix GHA error when publishing package release

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
+      pull-requests: write
     steps:
     - run: echo "Publishing release for ${{inputs.package}}"
     - uses: kanga333/variable-mapper@v0.3.0


### PR DESCRIPTION
## What, How & Why?

Fix error with workflow `publish-package-release.yml`: "Resource not accessible by integration"
