### PR TITLE
Fix performance tests

### DIFF
--- a/integration-tests/tests/src/performance-tests/property-reads.ts
+++ b/integration-tests/tests/src/performance-tests/property-reads.ts
@@ -29,6 +29,13 @@ const COLLECTION_MARKERS: Readonly<Record<string, string>> = {
   set: "<>",
 };
 
+/**
+ * Get a representative consistent name of the type depending on the schema.
+ *
+ * @example
+ * "int?[]"                                            -> "int?[]"
+ * { type: "list", objectType: "int", optional: true } -> "int?[]"
+ */
 function getTypeDisplayName(schema: PropertySchemaShorthand | PropertySchema) {
   const isShorthand = typeof schema === "string";
   if (isShorthand) {


### PR DESCRIPTION
## What, How & Why?

Fixes the broken performance tests and makes the type outputs from the tests consistent (no matter how you pass in the property schema).
