### PR TITLE
Add internal annotation to fix docs build

### DIFF
--- a/.github/workflows/pr-linting.yml
+++ b/.github/workflows/pr-linting.yml
@@ -18,5 +18,7 @@ jobs:
           node-version: 20
       - name: Install root package dependencies
         run: npm ci
+      - name: Check types
+        run: npm run check-types --workspace realm
       - name: Run linting of subpackages
         run: npm run lint

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -430,6 +430,7 @@ export function toItemType(type: binding.PropertyType) {
   return type & ~binding.PropertyType.Flags;
 }
 
+/** @internal */
 export function getTypeHelpers(type: binding.PropertyType, options: TypeOptions): TypeHelpers {
   const helpers = TYPES_MAPPING[type];
   assert(helpers, `Unexpected type ${type}`);


### PR DESCRIPTION
## What, How & Why?

Our docs build broke due to a function not marked as `@internal`.

(Also adding to the lint workflow to check the public types generated.)
