### PR TITLE
Simplify RealmJS.podspec to avoid passing the version

### DIFF
--- a/packages/realm/RealmJS.podspec
+++ b/packages/realm/RealmJS.podspec
@@ -52,9 +52,6 @@ Pod::Spec.new do |s|
                                 # Setting up clang
                                 'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
                                 'CLANG_CXX_LIBRARY' => 'libc++',
-                                # Setting the current project version and versioning system to get a symbol for analytics
-                                'CURRENT_PROJECT_VERSION' => s.version,
-                                'VERSIONING_SYSTEM' => 'apple-generic',
                                 # Header search paths are prefixes to the path specified in #include macros
                                 'HEADER_SEARCH_PATHS' => [
                                   '"$(PODS_TARGET_SRCROOT)/react-native/ios/RealmReact/"',


### PR DESCRIPTION
## What, How & Why?

I believe this was only used by https://github.com/realm/realm-js/blob/6593a851cd0a7f49fb85ad13bb7c4e1fd245f346/react-native/ios/RealmReact/RealmAnalytics.mm#L69C23-L69C43 and we've later refactored the analytics to send this information from the SDK: [here](https://github.com/realm/realm-js/blob/fc633f70b69596d84f7dce5a2d7f1fac9f8e25e1/packages/realm/src/platform/react-native/device-info.ts#L21) and [here](https://github.com/realm/realm-js/blob/fc633f70b69596d84f7dce5a2d7f1fac9f8e25e1/packages/realm/src/platform/react-native/device-info.ts#L65).
