### PR TITLE
RJS-1413: Add support for a logical counter as a presentation data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## vNext (TBD)
+
+### Deprecations
+* None
+
+### Enhancements
+* None
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* None
+
+### Compatibility
+* React Native >= v0.71.4
+* Realm Studio v15.0.0.
+* File format: generates Realms with format v24 (reads and upgrades file format v10).
+
+### Internal
+<!-- * Either mention core version or upgrade -->
+<!-- * Using Realm Core vX.Y.Z -->
+<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+
 ## 12.10.0-rc.0 (2024-05-31)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
 * A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. ([#6694](https://github.com/realm/realm-js/pull/6694))
+  * See the [API docs](https://www.mongodb.com/docs/realm-sdks/js/latest/classes/Realm.Types.Counter.html) for more information about the usage, or get a high-level introduction about counters in the [documentation](https://www.mongodb.com/docs/atlas/app-services/sync/details/conflict-resolution/#counters).
 ```typescript
 class MyObject extends Realm.Object {
   _id!: BSON.ObjectId;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 * None
 
 ### Enhancements
-* None
+* Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
+* Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* After compacting, a file upgrade would be triggered. This could cause loss of data for synced Realms. ([realm/realm-core#7747](https://github.com/realm/realm-core/issues/7747), since 12.7.0-rc.0)
+* The function `immediatelyRunFileActions` was not added to the bindgen's opt-list. This could lead to the error `TypeError: app.internal.immediatelyRunFileActions is not a function`. ([#6708](https://github.com/realm/realm-js/issues/6708), since v12.8.0)
+* Encrypted files on Windows had a maximum size of 2 GB even on x64 due to internal usage of `off_t`, which is a 32-bit type on 64-bit Windows. ([realm/realm-core#7698](https://github.com/realm/realm-core/pull/7698), since the introduction of encryption support on Windows - likely in v1.11.0)
+* Tokenizing strings for full-text search could lead to undefined behavior. ([realm/realm-core#7698](https://github.com/realm/realm-core/pull/7698), since v11.3.0-rc.0)
 
 ### Compatibility
 * React Native >= v0.71.4
@@ -16,15 +19,11 @@
 * File format: generates Realms with format v24 (reads and upgrades file format v10).
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Upgraded Realm Core from v14.7.0 to v14.10.0. ([#6701](https://github.com/realm/realm-js/issues/6701))
 
 ## 12.10.0-rc.0 (2024-05-31)
 
 ### Enhancements
-* Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
-* Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
 * A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. ([#6694](https://github.com/realm/realm-js/pull/6694))
   * See the [API docs](https://www.mongodb.com/docs/realm-sdks/js/latest/classes/Realm.Types.Counter.html) for more information about the usage, or get a high-level introduction about counters in the [documentation](https://www.mongodb.com/docs/atlas/app-services/sync/details/conflict-resolution/#counters).
 ```typescript
@@ -58,19 +57,11 @@ realm.write(() => {
 
 ### Fixed
 * A non-streaming progress notifier would not immediately call its callback after registration. Instead you would have to wait for a download message to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier. ([#7627](https://github.com/realm/realm-core/issues/7627), since v12.8.0)
-* After compacting, a file upgrade would be triggered. This could cause loss of data for synced Realms. ([realm/realm-core#7747](https://github.com/realm/realm-core/issues/7747), since 12.7.0-rc.0)
-* The function `immediatelyRunFileActions` was not added to the bindgen's opt-list. This could lead to the error `TypeError: app.internal.immediatelyRunFileActions is not a function`. ([#6708](https://github.com/realm/realm-js/issues/6708), since v12.8.0)
-* Encrypted files on Windows had a maximum size of 2 GB even on x64 due to internal usage of `off_t`, which is a 32-bit type on 64-bit Windows. ([realm/realm-core#7698](https://github.com/realm/realm-core/pull/7698), since the introduction of encryption support on Windows - likely in v1.11.0)
-* Tokenizing strings for full-text search could lead to undefined behavior. ([realm/realm-core#7698](https://github.com/realm/realm-core/pull/7698), since v11.3.0-rc.0)
-
 
 ### Compatibility
 * React Native >= v0.71.4
 * Realm Studio v15.0.0.
 * File format: generates Realms with format v24 (reads and upgrades file format v10).
-
-### Internal
-* Upgraded Realm Core from v14.7.0 to v14.10.0. ([#6701](https://github.com/realm/realm-js/issues/6701))
 
 ## 12.9.0 (2024-05-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
 * A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. ([#6694](https://github.com/realm/realm-js/pull/6694))
-```ts
+```typescript
 class MyObject extends Realm.Object {
   _id!: BSON.ObjectId;
   counter!: Realm.Types.Counter;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Enhancements
 * Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
-* A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. See the [API docs](https://www.mongodb.com/docs/realm-sdks/js/latest/classes/Realm.Types.Counter.html) for more information. ([#6694](https://github.com/realm/realm-js/pull/6694))
+* A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. ([#6694](https://github.com/realm/realm-js/pull/6694))
 ```ts
 class MyObject extends Realm.Object {
   _id!: BSON.ObjectId;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-## vNext (TBD)
-
-### Deprecations
-* None
+## 12.10.0-rc.0 (2024-05-31)
 
 ### Enhancements
 * Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@
 ### Enhancements
 * Report the originating error that caused a client reset to occur. ([realm/realm-core#6154](https://github.com/realm/realm-core/issues/6154))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions. ([realm/realm-core#7734](https://github.com/realm/realm-core/pull/7734))
+* A `counter` presentation data type has been introduced. The `int` data type can now be used as a logical counter for performing numeric updates that need to be synchronized as sequentially consistent events rather than individual reassignments of the number. See the [API docs](https://www.mongodb.com/docs/realm-sdks/js/latest/classes/Realm.Types.Counter.html) for more information. ([#6694](https://github.com/realm/realm-js/pull/6694))
+```ts
+class MyObject extends Realm.Object {
+  _id!: BSON.ObjectId;
+  counter!: Realm.Types.Counter;
+
+  static schema: ObjectSchema = {
+    name: "MyObject",
+    primaryKey: "_id",
+    properties: {
+      _id: { type: "objectId", default: () => new BSON.ObjectId() },
+      counter: "counter",
+      // or: counter: { type: "int", presentation: "counter" },
+    },
+  };
+}
+
+const realm = await Realm.open({ schema: [MyObject] });
+const object = realm.write(() => {
+  return realm.create(MyObject, { counter: 0 });
+});
+
+realm.write(() => {
+  object.counter.increment();
+  object.counter.value; // 1
+  object.counter.decrement(2);
+  object.counter.value; // -1
+});
+```
 
 ### Fixed
 * A non-streaming progress notifier would not immediately call its callback after registration. Instead you would have to wait for a download message to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier. ([#7627](https://github.com/realm/realm-core/issues/7627), since v12.8.0)

--- a/integration-tests/tests/src/tests.ts
+++ b/integration-tests/tests/src/tests.ts
@@ -50,6 +50,7 @@ import "./tests/alias";
 import "./tests/array-buffer";
 import "./tests/bson";
 import "./tests/class-models";
+import "./tests/counter";
 import "./tests/dictionary";
 import "./tests/dynamic-schema-updates";
 import "./tests/enums";

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -282,4 +282,119 @@ describe("Counter", () => {
       });
     });
   });
+
+  describe("Update", () => {
+    describe("Counter.value", () => {
+      it("increments", function (this: RealmContext) {
+        const { counter } = this.realm.write(() => {
+          return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+            counter: 0,
+          });
+        });
+        expectCounter(counter);
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.increment(0);
+        });
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.increment();
+        });
+        expect(counter.value).equals(1);
+
+        this.realm.write(() => {
+          counter.increment(19);
+        });
+        expect(counter.value).equals(20);
+
+        this.realm.write(() => {
+          counter.increment(-20);
+        });
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.increment();
+          counter.increment();
+          counter.increment();
+        });
+        expect(counter.value).equals(3);
+      });
+
+      it("decrements", function (this: RealmContext) {
+        const { counter } = this.realm.write(() => {
+          return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+            counter: 0,
+          });
+        });
+        expectCounter(counter);
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.decrement(0);
+        });
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.decrement();
+        });
+        expect(counter.value).equals(-1);
+
+        this.realm.write(() => {
+          counter.decrement(19);
+        });
+        expect(counter.value).equals(-20);
+
+        this.realm.write(() => {
+          counter.decrement(-20);
+        });
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.decrement();
+          counter.decrement();
+          counter.decrement();
+        });
+        expect(counter.value).equals(-3);
+      });
+
+      it("sets", function (this: RealmContext) {
+        const { counter } = this.realm.write(() => {
+          return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+            counter: 0,
+          });
+        });
+        expectCounter(counter);
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.set(0);
+        });
+        expect(counter.value).equals(0);
+
+        this.realm.write(() => {
+          counter.set(1);
+        });
+        expect(counter.value).equals(1);
+
+        this.realm.write(() => {
+          counter.set(20);
+        });
+        expect(counter.value).equals(20);
+
+        this.realm.write(() => {
+          counter.set(100_000);
+        });
+        expect(counter.value).equals(100_000);
+
+        this.realm.write(() => {
+          counter.set(1);
+          counter.set(2);
+          counter.set(3);
+        });
+        expect(counter.value).equals(3);
+      });
+    });
+  });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -444,8 +444,7 @@ describe("Counter", () => {
         expect(counter.value).equals(-3);
       });
 
-      // TODO(lj): To be implemented.
-      it.skip("sets", function (this: RealmContext) {
+      it("sets", function (this: RealmContext) {
         const { counter } = this.realm.write(() => {
           return this.realm.create<IWithCounter>(WithCounterSchema.name, {
             counter: 0,
@@ -683,8 +682,7 @@ describe("Counter", () => {
       expect(counter.value).equals(10);
     });
 
-    // TODO(lj): To be implemented.
-    it.skip("throws when setting to non-integer", function (this: RealmContext) {
+    it("throws when setting to non-integer", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {
           counter: 10,
@@ -697,14 +695,14 @@ describe("Counter", () => {
         this.realm.write(() => {
           counter.set(1.1);
         });
-      }).to.throw("Expected 'by' to be an integer, got a floating point number");
+      }).to.throw("Expected 'value' to be an integer, got a floating point number");
       expect(counter.value).equals(10);
 
       expect(() => {
         this.realm.write(() => {
           counter.set(NaN);
         });
-      }).to.throw("Expected 'by' to be an integer, got NaN");
+      }).to.throw("Expected 'value' to be an integer, got NaN");
       expect(counter.value).equals(10);
 
       expect(() => {
@@ -712,7 +710,7 @@ describe("Counter", () => {
           // @ts-expect-error Testing incorrect type.
           counter.set(new Number(1));
         });
-      }).to.throw("Expected 'by' to be an integer, got an instance of Number");
+      }).to.throw("Expected 'value' to be an integer, got an instance of Number");
       expect(counter.value).equals(10);
 
       expect(() => {
@@ -720,7 +718,7 @@ describe("Counter", () => {
           // @ts-expect-error Testing incorrect type.
           counter.set("1");
         });
-      }).to.throw("Expected 'by' to be an integer, got a string");
+      }).to.throw("Expected 'value' to be an integer, got a string");
       expect(counter.value).equals(10);
 
       expect(() => {
@@ -728,7 +726,7 @@ describe("Counter", () => {
           // @ts-expect-error Testing incorrect type.
           counter.set(BigInt(1));
         });
-      }).to.throw("Expected 'by' to be an integer, got a bigint");
+      }).to.throw("Expected 'value' to be an integer, got a bigint");
       expect(counter.value).equals(10);
     });
 

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -57,7 +57,7 @@ interface IWithDefaultCounter {
 const WithDefaultCounterSchema: ObjectSchema = {
   name: "WithDefaultCounter",
   properties: {
-    counterWithDefault: { type: "int", presentation: "counter", default: 0 },
+    counterWithDefault: { type: "int", presentation: "counter", default: 10 },
   },
 };
 
@@ -169,7 +169,7 @@ describe("Counter", () => {
 
         expect(this.realm.objects(WithDefaultCounterSchema.name).length).equals(1);
         expectCounter(counterWithDefault);
-        expect(counterWithDefault.value).equals(0);
+        expect(counterWithDefault.value).equals(10);
       });
 
       it("can create nullable counter with int or null", function (this: RealmContext) {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -34,16 +34,16 @@ const WithCounterSchema: ObjectSchema = {
 };
 
 interface IWithOptAndDefaultCounter {
-  optionalCounter?: Counter | null;
+  nullableCounter?: Counter | null;
   counterWithDefault: Counter;
 }
 
 const WithOptAndDefaultCounterSchema: ObjectSchema = {
   name: "WithOptAndDefaultCounter",
   properties: {
-    optionalCounter: "counter?",
+    nullableCounter: "counter?",
     counterWithDefault: { type: "int", presentation: "counter", default: 0 },
-    // TODO(lj): Add a 'listOfOptionalCounters'?
+    // TODO(lj): Add a 'listOfNullableCounters'?
   },
 };
 
@@ -113,7 +113,7 @@ function expectRealmSetOfCounters(
   }
 }
 
-describe.skip("Counter", () => {
+describe("Counter", () => {
   openRealmBeforeEach({ schema: [WithCounterSchema, WithOptAndDefaultCounterSchema, WithCounterCollectionsSchema] });
 
   const initialValuesList = [-100, 0, 1.0, 1000] as const;
@@ -192,12 +192,12 @@ describe.skip("Counter", () => {
       it("can create optional counter with int or null", function (this: RealmContext) {
         const { counter1, counter2 } = this.realm.write(() => {
           const counter1 = this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
-            optionalCounter: 0,
-          }).optionalCounter;
+            nullableCounter: 0,
+          }).nullableCounter;
 
           const counter2 = this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
-            optionalCounter: null,
-          }).optionalCounter;
+            nullableCounter: null,
+          }).nullableCounter;
 
           return { counter1, counter2 };
         });
@@ -457,32 +457,32 @@ describe.skip("Counter", () => {
       it("updates", function (this: RealmContext) {
         const object = this.realm.write(() => {
           return this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
-            optionalCounter: 0,
+            nullableCounter: 0,
           });
         });
-        expectCounter(object.optionalCounter);
+        expectCounter(object.nullableCounter);
 
         this.realm.write(() => {
-          object.optionalCounter = null;
+          object.nullableCounter = null;
         });
-        expect(object.optionalCounter).to.be.null;
+        expect(object.nullableCounter).to.be.null;
 
         this.realm.write(() => {
-          object.optionalCounter = 1;
+          object.nullableCounter = 1;
         });
-        expectCounter(object.optionalCounter);
-        expect(object.optionalCounter.value).equals(1);
+        expectCounter(object.nullableCounter);
+        expect(object.nullableCounter.value).equals(1);
 
         this.realm.write(() => {
-          object.optionalCounter = null;
+          object.nullableCounter = null;
         });
-        expect(object.optionalCounter).to.be.null;
+        expect(object.nullableCounter).to.be.null;
 
         this.realm.write(() => {
-          object.optionalCounter = -100_000;
+          object.nullableCounter = -100_000;
         });
-        expectCounter(object.optionalCounter);
-        expect(object.optionalCounter.value).equals(-100_000);
+        expectCounter(object.nullableCounter);
+        expect(object.nullableCounter.value).equals(-100_000);
       });
     });
 

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -343,7 +343,7 @@ describe("Counter", () => {
         expect(object.nullableCounter.value).equals(1);
 
         this.realm.write(() => {
-          object.nullableCounter = null;
+          object.nullableCounter = undefined;
         });
         expect(object.nullableCounter).to.be.null;
 
@@ -449,6 +449,24 @@ describe("Counter", () => {
         }
       });
       expect(filtered.length).equals(0);
+    });
+  });
+
+  describe("Realm.schema", () => {
+    it("includes `presentation: 'counter'` in the canonical property schema", function (this: RealmContext) {
+      const objectSchema = this.realm.schema.find((objectSchema) => objectSchema.name === WithCounterSchema.name);
+      expect(objectSchema).to.be.an("object");
+
+      const counterPropertySchema = objectSchema?.properties.counter;
+      expect(counterPropertySchema).deep.equals({
+        name: "counter",
+        type: "int",
+        presentation: "counter",
+        optional: false,
+        indexed: false,
+        mapTo: "counter",
+        default: undefined,
+      });
     });
   });
 

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -1,0 +1,168 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+import { Counter, ObjectSchema } from "realm";
+
+import { openRealmBeforeEach } from "../hooks";
+
+interface IWithCounter {
+  counter: Counter;
+}
+
+const WithCounterSchema: ObjectSchema = {
+  name: "WithCounter",
+  properties: {
+    counter: "counter",
+  },
+};
+
+interface IWithOptAndDefaultCounter {
+  optionalCounter?: Counter | null;
+  counterWithDefault: Counter;
+}
+
+const WithOptAndDefaultCounterSchema: ObjectSchema = {
+  name: "WithOptAndDefaultCounter",
+  properties: {
+    optionalCounter: "counter?",
+    counterWithDefault: { type: "counter", default: 0 },
+    // TODO(lj): Add a 'listOfOptionalCounters'?
+  },
+};
+
+interface IWithCounterCollections {
+  list: Realm.List<Counter>;
+  dictionary: Realm.Dictionary<Counter>;
+  set: Realm.Set<Counter>;
+}
+
+const WithCounterCollectionsSchema: ObjectSchema = {
+  name: "WithCounterCollections",
+  properties: {
+    list: "counter[]",
+    dictionary: "counter{}",
+    set: "counter<>",
+  },
+};
+
+function expectCounter(value: unknown): asserts value is Counter {
+  expect(value).to.be.instanceOf(Counter);
+}
+
+function expectKeys(dictionary: Realm.Dictionary, keys: string[]) {
+  expect(Object.keys(dictionary)).members(keys);
+}
+
+describe("Counter", () => {
+  openRealmBeforeEach({ schema: [WithCounterSchema, WithOptAndDefaultCounterSchema, WithCounterCollectionsSchema] });
+
+  const initialValuesList = [-100, 0, 1, 1000] as const;
+  const initialValuesDict: Readonly<Record<string, number>> = {
+    negative100: -100,
+    _0: 0,
+    _1: 1,
+    _1000: 1000,
+  };
+
+  describe("Create and access", () => {
+    describe("Via 'realm.create()'", () => {
+      it("can create and access (input: number)", function (this: RealmContext) {
+        for (let i = 0; i < initialValuesList.length; i++) {
+          const input = initialValuesList[i];
+          const { counter } = this.realm.write(() => {
+            console.log({ input });
+            return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+              counter: input,
+            });
+          });
+
+          const expectedNumObjects = i + 1;
+          expect(this.realm.objects(WithCounterSchema.name).length).equals(expectedNumObjects);
+          expectCounter(counter);
+          console.log({ initial: initialValuesList[i], counter: counter.value });
+          expect(counter.value).equals(input);
+        }
+      });
+
+      it("can create and access (input: Counter)", function (this: RealmContext) {
+        const initialNumValues = initialValuesList;
+        const initialCounterValues: Counter[] = [];
+
+        // First create Realm objects with counters.
+        this.realm.write(() => {
+          for (const input of initialNumValues) {
+            const { counter } = this.realm.create<IWithCounter>(WithCounterSchema.name, {
+              counter: input,
+            });
+            expectCounter(counter);
+            expect(counter.value).equals(input);
+
+            initialCounterValues.push(counter);
+          }
+        });
+
+        // Use the managed Counters as input, each in a separate transaction.
+        for (let i = 0; i < initialCounterValues.length; i++) {
+          const input = initialCounterValues[i];
+          console.log({ input: input instanceof Counter });
+          const { counter } = this.realm.write(() => {
+            return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+              counter: input,
+            });
+          });
+
+          const expectedNumObjects = initialNumValues.length + i + 1;
+          expect(this.realm.objects(WithCounterSchema.name).length).equals(expectedNumObjects);
+          expectCounter(counter);
+          expect(counter.value).equals(input.value);
+        }
+      });
+
+      it("can create and access (input: default value)", function (this: RealmContext) {
+        const { counterWithDefault } = this.realm.write(() => {
+          // Pass an empty object in order to use the default value from the schema.
+          return this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {});
+        });
+
+        expect(this.realm.objects(WithOptAndDefaultCounterSchema.name).length).equals(1);
+        expectCounter(counterWithDefault);
+        expect(counterWithDefault.value).equals(0);
+      });
+
+      it("can create optional counter with int or null", function (this: RealmContext) {
+        const { counter1, counter2 } = this.realm.write(() => {
+          const counter1 = this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
+            optionalCounter: 0,
+          }).optionalCounter;
+
+          const counter2 = this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
+            optionalCounter: null,
+          }).optionalCounter;
+
+          return { counter1, counter2 };
+        });
+
+        expect(this.realm.objects(WithOptAndDefaultCounterSchema.name).length).equals(2);
+        expectCounter(counter1);
+        expect(counter1.value).equals(0);
+        expect(counter2).to.be.null;
+      });
+    });
+  });
+});

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -110,8 +110,8 @@ describe("Counter", () => {
 
   const initialValuesList = [-100, 0, 1.0, 1000] as const;
 
-  describe("Create and access", () => {
-    describe("Via 'realm.create()'", () => {
+  describe("create and access", () => {
+    describe("via 'realm.create()'", () => {
       it("can create and access (input: number)", function (this: RealmContext) {
         for (let i = 0; i < initialValuesList.length; i++) {
           const input = initialValuesList[i];
@@ -207,7 +207,7 @@ describe("Counter", () => {
     });
   });
 
-  describe("Update", () => {
+  describe("update", () => {
     describe("Counter.value", () => {
       it("increments", function (this: RealmContext) {
         const { counter } = this.realm.write(() => {
@@ -420,7 +420,7 @@ describe("Counter", () => {
     });
   });
 
-  describe("Filtering", () => {
+  describe("filtering", () => {
     it("filters objects with counters", function (this: RealmContext) {
       this.realm.write(() => {
         this.realm.create<IWithCounter>(WithCounterSchema.name, { counter: -100_000 });
@@ -470,7 +470,7 @@ describe("Counter", () => {
     });
   });
 
-  describe("Invalid operations", () => {
+  describe("invalid operations", () => {
     it("throws when incrementing by non-integer", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -232,7 +232,7 @@ describe("Counter", () => {
         expect(counterWithDefault.value).equals(0);
       });
 
-      it("can create optional counter with int or null", function (this: RealmContext) {
+      it("can create nullable counter with int or null", function (this: RealmContext) {
         const { counter1, counter2 } = this.realm.write(() => {
           const counter1 = this.realm.create<IWithNullableCounter>(WithNullableCounterSchema.name, {
             nullableCounter: 0,
@@ -501,7 +501,7 @@ describe("Counter", () => {
     });
 
     describe("Realm object counter property", () => {
-      it("updates", function (this: RealmContext) {
+      it("updates nullable counter from int -> null -> int", function (this: RealmContext) {
         const object = this.realm.write(() => {
           return this.realm.create<IWithNullableCounter>(WithNullableCounterSchema.name, {
             nullableCounter: 0,

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -590,7 +590,7 @@ describe("Counter", () => {
     it("throws when incrementing by non-integer", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {
-          counter: 0,
+          counter: 10,
         });
       });
       expectCounter(counter);
@@ -638,7 +638,7 @@ describe("Counter", () => {
     it("throws when decrementing by non-integer", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {
-          counter: 0,
+          counter: 10,
         });
       });
       expectCounter(counter);
@@ -829,6 +829,25 @@ describe("Counter", () => {
         });
       }).to.throw("Counters can only be used when 'counter' is declared in the property schema");
       expect(objectWithInt.int).equals(10);
+    });
+
+    it("throws when getting the count on an invalidated obj", function (this: RealmContext) {
+      const object = this.realm.write(() => {
+        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+          counter: 10,
+        });
+      });
+      const counter = object.counter;
+      expectCounter(counter);
+      expect(counter.value).equals(10);
+      expect(this.realm.objects(WithCounterSchema.name).length).equals(1);
+
+      this.realm.write(() => {
+        this.realm.delete(object);
+      });
+      expect(this.realm.objects(WithCounterSchema.name).length).equals(0);
+
+      expect(() => counter.value).to.throw("Accessing object which has been invalidated or deleted");
     });
   });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -240,6 +240,20 @@ describe("Counter", () => {
         expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
         expectRealmSetOfCounters(set, initialValuesList);
       });
+
+      it("returns different reference for each access", function (this: RealmContext) {
+        const object = this.realm.write(() => {
+          return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+            counter: 0,
+          });
+        });
+
+        expectCounter(object.counter);
+        // @ts-expect-error Testing different types.
+        expect(object.counter === 0).to.be.false;
+        expect(object.counter === object.counter).to.be.false;
+        expect(Object.is(object.counter, object.counter)).to.be.false;
+      });
     });
 
     describe("Via collection accessors", () => {
@@ -293,6 +307,34 @@ describe("Counter", () => {
         });
 
         expectRealmSetOfCounters(set, initialValuesList);
+      });
+
+      it("returns different reference for each access", function (this: RealmContext) {
+        const { list, dictionary, set } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            list: [0],
+            dictionary: { key: 0 },
+            set: [0],
+          });
+        });
+
+        expectCounter(list[0]);
+        // @ts-expect-error Testing different types.
+        expect(list[0] === 0).to.be.false;
+        expect(list[0] === list[0]).to.be.false;
+        expect(Object.is(list[0], list[0])).to.be.false;
+
+        expectCounter(dictionary.key);
+        // @ts-expect-error Testing different types.
+        expect(dictionary.key === 0).to.be.false;
+        expect(dictionary.key === dictionary.key).to.be.false;
+        expect(Object.is(dictionary.key, dictionary.key)).to.be.false;
+
+        expectCounter(set[0]);
+        // @ts-expect-error Testing different types.
+        expect(set[0] === 0).to.be.false;
+        expect(set[0] === set[0]).to.be.false;
+        expect(Object.is(set[0], set[0])).to.be.false;
       });
     });
   });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -442,6 +442,72 @@ describe("Counter", () => {
         expectCounter(object.optionalCounter);
         expect(object.optionalCounter.value).equals(-100_000);
       });
+
+      it("updates list", function (this: RealmContext) {
+        let input = [-1, 0, 1, 100_000];
+        const object = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            list: input,
+          });
+        });
+        expectRealmListOfCounters(object.list, input);
+
+        input = [2, 10];
+        this.realm.write(() => {
+          object.list = input;
+        });
+        expectRealmListOfCounters(object.list, input);
+
+        input = [];
+        this.realm.write(() => {
+          object.list = input;
+        });
+        expectRealmListOfCounters(object.list, input);
+      });
+
+      it("updates dictionary", function (this: RealmContext) {
+        let input: Record<string, number> = { a: -1, b: 0, c: 1, d: 100_000 };
+        const object = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            dictionary: input,
+          });
+        });
+        expectRealmDictionaryOfCounters(object.dictionary, input);
+
+        input = { a: 2, b: 10 };
+        this.realm.write(() => {
+          object.dictionary = input;
+        });
+        expectRealmDictionaryOfCounters(object.dictionary, input);
+
+        input = {};
+        this.realm.write(() => {
+          object.dictionary = input;
+        });
+        expectRealmDictionaryOfCounters(object.dictionary, input);
+      });
+
+      it("updates set", function (this: RealmContext) {
+        let input = [-1, 0, 1, 100_000];
+        const object = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            set: input,
+          });
+        });
+        expectRealmSetOfCounters(object.set, input);
+
+        input = [2, 10];
+        this.realm.write(() => {
+          object.set = input;
+        });
+        expectRealmSetOfCounters(object.set, input);
+
+        input = [];
+        this.realm.write(() => {
+          object.set = input;
+        });
+        expectRealmSetOfCounters(object.set, input);
+      });
     });
   });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -168,7 +168,7 @@ describe("Counter", () => {
       it("can create nullable counter with int or null", function (this: RealmContext) {
         const { counter1, counter2 } = this.realm.write(() => {
           const counter1 = this.realm.create<IWithNullableCounter>(WithNullableCounterSchema.name, {
-            nullableCounter: 0,
+            nullableCounter: 10,
           }).nullableCounter;
 
           const counter2 = this.realm.create<IWithNullableCounter>(WithNullableCounterSchema.name, {
@@ -180,7 +180,7 @@ describe("Counter", () => {
 
         expect(this.realm.objects(WithNullableCounterSchema.name).length).equals(2);
         expectCounter(counter1);
-        expect(counter1.value).equals(0);
+        expect(counter1.value).equals(10);
         expect(counter2).to.be.null;
       });
 

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -464,149 +464,63 @@ describe("Counter", () => {
   });
 
   describe("invalid operations", () => {
-    it("throws when incrementing by non-integer", function (this: RealmContext) {
-      const { counter } = this.realm.write(() => {
-        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
-          counter: 10,
+    const operations = [
+      { opName: "increment", argName: "by" },
+      { opName: "decrement", argName: "by" },
+      { opName: "set", argName: "value" },
+    ] as const;
+
+    for (const { opName, argName } of operations) {
+      it(`throws when calling ${opName} with non-integer`, function (this: RealmContext) {
+        const { counter } = this.realm.write(() => {
+          return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+            counter: 10,
+          });
         });
+        expectCounter(counter);
+        expect(counter.value).equals(10);
+
+        const operation = counter[opName].bind(counter);
+
+        expect(() => {
+          this.realm.write(() => {
+            operation(1.1);
+          });
+        }).to.throw(`Expected '${argName}' to be an integer, got a decimal number`);
+        expect(counter.value).equals(10);
+
+        expect(() => {
+          this.realm.write(() => {
+            operation(NaN);
+          });
+        }).to.throw(`Expected '${argName}' to be an integer, got NaN`);
+        expect(counter.value).equals(10);
+
+        expect(() => {
+          this.realm.write(() => {
+            // @ts-expect-error Testing incorrect type.
+            operation(new Number(1));
+          });
+        }).to.throw(`Expected '${argName}' to be an integer, got an instance of Number`);
+        expect(counter.value).equals(10);
+
+        expect(() => {
+          this.realm.write(() => {
+            // @ts-expect-error Testing incorrect type.
+            operation("1");
+          });
+        }).to.throw(`Expected '${argName}' to be an integer, got a string`);
+        expect(counter.value).equals(10);
+
+        expect(() => {
+          this.realm.write(() => {
+            // @ts-expect-error Testing incorrect type.
+            operation(BigInt(1));
+          });
+        }).to.throw(`Expected '${argName}' to be an integer, got a bigint`);
+        expect(counter.value).equals(10);
       });
-      expectCounter(counter);
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.increment(1.1);
-        });
-      }).to.throw("Expected 'by' to be an integer, got a decimal number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.increment(NaN);
-        });
-      }).to.throw("Expected 'by' to be an integer, got NaN");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.increment(new Number(1));
-        });
-      }).to.throw("Expected 'by' to be an integer, got an instance of Number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.increment("1");
-        });
-      }).to.throw("Expected 'by' to be an integer, got a string");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.increment(BigInt(1));
-        });
-      }).to.throw("Expected 'by' to be an integer, got a bigint");
-      expect(counter.value).equals(10);
-    });
-
-    it("throws when decrementing by non-integer", function (this: RealmContext) {
-      const { counter } = this.realm.write(() => {
-        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
-          counter: 10,
-        });
-      });
-      expectCounter(counter);
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.decrement(1.1);
-        });
-      }).to.throw("Expected 'by' to be an integer, got a decimal number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.decrement(NaN);
-        });
-      }).to.throw("Expected 'by' to be an integer, got NaN");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.decrement(new Number(1));
-        });
-      }).to.throw("Expected 'by' to be an integer, got an instance of Number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.decrement("1");
-        });
-      }).to.throw("Expected 'by' to be an integer, got a string");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.decrement(BigInt(1));
-        });
-      }).to.throw("Expected 'by' to be an integer, got a bigint");
-      expect(counter.value).equals(10);
-    });
-
-    it("throws when setting to non-integer", function (this: RealmContext) {
-      const { counter } = this.realm.write(() => {
-        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
-          counter: 10,
-        });
-      });
-      expectCounter(counter);
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.set(1.1);
-        });
-      }).to.throw("Expected 'value' to be an integer, got a decimal number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          counter.set(NaN);
-        });
-      }).to.throw("Expected 'value' to be an integer, got NaN");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.set(new Number(1));
-        });
-      }).to.throw("Expected 'value' to be an integer, got an instance of Number");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.set("1");
-        });
-      }).to.throw("Expected 'value' to be an integer, got a string");
-      expect(counter.value).equals(10);
-
-      expect(() => {
-        this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
-          counter.set(BigInt(1));
-        });
-      }).to.throw("Expected 'value' to be an integer, got a bigint");
-      expect(counter.value).equals(10);
-    });
+    }
 
     it("throws when setting 'Counter.value' directly", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -20,7 +20,7 @@ import { expect } from "chai";
 import Realm, { BSON, Counter, ObjectSchema, UpdateMode } from "realm";
 
 import { openRealmBeforeEach } from "../hooks";
-import { expectRealmDictionary, expectRealmList, expectRealmSet } from "../utils/expects";
+import { expectCounter, expectRealmDictionary, expectRealmList, expectRealmSet } from "../utils/expects";
 
 interface IWithCounter {
   _id: BSON.ObjectId;
@@ -88,10 +88,6 @@ const WithMixedSchema: ObjectSchema = {
     set: "mixed<>",
   },
 };
-
-function expectCounter(value: unknown): asserts value is Counter {
-  expect(value).to.be.instanceOf(Counter);
-}
 
 function expectKeys(dictionary: Realm.Dictionary, keys: string[]) {
   expect(Object.keys(dictionary)).members(keys);

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -732,6 +732,31 @@ describe("Counter", () => {
       expect(counter.value).equals(10);
     });
 
+    it("throws when updating outside write transaction", function (this: RealmContext) {
+      const { counter } = this.realm.write(() => {
+        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+          counter: 10,
+        });
+      });
+      expectCounter(counter);
+      expect(counter.value).equals(10);
+
+      expect(() => {
+        counter.increment();
+      }).to.throw("Cannot modify managed objects outside of a write transaction.");
+      expect(counter.value).equals(10);
+
+      expect(() => {
+        counter.decrement();
+      }).to.throw("Cannot modify managed objects outside of a write transaction.");
+      expect(counter.value).equals(10);
+
+      expect(() => {
+        counter.set(1);
+      }).to.throw("Cannot modify managed objects outside of a write transaction.");
+      expect(counter.value).equals(10);
+    });
+
     it("throws when setting a non-nullable Realm object counter property", function (this: RealmContext) {
       const object = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -126,19 +126,16 @@ describe("Counter", () => {
 
       it("can create and access (input: Counter)", function (this: RealmContext) {
         const initialNumValues = initialValuesList;
-        const initialCounterValues: Counter[] = [];
-
         // First create Realm objects with counters.
-        this.realm.write(() => {
-          for (const input of initialNumValues) {
+        const initialCounterValues = this.realm.write(() => {
+          return initialNumValues.map((input) => {
             const { counter } = this.realm.create<IWithCounter>(WithCounterSchema.name, {
               counter: input,
             });
             expectCounter(counter);
             expect(counter.value).equals(input);
-
-            initialCounterValues.push(counter);
-          }
+            return counter;
+          });
         });
 
         // Use the managed Counters as input, each in a separate transaction.

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -17,9 +17,10 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import { Counter, ObjectSchema } from "realm";
+import Realm, { Counter, ObjectSchema } from "realm";
 
 import { openRealmBeforeEach } from "../hooks";
+import { expectRealmDictionary, expectRealmList, expectRealmSet } from "../utils/expects";
 
 interface IWithCounter {
   counter: Counter;
@@ -67,6 +68,49 @@ function expectCounter(value: unknown): asserts value is Counter {
 
 function expectKeys(dictionary: Realm.Dictionary, keys: string[]) {
   expect(Object.keys(dictionary)).members(keys);
+}
+
+function expectRealmListOfCounters(
+  actual: unknown,
+  expectedCounts: readonly number[],
+): asserts actual is Realm.List<Counter> {
+  expectRealmList(actual);
+  expect(actual.length).equals(expectedCounts.length);
+
+  for (let i = 0; i < actual.length; i++) {
+    const counter = actual[i];
+    expectCounter(counter);
+    expect(counter.value).equals(expectedCounts[i]);
+  }
+}
+
+function expectRealmDictionaryOfCounters(
+  actual: unknown,
+  expectedCounts: Record<string, number>,
+): asserts actual is Realm.Dictionary<Counter> {
+  expectRealmDictionary(actual);
+  expectKeys(actual, Object.keys(expectedCounts));
+
+  for (const key in actual) {
+    const counter = actual[key];
+    expectCounter(counter);
+    expect(counter.value).equals(expectedCounts[key]);
+  }
+}
+
+function expectRealmSetOfCounters(
+  actual: unknown,
+  expectedCounts: readonly number[],
+): asserts actual is Realm.Set<Counter> {
+  expectRealmSet(actual);
+  const size = actual.size;
+  expect(size).equals(expectedCounts.length);
+
+  for (let i = 0; i < size; i++) {
+    const counter = actual[i];
+    expectCounter(counter);
+    expect(counter.value).equals(expectedCounts[i]);
+  }
 }
 
 describe("Counter", () => {
@@ -172,12 +216,7 @@ describe("Counter", () => {
         });
 
         expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
-        expect(list.length).equals(initialValuesList.length);
-        for (let i = 0; i < list.length; i++) {
-          const counter = list[i];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesList[i]);
-        }
+        expectRealmListOfCounters(list, initialValuesList);
       });
 
       it("can create and access dictionary (input: JS Object)", function (this: RealmContext) {
@@ -188,12 +227,7 @@ describe("Counter", () => {
         });
 
         expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
-        expectKeys(dictionary, Object.keys(initialValuesDict));
-        for (const key in dictionary) {
-          const counter = dictionary[key];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesDict[key]);
-        }
+        expectRealmDictionaryOfCounters(dictionary, initialValuesDict);
       });
 
       it("can create and access set (input: number[])", function (this: RealmContext) {
@@ -204,12 +238,7 @@ describe("Counter", () => {
         });
 
         expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
-        expect(set.length).equals(initialValuesList.length);
-        for (let i = 0; i < set.length; i++) {
-          const counter = set[i];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesList[i]);
-        }
+        expectRealmSetOfCounters(set, initialValuesList);
       });
     });
 
@@ -227,12 +256,7 @@ describe("Counter", () => {
           list.push(...initialValuesList);
         });
 
-        expect(list.length).equals(initialValuesList.length);
-        for (let i = 0; i < list.length; i++) {
-          const counter = list[i];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesList[i]);
-        }
+        expectRealmListOfCounters(list, initialValuesList);
       });
 
       it("can create and access dictionary entries", function (this: RealmContext) {
@@ -250,12 +274,7 @@ describe("Counter", () => {
           }
         });
 
-        expectKeys(dictionary, Object.keys(initialValuesDict));
-        for (const key in dictionary) {
-          const counter = dictionary[key];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesDict[key]);
-        }
+        expectRealmDictionaryOfCounters(dictionary, initialValuesDict);
       });
 
       it("can create and access set items", function (this: RealmContext) {
@@ -273,12 +292,7 @@ describe("Counter", () => {
           }
         });
 
-        expect(set.length).equals(initialValuesList.length);
-        for (let i = 0; i < set.length; i++) {
-          const counter = set[i];
-          expectCounter(counter);
-          expect(counter.value).equals(initialValuesList[i]);
-        }
+        expectRealmSetOfCounters(set, initialValuesList);
       });
     });
   });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -163,6 +163,54 @@ describe("Counter", () => {
         expect(counter1.value).equals(0);
         expect(counter2).to.be.null;
       });
+
+      it("can create and access list (input: number[])", function (this: RealmContext) {
+        const { list } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            list: initialValuesList,
+          });
+        });
+
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expect(list.length).equals(initialValuesList.length);
+        for (let i = 0; i < list.length; i++) {
+          const counter = list[i];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesList[i]);
+        }
+      });
+
+      it("can create and access dictionary (input: JS Object)", function (this: RealmContext) {
+        const { dictionary } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            dictionary: initialValuesDict,
+          });
+        });
+
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expectKeys(dictionary, Object.keys(initialValuesDict));
+        for (const key in dictionary) {
+          const counter = dictionary[key];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesDict[key]);
+        }
+      });
+
+      it("can create and access set (input: number[])", function (this: RealmContext) {
+        const { set } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            set: initialValuesList,
+          });
+        });
+
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expect(set.length).equals(initialValuesList.length);
+        for (let i = 0; i < set.length; i++) {
+          const counter = set[i];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesList[i]);
+        }
+      });
     });
   });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -615,6 +615,23 @@ describe("Counter", () => {
       expect(counter.value).equals(10);
     });
 
+    it("throws when setting 'Counter.value' directly", function (this: RealmContext) {
+      const { counter } = this.realm.write(() => {
+        return this.realm.create<IWithCounter>(WithCounterSchema.name, {
+          counter: 10,
+        });
+      });
+      expectCounter(counter);
+      expect(counter.value).equals(10);
+
+      expect(() => {
+        this.realm.write(() => {
+          // @ts-expect-error Assigning to read-only property.
+          counter.value = 20;
+        });
+      }).to.throw("To update the value, use the methods on the Counter");
+    });
+
     it("throws when updating outside write transaction", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -806,5 +806,29 @@ describe("Counter", () => {
       );
       expect(object.nullableCounter.value).equals(10);
     });
+
+    it("throws when setting an int property to a counter", function (this: RealmContext) {
+      const { objectWithInt, counter } = this.realm.write(() => {
+        const objectWithInt = this.realm.create<IWithRegularInt>(WithRegularIntSchema.name, {
+          int: 10,
+        });
+        // Create and object with a counter that will be used for setting an 'int' property.
+        const { counter } = this.realm.create<IWithCounter>(WithCounterSchema.name, {
+          counter: 20,
+        });
+        return { objectWithInt, counter };
+      });
+      expectCounter(counter);
+      expect(counter.value).equals(20);
+      expect(objectWithInt.int).equals(10);
+
+      expect(() => {
+        this.realm.write(() => {
+          // @ts-expect-error Testing incorrect type.
+          objectWithInt.int = counter;
+        });
+      }).to.throw("Counters can only be used when 'counter' is declared in the property schema");
+      expect(objectWithInt.int).equals(10);
+    });
   });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -104,13 +104,13 @@ describe("Counter", () => {
     ],
   });
 
-  const initialValuesList = [-100, 0, 1.0, 1000] as const;
+  const initialValues = [-100, 0, 1.0, 1000] as const;
 
   describe("create and access", () => {
     describe("via 'realm.create()'", () => {
       it("can create and access (input: number)", function (this: RealmContext) {
-        for (let i = 0; i < initialValuesList.length; i++) {
-          const input = initialValuesList[i];
+        for (let i = 0; i < initialValues.length; i++) {
+          const input = initialValues[i];
           const { counter } = this.realm.write(() => {
             return this.realm.create<IWithCounter>(WithCounterSchema.name, {
               counter: input,
@@ -125,7 +125,7 @@ describe("Counter", () => {
       });
 
       it("can create and access (input: Counter)", function (this: RealmContext) {
-        const initialNumValues = initialValuesList;
+        const initialNumValues = initialValues;
         // First create Realm objects with counters.
         const initialCounterValues = this.realm.write(() => {
           return initialNumValues.map((input) => {
@@ -623,6 +623,7 @@ describe("Counter", () => {
           counter.value = 20;
         });
       }).to.throw("To update the value, use the methods on the Counter");
+      expect(counter.value).equals(10);
     });
 
     it("throws when updating outside write transaction", function (this: RealmContext) {
@@ -741,7 +742,7 @@ describe("Counter", () => {
 
       expect(() => {
         this.realm.write(() => {
-          // @ts-expect-error Testing incorrect type.
+          // @ts-expect-error Cannot currently express in TS that a Counter can be set to a number (while 'get' returns Counter).
           object.nullableCounter = 0;
         });
       }).to.throw(

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -396,5 +396,38 @@ describe("Counter", () => {
         expect(counter.value).equals(3);
       });
     });
+
+    describe("Realm object counter property", () => {
+      it("updates", function (this: RealmContext) {
+        const object = this.realm.write(() => {
+          return this.realm.create<IWithOptAndDefaultCounter>(WithOptAndDefaultCounterSchema.name, {
+            optionalCounter: 0,
+          });
+        });
+        expectCounter(object.optionalCounter);
+
+        this.realm.write(() => {
+          object.optionalCounter = null;
+        });
+        expect(object.optionalCounter).to.be.null;
+
+        this.realm.write(() => {
+          object.optionalCounter = 1;
+        });
+        expectCounter(object.optionalCounter);
+        expect(object.optionalCounter.value).equals(1);
+
+        this.realm.write(() => {
+          object.optionalCounter = null;
+        });
+        expect(object.optionalCounter).to.be.null;
+
+        this.realm.write(() => {
+          object.optionalCounter = -100_000;
+        });
+        expectCounter(object.optionalCounter);
+        expect(object.optionalCounter.value).equals(-100_000);
+      });
+    });
   });
 });

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -477,7 +477,7 @@ describe("Counter", () => {
         this.realm.write(() => {
           counter.increment(1.1);
         });
-      }).to.throw("Expected 'by' to be an integer, got a floating point number");
+      }).to.throw("Expected 'by' to be an integer, got a decimal number");
       expect(counter.value).equals(10);
 
       expect(() => {
@@ -525,7 +525,7 @@ describe("Counter", () => {
         this.realm.write(() => {
           counter.decrement(1.1);
         });
-      }).to.throw("Expected 'by' to be an integer, got a floating point number");
+      }).to.throw("Expected 'by' to be an integer, got a decimal number");
       expect(counter.value).equals(10);
 
       expect(() => {
@@ -573,7 +573,7 @@ describe("Counter", () => {
         this.realm.write(() => {
           counter.set(1.1);
         });
-      }).to.throw("Expected 'value' to be an integer, got a floating point number");
+      }).to.throw("Expected 'value' to be an integer, got a decimal number");
       expect(counter.value).equals(10);
 
       expect(() => {

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -130,7 +130,6 @@ describe("Counter", () => {
         for (let i = 0; i < initialValuesList.length; i++) {
           const input = initialValuesList[i];
           const { counter } = this.realm.write(() => {
-            console.log({ input });
             return this.realm.create<IWithCounter>(WithCounterSchema.name, {
               counter: input,
             });
@@ -139,7 +138,6 @@ describe("Counter", () => {
           const expectedNumObjects = i + 1;
           expect(this.realm.objects(WithCounterSchema.name).length).equals(expectedNumObjects);
           expectCounter(counter);
-          console.log({ initial: initialValuesList[i], counter: counter.value });
           expect(counter.value).equals(input);
         }
       });
@@ -164,7 +162,6 @@ describe("Counter", () => {
         // Use the managed Counters as input, each in a separate transaction.
         for (let i = 0; i < initialCounterValues.length; i++) {
           const input = initialCounterValues[i];
-          console.log({ input: input instanceof Counter });
           const { counter } = this.realm.write(() => {
             return this.realm.create<IWithCounter>(WithCounterSchema.name, {
               counter: input,
@@ -208,7 +205,8 @@ describe("Counter", () => {
         expect(counter2).to.be.null;
       });
 
-      it("can create and access list (input: number[])", function (this: RealmContext) {
+      // TODO(lj): To be implemented.
+      it.skip("can create and access list (input: number[])", function (this: RealmContext) {
         const { list } = this.realm.write(() => {
           return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
             list: initialValuesList,
@@ -219,7 +217,8 @@ describe("Counter", () => {
         expectRealmListOfCounters(list, initialValuesList);
       });
 
-      it("can create and access dictionary (input: JS Object)", function (this: RealmContext) {
+      // TODO(lj): To be implemented.
+      it.skip("can create and access dictionary (input: JS Object)", function (this: RealmContext) {
         const { dictionary } = this.realm.write(() => {
           return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
             dictionary: initialValuesDict,
@@ -230,7 +229,8 @@ describe("Counter", () => {
         expectRealmDictionaryOfCounters(dictionary, initialValuesDict);
       });
 
-      it("can create and access set (input: number[])", function (this: RealmContext) {
+      // TODO(lj): To be implemented.
+      it.skip("can create and access set (input: number[])", function (this: RealmContext) {
         const { set } = this.realm.write(() => {
           return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
             set: initialValuesList,
@@ -256,7 +256,8 @@ describe("Counter", () => {
       });
     });
 
-    describe("Via collection accessors", () => {
+    // TODO(lj): To be implemented.
+    describe.skip("Via collection accessors", () => {
       it("can create and access list items", function (this: RealmContext) {
         const { list } = this.realm.write(() => {
           return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
@@ -415,7 +416,8 @@ describe("Counter", () => {
         expect(counter.value).equals(-3);
       });
 
-      it("sets", function (this: RealmContext) {
+      // TODO(lj): To be implemented.
+      it.skip("sets", function (this: RealmContext) {
         const { counter } = this.realm.write(() => {
           return this.realm.create<IWithCounter>(WithCounterSchema.name, {
             counter: 0,
@@ -486,7 +488,8 @@ describe("Counter", () => {
       });
     });
 
-    describe("Realm object collection of counters property", () => {
+    // TODO(lj): To be implemented.
+    describe.skip("Realm object collection of counters property", () => {
       it("updates list", function (this: RealmContext) {
         let input = [-1, 0, 1, 100_000];
         const object = this.realm.write(() => {
@@ -652,7 +655,8 @@ describe("Counter", () => {
       expect(counter.value).equals(0);
     });
 
-    it("throws when setting to non-integer", function (this: RealmContext) {
+    // TODO(lj): To be implemented.
+    it.skip("throws when setting to non-integer", function (this: RealmContext) {
       const { counter } = this.realm.write(() => {
         return this.realm.create<IWithCounter>(WithCounterSchema.name, {
           counter: 0,

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -42,7 +42,7 @@ const WithOptAndDefaultCounterSchema: ObjectSchema = {
   name: "WithOptAndDefaultCounter",
   properties: {
     optionalCounter: "counter?",
-    counterWithDefault: { type: "counter", default: 0 },
+    counterWithDefault: { type: "int", presentation: "counter", default: 0 },
     // TODO(lj): Add a 'listOfOptionalCounters'?
   },
 };
@@ -113,7 +113,7 @@ function expectRealmSetOfCounters(
   }
 }
 
-describe("Counter", () => {
+describe.skip("Counter", () => {
   openRealmBeforeEach({ schema: [WithCounterSchema, WithOptAndDefaultCounterSchema, WithCounterCollectionsSchema] });
 
   const initialValuesList = [-100, 0, 1.0, 1000] as const;

--- a/integration-tests/tests/src/tests/counter.ts
+++ b/integration-tests/tests/src/tests/counter.ts
@@ -212,5 +212,74 @@ describe("Counter", () => {
         }
       });
     });
+
+    describe("Via collection accessors", () => {
+      it("can create and access list items", function (this: RealmContext) {
+        const { list } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            list: [],
+          });
+        });
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expect(list.length).equals(0);
+
+        this.realm.write(() => {
+          list.push(...initialValuesList);
+        });
+
+        expect(list.length).equals(initialValuesList.length);
+        for (let i = 0; i < list.length; i++) {
+          const counter = list[i];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesList[i]);
+        }
+      });
+
+      it("can create and access dictionary entries", function (this: RealmContext) {
+        const { dictionary } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            dictionary: {},
+          });
+        });
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expect(Object.keys(dictionary).length).equals(0);
+
+        this.realm.write(() => {
+          for (const key in initialValuesDict) {
+            dictionary[key] = initialValuesDict[key];
+          }
+        });
+
+        expectKeys(dictionary, Object.keys(initialValuesDict));
+        for (const key in dictionary) {
+          const counter = dictionary[key];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesDict[key]);
+        }
+      });
+
+      it("can create and access set items", function (this: RealmContext) {
+        const { set } = this.realm.write(() => {
+          return this.realm.create<IWithCounterCollections>(WithCounterCollectionsSchema.name, {
+            set: [] as number[],
+          });
+        });
+        expect(this.realm.objects(WithCounterCollectionsSchema.name).length).equals(1);
+        expect(set.length).equals(0);
+
+        this.realm.write(() => {
+          for (const input of initialValuesList) {
+            set.add(input);
+          }
+        });
+
+        expect(set.length).equals(initialValuesList.length);
+        for (let i = 0; i < set.length; i++) {
+          const counter = set[i];
+          expectCounter(counter);
+          expect(counter.value).equals(initialValuesList[i]);
+        }
+      });
+    });
   });
 });

--- a/integration-tests/tests/src/tests/dynamic-schema-updates.ts
+++ b/integration-tests/tests/src/tests/dynamic-schema-updates.ts
@@ -66,6 +66,7 @@ describe("realm._updateSchema", () => {
           name: "myField",
           optional: false,
           type: "string",
+          presentation: undefined,
           default: undefined,
         },
       },
@@ -100,6 +101,7 @@ describe("realm._updateSchema", () => {
           name: "age",
           optional: false,
           type: "int",
+          presentation: undefined,
           default: undefined,
         },
         friends: {
@@ -109,6 +111,7 @@ describe("realm._updateSchema", () => {
           objectType: "Dog",
           optional: false,
           type: "list",
+          presentation: undefined,
           default: undefined,
         },
         name: {
@@ -117,6 +120,7 @@ describe("realm._updateSchema", () => {
           name: "name",
           optional: false,
           type: "string",
+          presentation: undefined,
           default: undefined,
         },
         owner: {
@@ -126,6 +130,7 @@ describe("realm._updateSchema", () => {
           objectType: "Person",
           optional: true,
           type: "object",
+          presentation: undefined,
           default: undefined,
         },
       },

--- a/integration-tests/tests/src/tests/mixed.ts
+++ b/integration-tests/tests/src/tests/mixed.ts
@@ -20,6 +20,7 @@ import Realm, { BSON, ObjectSchema } from "realm";
 import { expect } from "chai";
 
 import { openRealmBefore, openRealmBeforeEach } from "../hooks";
+import { expectRealmDictionary, expectRealmList, expectRealmResults } from "../utils/expects";
 
 interface ISingle {
   a: Realm.Mixed;
@@ -366,18 +367,6 @@ describe("Mixed", () => {
         EmbeddedObjectSchema,
       ],
     });
-
-    function expectRealmList(value: unknown): asserts value is Realm.List<unknown> {
-      expect(value).instanceOf(Realm.List);
-    }
-
-    function expectRealmDictionary(value: unknown): asserts value is Realm.Dictionary<unknown> {
-      expect(value).instanceOf(Realm.Dictionary);
-    }
-
-    function expectRealmResults(value: unknown): asserts value is Realm.Results<unknown> {
-      expect(value).instanceOf(Realm.Results);
-    }
 
     /**
      * Expects the provided value to contain:

--- a/integration-tests/tests/src/tests/observable.ts
+++ b/integration-tests/tests/src/tests/observable.ts
@@ -375,6 +375,7 @@ describe("Observable", () => {
                   name: {
                     name: "name",
                     type: "string",
+                    presentation: undefined,
                     optional: false,
                     indexed: false,
                     mapTo: "name",

--- a/integration-tests/tests/src/utils/expects.ts
+++ b/integration-tests/tests/src/utils/expects.ts
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { expect } from "chai";
+import Realm from "realm";
+
+export function expectRealmList(value: unknown): asserts value is Realm.List<unknown> {
+  expect(value).instanceOf(Realm.List);
+}
+
+export function expectRealmDictionary(value: unknown): asserts value is Realm.Dictionary<unknown> {
+  expect(value).instanceOf(Realm.Dictionary);
+}
+
+export function expectRealmResults(value: unknown): asserts value is Realm.Results<unknown> {
+  expect(value).instanceOf(Realm.Results);
+}
+
+export function expectRealmSet(value: unknown): asserts value is Realm.Set<unknown> {
+  expect(value).instanceOf(Realm.Set);
+}

--- a/integration-tests/tests/src/utils/expects.ts
+++ b/integration-tests/tests/src/utils/expects.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { expect } from "chai";
-import Realm from "realm";
+import Realm, { Counter } from "realm";
 
 export function expectRealmList(value: unknown): asserts value is Realm.List<unknown> {
   expect(value).instanceOf(Realm.List);
@@ -33,4 +33,8 @@ export function expectRealmResults(value: unknown): asserts value is Realm.Resul
 
 export function expectRealmSet(value: unknown): asserts value is Realm.Set<unknown> {
   expect(value).instanceOf(Realm.Set);
+}
+
+export function expectCounter(value: unknown): asserts value is Counter {
+  expect(value).to.be.instanceOf(Counter);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26277,7 +26277,7 @@
       }
     },
     "packages/realm": {
-      "version": "12.9.0",
+      "version": "12.10.0-rc.0",
       "hasInstallScript": true,
       "license": "apache-2.0",
       "dependencies": {

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -302,6 +302,7 @@ classes:
       - get_any
       - set_any
       - set_collection
+      - add_int
       - get_linked_object
       - get_backlink_count
       - get_backlink_view

--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm",
-  "version": "12.9.0",
+  "version": "12.10.0-rc.0",
   "description": "Realm by MongoDB is an offline-first mobile database: an alternative to SQLite and key-value stores",
   "license": "apache-2.0",
   "homepage": "https://www.mongodb.com/docs/realm/",

--- a/packages/realm/src/ClassMap.ts
+++ b/packages/realm/src/ClassMap.ts
@@ -153,7 +153,7 @@ export class ClassMap {
       // Get the uninitialized property map
       const { properties } = getClassHelpers(constructor as typeof RealmObject);
       // Initialize the property map, now that all classes have helpers set
-      properties.initialize(objectSchema, defaults, {
+      properties.initialize(objectSchema, canonicalObjectSchema, defaults, {
         realm,
         getClassHelpers: (name: string) => this.getHelpers(name),
       });

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -52,14 +52,14 @@ const COLUMN_KEY = Symbol("Counter#columnKey");
  * ```ts
  * realm.write(() => {
  *   realm.create(MyObject, { _id, counter: 0 });
- * })
+ * });
  * ```
  *
  * To update a `null` counter, use {@link UpdateMode.Modified} or {@link UpdateMode.All}.
  * ```ts
  * realm.write(() => {
  *   realm.create(MyObject, { _id, counter: 0 }, UpdateMode.Modified);
- * })
+ * });
  * ```
  *
  * __Nullability__:

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { IllegalConstructorError, binding } from "./internal";
+
+/**
+ * TODO(lj)
+ */
+export class Counter {
+  /**
+   * The binding representation of the associated obj.
+   * @internal
+   */
+  private declare readonly objInternal: binding.Obj;
+  /**
+   * The column key on the obj.
+   * @internal
+   */
+  private declare readonly columnKey: binding.ColKey;
+
+  /** @internal */
+  constructor(obj: binding.Obj, columnKey: binding.ColKey /*, value = 0*/) {
+    if (!(obj instanceof binding.Obj)) {
+      throw new IllegalConstructorError("Counter");
+    }
+
+    Object.defineProperty(this, "internalObj", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: obj,
+    });
+    Object.defineProperty(this, "columnKey", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: columnKey,
+    });
+  }
+
+  /**
+   * TODO(lj)
+   */
+  get value(): number {
+    // TODO(lj)
+    return 0;
+  }
+
+  /**
+   * TODO(lj)
+   * @param by The value to increment by.
+   */
+  increment(by: number): void {
+    // TODO(lj)
+    console.log(`Incrementing counter by ${by}.`);
+  }
+
+  /**
+   * TODO(lj)
+   * @param by The value to decrement by.
+   */
+  decrement(by: number): void {
+    // TODO(lj)
+    console.log(`Decrementing counter by ${by}.`);
+  }
+
+  /**
+   * TODO(lj)
+   * @param value The value to reset the counter to.
+   */
+  set(value: number): void {
+    // TODO(lj)
+    console.log(`Setting counter to ${value}.`);
+  }
+
+  /**
+   * TODO(lj)
+   */
+  valueOf(): number {
+    return this.value;
+  }
+}

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -24,15 +24,9 @@ import { IllegalConstructorError, Realm, assert, binding } from "./internal";
 export class Counter {
   /** @internal */
   private declare readonly realm: Realm;
-  /**
-   * The binding representation of the associated obj.
-   * @internal
-   */
+  /** @internal */
   private declare readonly obj: binding.Obj;
-  /**
-   * The column key on the obj.
-   * @internal
-   */
+  /** @internal */
   private declare readonly columnKey: binding.ColKey;
 
   /** @internal */
@@ -66,7 +60,13 @@ export class Counter {
    * TODO(lj)
    */
   get value(): number {
-    return Number(this.obj.getAny(this.columnKey));
+    try {
+      return Number(this.obj.getAny(this.columnKey));
+    } catch (err) {
+      // Throw a custom error message instead of Core's.
+      assert.isValid(this.obj);
+      throw err;
+    }
   }
 
   /**

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -31,6 +31,15 @@ const COLUMN_KEY = Symbol("Counter#columnKey");
  * as `0`, can both call `Counter.increment(1)`. Once online, the value will
  * converge to `2`.
  * @note
+ * __Not supported__:
+ *
+ * Counter types are __not__ supported as:
+ * - `Mixed` values
+ * - Primary keys
+ * - Inside collections
+ * - Query arguments for placeholders (e.g. `$0`) in {@link Realm.Results.filtered | filtered()}
+ *   - If you need to use the value of the `Counter` when filtering, use `Counter.value`.
+ *
  * __Declaring a counter__:
  *
  * A property schema is declared as either:

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -149,11 +149,4 @@ export class Counter {
     assert.integer(value, "value");
     this.obj.setAny(this.columnKey, binding.Int64.numToInt(value));
   }
-
-  /**
-   * TODO(lj)
-   */
-  valueOf(): number {
-    return this.value;
-  }
 }

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -48,18 +48,16 @@ const COLUMN_KEY = Symbol("Counter#columnKey");
  * ### Creating a counter
  *
  * Use a `number` when creating your counter on a {@link Realm.Object}.
- * ```ts
+ *
+ * ```typescript
  * realm.write(() => {
  *   realm.create(MyObject, { _id: "123", counter: 0 });
  * });
  * ```
  *
- * To update a `null` counter, use {@link UpdateMode.Modified} or {@link UpdateMode.All}.
- * ```ts
- * realm.write(() => {
- *   realm.create(MyObject, { _id: "123", counter: 0 }, UpdateMode.Modified);
- * });
- * ```
+ * ### Updating the count
+ *
+ * Use the instance methods to update the underlying count.
  *
  * ### Nullability
  *
@@ -67,12 +65,14 @@ const COLUMN_KEY = Symbol("Counter#columnKey");
  * A `Counter` never stores `null` values itself, but the counter property
  * on the {@link Realm.Object} (e.g. `myRealmObject.myCounter`) can be `null`.
  *
- * ### Not a live object
+ * To create a counter from a previously `null` value, or to reset a nullable
+ * counter to `null`, use {@link UpdateMode.Modified} or {@link UpdateMode.All}.
  *
- * The `Counter` instance itself is *not* a live object. Calling `myCounter.value`
- * will always return the most recent locally persisted (and synced) state, and
- * calling `myRealmObject.myCounter` always returns a new `Counter` instance (or
- * potentially `null` for nullable counters).
+ * ```typescript
+ * realm.write(() => {
+ *   realm.create(MyObject, { _id: "123", counter: 0 }, UpdateMode.Modified);
+ * });
+ * ```
  */
 export class Counter {
   /** @internal */

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -30,47 +30,46 @@ const COLUMN_KEY = Symbol("Counter#columnKey");
  * For instance, offline Client 1 and Client 2 which both see `Counter.value`
  * as `0`, can both call `Counter.increment(1)`. Once online, the value will
  * converge to `2`.
- * @note
- * __Not supported__:
  *
- * Counter types are __not__ supported as:
+ * ### Counter types are *not* supported as:
+ *
  * - `Mixed` values
  * - Primary keys
  * - Inside collections
  * - Query arguments for placeholders (e.g. `$0`) in {@link Realm.Results.filtered | filtered()}
  *   - If you need to use the value of the `Counter` when filtering, use `Counter.value`.
  *
- * __Declaring a counter__:
+ * ### Declaring a counter
  *
  * A property schema is declared as either:
  * - `"counter"`
  * - `{ type: "int", presentation: "counter" }`
  *
- * __Creating a counter__:
+ * ### Creating a counter
  *
  * Use a `number` when creating your counter on a {@link Realm.Object}.
  * ```ts
  * realm.write(() => {
- *   realm.create(MyObject, { _id, counter: 0 });
+ *   realm.create(MyObject, { _id: "123", counter: 0 });
  * });
  * ```
  *
  * To update a `null` counter, use {@link UpdateMode.Modified} or {@link UpdateMode.All}.
  * ```ts
  * realm.write(() => {
- *   realm.create(MyObject, { _id, counter: 0 }, UpdateMode.Modified);
+ *   realm.create(MyObject, { _id: "123", counter: 0 }, UpdateMode.Modified);
  * });
  * ```
  *
- * __Nullability__:
+ * ### Nullability
  *
  * The above property schema can be extended to allow a nullable counter.
  * A `Counter` never stores `null` values itself, but the counter property
  * on the {@link Realm.Object} (e.g. `myRealmObject.myCounter`) can be `null`.
  *
- * __Not a live object__:
+ * ### Not a live object
  *
- * The `Counter` instance itself is _not_ a live object. Calling `myCounter.value`
+ * The `Counter` instance itself is *not* a live object. Calling `myCounter.value`
  * will always return the most recent locally persisted (and synced) state, and
  * calling `myRealmObject.myCounter` always returns a new `Counter` instance (or
  * potentially `null` for nullable counters).

--- a/packages/realm/src/Counter.ts
+++ b/packages/realm/src/Counter.ts
@@ -105,8 +105,8 @@ export class Counter {
    */
   set(value: number): void {
     assert.inTransaction(this.realm);
-    // TODO(lj)
-    console.log(`Setting counter to ${value}.`);
+    assert.integer(value, "value");
+    this.obj.setAny(this.columnKey, binding.Int64.numToInt(value));
   }
 
   /**

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -43,25 +43,27 @@ import {
 } from "./internal";
 
 /**
- * The update mode to use when creating an object that already exists.
+ * The update mode to use when creating an object that already exists,
+ * which is determined by a matching primary key.
  */
 export enum UpdateMode {
   /**
-   * Objects are only created. If an existing object exists, an exception is thrown.
+   * Objects are only created. If an existing object exists (determined by a
+   * matching primary key), an exception is thrown.
    */
   Never = "never",
   /**
-   * If an existing object exists, only properties where the value has actually
-   * changed will be updated. This improves notifications and server side
-   * performance but also have implications for how changes across devices are
-   * merged. For most use cases, the behavior will match the intuitive behavior
-   * of how changes should be merged, but if updating an entire object is
-   * considered an atomic operation, this mode should not be used.
+   * If an existing object exists (determined by a matching primary key), only
+   * properties where the value has actually changed will be updated. This improves
+   * notifications and server side performance but also have implications for how
+   * changes across devices are merged. For most use cases, the behavior will match
+   * the intuitive behavior of how changes should be merged, but if updating an
+   * entire object is considered an atomic operation, this mode should not be used.
    */
   Modified = "modified",
   /**
-   * If an existing object is found, all properties provided will be updated,
-   * any other properties will remain unchanged.
+   * If an existing object exists (determined by a matching primary key), all
+   * properties provided will be updated, any other properties will remain unchanged.
    */
   All = "all",
 }
@@ -231,9 +233,6 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
           // Calling `set`/`setProperty` (or `result[propertyName] = propertyValue`)
           // will call into the property setter in PropertyHelpers.ts.
           // (E.g. the setter for [binding.PropertyType.Array] in the case of lists.)
-
-          // Some setters need to allow/disallow certain operations based on
-          // whether the setter is called for the first time via object creation.
           setProperty(obj, propertyValue, created);
         }
       } else {

--- a/packages/realm/src/Object.ts
+++ b/packages/realm/src/Object.ts
@@ -220,7 +220,6 @@ export class RealmObject<T = DefaultObject, RequiredProperties extends keyof Omi
     const result = wrapObject(obj);
     assert(result);
     // Persist any values provided
-    // TODO: Consider using the property helpers directly to improve performance
     for (const property of persistedProperties) {
       const propertyName = property.publicName || property.name;
       const { default: defaultValue, get: getProperty, set: setProperty } = properties.get(propertyName);

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -22,6 +22,7 @@ import {
   Dictionary,
   List,
   ListAccessor,
+  PresentationPropertyTypeName,
   Realm,
   RealmSet,
   Results,
@@ -46,7 +47,7 @@ type PropertyContext = binding.Property & {
   type: binding.PropertyType;
   objectSchemaName: string;
   embedded: boolean;
-  isCounter: boolean;
+  presentation?: PresentationPropertyTypeName;
   default?: unknown;
 };
 
@@ -61,7 +62,7 @@ type PropertyOptions = {
   columnKey: binding.ColKey;
   optional: boolean;
   embedded: boolean;
-  isCounter: boolean;
+  presentation?: PresentationPropertyTypeName;
 } & HelperOptions &
   binding.Property_Relaxed;
 
@@ -125,9 +126,9 @@ type AccessorFactory = (options: PropertyOptions) => PropertyAccessor;
 
 const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>> = {
   [binding.PropertyType.Int](options) {
-    const { realm, columnKey, isCounter } = options;
+    const { realm, columnKey, presentation } = options;
 
-    if (isCounter) {
+    if (presentation === "counter") {
       return {
         get(obj) {
           return new Counter(realm, obj, columnKey);
@@ -390,7 +391,7 @@ export function createPropertyHelpers(property: PropertyContext, options: Helper
     objectType: property.objectType,
     objectSchemaName: property.objectSchemaName,
     optional: !!(property.type & binding.PropertyType.Nullable),
-    isCounter: property.isCounter,
+    presentation: property.presentation,
     columnKey: property.columnKey,
   };
   if (collectionType) {

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -18,6 +18,7 @@
 
 import {
   ClassHelpers,
+  Counter,
   Dictionary,
   List,
   ListAccessor,
@@ -123,6 +124,23 @@ function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions)
 type AccessorFactory = (options: PropertyOptions) => PropertyAccessor;
 
 const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>> = {
+  [binding.PropertyType.Int](options) {
+    const { realm, columnKey, isCounter } = options;
+
+    if (isCounter) {
+      return {
+        get(obj) {
+          return new Counter(realm, obj, columnKey);
+        },
+        set: defaultSet(options),
+      };
+    } else {
+      return {
+        get: defaultGet(options),
+        set: defaultSet(options),
+      };
+    }
+  },
   [binding.PropertyType.Object](options) {
     const {
       columnKey,

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -131,7 +131,7 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
     if (presentation === "counter") {
       return {
         get(obj) {
-          return new Counter(realm, obj, columnKey);
+          return obj.getAny(columnKey) === null ? null : new Counter(realm, obj, columnKey);
         },
         set(obj, value, isCreating) {
           // We only allow resetting a counter this way (e.g. realmObject.counter = 5)

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -45,6 +45,7 @@ type PropertyContext = binding.Property & {
   type: binding.PropertyType;
   objectSchemaName: string;
   embedded: boolean;
+  isCounter: boolean;
   default?: unknown;
 };
 
@@ -59,6 +60,7 @@ type PropertyOptions = {
   columnKey: binding.ColKey;
   optional: boolean;
   embedded: boolean;
+  isCounter: boolean;
 } & HelperOptions &
   binding.Property_Relaxed;
 
@@ -370,6 +372,8 @@ export function createPropertyHelpers(property: PropertyContext, options: Helper
     objectType: property.objectType,
     objectSchemaName: property.objectSchemaName,
     optional: !!(property.type & binding.PropertyType.Nullable),
+    isCounter: property.isCounter,
+    columnKey: property.columnKey,
   };
   if (collectionType) {
     return getPropertyHelpers(collectionType, {

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -414,7 +414,6 @@ export function createPropertyHelpers(property: PropertyContext, options: Helper
     objectSchemaName: property.objectSchemaName,
     optional: !!(property.type & binding.PropertyType.Nullable),
     presentation: property.presentation,
-    columnKey: property.columnKey,
   };
   if (collectionType) {
     return getPropertyHelpers(collectionType, {

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -151,9 +151,9 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
             }
           }
           throw new Error(
-            "You can only directly reset a Counter instance when initializing a previously " +
-              "null Counter or resetting a nullable Counter to null. To update the value of " +
-              "the Counter, use its instance methods.",
+            "You can only reset a Counter instance when initializing a previously " +
+              "null Counter or resetting a nullable Counter to null. To update the " +
+              "value of the Counter, use its instance methods.",
           );
         },
       };

--- a/packages/realm/src/PropertyMap.ts
+++ b/packages/realm/src/PropertyMap.ts
@@ -60,10 +60,10 @@ export class PropertyMap {
 
         const canonicalPropertySchema = canonicalObjectSchema.properties[propertyName];
         assert(canonicalPropertySchema, `Expected ${propertyName} to exist on the CanonicalObjectSchema.`);
-        const isCounter =
-          canonicalPropertySchema.type === "counter" || canonicalPropertySchema.objectType === "counter";
-
-        const helpers = createPropertyHelpers({ ...property, embedded, objectSchemaName, isCounter }, options);
+        const helpers = createPropertyHelpers(
+          { ...property, embedded, objectSchemaName, presentation: canonicalPropertySchema.presentation },
+          options,
+        );
         // Allow users to override the default value of properties
         const defaultValue = defaults[propertyName];
         helpers.default = typeof defaultValue !== "undefined" ? defaultValue : helpers.default;

--- a/packages/realm/src/PropertyMap.ts
+++ b/packages/realm/src/PropertyMap.ts
@@ -59,7 +59,7 @@ export class PropertyMap {
           : false;
 
         const canonicalPropertySchema = canonicalObjectSchema.properties[propertyName];
-        assert(canonicalPropertySchema, `Expected ${propertyName} to exist on the CanonicalObjectSchema.`);
+        assert(canonicalPropertySchema, `Expected '${propertyName}' to exist on the CanonicalObjectSchema.`);
         const helpers = createPropertyHelpers(
           { ...property, embedded, objectSchemaName, presentation: canonicalPropertySchema.presentation },
           options,

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -662,8 +662,6 @@ export class Realm {
       if (extras) {
         objectSchema.ctor = extras.constructor;
       }
-      // Some tests require that the properties exist on the object, even
-      // if the value is `undefined`. Thus, explicitly set to `undefined`.
       for (const property of Object.values(objectSchema.properties)) {
         property.default = extras ? extras.defaults[property.name] : undefined;
         property.presentation = extras ? extras.presentations[property.name] : undefined;

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -37,6 +37,7 @@ import {
   LoggerCallback2,
   MigrationCallback,
   ObjectSchema,
+  PresentationPropertyTypeName,
   ProgressRealmPromise,
   REALM,
   RealmEvent,
@@ -80,6 +81,7 @@ type RealmSchemaExtra = Record<string, ObjectSchemaExtra | undefined>;
 type ObjectSchemaExtra = {
   constructor?: RealmObjectConstructor;
   defaults: Record<string, unknown>;
+  presentations: Record<string, PresentationPropertyTypeName | undefined>;
   // objectTypes: Record<string, unknown>;
 };
 
@@ -398,17 +400,26 @@ export class Realm {
     }
   }
 
-  private static extractSchemaExtras(schemas: CanonicalObjectSchema[]): RealmSchemaExtra {
-    return Object.fromEntries(
-      schemas.map((schema) => {
-        const defaults = Object.fromEntries(
-          Object.entries(schema.properties).map(([name, property]) => {
-            return [name, property.default];
-          }),
-        );
-        return [schema.name, { defaults, constructor: schema.ctor }];
-      }),
-    );
+  private static extractRealmSchemaExtras(schemas: CanonicalObjectSchema[]): RealmSchemaExtra {
+    const extras: RealmSchemaExtra = {};
+    for (const schema of schemas) {
+      extras[schema.name] = this.extractObjectSchemaExtras(schema);
+    }
+
+    return extras;
+  }
+
+  /** @internal */
+  private static extractObjectSchemaExtras(schema: CanonicalObjectSchema): ObjectSchemaExtra {
+    const defaults: Record<string, unknown> = {};
+    const presentations: Record<string, PresentationPropertyTypeName | undefined> = {};
+
+    for (const [name, propertySchema] of Object.entries(schema.properties)) {
+      defaults[name] = propertySchema.default;
+      presentations[name] = propertySchema.presentation;
+    }
+
+    return { constructor: schema.ctor, defaults, presentations };
   }
 
   /** @internal */
@@ -417,7 +428,7 @@ export class Realm {
     bindingConfig: binding.RealmConfig_Relaxed;
   } {
     const normalizedSchema = config.schema && normalizeRealmSchema(config.schema);
-    const schemaExtras = Realm.extractSchemaExtras(normalizedSchema || []);
+    const schemaExtras = Realm.extractRealmSchemaExtras(normalizedSchema || []);
     const path = Realm.determinePath(config);
     const { fifoFilesFallbackPath, shouldCompact, inMemory } = config;
     const bindingSchema = normalizedSchema && toBindingSchema(normalizedSchema);
@@ -560,8 +571,6 @@ export class Realm {
         },
         schemaDidChange: (r) => {
           r.verifyOpen();
-          // TODO(lj): Use normalized schema from the user-defined one instead of
-          //           `this.schema`, since `this.schema` normalizes based on the binding.
           this.classes = new ClassMap(this, this.internal.schema, this.schema);
           this.schemaListeners.notify(this.schema);
         },
@@ -588,8 +597,6 @@ export class Realm {
       writable: false,
     });
 
-    // TODO(lj): Use normalized schema from the user-defined one instead of
-    //           `this.schema`, since `this.schema` normalizes based on the binding.
     this.classes = new ClassMap(this, this.internal.schema, this.schema);
 
     const syncSession = this.internal.syncSession;
@@ -648,13 +655,6 @@ export class Realm {
    * @since 0.12.0
    */
   get schema(): CanonicalObjectSchema[] {
-    // TODO(lj):
-    // * Why does this need to be calculated on each invocation?
-    //   * The below code is already handled during normalization.
-    // * This currently creates the SDK canonical schema via the binding
-    //   schema. Since the binding will not have information about the counter,
-    //   the canonical schema returned will be incorrect for counters.
-
     const schemas = fromBindingRealmSchema(this.internal.schema);
     // Stitch in the constructors and defaults stored in this.schemaExtras
     for (const objectSchema of schemas) {
@@ -662,8 +662,11 @@ export class Realm {
       if (extras) {
         objectSchema.ctor = extras.constructor;
       }
+      // Some tests require that the properties exist on the object, even
+      // if the value is `undefined`. Thus, explicitly set to `undefined`.
       for (const property of Object.values(objectSchema.properties)) {
         property.default = extras ? extras.defaults[property.name] : undefined;
+        property.presentation = extras ? extras.presentations[property.name] : undefined;
       }
     }
     return schemas;
@@ -1316,6 +1319,7 @@ export namespace Realm {
   export import OpenRealmTimeOutBehavior = internal.OpenRealmTimeOutBehavior;
   export import OrderedCollection = internal.OrderedCollection;
   export import PartitionSyncConfiguration = internal.PartitionSyncConfiguration;
+  export import PresentationPropertyTypeName = internal.PresentationPropertyTypeName;
   export import PrimaryKey = internal.PrimaryKey;
   export import PrimitivePropertyTypeName = internal.PrimitivePropertyTypeName;
   export import ProgressDirection = internal.ProgressDirection;
@@ -1342,6 +1346,7 @@ export namespace Realm {
   export import SessionState = internal.SessionState;
   export import SessionStopPolicy = internal.SessionStopPolicy;
   export import Set = internal.RealmSet;
+  export import ShorthandPrimitivePropertyTypeName = internal.ShorthandPrimitivePropertyTypeName;
   export import SortDescriptor = internal.SortDescriptor;
   export import SSLConfiguration = internal.SSLConfiguration;
   export import SSLVerifyCallback = internal.SSLVerifyCallback;

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -560,6 +560,8 @@ export class Realm {
         },
         schemaDidChange: (r) => {
           r.verifyOpen();
+          // TODO(lj): Use normalized schema from the user-defined one instead of
+          //           `this.schema`, since `this.schema` normalizes based on the binding.
           this.classes = new ClassMap(this, this.internal.schema, this.schema);
           this.schemaListeners.notify(this.schema);
         },
@@ -586,6 +588,8 @@ export class Realm {
       writable: false,
     });
 
+    // TODO(lj): Use normalized schema from the user-defined one instead of
+    //           `this.schema`, since `this.schema` normalizes based on the binding.
     this.classes = new ClassMap(this, this.internal.schema, this.schema);
 
     const syncSession = this.internal.syncSession;
@@ -644,6 +648,13 @@ export class Realm {
    * @since 0.12.0
    */
   get schema(): CanonicalObjectSchema[] {
+    // TODO(lj):
+    // * Why does this need to be calculated on each invocation?
+    //   * The below code is already handled during normalization.
+    // * This currently creates the SDK canonical schema via the binding
+    //   schema. Since the binding will not have information about the counter,
+    //   the canonical schema returned will be incorrect for counters.
+
     const schemas = fromBindingRealmSchema(this.internal.schema);
     // Stitch in the constructors and defaults stored in this.schemaExtras
     for (const objectSchema of schemas) {
@@ -1262,6 +1273,7 @@ export namespace Realm {
   export import ConfigurationWithSync = internal.ConfigurationWithSync;
   export import ConnectionNotificationCallback = internal.ConnectionNotificationCallback;
   export import ConnectionState = internal.ConnectionState;
+  export import Counter = internal.Counter;
   export import Credentials = internal.Credentials;
   export import DefaultFunctionsFactory = internal.DefaultFunctionsFactory;
   export import DefaultUserProfileData = internal.DefaultUserProfileData;

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -1242,6 +1242,7 @@ export namespace Realm {
   export import AnyList = internal.AnyList;
   export import AnyRealmObject = internal.AnyRealmObject;
   export import AnyResults = internal.AnyResults;
+  export import AnySet = internal.AnySet;
   export import AnyUser = internal.AnyUser;
   export import ApiKey = internal.ApiKey;
   export import AppChangeCallback = internal.AppChangeCallback;

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -118,6 +118,7 @@ export function mixedToBinding(
   value: unknown,
   { isQueryArg } = { isQueryArg: false },
 ): binding.MixedArg {
+  const displayedType = isQueryArg ? "a query argument" : "a Mixed value";
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
     // Fast track pass through for the most commonly used types
     return value;
@@ -127,13 +128,15 @@ export function mixedToBinding(
     return binding.Timestamp.fromDate(value);
   } else if (value instanceof RealmObject) {
     if (value.objectSchema().embedded) {
-      throw new Error(`Using an embedded object (${value.constructor.name}) as a Mixed value is not supported.`);
+      throw new Error(`Using an embedded object (${value.constructor.name}) as ${displayedType} is not supported.`);
     }
     const otherRealm = value[REALM].internal;
     assert.isSameRealm(realm, otherRealm, "Realm object is from another Realm");
     return value[INTERNAL];
   } else if (value instanceof RealmSet || value instanceof Set) {
-    throw new Error(`Using a ${value.constructor.name} as a Mixed value is not supported.`);
+    throw new Error(`Using a ${value.constructor.name} as ${displayedType} is not supported.`);
+  } else if (value instanceof Counter) {
+    throw new Error(`Using a Counter as ${displayedType} is not supported.`);
   } else {
     if (isQueryArg) {
       if (value instanceof Collection || Array.isArray(value)) {

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -136,7 +136,9 @@ export function mixedToBinding(
   } else if (value instanceof RealmSet || value instanceof Set) {
     throw new Error(`Using a ${value.constructor.name} as ${displayedType} is not supported.`);
   } else if (value instanceof Counter) {
-    throw new Error(`Using a Counter as ${displayedType} is not supported.`);
+    let errMessage = `Using a Counter as ${displayedType} is not supported.`;
+    errMessage += isQueryArg ? " Use 'Counter.value'." : "";
+    throw new Error(errMessage);
   } else {
     if (isQueryArg) {
       if (value instanceof Collection || Array.isArray(value)) {

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -96,7 +96,6 @@ export type TypeOptions = {
   objectType: string | undefined;
   objectSchemaName: string | undefined;
   presentation?: PresentationPropertyTypeName;
-  columnKey?: binding.ColKey;
   getClassHelpers(nameOrTableKey: string | binding.TableKey): ClassHelpers;
 };
 
@@ -226,7 +225,7 @@ function nullPassthrough<T, R extends any[], F extends (value: unknown, ...rest:
 }
 
 const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => TypeHelpers> = {
-  [binding.PropertyType.Int]({ /*realm, columnKey,*/ presentation, optional }) {
+  [binding.PropertyType.Int]({ presentation, optional }) {
     return {
       toBinding: nullPassthrough((value) => {
         if (typeof value === "number") {
@@ -243,15 +242,7 @@ const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => Type
         }
       }, optional),
       // TODO: Support returning bigints to end-users
-      fromBinding: nullPassthrough((value) => {
-        if (presentation === "counter") {
-          // TODO(lj)
-          console.warn("Not yet implemented. TypeHelpers.ts: Returning -1");
-          return -1;
-        } else {
-          return Number(value);
-        }
-      }, optional),
+      fromBinding: nullPassthrough((value) => Number(value), optional),
     };
   },
   [binding.PropertyType.Bool]({ optional }) {

--- a/packages/realm/src/Types.ts
+++ b/packages/realm/src/Types.ts
@@ -32,6 +32,7 @@ export namespace Types {
   export import Decimal128 = internal.BSON.Decimal128;
   export import ObjectId = internal.BSON.ObjectId;
   export import UUID = internal.BSON.UUID;
+  export import Counter = internal.Counter;
 
   export type Date = GlobalDate;
   export const Date = GlobalDate;

--- a/packages/realm/src/Unmanaged.ts
+++ b/packages/realm/src/Unmanaged.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import type { AnyRealmObject, Collection, Counter, Dictionary, List, Realm } from "./internal";
+import type { AnyRealmObject, Collection, Counter, Dictionary, List, Realm, RealmSet } from "./internal";
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- We define these once to avoid using "any" through the code */
 export type AnyCollection = Collection<any, any, any, any, any>;
@@ -24,6 +24,8 @@ export type AnyCollection = Collection<any, any, any, any, any>;
 export type AnyDictionary = Dictionary<any>;
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- We define these once to avoid using "any" through the code */
 export type AnyList = List<any>;
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- We define these once to avoid using "any" through the code */
+export type AnySet = RealmSet<any>;
 
 type ExtractPropertyNamesOfType<T, PropType> = {
   [K in keyof T]: T[K] extends PropType ? K : never;
@@ -47,6 +49,13 @@ type RealmDictionaryRemappedModelPart<T> = {
   [K in ExtractPropertyNamesOfType<T, AnyDictionary>]?: T[K] extends Dictionary<infer ValueType>
     ? { [key: string]: ValueType }
     : never;
+};
+
+/**
+ * Exchanges properties defined as {@link RealmSet} with an optional {@link Array}.
+ */
+type RealmSetRemappedModelPart<T> = {
+  [K in ExtractPropertyNamesOfType<T, AnySet>]?: T[K] extends RealmSet<infer GT> ? Array<GT | Unmanaged<GT>> : never;
 };
 
 /**
@@ -82,6 +91,7 @@ type OmittedRealmTypesWithRequired<T, RequiredProperties extends keyof OmittedRe
 /** Remaps realm types to "simpler" types (arrays and objects) */
 type RemappedRealmTypes<T> = RealmListRemappedModelPart<T> &
   RealmDictionaryRemappedModelPart<T> &
+  RealmSetRemappedModelPart<T> &
   RealmCounterRemappedModelPart<T>;
 
 /**

--- a/packages/realm/src/Unmanaged.ts
+++ b/packages/realm/src/Unmanaged.ts
@@ -31,7 +31,7 @@ type ExtractPropertyNamesOfType<T, PropType> = {
   [K in keyof T]: T[K] extends PropType ? K : never;
 }[keyof T];
 
-type ExtractPropertyNamesOfTypeExclNullability<T, PropType> = {
+type ExtractPropertyNamesOfTypeExcludingNullability<T, PropType> = {
   [K in keyof T]: Exclude<T[K], null | undefined> extends PropType ? K : never;
 }[keyof T];
 
@@ -62,7 +62,7 @@ type RealmSetRemappedModelPart<T> = {
  * Exchanges properties defined as a {@link Counter} with a `number`.
  */
 type RealmCounterRemappedModelPart<T> = {
-  [K in ExtractPropertyNamesOfTypeExclNullability<T, Counter>]?: Counter | number | Exclude<T[K], Counter>;
+  [K in ExtractPropertyNamesOfTypeExcludingNullability<T, Counter>]?: Counter | number | Exclude<T[K], Counter>;
 };
 
 /** Omits all properties of a model which are not defined by the schema */
@@ -73,7 +73,7 @@ export type OmittedRealmTypes<T> = Omit<
   | ExtractPropertyNamesOfType<T, Function> // TODO: Figure out the use-case for this
   | ExtractPropertyNamesOfType<T, AnyCollection>
   | ExtractPropertyNamesOfType<T, AnyDictionary>
-  | ExtractPropertyNamesOfTypeExclNullability<T, Counter>
+  | ExtractPropertyNamesOfTypeExcludingNullability<T, Counter>
 >;
 
 /** Make all fields optional except those specified in K */

--- a/packages/realm/src/assert.ts
+++ b/packages/realm/src/assert.ts
@@ -64,6 +64,10 @@ assert.number = (value: unknown, target?: string): asserts value is number => {
   assert(typeof value === "number", () => new TypeAssertionError("a number", value, target));
 };
 
+assert.integer = (value: unknown, target?: string): asserts value is number => {
+  assert(Number.isInteger(value), () => new TypeAssertionError("an integer", value, target));
+};
+
 assert.numericString = (value: unknown, target?: string) => {
   assert.string(value);
   assert(/^-?\d+$/.test(value), () => new TypeAssertionError("a numeric string", value, target));

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -45,6 +45,14 @@ export class TypeAssertionError extends AssertionError {
       return typeof value;
     } else if (typeof value === "function") {
       return `a function or class named ${value.name}`;
+    } else if (typeof value === "number") {
+      let type = "a number";
+      if (Number.isNaN(value)) {
+        type = "NaN";
+      } else if (!Number.isInteger(value)) {
+        type = "a floating point number";
+      }
+      return type;
     } else {
       return "a " + typeof value;
     }

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -46,13 +46,12 @@ export class TypeAssertionError extends AssertionError {
     } else if (typeof value === "function") {
       return `a function or class named ${value.name}`;
     } else if (typeof value === "number") {
-      let type = "a number";
       if (Number.isNaN(value)) {
-        type = "NaN";
+        return "NaN";
       } else if (!Number.isInteger(value)) {
-        type = "a floating point number";
+        return "a decimal number";
       }
-      return type;
+      return "a number";
     } else {
       return "a " + typeof value;
     }

--- a/packages/realm/src/errors.ts
+++ b/packages/realm/src/errors.ts
@@ -50,8 +50,9 @@ export class TypeAssertionError extends AssertionError {
         return "NaN";
       } else if (!Number.isInteger(value)) {
         return "a decimal number";
+      } else {
+        return "a number";
       }
-      return "a number";
     } else {
       return "a " + typeof value;
     }

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -67,6 +67,7 @@ export * from "./Results";
 export * from "./List";
 export * from "./Set";
 export * from "./Dictionary";
+export * from "./Counter";
 
 export * from "./Types";
 export * from "./GeoSpatial";

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -62,6 +62,7 @@ const PRIMITIVE_TYPES = new Set<PrimitivePropertyTypeName>([
   "date",
   "mixed",
   "uuid",
+  "counter",
 ]);
 
 const COLLECTION_TYPES = new Set<CollectionPropertyTypeName>(["list", "dictionary", "set"]);
@@ -319,6 +320,7 @@ function normalizePropertySchemaObject(info: PropertyInfoUsingObject): Canonical
   if (info.isPrimaryKey) {
     assert(indexed !== false, propError(info, "Primary keys must always be indexed."));
     assert(indexed !== "full-text", propError(info, "Primary keys cannot be full-text indexed."));
+    assert(type !== "counter" && objectType !== "counter", propError(info, "Counters cannot be primary keys."));
     indexed = true;
   }
 

--- a/packages/realm/src/schema/normalize.ts
+++ b/packages/realm/src/schema/normalize.ts
@@ -257,6 +257,15 @@ function normalizePropertySchemaShorthand(info: PropertyInfoUsingShorthand): Can
     }
   }
 
+  switch (presentation) {
+    case "counter":
+      // If `type` is not an int at this point, a collection shorthand is used.
+      assert(type === "int", propError(info, "Counters cannot be used in collections."));
+      break;
+    default:
+      break;
+  }
+
   if (isAlwaysOptional(type, objectType)) {
     optional = true;
   } else if (isNeverOptional(type, objectType)) {
@@ -319,6 +328,14 @@ function normalizePropertySchemaObject(info: PropertyInfoUsingObject): Canonical
 
   if (type !== "linkingObjects") {
     assert(property === undefined, propError(info, "'property' can only be specified if 'type' is 'linkingObjects'."));
+  }
+
+  switch (presentation) {
+    case "counter":
+      assert(type === "int", propError(info, "Counters can only be used when 'type' is 'int'."));
+      break;
+    default:
+      break;
   }
 
   if (isAlwaysOptional(type, objectType)) {

--- a/packages/realm/src/schema/types.ts
+++ b/packages/realm/src/schema/types.ts
@@ -248,13 +248,6 @@ export type PropertySchema = {
    *    type: "int",
    *    presentation: "counter",
    * }
-   *
-   * // A list of counters
-   * {
-   *    type: "list",
-   *    objectType: "int",
-   *    presentation: "counter",
-   * }
    */
   presentation?: PresentationPropertyTypeName;
   /**
@@ -294,7 +287,7 @@ export type PropertySchema = {
  * Keys used in the property schema that are common among all variations of {@link PropertySchemaStrict}.
  */
 export type PropertySchemaCommon = {
-  presentation?: PresentationPropertyTypeName;
+  presentation: never;
   indexed?: IndexedType;
   mapTo?: string;
   default?: unknown;
@@ -313,8 +306,13 @@ export type PropertySchemaCommon = {
 export type PropertySchemaStrict = PropertySchemaCommon &
   (
     | {
-        type: Exclude<PrimitivePropertyTypeName, "mixed">;
+        type: Exclude<PrimitivePropertyTypeName, "mixed" | "int">;
         optional?: boolean;
+      }
+    | {
+        type: "int";
+        optional?: boolean;
+        presentation?: "counter";
       }
     | {
         type: "mixed";

--- a/packages/realm/src/schema/types.ts
+++ b/packages/realm/src/schema/types.ts
@@ -53,8 +53,13 @@ export type PrimitivePropertyTypeName =
   | "data"
   | "date"
   | "mixed"
-  | "uuid"
-  | "counter";
+  | "uuid";
+
+/**
+ * The names of the supported Realm primitive property types and their
+ * presentation types used in {@link PropertySchemaShorthand}.
+ */
+export type ShorthandPrimitivePropertyTypeName = PrimitivePropertyTypeName | PresentationPropertyTypeName;
 
 /**
  * The names of the supported Realm collection property types.
@@ -65,6 +70,15 @@ export type CollectionPropertyTypeName = "list" | "dictionary" | "set";
  * The names of the supported Realm relationship property types.
  */
 export type RelationshipPropertyTypeName = "object" | "linkingObjects";
+
+/**
+ * The names of the supported Realm presentation property types.
+ *
+ * Some types can be presented as a type different from the database type.
+ * For instance, an integer that should behave like a logical counter is
+ * presented as a `"counter"` type.
+ */
+export type PresentationPropertyTypeName = "counter";
 
 /**
  * The name of a user-defined Realm object type. It must contain at least 1 character
@@ -90,10 +104,11 @@ export type IndexedType = boolean | "full-text";
 export type CanonicalPropertySchema = {
   name: string;
   type: PropertyTypeName;
+  objectType?: string;
+  presentation?: PresentationPropertyTypeName;
   optional: boolean;
   indexed: IndexedType;
   mapTo: string; // TODO: Make this optional and leave it out when it equals the name
-  objectType?: string;
   property?: string;
   default?: unknown;
 };
@@ -166,7 +181,7 @@ export type CanonicalPropertiesTypes<K extends symbol | number | string = string
  * Realm object property.
  *
  * Required string structure:
- * - ({@link PrimitivePropertyTypeName} | {@link UserTypeName})(`"?"` | `""`)(`"[]"` | `"{}"` | `"<>"` | `""`)
+ * - ({@link ShorthandPrimitivePropertyTypeName} | {@link UserTypeName})(`"?"` | `""`)(`"[]"` | `"{}"` | `"<>"` | `""`)
  *   - `"?"`
  *     - The marker to declare an optional type or an optional element in a collection
  *       if the type itself is a collection. Can only be used when declaring property
@@ -222,6 +237,27 @@ export type PropertySchema = {
    */
   objectType?: PrimitivePropertyTypeName | UserTypeName;
   /**
+   * The presentation type of the property.
+   *
+   * Some types can be presented as a type different from the database type.
+   * For instance, an integer that should behave like a logical counter is
+   * presented as a `"counter"` type.
+   * @example
+   * // A counter
+   * {
+   *    type: "int",
+   *    presentation: "counter",
+   * }
+   *
+   * // A list of counters
+   * {
+   *    type: "list",
+   *    objectType: "int",
+   *    presentation: "counter",
+   * }
+   */
+  presentation?: PresentationPropertyTypeName;
+  /**
    * The name of the property of the object specified in `objectType` that creates this
    * link. (Can only be set for linking objects.)
    */
@@ -258,6 +294,7 @@ export type PropertySchema = {
  * Keys used in the property schema that are common among all variations of {@link PropertySchemaStrict}.
  */
 export type PropertySchemaCommon = {
+  presentation?: PresentationPropertyTypeName;
   indexed?: IndexedType;
   mapTo?: string;
   default?: unknown;

--- a/packages/realm/src/schema/types.ts
+++ b/packages/realm/src/schema/types.ts
@@ -53,7 +53,8 @@ export type PrimitivePropertyTypeName =
   | "data"
   | "date"
   | "mixed"
-  | "uuid";
+  | "uuid"
+  | "counter";
 
 /**
  * The names of the supported Realm collection property types.
@@ -204,8 +205,8 @@ export type ObjectSchemaProperty = PropertySchema;
  * @see {@link PropertySchemaShorthand} for a shorthand representation of a property
  * schema.
  * @see {@link PropertySchemaStrict} for a precise type definition of the requirements
- * with the allowed combinations. This type is less strict in order to provide a more
- * user-friendly option due to misleading TypeScript error messages when working with
+ * with the allowed combinations. {@link PropertySchema} is less strict in order to provide
+ * a more user-friendly option due to misleading TypeScript error messages when working with
  * the strict type. This type is currently recommended for that reason, but the strict
  * type is provided as guidance. (Exact errors will always be shown when creating a
  * {@link Realm} instance if the schema is invalid.)
@@ -265,7 +266,7 @@ export type PropertySchemaCommon = {
 /**
  * The strict schema for specifying the type of a specific Realm object property.
  *
- * Unlike the less strict {@link PropertySchema}, this type precisely defines the type
+ * Unlike the less strict {@link PropertySchema}, the strict type precisely defines the type
  * requirements and their allowed combinations; however, TypeScript error messages tend
  * to be more misleading. {@link PropertySchema} is recommended for that reason, but the
  * strict type is provided as guidance.

--- a/packages/realm/src/schema/validate.ts
+++ b/packages/realm/src/schema/validate.ts
@@ -49,6 +49,7 @@ const OBJECT_SCHEMA_KEYS = new Set<keyof CanonicalObjectSchema>([
 const PROPERTY_SCHEMA_KEYS = new Set<keyof CanonicalPropertySchema>([
   "type",
   "objectType",
+  "presentation",
   "property",
   "default",
   "optional",
@@ -150,10 +151,13 @@ export function validatePropertySchema(
 ): asserts propertySchema is PropertySchema {
   try {
     assert.object(propertySchema, `'${propertyName}' on '${objectName}'`, { allowArrays: false });
-    const { type, objectType, optional, property, indexed, mapTo } = propertySchema;
+    const { type, objectType, presentation, optional, property, indexed, mapTo } = propertySchema;
     assert.string(type, `'${propertyName}.type' on '${objectName}'`);
     if (objectType !== undefined) {
       assert.string(objectType, `'${propertyName}.objectType' on '${objectName}'`);
+    }
+    if (presentation !== undefined) {
+      assert.string(presentation, `'${propertyName}.presentation' on '${objectName}'`);
     }
     if (optional !== undefined) {
       assert.boolean(optional, `'${propertyName}.optional' on '${objectName}'`);

--- a/packages/realm/src/tests/milestone-2.test.ts
+++ b/packages/realm/src/tests/milestone-2.test.ts
@@ -45,6 +45,7 @@ describe("Milestone #2", () => {
               name: {
                 name: "name",
                 type: "string",
+                presentation: undefined,
                 optional: false,
                 indexed: true,
                 mapTo: "name",
@@ -57,6 +58,7 @@ describe("Milestone #2", () => {
                 name: "age",
                 optional: true,
                 type: "int",
+                presentation: undefined,
               },
               bestFriend: {
                 indexed: false,
@@ -65,6 +67,7 @@ describe("Milestone #2", () => {
                 optional: true,
                 type: "object",
                 objectType: "Person",
+                presentation: undefined,
                 default: undefined,
               },
             },

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -127,48 +127,56 @@ describe("normalizePropertySchema", () => {
 
       describe("'counter' & collection combinations", () => {
         itNormalizes("counter", {
-          type: "counter",
+          type: "int",
+          presentation: "counter",
           optional: false,
         });
 
         itNormalizes("counter?", {
-          type: "counter",
+          type: "int",
+          presentation: "counter",
           optional: true,
         });
 
         itNormalizes("counter[]", {
           type: "list",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: false,
         });
 
         itNormalizes("counter?[]", {
           type: "list",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: true,
         });
 
         itNormalizes("counter{}", {
           type: "dictionary",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: false,
         });
 
         itNormalizes("counter?{}", {
           type: "dictionary",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: true,
         });
 
         itNormalizes("counter<>", {
           type: "set",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: false,
         });
 
         itNormalizes("counter?<>", {
           type: "set",
-          objectType: "counter",
+          objectType: "int",
+          presentation: "counter",
           optional: true,
         });
       });
@@ -556,32 +564,38 @@ describe("normalizePropertySchema", () => {
       describe("'counter' & collection combinations", () => {
         itNormalizes(
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
           },
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
             optional: false,
           },
         );
 
         itNormalizes(
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
             optional: false,
           },
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
             optional: false,
           },
         );
 
         itNormalizes(
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
             optional: true,
           },
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
             optional: true,
           },
         );
@@ -589,24 +603,13 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "list",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
           },
           {
             type: "list",
-            objectType: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "list",
-            objectType: "counter",
-            optional: false,
-          },
-          {
-            type: "list",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
         );
@@ -614,12 +617,29 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "list",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
+            optional: false,
+          },
+          {
+            type: "list",
+            objectType: "int",
+            presentation: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
           {
             type: "list",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
         );
@@ -627,11 +647,13 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
           },
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
         );
@@ -639,12 +661,14 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
         );
@@ -652,12 +676,14 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
           {
             type: "dictionary",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
         );
@@ -665,11 +691,13 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
           },
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
         );
@@ -677,12 +705,14 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: false,
           },
         );
@@ -690,12 +720,14 @@ describe("normalizePropertySchema", () => {
         itNormalizes(
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
           {
             type: "set",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
             optional: true,
           },
         );
@@ -942,7 +974,7 @@ describe("normalizePropertySchema", () => {
     describe("Invalid object notation", () => {
       itThrowsWhenNormalizing(
         {
-          // @ts-expect-error Passing in the wrong type
+          // @ts-expect-error Passing in the wrong type.
           type: "",
         },
         "'type' must be specified",
@@ -987,7 +1019,7 @@ describe("normalizePropertySchema", () => {
 
       itThrowsWhenNormalizing(
         {
-          // @ts-expect-error Passing in the wrong type
+          // @ts-expect-error Passing in the wrong type.
           type: "Person",
         },
         "If you meant to define a relationship, use { type: 'object', objectType: 'Person' } or { type: 'linkingObjects', objectType: 'Person', property: 'The Person property' }",
@@ -1107,7 +1139,7 @@ describe("normalizePropertySchema", () => {
       describe("Mixing shorthand inside object notation", () => {
         itThrowsWhenNormalizing(
           {
-            // @ts-expect-error Passing in the wrong type
+            // @ts-expect-error Passing in the wrong type.
             type: "int?",
           },
           "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
@@ -1115,7 +1147,7 @@ describe("normalizePropertySchema", () => {
 
         itThrowsWhenNormalizing(
           {
-            // @ts-expect-error Passing in the wrong type
+            // @ts-expect-error Passing in the wrong type.
             type: "int?[]",
           },
           "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
@@ -1144,6 +1176,22 @@ describe("normalizePropertySchema", () => {
           },
           "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
         );
+
+        itThrowsWhenNormalizing(
+          {
+            // @ts-expect-error Passing in the wrong type.
+            type: "counter",
+          },
+          "Cannot use shorthand 'counter' in 'type' or 'objectType' when defining property objects. To use presentation types such as 'counter', use the field 'presentation'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "counter?",
+          },
+          "Cannot use shorthand '?' and 'counter' in 'type' or 'objectType' when defining property objects. To use presentation types such as 'counter', use the field 'presentation'",
+        );
       });
 
       describe("Indexed and primary key combinations", () => {
@@ -1168,7 +1216,8 @@ describe("normalizePropertySchema", () => {
 
         itThrowsWhenNormalizing(
           {
-            type: "counter",
+            type: "int",
+            presentation: "counter",
           },
           "Counters cannot be primary keys.",
           { isPrimaryKey: true },
@@ -1177,7 +1226,8 @@ describe("normalizePropertySchema", () => {
         itThrowsWhenNormalizing(
           {
             type: "list",
-            objectType: "counter",
+            objectType: "int",
+            presentation: "counter",
           },
           "Counters cannot be primary keys.",
           { isPrimaryKey: true },

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -27,982 +27,950 @@ const OBJECT_NAME = "MyObject";
 const PROPERTY_NAME = "prop";
 
 describe("normalizePropertySchema", () => {
-  // ------------------------------------------------------------------------
-  // Valid string notation
-  // ------------------------------------------------------------------------
+  describe("Shorthand notation", () => {
+    describe("Valid combinations", () => {
+      describe("'string' & collection combinations", () => {
+        itNormalizes("string", {
+          type: "string",
+          optional: false,
+        });
 
-  describe("using valid string notation", () => {
-    // -----------------
-    // string
-    // -----------------
+        itNormalizes("string?", {
+          type: "string",
+          optional: true,
+        });
 
-    itNormalizes("string", {
-      type: "string",
-      optional: false,
+        itNormalizes("string[]", {
+          type: "list",
+          objectType: "string",
+          optional: false,
+        });
+
+        itNormalizes("string?[]", {
+          type: "list",
+          objectType: "string",
+          optional: true,
+        });
+
+        itNormalizes("string{}", {
+          type: "dictionary",
+          objectType: "string",
+          optional: false,
+        });
+
+        itNormalizes("string?{}", {
+          type: "dictionary",
+          objectType: "string",
+          optional: true,
+        });
+
+        itNormalizes("string<>", {
+          type: "set",
+          objectType: "string",
+          optional: false,
+        });
+
+        itNormalizes("string?<>", {
+          type: "set",
+          objectType: "string",
+          optional: true,
+        });
+      });
+
+      describe("'mixed' & collection combinations", () => {
+        itNormalizes("mixed", {
+          type: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed?", {
+          type: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed[]", {
+          type: "list",
+          objectType: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed?[]", {
+          type: "list",
+          objectType: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed{}", {
+          type: "dictionary",
+          objectType: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed?{}", {
+          type: "dictionary",
+          objectType: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed<>", {
+          type: "set",
+          objectType: "mixed",
+          optional: true,
+        });
+
+        itNormalizes("mixed?<>", {
+          type: "set",
+          objectType: "mixed",
+          optional: true,
+        });
+      });
+
+      describe("User-defined 'Person' & collection combinations", () => {
+        itNormalizes("Person", {
+          type: "object",
+          objectType: "Person",
+          optional: true,
+        });
+
+        itNormalizes("Person?", {
+          type: "object",
+          objectType: "Person",
+          optional: true,
+        });
+
+        itNormalizes("Person[]", {
+          type: "list",
+          objectType: "Person",
+          optional: false,
+        });
+
+        itNormalizes("Person<>", {
+          type: "set",
+          objectType: "Person",
+          optional: false,
+        });
+
+        itNormalizes("Person{}", {
+          type: "dictionary",
+          objectType: "Person",
+          optional: true,
+        });
+
+        itNormalizes("Person?{}", {
+          type: "dictionary",
+          objectType: "Person",
+          optional: true,
+        });
+      });
+
+      describe("Indexed and primary key combinations", () => {
+        itNormalizes(
+          "string",
+          {
+            type: "string",
+            indexed: true,
+            optional: false,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          "string?",
+          {
+            type: "string",
+            indexed: true,
+            optional: true,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          "mixed?",
+          {
+            type: "mixed",
+            indexed: true,
+            optional: true,
+          },
+          { isPrimaryKey: true },
+        );
+      });
     });
 
-    itNormalizes("string?", {
-      type: "string",
-      optional: true,
+    describe("Invalid shorthand notation", () => {
+      itThrowsWhenNormalizing("", "The type must be specified");
+
+      itThrowsWhenNormalizing("?", "The type must be specified");
+
+      itThrowsWhenNormalizing("?[]", "The type must be specified");
+
+      itThrowsWhenNormalizing("[]", "The element type must be specified");
+
+      itThrowsWhenNormalizing("{}", "The element type must be specified");
+
+      itThrowsWhenNormalizing("<>", "The element type must be specified");
+
+      itThrowsWhenNormalizing("[][]", "Nested collections are not supported");
+
+      itThrowsWhenNormalizing("{}[]", "Nested collections are not supported");
+
+      itThrowsWhenNormalizing("[]<>", "Nested collections are not supported");
+
+      itThrowsWhenNormalizing("int[][]", "Nested collections are not supported");
+
+      itThrowsWhenNormalizing(
+        "[]?",
+        "Collections cannot be optional. To allow elements of the collection to be optional, use '?' after the element type",
+      );
+
+      itThrowsWhenNormalizing(
+        "int[]?",
+        "Collections cannot be optional. To allow elements of the collection to be optional, use '?' after the element type",
+      );
+
+      itThrowsWhenNormalizing("list", "Cannot use the collection name");
+
+      itThrowsWhenNormalizing("dictionary", "Cannot use the collection name");
+
+      itThrowsWhenNormalizing("set", "Cannot use the collection name");
+
+      itThrowsWhenNormalizing("list[]", "Cannot use the collection name");
+
+      itThrowsWhenNormalizing(
+        "Person?[]",
+        "User-defined types in lists and sets are always non-optional and cannot be made optional. Remove '?' or change the type.",
+      );
+
+      itThrowsWhenNormalizing(
+        "Person?<>",
+        "User-defined types in lists and sets are always non-optional and cannot be made optional. Remove '?' or change the type.",
+      );
+
+      itThrowsWhenNormalizing(
+        "object",
+        "To define a relationship, use either 'MyObjectType' or { type: 'object', objectType: 'MyObjectType' }",
+      );
+
+      itThrowsWhenNormalizing(
+        "linkingObjects",
+        "To define an inverse relationship, use { type: 'linkingObjects', objectType: 'MyObjectType', property: 'myObjectTypesProperty' }",
+      );
     });
-
-    itNormalizes("string[]", {
-      type: "list",
-      objectType: "string",
-      optional: false,
-    });
-
-    itNormalizes("string?[]", {
-      type: "list",
-      objectType: "string",
-      optional: true,
-    });
-
-    itNormalizes("string{}", {
-      type: "dictionary",
-      objectType: "string",
-      optional: false,
-    });
-
-    itNormalizes("string?{}", {
-      type: "dictionary",
-      objectType: "string",
-      optional: true,
-    });
-
-    itNormalizes("string<>", {
-      type: "set",
-      objectType: "string",
-      optional: false,
-    });
-
-    itNormalizes("string?<>", {
-      type: "set",
-      objectType: "string",
-      optional: true,
-    });
-
-    // -----------------
-    // mixed
-    // -----------------
-
-    itNormalizes("mixed", {
-      type: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed?", {
-      type: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed[]", {
-      type: "list",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed?[]", {
-      type: "list",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed{}", {
-      type: "dictionary",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed?{}", {
-      type: "dictionary",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed<>", {
-      type: "set",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    itNormalizes("mixed?<>", {
-      type: "set",
-      objectType: "mixed",
-      optional: true,
-    });
-
-    // -------------------------
-    // User-defined type: Person
-    // -------------------------
-
-    itNormalizes("Person", {
-      type: "object",
-      objectType: "Person",
-      optional: true,
-    });
-
-    itNormalizes("Person?", {
-      type: "object",
-      objectType: "Person",
-      optional: true,
-    });
-
-    itNormalizes("Person[]", {
-      type: "list",
-      objectType: "Person",
-      optional: false,
-    });
-
-    itNormalizes("Person<>", {
-      type: "set",
-      objectType: "Person",
-      optional: false,
-    });
-
-    itNormalizes("Person{}", {
-      type: "dictionary",
-      objectType: "Person",
-      optional: true,
-    });
-
-    itNormalizes("Person?{}", {
-      type: "dictionary",
-      objectType: "Person",
-      optional: true,
-    });
-
-    // -------------------------
-    // Indexed & Primary Keys
-    // -------------------------
-
-    itNormalizes(
-      "string",
-      {
-        type: "string",
-        indexed: true,
-        optional: false,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      "string?",
-      {
-        type: "string",
-        indexed: true,
-        optional: true,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      "mixed?",
-      {
-        type: "mixed",
-        indexed: true,
-        optional: true,
-      },
-      { isPrimaryKey: true },
-    );
   });
 
-  // ------------------------------------------------------------------------
-  // Invalid string notation
-  // ------------------------------------------------------------------------
-
-  describe("using invalid string notation", () => {
-    itThrowsWhenNormalizing("", "The type must be specified");
-
-    itThrowsWhenNormalizing("?", "The type must be specified");
-
-    itThrowsWhenNormalizing("?[]", "The type must be specified");
-
-    itThrowsWhenNormalizing("[]", "The element type must be specified");
-
-    itThrowsWhenNormalizing("{}", "The element type must be specified");
-
-    itThrowsWhenNormalizing("<>", "The element type must be specified");
-
-    itThrowsWhenNormalizing("[][]", "Nested collections are not supported");
-
-    itThrowsWhenNormalizing("{}[]", "Nested collections are not supported");
-
-    itThrowsWhenNormalizing("[]<>", "Nested collections are not supported");
-
-    itThrowsWhenNormalizing("int[][]", "Nested collections are not supported");
-
-    itThrowsWhenNormalizing(
-      "[]?",
-      "Collections cannot be optional. To allow elements of the collection to be optional, use '?' after the element type",
-    );
-
-    itThrowsWhenNormalizing(
-      "int[]?",
-      "Collections cannot be optional. To allow elements of the collection to be optional, use '?' after the element type",
-    );
-
-    itThrowsWhenNormalizing("list", "Cannot use the collection name");
-
-    itThrowsWhenNormalizing("dictionary", "Cannot use the collection name");
-
-    itThrowsWhenNormalizing("set", "Cannot use the collection name");
-
-    itThrowsWhenNormalizing("list[]", "Cannot use the collection name");
-
-    itThrowsWhenNormalizing(
-      "Person?[]",
-      "User-defined types in lists and sets are always non-optional and cannot be made optional. Remove '?' or change the type.",
-    );
-
-    itThrowsWhenNormalizing(
-      "Person?<>",
-      "User-defined types in lists and sets are always non-optional and cannot be made optional. Remove '?' or change the type.",
-    );
-
-    itThrowsWhenNormalizing(
-      "object",
-      "To define a relationship, use either 'MyObjectType' or { type: 'object', objectType: 'MyObjectType' }",
-    );
-
-    itThrowsWhenNormalizing(
-      "linkingObjects",
-      "To define an inverse relationship, use { type: 'linkingObjects', objectType: 'MyObjectType', property: 'myObjectTypesProperty' }",
-    );
-  });
-
-  // ------------------------------------------------------------------------
-  // Valid object notation
-  // ------------------------------------------------------------------------
-
-  describe("using valid object notation", () => {
-    // -----------------
-    // string
-    // -----------------
-
-    itNormalizes(
-      {
-        type: "string",
-      },
-      {
-        type: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        optional: false,
-      },
-      {
-        type: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        optional: true,
-      },
-      {
-        type: "string",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "string",
-      },
-      {
-        type: "list",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "string",
-        optional: false,
-      },
-      {
-        type: "list",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "string",
-        optional: true,
-      },
-      {
-        type: "list",
-        objectType: "string",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "string",
-      },
-      {
-        type: "dictionary",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "string",
-        optional: false,
-      },
-      {
-        type: "dictionary",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "string",
-        optional: true,
-      },
-      {
-        type: "dictionary",
-        objectType: "string",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "string",
-      },
-      {
-        type: "set",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "string",
-        optional: false,
-      },
-      {
-        type: "set",
-        objectType: "string",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "string",
-        optional: true,
-      },
-      {
-        type: "set",
-        objectType: "string",
-        optional: true,
-      },
-    );
-
-    // -----------------
-    // mixed
-    // -----------------
-
-    itNormalizes(
-      {
-        type: "mixed",
-      },
-      {
-        type: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "mixed",
-        optional: true,
-      },
-      {
-        type: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "mixed",
-      },
-      {
-        type: "list",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "mixed",
-        optional: true,
-      },
-      {
-        type: "list",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "mixed",
-      },
-      {
-        type: "dictionary",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "mixed",
-        optional: true,
-      },
-      {
-        type: "dictionary",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "mixed",
-      },
-      {
-        type: "set",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "mixed",
-        optional: true,
-      },
-      {
-        type: "set",
-        objectType: "mixed",
-        optional: true,
-      },
-    );
-
-    // -------------------------
-    // User-defined type: Person
-    // -------------------------
-
-    itNormalizes(
-      {
-        type: "object",
-        objectType: "Person",
-      },
-      {
-        type: "object",
-        objectType: "Person",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "object",
-        objectType: "Person",
-        optional: true,
-      },
-      {
-        type: "object",
-        objectType: "Person",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "Person",
-      },
-      {
-        type: "list",
-        objectType: "Person",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "Person",
-        optional: false,
-      },
-      {
-        type: "list",
-        objectType: "Person",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "Person",
-      },
-      {
-        type: "set",
-        objectType: "Person",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "set",
-        objectType: "Person",
-        optional: false,
-      },
-      {
-        type: "set",
-        objectType: "Person",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "Person",
-      },
-      {
-        type: "dictionary",
-        objectType: "Person",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "dictionary",
-        objectType: "Person",
-        optional: true,
-      },
-      {
-        type: "dictionary",
-        objectType: "Person",
-        optional: true,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "tasks",
-      },
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "tasks",
-        optional: false,
-      },
-    );
-
-    itNormalizes(
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "tasks",
-        optional: false,
-      },
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "tasks",
-        optional: false,
-      },
-    );
-
-    // -------------------------
-    // Indexed & Primary Keys
-    // -------------------------
-
-    itNormalizes(
-      {
-        type: "string",
-      },
-      {
-        type: "string",
-        indexed: true,
-        optional: false,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        indexed: true,
-      },
-      {
-        type: "string",
-        indexed: true,
-        optional: false,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        indexed: true,
-      },
-      {
-        type: "string",
-        indexed: true,
-        optional: false,
-      },
-      { isPrimaryKey: false },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        indexed: "full-text",
-      },
-      {
-        type: "string",
-        indexed: "full-text",
-        optional: false,
-      },
-      { isPrimaryKey: false },
-    );
-
-    itNormalizes(
-      {
-        type: "string",
-        optional: true,
-      },
-      {
-        type: "string",
-        indexed: true,
-        optional: true,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      {
-        type: "mixed",
-      },
-      {
-        type: "mixed",
-        indexed: true,
-        optional: true,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      {
-        type: "mixed",
-        optional: true,
-      },
-      {
-        type: "mixed",
-        indexed: true,
-        optional: true,
-      },
-      { isPrimaryKey: true },
-    );
-
-    itNormalizes(
-      {
-        type: "list",
-        objectType: "string",
-        indexed: true,
-      },
-      {
-        type: "list",
-        objectType: "string",
-        indexed: true,
-        optional: false,
-      },
-      { isPrimaryKey: false },
-    );
-  });
-
-  // ------------------------------------------------------------------------
-  // Invalid object notation
-  // ------------------------------------------------------------------------
-
-  describe("using invalid object notation", () => {
-    itThrowsWhenNormalizing(
-      {
-        // @ts-expect-error Passing in the wrong type
-        type: "",
-      },
-      "'type' must be specified",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "string",
-        objectType: "string",
-      },
-      "'objectType' cannot be defined when 'type' is 'string'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "list",
-      },
-      "A list must contain only primitive or user-defined types specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "dictionary",
-      },
-      "A dictionary must contain only primitive or user-defined types specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "set",
-      },
-      "A set must contain only primitive or user-defined types specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "list",
-        objectType: "list",
-      },
-      "A list must contain only primitive or user-defined types specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        // @ts-expect-error Passing in the wrong type
-        type: "Person",
-      },
-      "If you meant to define a relationship, use { type: 'object', objectType: 'Person' } or { type: 'linkingObjects', objectType: 'Person', property: 'The Person property' }",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "object",
-      },
-      "A user-defined type must be specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "object",
-        objectType: "string",
-      },
-      "A user-defined type must be specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "object",
-        objectType: "Person",
-        optional: false,
-      },
-      "User-defined types as standalone objects and in dictionaries are always optional and cannot be made non-optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "mixed",
-        optional: false,
-      },
-      "'mixed' types are always optional and cannot be made non-optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "list",
-        objectType: "mixed",
-        optional: false,
-      },
-      "'mixed' types are always optional and cannot be made non-optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "list",
-        objectType: "Person",
-        optional: true,
-      },
-      "User-defined types in lists and sets are always non-optional and cannot be made optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "set",
-        objectType: "Person",
-        optional: true,
-      },
-      "User-defined types in lists and sets are always non-optional and cannot be made optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "dictionary",
-        objectType: "Person",
-        optional: false,
-      },
-      "User-defined types as standalone objects and in dictionaries are always optional and cannot be made non-optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "linkingObjects",
-      },
-      "A user-defined type must be specified through 'objectType'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-      },
-      "The linking object's property name must be specified through 'property'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "",
-      },
-      "The linking object's property name must be specified through 'property'",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "linkingObjects",
-        objectType: "Person",
-        property: "tasks",
-        optional: true,
-      },
-      "User-defined types in lists and sets are always non-optional and cannot be made optional",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "object",
-        objectType: "Person",
-        property: "tasks",
-      },
-      "'property' can only be specified if 'type' is 'linkingObjects'",
-    );
-
-    // -------------------------
-    // Combining with shorthand
-    // -------------------------
-
-    itThrowsWhenNormalizing(
-      {
-        // @ts-expect-error Passing in the wrong type
-        type: "int?",
-      },
-      "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        // @ts-expect-error Passing in the wrong type
-        type: "int?[]",
-      },
-      "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "int",
-        objectType: "[]",
-      },
-      "Cannot use shorthand '[]' in 'type' or 'objectType' when defining property objects",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "int",
-        objectType: "?[]",
-      },
-      "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "list",
-        objectType: "int?",
-      },
-      "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
-    );
-
-    // -------------------------
-    // Indexed & Primary Keys
-    // -------------------------
-
-    itThrowsWhenNormalizing(
-      {
-        type: "string",
-        indexed: false,
-        optional: false,
-      },
-      "Primary keys must always be indexed.",
-      { isPrimaryKey: true },
-    );
-
-    itThrowsWhenNormalizing(
-      {
-        type: "string",
-        indexed: "full-text",
-      },
-      "Primary keys cannot be full-text indexed.",
-      { isPrimaryKey: true },
-    );
+  describe("Object notation", () => {
+    describe("Valid object notation", () => {
+      describe("'string' & collection combinations", () => {
+        itNormalizes(
+          {
+            type: "string",
+          },
+          {
+            type: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            optional: false,
+          },
+          {
+            type: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            optional: true,
+          },
+          {
+            type: "string",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "string",
+          },
+          {
+            type: "list",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "string",
+            optional: false,
+          },
+          {
+            type: "list",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "string",
+            optional: true,
+          },
+          {
+            type: "list",
+            objectType: "string",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "string",
+          },
+          {
+            type: "dictionary",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "string",
+            optional: false,
+          },
+          {
+            type: "dictionary",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "string",
+            optional: true,
+          },
+          {
+            type: "dictionary",
+            objectType: "string",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "string",
+          },
+          {
+            type: "set",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "string",
+            optional: false,
+          },
+          {
+            type: "set",
+            objectType: "string",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "string",
+            optional: true,
+          },
+          {
+            type: "set",
+            objectType: "string",
+            optional: true,
+          },
+        );
+      });
+
+      describe("'mixed' & collection combinations", () => {
+        itNormalizes(
+          {
+            type: "mixed",
+          },
+          {
+            type: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "mixed",
+            optional: true,
+          },
+          {
+            type: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "mixed",
+          },
+          {
+            type: "list",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "mixed",
+            optional: true,
+          },
+          {
+            type: "list",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "mixed",
+          },
+          {
+            type: "dictionary",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "mixed",
+            optional: true,
+          },
+          {
+            type: "dictionary",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "mixed",
+          },
+          {
+            type: "set",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "mixed",
+            optional: true,
+          },
+          {
+            type: "set",
+            objectType: "mixed",
+            optional: true,
+          },
+        );
+      });
+
+      describe("User-defined 'Person' & collection combinations", () => {
+        itNormalizes(
+          {
+            type: "object",
+            objectType: "Person",
+          },
+          {
+            type: "object",
+            objectType: "Person",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "object",
+            objectType: "Person",
+            optional: true,
+          },
+          {
+            type: "object",
+            objectType: "Person",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "Person",
+          },
+          {
+            type: "list",
+            objectType: "Person",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "Person",
+            optional: false,
+          },
+          {
+            type: "list",
+            objectType: "Person",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "Person",
+          },
+          {
+            type: "set",
+            objectType: "Person",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "Person",
+            optional: false,
+          },
+          {
+            type: "set",
+            objectType: "Person",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "Person",
+          },
+          {
+            type: "dictionary",
+            objectType: "Person",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "Person",
+            optional: true,
+          },
+          {
+            type: "dictionary",
+            objectType: "Person",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "linkingObjects",
+            objectType: "Person",
+            property: "tasks",
+          },
+          {
+            type: "linkingObjects",
+            objectType: "Person",
+            property: "tasks",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "linkingObjects",
+            objectType: "Person",
+            property: "tasks",
+            optional: false,
+          },
+          {
+            type: "linkingObjects",
+            objectType: "Person",
+            property: "tasks",
+            optional: false,
+          },
+        );
+      });
+
+      describe("Indexed and primary key combinations", () => {
+        itNormalizes(
+          {
+            type: "string",
+          },
+          {
+            type: "string",
+            indexed: true,
+            optional: false,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            indexed: true,
+          },
+          {
+            type: "string",
+            indexed: true,
+            optional: false,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            indexed: true,
+          },
+          {
+            type: "string",
+            indexed: true,
+            optional: false,
+          },
+          { isPrimaryKey: false },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            indexed: "full-text",
+          },
+          {
+            type: "string",
+            indexed: "full-text",
+            optional: false,
+          },
+          { isPrimaryKey: false },
+        );
+
+        itNormalizes(
+          {
+            type: "string",
+            optional: true,
+          },
+          {
+            type: "string",
+            indexed: true,
+            optional: true,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          {
+            type: "mixed",
+          },
+          {
+            type: "mixed",
+            indexed: true,
+            optional: true,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          {
+            type: "mixed",
+            optional: true,
+          },
+          {
+            type: "mixed",
+            indexed: true,
+            optional: true,
+          },
+          { isPrimaryKey: true },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "string",
+            indexed: true,
+          },
+          {
+            type: "list",
+            objectType: "string",
+            indexed: true,
+            optional: false,
+          },
+          { isPrimaryKey: false },
+        );
+      });
+    });
+
+    describe("Invalid object notation", () => {
+      itThrowsWhenNormalizing(
+        {
+          // @ts-expect-error Passing in the wrong type
+          type: "",
+        },
+        "'type' must be specified",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "string",
+          objectType: "string",
+        },
+        "'objectType' cannot be defined when 'type' is 'string'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "list",
+        },
+        "A list must contain only primitive or user-defined types specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "dictionary",
+        },
+        "A dictionary must contain only primitive or user-defined types specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "set",
+        },
+        "A set must contain only primitive or user-defined types specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "list",
+          objectType: "list",
+        },
+        "A list must contain only primitive or user-defined types specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          // @ts-expect-error Passing in the wrong type
+          type: "Person",
+        },
+        "If you meant to define a relationship, use { type: 'object', objectType: 'Person' } or { type: 'linkingObjects', objectType: 'Person', property: 'The Person property' }",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "object",
+        },
+        "A user-defined type must be specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "object",
+          objectType: "string",
+        },
+        "A user-defined type must be specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "object",
+          objectType: "Person",
+          optional: false,
+        },
+        "User-defined types as standalone objects and in dictionaries are always optional and cannot be made non-optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "mixed",
+          optional: false,
+        },
+        "'mixed' types are always optional and cannot be made non-optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "list",
+          objectType: "mixed",
+          optional: false,
+        },
+        "'mixed' types are always optional and cannot be made non-optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "list",
+          objectType: "Person",
+          optional: true,
+        },
+        "User-defined types in lists and sets are always non-optional and cannot be made optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "set",
+          objectType: "Person",
+          optional: true,
+        },
+        "User-defined types in lists and sets are always non-optional and cannot be made optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "dictionary",
+          objectType: "Person",
+          optional: false,
+        },
+        "User-defined types as standalone objects and in dictionaries are always optional and cannot be made non-optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "linkingObjects",
+        },
+        "A user-defined type must be specified through 'objectType'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "linkingObjects",
+          objectType: "Person",
+        },
+        "The linking object's property name must be specified through 'property'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "linkingObjects",
+          objectType: "Person",
+          property: "",
+        },
+        "The linking object's property name must be specified through 'property'",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "linkingObjects",
+          objectType: "Person",
+          property: "tasks",
+          optional: true,
+        },
+        "User-defined types in lists and sets are always non-optional and cannot be made optional",
+      );
+
+      itThrowsWhenNormalizing(
+        {
+          type: "object",
+          objectType: "Person",
+          property: "tasks",
+        },
+        "'property' can only be specified if 'type' is 'linkingObjects'",
+      );
+
+      describe("Mixing shorthand inside object notation", () => {
+        itThrowsWhenNormalizing(
+          {
+            // @ts-expect-error Passing in the wrong type
+            type: "int?",
+          },
+          "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            // @ts-expect-error Passing in the wrong type
+            type: "int?[]",
+          },
+          "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "int",
+            objectType: "[]",
+          },
+          "Cannot use shorthand '[]' in 'type' or 'objectType' when defining property objects",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "int",
+            objectType: "?[]",
+          },
+          "Cannot use shorthand '[]' and '?' in 'type' or 'objectType' when defining property objects",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "int?",
+          },
+          "Cannot use shorthand '?' in 'type' or 'objectType' when defining property objects",
+        );
+      });
+
+      describe("Indexed and primary key combinations", () => {
+        itThrowsWhenNormalizing(
+          {
+            type: "string",
+            indexed: false,
+            optional: false,
+          },
+          "Primary keys must always be indexed.",
+          { isPrimaryKey: true },
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "string",
+            indexed: "full-text",
+          },
+          "Primary keys cannot be full-text indexed.",
+          { isPrimaryKey: true },
+        );
+      });
+    });
   });
 });
 
@@ -1025,9 +993,7 @@ function itNormalizes(
   expected: Partial<CanonicalPropertySchema>,
   { isPrimaryKey } = { isPrimaryKey: false },
 ): void {
-  it(`normalizes ${inspect(input, { compact: true, breakLength: Number.MAX_SAFE_INTEGER })} ${
-    isPrimaryKey ? "(primary key)" : ""
-  }`, () => {
+  it(`normalizes ${stringifyToOneLine(input, isPrimaryKey)}`, () => {
     const result = normalizePropertySchema({
       objectName: OBJECT_NAME,
       propertyName: PROPERTY_NAME,
@@ -1056,9 +1022,7 @@ function itThrowsWhenNormalizing(
   errMessage: string,
   { isPrimaryKey } = { isPrimaryKey: false },
 ): void {
-  it(`throws when normalizing ${inspect(input, { compact: true, breakLength: Number.MAX_SAFE_INTEGER })} ${
-    isPrimaryKey ? "(primary key)" : ""
-  }`, () => {
+  it(`throws when normalizing ${stringifyToOneLine(input, isPrimaryKey)}`, () => {
     const normalizeFn = () =>
       normalizePropertySchema({
         objectName: OBJECT_NAME,
@@ -1071,4 +1035,9 @@ function itThrowsWhenNormalizing(
       `Invalid type declaration for property '${PROPERTY_NAME}' on '${OBJECT_NAME}': ${errMessage}`,
     );
   });
+}
+
+function stringifyToOneLine(input: PropertySchema | PropertySchemaShorthand, isPrimaryKey: boolean) {
+  const stringified = inspect(input, { compact: true, breakLength: Number.MAX_SAFE_INTEGER });
+  return stringified + (isPrimaryKey ? " (primary key)" : "");
 }

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -125,6 +125,54 @@ describe("normalizePropertySchema", () => {
         });
       });
 
+      describe("'counter' & collection combinations", () => {
+        itNormalizes("counter", {
+          type: "counter",
+          optional: false,
+        });
+
+        itNormalizes("counter?", {
+          type: "counter",
+          optional: true,
+        });
+
+        itNormalizes("counter[]", {
+          type: "list",
+          objectType: "counter",
+          optional: false,
+        });
+
+        itNormalizes("counter?[]", {
+          type: "list",
+          objectType: "counter",
+          optional: true,
+        });
+
+        itNormalizes("counter{}", {
+          type: "dictionary",
+          objectType: "counter",
+          optional: false,
+        });
+
+        itNormalizes("counter?{}", {
+          type: "dictionary",
+          objectType: "counter",
+          optional: true,
+        });
+
+        itNormalizes("counter<>", {
+          type: "set",
+          objectType: "counter",
+          optional: false,
+        });
+
+        itNormalizes("counter?<>", {
+          type: "set",
+          objectType: "counter",
+          optional: true,
+        });
+      });
+
       describe("User-defined 'Person' & collection combinations", () => {
         itNormalizes("Person", {
           type: "object",
@@ -500,6 +548,154 @@ describe("normalizePropertySchema", () => {
           {
             type: "set",
             objectType: "mixed",
+            optional: true,
+          },
+        );
+      });
+
+      describe("'counter' & collection combinations", () => {
+        itNormalizes(
+          {
+            type: "counter",
+          },
+          {
+            type: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "counter",
+            optional: false,
+          },
+          {
+            type: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "counter",
+            optional: true,
+          },
+          {
+            type: "counter",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "counter",
+          },
+          {
+            type: "list",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "counter",
+            optional: false,
+          },
+          {
+            type: "list",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "list",
+            objectType: "counter",
+            optional: true,
+          },
+          {
+            type: "list",
+            objectType: "counter",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "counter",
+          },
+          {
+            type: "dictionary",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "counter",
+            optional: false,
+          },
+          {
+            type: "dictionary",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "dictionary",
+            objectType: "counter",
+            optional: true,
+          },
+          {
+            type: "dictionary",
+            objectType: "counter",
+            optional: true,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "counter",
+          },
+          {
+            type: "set",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "counter",
+            optional: false,
+          },
+          {
+            type: "set",
+            objectType: "counter",
+            optional: false,
+          },
+        );
+
+        itNormalizes(
+          {
+            type: "set",
+            objectType: "counter",
+            optional: true,
+          },
+          {
+            type: "set",
+            objectType: "counter",
             optional: true,
           },
         );
@@ -967,6 +1163,23 @@ describe("normalizePropertySchema", () => {
             indexed: "full-text",
           },
           "Primary keys cannot be full-text indexed.",
+          { isPrimaryKey: true },
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "counter",
+          },
+          "Counters cannot be primary keys.",
+          { isPrimaryKey: true },
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "counter",
+          },
+          "Counters cannot be primary keys.",
           { isPrimaryKey: true },
         );
       });

--- a/packages/realm/src/tests/schema-normalization.test.ts
+++ b/packages/realm/src/tests/schema-normalization.test.ts
@@ -125,7 +125,7 @@ describe("normalizePropertySchema", () => {
         });
       });
 
-      describe("'counter' & collection combinations", () => {
+      describe("'counter'", () => {
         itNormalizes("counter", {
           type: "int",
           presentation: "counter",
@@ -134,48 +134,6 @@ describe("normalizePropertySchema", () => {
 
         itNormalizes("counter?", {
           type: "int",
-          presentation: "counter",
-          optional: true,
-        });
-
-        itNormalizes("counter[]", {
-          type: "list",
-          objectType: "int",
-          presentation: "counter",
-          optional: false,
-        });
-
-        itNormalizes("counter?[]", {
-          type: "list",
-          objectType: "int",
-          presentation: "counter",
-          optional: true,
-        });
-
-        itNormalizes("counter{}", {
-          type: "dictionary",
-          objectType: "int",
-          presentation: "counter",
-          optional: false,
-        });
-
-        itNormalizes("counter?{}", {
-          type: "dictionary",
-          objectType: "int",
-          presentation: "counter",
-          optional: true,
-        });
-
-        itNormalizes("counter<>", {
-          type: "set",
-          objectType: "int",
-          presentation: "counter",
-          optional: false,
-        });
-
-        itNormalizes("counter?<>", {
-          type: "set",
-          objectType: "int",
           presentation: "counter",
           optional: true,
         });
@@ -310,6 +268,18 @@ describe("normalizePropertySchema", () => {
         "linkingObjects",
         "To define an inverse relationship, use { type: 'linkingObjects', objectType: 'MyObjectType', property: 'myObjectTypesProperty' }",
       );
+
+      itThrowsWhenNormalizing("counter[]", "Counters cannot be used in collections");
+
+      itThrowsWhenNormalizing("counter?[]", "Counters cannot be used in collections");
+
+      itThrowsWhenNormalizing("counter{}", "Counters cannot be used in collections");
+
+      itThrowsWhenNormalizing("counter?{}", "Counters cannot be used in collections");
+
+      itThrowsWhenNormalizing("counter<>", "Counters cannot be used in collections");
+
+      itThrowsWhenNormalizing("counter?<>", "Counters cannot be used in collections");
     });
   });
 
@@ -561,7 +531,7 @@ describe("normalizePropertySchema", () => {
         );
       });
 
-      describe("'counter' & collection combinations", () => {
+      describe("'counter'", () => {
         itNormalizes(
           {
             type: "int",
@@ -595,138 +565,6 @@ describe("normalizePropertySchema", () => {
           },
           {
             type: "int",
-            presentation: "counter",
-            optional: true,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-          },
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-            optional: true,
-          },
-          {
-            type: "list",
-            objectType: "int",
-            presentation: "counter",
-            optional: true,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-          },
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-            optional: true,
-          },
-          {
-            type: "dictionary",
-            objectType: "int",
-            presentation: "counter",
-            optional: true,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "set",
-            objectType: "int",
-            presentation: "counter",
-          },
-          {
-            type: "set",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "set",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-          {
-            type: "set",
-            objectType: "int",
-            presentation: "counter",
-            optional: false,
-          },
-        );
-
-        itNormalizes(
-          {
-            type: "set",
-            objectType: "int",
-            presentation: "counter",
-            optional: true,
-          },
-          {
-            type: "set",
-            objectType: "int",
             presentation: "counter",
             optional: true,
           },
@@ -1194,6 +1032,95 @@ describe("normalizePropertySchema", () => {
         );
       });
 
+      describe("'counter' & collection combinations", () => {
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "int",
+            presentation: "counter",
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "int",
+            presentation: "counter",
+            optional: false,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "list",
+            objectType: "int",
+            presentation: "counter",
+            optional: true,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "dictionary",
+            objectType: "int",
+            presentation: "counter",
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "dictionary",
+            objectType: "int",
+            presentation: "counter",
+            optional: false,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "dictionary",
+            objectType: "int",
+            presentation: "counter",
+            optional: true,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "set",
+            objectType: "int",
+            presentation: "counter",
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "set",
+            objectType: "int",
+            presentation: "counter",
+            optional: false,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+
+        itThrowsWhenNormalizing(
+          {
+            type: "set",
+            objectType: "int",
+            presentation: "counter",
+            optional: true,
+          },
+          "Counters can only be used when 'type' is 'int'",
+        );
+      });
+
       describe("Indexed and primary key combinations", () => {
         itThrowsWhenNormalizing(
           {
@@ -1217,16 +1144,6 @@ describe("normalizePropertySchema", () => {
         itThrowsWhenNormalizing(
           {
             type: "int",
-            presentation: "counter",
-          },
-          "Counters cannot be primary keys.",
-          { isPrimaryKey: true },
-        );
-
-        itThrowsWhenNormalizing(
-          {
-            type: "list",
-            objectType: "int",
             presentation: "counter",
           },
           "Counters cannot be primary keys.",

--- a/packages/realm/src/tests/schema-validation.test.ts
+++ b/packages/realm/src/tests/schema-validation.test.ts
@@ -138,6 +138,7 @@ describe("validatePropertySchema", () => {
     itValidates("an object with all fields defined", {
       type: "",
       objectType: "",
+      presentation: "",
       optional: true,
       property: "",
       indexed: true,
@@ -148,6 +149,7 @@ describe("validatePropertySchema", () => {
     itValidates("an object with required fields defined and optional fields set to 'undefined'", {
       type: "",
       objectType: undefined,
+      presentation: undefined,
       optional: undefined,
       property: undefined,
       indexed: undefined,
@@ -190,6 +192,15 @@ describe("validatePropertySchema", () => {
         objectType: NOT_A_STRING,
       },
       `Expected '${PROPERTY_NAME}.objectType' on '${OBJECT_NAME}' to be a string, got a number`,
+    );
+
+    itThrowsWhenValidating(
+      "an object with invalid type for property 'presentation'",
+      {
+        type: "",
+        presentation: NOT_A_STRING,
+      },
+      `Expected '${PROPERTY_NAME}.presentation' on '${OBJECT_NAME}' to be a string, got a number`,
     );
 
     itThrowsWhenValidating(

--- a/packages/realm/src/tests/schema-validation.test.ts
+++ b/packages/realm/src/tests/schema-validation.test.ts
@@ -28,11 +28,7 @@ const NOT_A_BOOLEAN = 0;
 const NOT_AN_OBJECT = 0;
 
 describe("validateObjectSchema", () => {
-  // ------------------------------------------------------------------------
-  // Valid shape of input
-  // ------------------------------------------------------------------------
-
-  describe("using valid shape of input", () => {
+  describe("Valid shape of input", () => {
     itValidates("an object with all top-level fields defined", {
       name: "",
       primaryKey: "",
@@ -55,11 +51,7 @@ describe("validateObjectSchema", () => {
     });
   });
 
-  // ------------------------------------------------------------------------
-  // Invalid shape of input
-  // ------------------------------------------------------------------------
-
-  describe("using invalid shape of input", () => {
+  describe("Invalid shape of input", () => {
     itThrowsWhenValidating("an array", [], "Expected 'object schema' to be an object, got an array");
 
     itThrowsWhenValidating("'null'", null, "Expected 'object schema' to be an object, got null");
@@ -142,11 +134,7 @@ describe("validateObjectSchema", () => {
 });
 
 describe("validatePropertySchema", () => {
-  // ------------------------------------------------------------------------
-  // Valid shape of input
-  // ------------------------------------------------------------------------
-
-  describe("using valid shape of input", () => {
+  describe("Valid shape of input", () => {
     itValidates("an object with all fields defined", {
       type: "",
       objectType: "",
@@ -172,11 +160,7 @@ describe("validatePropertySchema", () => {
     });
   });
 
-  // ------------------------------------------------------------------------
-  // Invalid shape of input
-  // ------------------------------------------------------------------------
-
-  describe("using invalid shape of input", () => {
+  describe("Invalid shape of input", () => {
     itThrowsWhenValidating(
       "an array",
       [],


### PR DESCRIPTION
## What, How & Why?

A `Counter` class and `counter` presentation data type have been added, representing a logical counter.

Note that `counter` types are **not** supported as:
* `Mixed` values
* Primary keys
* Inside collections
* Query arguments for placeholders (use `Counter.value`)

## Usage

**Valid property schema:**
```typescript
// Shorthand
"counter"
"counter?"

// Object form
{
  type: "int",
  presentation: "counter",
  optional: <true/false/undefined>
}
```

**Creating an object with a counter:**
```typescript
realm.write(() => {
  realm.create(MyObject, { _id: "123", counter: 0 });
});
```

**Updating the count:**
```typescript
realm.write(() => {
  object.counter.increment();
  object.counter.value; // 1
  object.counter.decrement(2);
  object.counter.value; // -1
  object.counter.set(100);
  object.counter.value; // 100
});
```

**Creating a counter from a previously `null` value:**
```ts
realm.write(() => {
  realm.create(MyObject, { _id: "123", counter: 0 }, UpdateMode.Modified);
});
```

## Notes

* **No implicit coercion to `number`**:
  * We decided not to support implicit coercion into number via `valueOf` partly due to TypeScript [not supporting it](https://github.com/microsoft/TypeScript/issues/2361).
* **Potential future reference**
  * We decided to remove support for collections of counters.
    * If this becomes relevant in the future, [this is the commit](https://github.com/realm/realm-js/pull/6694/commits/b975c563a60f3b05a0f22a859c1855ead8d1afa7) that removed related implementation and tests.

## Test overview

<details>
<summary>Click to expand</summary>

```
  Counter
    create and access
      via 'realm.create()'
        ✓ can create and access (input: number)
        ✓ can create and access (input: Counter)
        ✓ can create and access (input: default value)
        ✓ can create nullable counter with int or null
        ✓ returns different reference for each access
    update
      Counter.value
        ✓ increments
        ✓ decrements
        ✓ sets
      Realm object counter property
        ✓ updates nullable counter from int -> null -> int via setter
        ✓ updates nullable counter from int -> null -> int via UpdateMode: modified
        ✓ updates nullable counter from int -> null -> int via UpdateMode: all
    filtering
      ✓ filters objects with counters
    Realm.schema
      ✓ includes `presentation: 'counter'` in the canonical property schema
    invalid operations
      ✓ throws when calling increment with non-integer
      ✓ throws when calling decrement with non-integer
      ✓ throws when calling set with non-integer
      ✓ throws when setting 'Counter.value' directly
      ✓ throws when updating outside write transaction
      ✓ throws when setting a non-nullable counter via setter
      ✓ throws when setting a non-nullable counter via UpdateMode: modified
      ✓ throws when setting a non-nullable counter via UpdateMode: all
      ✓ throws when setting a nullable counter from number -> number via setter
      ✓ throws when setting a nullable counter from number -> number via UpdateMode: modified
      ✓ throws when setting a nullable counter from number -> number via UpdateMode: all
      ✓ throws when setting an int property to a counter
      ✓ throws when getting the count on an invalidated obj
      ✓ throws when setting a mixed to a counter via object creation
      ✓ throws when setting a mixed to a counter via object setter
      ✓ throws when adding a counter to mixed collections via object creation
      ✓ throws when adding a counter to mixed collections via setters
      ✓ throws when using counter as query argument

  normalizePropertySchema
    Shorthand notation
      Valid combinations
        'counter'
          ✔ normalizes 'counter'
          ✔ normalizes 'counter?'
      Invalid shorthand notation
        ✔ throws when normalizing 'counter[]'
        ✔ throws when normalizing 'counter?[]'
        ✔ throws when normalizing 'counter{}'
        ✔ throws when normalizing 'counter?{}'
        ✔ throws when normalizing 'counter<>'
        ✔ throws when normalizing 'counter?<>'
    Object notation
      Valid object notation
        'counter'
          ✔ normalizes { type: 'int', presentation: 'counter' }
          ✔ normalizes { type: 'int', presentation: 'counter', optional: false }
          ✔ normalizes { type: 'int', presentation: 'counter', optional: true }
      Invalid object notation
        Mixing shorthand inside object notation
          ✔ throws when normalizing { type: 'counter' }
          ✔ throws when normalizing { type: 'list', objectType: 'counter?' }
        'counter' & collection combinations
          ✔ throws when normalizing { type: 'list', objectType: 'int', presentation: 'counter' }
          ✔ throws when normalizing { type: 'list', objectType: 'int', presentation: 'counter', optional: false }
          ✔ throws when normalizing { type: 'list', objectType: 'int', presentation: 'counter', optional: true }
          ✔ throws when normalizing { type: 'dictionary', objectType: 'int', presentation: 'counter' }
          ✔ throws when normalizing { type: 'dictionary', objectType: 'int', presentation: 'counter', optional: false }
          ✔ throws when normalizing { type: 'dictionary', objectType: 'int', presentation: 'counter', optional: true }
          ✔ throws when normalizing { type: 'set', objectType: 'int', presentation: 'counter' }
          ✔ throws when normalizing { type: 'set', objectType: 'int', presentation: 'counter', optional: false }
          ✔ throws when normalizing { type: 'set', objectType: 'int', presentation: 'counter', optional: true }
        Indexed and primary key combinations
          ✔ throws when normalizing { type: 'int', presentation: 'counter' } (primary key)
```
</details>

This closes #4089

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 🚦 Tests
