### PR TITLE
Use latest local docker image by default

### DIFF
--- a/integration-tests/baas-test-server/cli.ts
+++ b/integration-tests/baas-test-server/cli.ts
@@ -88,7 +88,7 @@ yargs(hideBin(process.argv))
       yargs
         .positional("githash", { type: "string" })
         .option("branch", { default: "master" })
-        .option("latest-local", { default: false, boolean: true }),
+        .option("pull-latest", { default: false, boolean: true }),
     wrapCommand(async (argv) => {
       const { AWS_PROFILE, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = process.env;
       assert(AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY, "Missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY env");
@@ -99,19 +99,16 @@ yargs(hideBin(process.argv))
       docker.ensureNoBaas();
 
       if (argv.githash) {
-        docker.spawnBaaS({
-          image: argv.githash,
-          accessKeyId: AWS_ACCESS_KEY_ID,
-          secretAccessKey: AWS_SECRET_ACCESS_KEY,
-        });
-      } else if (argv["latest-local"]) {
-        const id = docker.getLatestLocalId();
+        const id = docker.getLatestLocalId(argv.githash);
         docker.spawnBaaS({ image: id, accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY });
-      } else {
+      } else if (argv["pull-latest"]) {
         const tag = await docker.fetchBaasTag(argv.branch);
         assert(AWS_PROFILE, "Missing AWS_PROFILE env");
         docker.pullBaas({ profile: AWS_PROFILE, tag });
         docker.spawnBaaS({ image: tag, accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY });
+      } else {
+        const id = docker.getLatestLocalId();
+        docker.spawnBaaS({ image: id, accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY });
       }
     }),
   )

--- a/integration-tests/baas-test-server/docker.ts
+++ b/integration-tests/baas-test-server/docker.ts
@@ -89,13 +89,18 @@ export async function fetchBaasTag(branch: string) {
   }
 }
 
-export function getLatestLocalId() {
+export function getLatestLocalId(githash?: string) {
   const imagesOutput = execSync("docker images --format json", { encoding: "utf8" });
   for (const line of imagesOutput.split("\n")) {
     if (line) {
       const image = JSON.parse(line.trim());
       if (image.Repository === ECR_HOSTNAME + ECR_PATHNAME && image.Tag.startsWith(BAAS_VARIANT)) {
-        return image.ID;
+        if (typeof githash === "string" && image.Tag === BAAS_VARIANT + "-race-" + githash) {
+          return image.ID;
+        } else {
+          // Latest and greatest
+          return image.ID;
+        }
       }
     }
   }
@@ -125,7 +130,7 @@ export function spawnBaaS({
   accessKeyId: string;
   secretAccessKey: string;
 }) {
-  console.log("Starting server from tag", chalk.dim(image));
+  console.log("Starting server from", chalk.dim(image));
   spawn(chalk.blueBright("baas"), "docker", [
     "run",
     "--name",


### PR DESCRIPTION
## What, How & Why?

- Turning around the defaults to use the latest local BaaS from docker instead of pulling by default.
- Adding a `--pull-latest` runtime argument for the baas test server to pull the latest docker image from the server.
- Adding the ability to specify the BaaS repo's git hash via a positional argument, instead of having to provide the entire image id / tag.
