### PR TITLE
Explicitly enable anonymous auth provider in tests

### DIFF
--- a/integration-tests/tests/src/tests/sync/partition-values.ts
+++ b/integration-tests/tests/src/tests/sync/partition-values.ts
@@ -125,7 +125,7 @@ describe("Partition-values", () => {
   });
 
   describe("integer", () => {
-    importAppBefore(buildAppConfig("pv-int-tests").partitionBasedSync({ key: "realm_id", type: "long" }));
+    importAppBefore(buildAppConfig("pv-int-tests").anonAuth().partitionBasedSync({ key: "realm_id", type: "long" }));
     authenticateUserBefore();
 
     it("works", async function (this: Mocha.Context & AppContext & UserContext) {
@@ -165,7 +165,9 @@ describe("Partition-values", () => {
   });
 
   describe("string", () => {
-    importAppBefore(buildAppConfig("pv-string-tests").partitionBasedSync({ key: "realm_id", type: "string" }));
+    importAppBefore(
+      buildAppConfig("pv-string-tests").anonAuth().partitionBasedSync({ key: "realm_id", type: "string" }),
+    );
     authenticateUserBefore();
 
     it("works", async function (this: Mocha.Context & AppContext & UserContext) {
@@ -205,7 +207,7 @@ describe("Partition-values", () => {
   });
 
   describe("UUID", () => {
-    importAppBefore(buildAppConfig("pv-uuid-tests").partitionBasedSync({ key: "realm_id", type: "uuid" }));
+    importAppBefore(buildAppConfig("pv-uuid-tests").anonAuth().partitionBasedSync({ key: "realm_id", type: "uuid" }));
     authenticateUserBefore();
 
     it("works", async function (this: Mocha.Context & AppContext & UserContext) {
@@ -253,7 +255,9 @@ describe("Partition-values", () => {
   });
 
   describe("objectId", () => {
-    importAppBefore(buildAppConfig("pv-objectid-tests").partitionBasedSync({ key: "realm_id", type: "objectId" }));
+    importAppBefore(
+      buildAppConfig("pv-objectid-tests").anonAuth().partitionBasedSync({ key: "realm_id", type: "objectId" }),
+    );
     authenticateUserBefore();
 
     it("works", async function (this: Mocha.Context & AppContext & UserContext) {

--- a/integration-tests/tests/src/tests/sync/sync-session.ts
+++ b/integration-tests/tests/src/tests/sync/sync-session.ts
@@ -124,7 +124,7 @@ async function seedDataWithExternalUser(app: Realm.App, partition: string) {
 }
 
 describe("SessionTest", () => {
-  importAppBefore(buildAppConfig("with-pbs").emailPasswordAuth().partitionBasedSync({ required: true }));
+  importAppBefore(buildAppConfig("with-pbs").anonAuth().emailPasswordAuth().partitionBasedSync({ required: true }));
 
   describe("invalid syncsessions", () => {
     afterEach(() => Realm.clearTestState());


### PR DESCRIPTION
## What, How & Why?

This fix the failures we're currently experiencing with the latest server version.
It turns out our tests were depending on the anonymous authentication provider being implicitly enabled, which is no longer the case after the merge of https://github.com/10gen/baas/pull/14325.
