### PR TITLE
Fix starting local Docker

### DIFF
--- a/integration-tests/baas-test-server/docker.ts
+++ b/integration-tests/baas-test-server/docker.ts
@@ -90,7 +90,7 @@ export async function fetchBaasTag(branch: string) {
 }
 
 export function getLatestLocalId() {
-  const imagesOutput = execSync("docker images --format json", { encoding: "utf8" });
+  const imagesOutput = execSync("docker images --format '{{json .}}'", { encoding: "utf8" });
   for (const line of imagesOutput.split("\n")) {
     if (line) {
       const { Repository: repository, Tag: tag, ID: id } = JSON.parse(line.trim());


### PR DESCRIPTION
## What, How & Why?

For the tests, when running `baas-test-server docker` (or `npm start`) the docker images output was malformed causing `JSON.parse()` to throw.
