### PR TITLE
Refactored type and property helpers

### DIFF
--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -16,162 +16,32 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { TypeOptions, binding, getTypeHelpers, toItemType } from "./internal";
+
+import { createArrayPropertyAccessor } from "./property-accessors/Array";
+import { createObjectPropertyAccessor } from "./property-accessors/Object";
+import { createDictionaryPropertyAccessor } from "./property-accessors/Dictionary";
+import { createDefaultPropertyAccessor } from "./property-accessors/default";
+import { createSetPropertyAccessor } from "./property-accessors/Set";
+import { createMixedPropertyAccessor } from "./property-accessors/Mixed";
 import {
-  ClassHelpers,
-  Counter,
-  Dictionary,
-  List,
-  ListAccessor,
-  PresentationPropertyTypeName,
-  Realm,
-  RealmSet,
-  Results,
-  TypeAssertionError,
-  TypeHelpers,
-  TypeOptions,
-  assert,
-  binding,
-  createDictionaryAccessor,
-  createListAccessor,
-  createResultsAccessor,
-  createSetAccessor,
-  getTypeHelpers,
-  insertIntoDictionaryOfMixed,
-  insertIntoListOfMixed,
-  isJsOrRealmDictionary,
-  isJsOrRealmList,
-  toItemType,
-} from "./internal";
-
-type PropertyContext = binding.Property & {
-  type: binding.PropertyType;
-  objectSchemaName: string;
-  embedded: boolean;
-  presentation?: PresentationPropertyTypeName;
-  default?: unknown;
-};
-
-/** @internal */
-export type HelperOptions = {
-  realm: Realm;
-  getClassHelpers: (name: string) => ClassHelpers;
-};
-
-type PropertyOptions = {
-  typeHelpers: TypeHelpers;
-  columnKey: binding.ColKey;
-  optional: boolean;
-  embedded: boolean;
-  presentation?: PresentationPropertyTypeName;
-} & HelperOptions &
-  binding.Property_Relaxed;
-
-type PropertyAccessor = {
-  get(obj: binding.Obj): unknown;
-  set(obj: binding.Obj, value: unknown, isCreating?: boolean): unknown;
-  listAccessor?: ListAccessor;
-};
-
-/** @internal */
-export type PropertyHelpers = TypeHelpers &
-  PropertyAccessor & {
-    type: binding.PropertyType;
-    columnKey: binding.ColKey;
-    embedded: boolean;
-    default?: unknown;
-    objectType?: string;
-  };
-
-const defaultGet =
-  ({ typeHelpers: { fromBinding }, columnKey }: PropertyOptions) =>
-  (obj: binding.Obj) => {
-    try {
-      return fromBinding(obj.getAny(columnKey));
-    } catch (err) {
-      assert.isValid(obj);
-      throw err;
-    }
-  };
-
-const defaultSet =
-  ({ realm, typeHelpers: { toBinding }, columnKey }: PropertyOptions) =>
-  (obj: binding.Obj, value: unknown) => {
-    assert.inTransaction(realm);
-    try {
-      if (!realm.isInMigration && obj.table.getPrimaryKeyColumn() === columnKey) {
-        throw new Error(`Cannot change value of primary key outside migration function`);
-      }
-      obj.setAny(columnKey, toBinding(value));
-    } catch (err) {
-      assert.isValid(obj);
-      throw err;
-    }
-  };
-
-function embeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
-  return (obj: binding.Obj, value: unknown) => {
-    // Asking for the toBinding will create the object and link it to the parent in one operation.
-    // Thus, no need to actually set the value on the `obj` unless it's an optional null value.
-    const bindingValue = toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
-    // No need to destructure `optional` and check that it's `true` in this condition before setting
-    // it to null as objects are always optional. The condition is placed after the invocation of
-    // `toBinding()` in order to leave the type conversion responsibility to `toBinding()`.
-    if (bindingValue === null) {
-      obj.setAny(columnKey, bindingValue);
-    }
-  };
-}
+  HelperOptions,
+  PropertyAccessor,
+  PropertyContext,
+  PropertyHelpers,
+  PropertyOptions,
+} from "./property-accessors/types";
+import { createIntPropertyAccessor } from "./property-accessors/Int";
 
 type AccessorFactory = (options: PropertyOptions) => PropertyAccessor;
 
 const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>> = {
-  [binding.PropertyType.Int](options) {
-    const { realm, columnKey, presentation, optional } = options;
-
-    if (presentation === "counter") {
-      return {
-        get(obj) {
-          return obj.getAny(columnKey) === null ? null : new Counter(realm, obj, columnKey);
-        },
-        set(obj, value, isCreating) {
-          // We only allow resetting a counter this way (e.g. realmObject.counter = 5)
-          // when it is first created, or when resetting a nullable/optional counter
-          // to `null`, or when a nullable counter was previously `null`.
-          const isAllowed =
-            isCreating || (optional && (value === null || value === undefined || obj.getAny(columnKey) === null));
-
-          if (isAllowed) {
-            defaultSet(options)(obj, value);
-          } else {
-            throw new Error(
-              "You can only reset a Counter instance when initializing a previously " +
-                "null Counter or resetting a nullable Counter to null. To update the " +
-                "value of the Counter, use its instance methods.",
-            );
-          }
-        },
-      };
-    } else {
-      return {
-        get: defaultGet(options),
-        set: defaultSet(options),
-      };
-    }
-  },
-  [binding.PropertyType.Object](options) {
-    const {
-      columnKey,
-      typeHelpers: { fromBinding },
-      embedded,
-    } = options;
-    assert(options.optional, "Objects are always nullable");
-    return {
-      get(this: PropertyHelpers, obj) {
-        return fromBinding(obj.getLinkedObject(columnKey));
-      },
-      set: embedded ? embeddedSet(options) : defaultSet(options),
-    };
-  },
+  [binding.PropertyType.Int]: createIntPropertyAccessor,
+  [binding.PropertyType.Object]: createObjectPropertyAccessor,
+  [binding.PropertyType.Array]: createArrayPropertyAccessor,
+  [binding.PropertyType.Dictionary]: createDictionaryPropertyAccessor,
+  [binding.PropertyType.Set]: createSetPropertyAccessor,
+  [binding.PropertyType.Mixed]: createMixedPropertyAccessor,
   [binding.PropertyType.LinkingObjects]() {
     return {
       get() {
@@ -182,218 +52,27 @@ const ACCESSOR_FACTORIES: Partial<Record<binding.PropertyType, AccessorFactory>>
       },
     };
   },
-  [binding.PropertyType.Array]({
-    realm,
-    type,
-    name,
-    columnKey,
-    objectType,
-    embedded,
-    linkOriginPropertyName,
-    getClassHelpers,
-    optional,
-  }) {
-    const realmInternal = realm.internal;
-    const itemType = toItemType(type);
-    const itemHelpers = getTypeHelpers(itemType, {
-      realm,
-      name: `element of ${name}`,
-      optional,
-      getClassHelpers,
-      objectType,
-      objectSchemaName: undefined,
-    });
-
-    if (itemType === binding.PropertyType.LinkingObjects) {
-      // Locate the table of the targeted object
-      assert.string(objectType, "object type");
-      assert(objectType !== "", "Expected a non-empty string");
-      const targetClassHelpers = getClassHelpers(objectType);
-      const {
-        objectSchema: { tableKey, persistedProperties },
-      } = targetClassHelpers;
-      // TODO: Check if we want to match with the `p.name` or `p.publicName` here
-      const targetProperty = persistedProperties.find((p) => p.name === linkOriginPropertyName);
-      assert(targetProperty, `Expected a '${linkOriginPropertyName}' property on ${objectType}`);
-      const tableRef = binding.Helpers.getTable(realmInternal, tableKey);
-      const resultsAccessor = createResultsAccessor({ realm, typeHelpers: itemHelpers, itemType });
-
-      return {
-        get(obj: binding.Obj) {
-          const tableView = obj.getBacklinkView(tableRef, targetProperty.columnKey);
-          const results = binding.Results.fromTableView(realmInternal, tableView);
-          return new Results(realm, results, resultsAccessor, itemHelpers);
-        },
-        set() {
-          throw new Error("Not supported");
-        },
-      };
-    } else {
-      const listAccessor = createListAccessor({ realm, typeHelpers: itemHelpers, itemType, isEmbedded: embedded });
-
-      return {
-        listAccessor,
-        get(obj: binding.Obj) {
-          const internal = binding.List.make(realm.internal, obj, columnKey);
-          assert.instanceOf(internal, binding.List);
-          return new List(realm, internal, listAccessor, itemHelpers);
-        },
-        set(obj, values) {
-          assert.inTransaction(realm);
-          assert.iterable(values);
-
-          const internal = binding.List.make(realm.internal, obj, columnKey);
-          internal.removeAll();
-          let index = 0;
-          try {
-            for (const value of values) {
-              listAccessor.insert(internal, index++, value);
-            }
-          } catch (err) {
-            if (err instanceof TypeAssertionError) {
-              err.rename(`${name}[${index - 1}]`);
-            }
-            throw err;
-          }
-        },
-      };
-    }
-  },
-  [binding.PropertyType.Dictionary]({ columnKey, realm, name, type, optional, objectType, getClassHelpers, embedded }) {
-    const itemType = toItemType(type);
-    const itemHelpers = getTypeHelpers(itemType, {
-      realm,
-      name: `value in ${name}`,
-      getClassHelpers,
-      objectType,
-      optional,
-      objectSchemaName: undefined,
-    });
-    const dictionaryAccessor = createDictionaryAccessor({
-      realm,
-      typeHelpers: itemHelpers,
-      itemType,
-      isEmbedded: embedded,
-    });
-
-    return {
-      get(obj) {
-        const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-        return new Dictionary(realm, internal, dictionaryAccessor, itemHelpers);
-      },
-      set(obj, value) {
-        assert.inTransaction(realm);
-
-        const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-        // Clear the dictionary before adding new values
-        internal.removeAll();
-        assert.object(value, `values of ${name}`, { allowArrays: false });
-        for (const [k, v] of Object.entries(value)) {
-          try {
-            dictionaryAccessor.set(internal, k, v);
-          } catch (err) {
-            if (err instanceof TypeAssertionError) {
-              err.rename(`${name}["${k}"]`);
-            }
-            throw err;
-          }
-        }
-      },
-    };
-  },
-  [binding.PropertyType.Set]({ columnKey, realm, name, type, optional, objectType, getClassHelpers }) {
-    const itemType = toItemType(type);
-    const itemHelpers = getTypeHelpers(itemType, {
-      realm,
-      name: `value in ${name}`,
-      getClassHelpers,
-      objectType,
-      optional,
-      objectSchemaName: undefined,
-    });
-    assert.string(objectType);
-    const setAccessor = createSetAccessor({ realm, typeHelpers: itemHelpers, itemType });
-
-    return {
-      get(obj) {
-        const internal = binding.Set.make(realm.internal, obj, columnKey);
-        return new RealmSet(realm, internal, setAccessor, itemHelpers);
-      },
-      set(obj, value) {
-        assert.inTransaction(realm);
-
-        const internal = binding.Set.make(realm.internal, obj, columnKey);
-        // Clear the set before adding new values
-        internal.removeAll();
-        assert.array(value, "values");
-        for (const v of value) {
-          setAccessor.insert(internal, v);
-        }
-      },
-    };
-  },
-  [binding.PropertyType.Mixed](options) {
-    const { realm, columnKey, typeHelpers } = options;
-    const { fromBinding, toBinding } = typeHelpers;
-    const listAccessor = createListAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
-    const dictionaryAccessor = createDictionaryAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
-
-    return {
-      get(obj) {
-        try {
-          const value = obj.getAny(columnKey);
-          switch (value) {
-            case binding.ListSentinel: {
-              const internal = binding.List.make(realm.internal, obj, columnKey);
-              return new List(realm, internal, listAccessor, typeHelpers);
-            }
-            case binding.DictionarySentinel: {
-              const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-              return new Dictionary(realm, internal, dictionaryAccessor, typeHelpers);
-            }
-            default:
-              return fromBinding(value);
-          }
-        } catch (err) {
-          assert.isValid(obj);
-          throw err;
-        }
-      },
-      set(obj: binding.Obj, value: unknown) {
-        assert.inTransaction(realm);
-
-        if (isJsOrRealmList(value)) {
-          obj.setCollection(columnKey, binding.CollectionType.List);
-          const internal = binding.List.make(realm.internal, obj, columnKey);
-          insertIntoListOfMixed(value, internal, toBinding);
-        } else if (isJsOrRealmDictionary(value)) {
-          obj.setCollection(columnKey, binding.CollectionType.Dictionary);
-          const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
-          insertIntoDictionaryOfMixed(value, internal, toBinding);
-        } else {
-          defaultSet(options)(obj, value);
-        }
-      },
-    };
-  },
 };
+
+function createDefaultPropertyHelpers(options: PropertyOptions): PropertyHelpers {
+  const { typeHelpers, columnKey, embedded, objectType } = options;
+  return {
+    ...createDefaultPropertyAccessor(options),
+    ...typeHelpers,
+    type: options.type,
+    columnKey,
+    embedded,
+    objectType,
+  };
+}
 
 function getPropertyHelpers(type: binding.PropertyType, options: PropertyOptions): PropertyHelpers {
   const { typeHelpers, columnKey, embedded, objectType } = options;
   const accessorFactory = ACCESSOR_FACTORIES[type];
   if (accessorFactory) {
-    const accessors = accessorFactory(options);
-    return { ...accessors, ...typeHelpers, type: options.type, columnKey, embedded, objectType };
+    return { ...accessorFactory(options), ...typeHelpers, type: options.type, columnKey, embedded, objectType };
   } else {
-    return {
-      get: defaultGet(options),
-      set: defaultSet(options),
-      ...typeHelpers,
-      type: options.type,
-      columnKey,
-      embedded,
-      objectType,
-    };
+    return createDefaultPropertyHelpers(options);
   }
 }
 

--- a/packages/realm/src/PropertyHelpers.ts
+++ b/packages/realm/src/PropertyHelpers.ts
@@ -21,9 +21,10 @@ import { TypeOptions, binding, getTypeHelpers, toItemType } from "./internal";
 import { createArrayPropertyAccessor } from "./property-accessors/Array";
 import { createObjectPropertyAccessor } from "./property-accessors/Object";
 import { createDictionaryPropertyAccessor } from "./property-accessors/Dictionary";
-import { createDefaultPropertyAccessor } from "./property-accessors/default";
 import { createSetPropertyAccessor } from "./property-accessors/Set";
+import { createIntPropertyAccessor } from "./property-accessors/Int";
 import { createMixedPropertyAccessor } from "./property-accessors/Mixed";
+import { createDefaultPropertyAccessor } from "./property-accessors/default";
 import {
   HelperOptions,
   PropertyAccessor,
@@ -31,7 +32,6 @@ import {
   PropertyHelpers,
   PropertyOptions,
 } from "./property-accessors/types";
-import { createIntPropertyAccessor } from "./property-accessors/Int";
 
 type AccessorFactory = (options: PropertyOptions) => PropertyAccessor;
 

--- a/packages/realm/src/PropertyMap.ts
+++ b/packages/realm/src/PropertyMap.ts
@@ -16,14 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import {
-  CanonicalObjectSchema,
-  HelperOptions,
-  PropertyHelpers,
-  assert,
-  binding,
-  createPropertyHelpers,
-} from "./internal";
+import { CanonicalObjectSchema, assert, binding, createPropertyHelpers } from "./internal";
+import { HelperOptions, PropertyHelpers } from "./property-accessors/types";
 
 class UninitializedPropertyMapError extends Error {
   constructor() {

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -34,7 +34,6 @@ import { createUuidTypeHelpers } from "./type-helpers/Uuid";
 import { createArrayTypeHelpers } from "./type-helpers/Array";
 
 import type { TypeHelpers, TypeOptions } from "./type-helpers/types";
-export type { TypeHelpers, TypeOptions };
 
 function createUnsupportedTypeHelpers(): TypeHelpers {
   return {
@@ -47,6 +46,7 @@ function createUnsupportedTypeHelpers(): TypeHelpers {
   };
 }
 
+/** @internal */
 export type MappableTypeHelpers = Exclude<
   binding.PropertyType,
   binding.PropertyType.Nullable | binding.PropertyType.Collection | binding.PropertyType.Flags

--- a/packages/realm/src/TypeHelpers.ts
+++ b/packages/realm/src/TypeHelpers.ts
@@ -16,426 +16,60 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import {
-  BSON,
-  ClassHelpers,
-  Collection,
-  Counter,
-  Dictionary,
-  INTERNAL,
-  List,
-  ObjCreator,
-  PresentationPropertyTypeName,
-  REALM,
-  Realm,
-  RealmObject,
-  RealmSet,
-  TypeAssertionError,
-  UpdateMode,
-  assert,
-  binding,
-  boxToBindingGeospatial,
-  circleToBindingGeospatial,
-  createDictionaryAccessor,
-  createListAccessor,
-  isGeoBox,
-  isGeoCircle,
-  isGeoPolygon,
-  polygonToBindingGeospatial,
-  safeGlobalThis,
-} from "./internal";
+import { assert, binding } from "./internal";
 
-const TYPED_ARRAY_CONSTRUCTORS = new Set(
-  [
-    DataView,
-    Int8Array,
-    Uint8Array,
-    Uint8ClampedArray,
-    Int16Array,
-    Uint16Array,
-    Int32Array,
-    Uint32Array,
-    Float32Array,
-    Float64Array,
-    // These will not be present on old versions of JSC without BigInt support.
-    safeGlobalThis.BigInt64Array,
-    safeGlobalThis.BigUint64Array,
-  ].filter((ctor) => ctor !== undefined),
-);
+import { createIntTypeHelpers } from "./type-helpers/Int";
+import { createBoolTypeHelpers } from "./type-helpers/Bool";
+import { createStringTypeHelpers } from "./type-helpers/String";
+import { createDataTypeHelpers } from "./type-helpers/Data";
+import { createDateTypeHelpers } from "./type-helpers/Date";
+import { createMixedTypeHelpers } from "./type-helpers/Mixed";
+import { createObjectIdTypeHelpers } from "./type-helpers/ObjectId";
+import { createFloatTypeHelpers } from "./type-helpers/Float";
+import { createDoubleTypeHelpers } from "./type-helpers/Double";
+import { createObjectTypeHelpers } from "./type-helpers/Object";
+import { createLinkingObjectsTypeHelpers } from "./type-helpers/LinkingObjects";
+import { createDecimalTypeHelpers } from "./type-helpers/Decimal";
+import { createUuidTypeHelpers } from "./type-helpers/Uuid";
+import { createArrayTypeHelpers } from "./type-helpers/Array";
 
-export function toArrayBuffer(value: unknown, stringToBase64 = true) {
-  if (typeof value === "string" && stringToBase64) {
-    return binding.Helpers.base64Decode(value);
-  }
-  for (const TypedArray of TYPED_ARRAY_CONSTRUCTORS) {
-    if (value instanceof TypedArray) {
-      return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
-    }
-  }
-  assert.instanceOf(value, ArrayBuffer);
-  return value;
+import type { TypeHelpers, TypeOptions } from "./type-helpers/types";
+export type { TypeHelpers, TypeOptions };
+
+function createUnsupportedTypeHelpers(): TypeHelpers {
+  return {
+    fromBinding() {
+      throw new Error("Not yet supported");
+    },
+    toBinding() {
+      throw new Error("Not yet supported");
+    },
+  };
 }
 
-/**
- * Helpers for converting a value to and from its binding representation.
- * @internal
- */
-export type TypeHelpers<T = unknown> = {
-  toBinding(
-    value: T,
-    options?: { createObj?: ObjCreator; updateMode?: UpdateMode; isQueryArg?: boolean },
-  ): binding.MixedArg;
-  fromBinding(value: unknown): T;
-};
+export type MappableTypeHelpers = Exclude<
+  binding.PropertyType,
+  binding.PropertyType.Nullable | binding.PropertyType.Collection | binding.PropertyType.Flags
+>;
 
-/** @internal */
-export type TypeOptions = {
-  realm: Realm;
-  name: string;
-  optional: boolean;
-  objectType: string | undefined;
-  objectSchemaName: string | undefined;
-  presentation?: PresentationPropertyTypeName;
-  getClassHelpers(nameOrTableKey: string | binding.TableKey): ClassHelpers;
-};
-
-// TODO: Consider testing for expected object instance types and throw something similar to the legacy SDK:
-// "Only Realm instances are supported." (which should probably have been "RealmObject")
-// instead of relying on the binding to throw.
-/**
- * Convert an SDK value to a Binding value representation.
- * @param realm The Realm used.
- * @param value The value to convert.
- * @param options Options needed.
- * @param options.isQueryArg Whether the value to convert is a query argument used
- *  for `OrderedCollection.filtered()`. If so, this will be validated differently.
- * @returns The `MixedArg` binding representation.
- * @internal
- */
-export function mixedToBinding(
-  realm: binding.Realm,
-  value: unknown,
-  { isQueryArg } = { isQueryArg: false },
-): binding.MixedArg {
-  const displayedType = isQueryArg ? "a query argument" : "a Mixed value";
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
-    // Fast track pass through for the most commonly used types
-    return value;
-  } else if (value === undefined) {
-    return null;
-  } else if (value instanceof Date) {
-    return binding.Timestamp.fromDate(value);
-  } else if (value instanceof RealmObject) {
-    if (value.objectSchema().embedded) {
-      throw new Error(`Using an embedded object (${value.constructor.name}) as ${displayedType} is not supported.`);
-    }
-    const otherRealm = value[REALM].internal;
-    assert.isSameRealm(realm, otherRealm, "Realm object is from another Realm");
-    return value[INTERNAL];
-  } else if (value instanceof RealmSet || value instanceof Set) {
-    throw new Error(`Using a ${value.constructor.name} as ${displayedType} is not supported.`);
-  } else if (value instanceof Counter) {
-    let errMessage = `Using a Counter as ${displayedType} is not supported.`;
-    errMessage += isQueryArg ? " Use 'Counter.value'." : "";
-    throw new Error(errMessage);
-  } else {
-    if (isQueryArg) {
-      if (value instanceof Collection || Array.isArray(value)) {
-        throw new Error(`Using a ${value.constructor.name} as a query argument is not supported.`);
-      }
-      // Geospatial types can currently only be used when querying and
-      // are not yet supported as standalone data types in the schema.
-      if (typeof value === "object") {
-        if (isGeoCircle(value)) {
-          return circleToBindingGeospatial(value);
-        } else if (isGeoBox(value)) {
-          return boxToBindingGeospatial(value);
-        } else if (isGeoPolygon(value)) {
-          return polygonToBindingGeospatial(value);
-        }
-      }
-    }
-
-    // Convert typed arrays to an `ArrayBuffer`
-    for (const TypedArray of TYPED_ARRAY_CONSTRUCTORS) {
-      if (value instanceof TypedArray) {
-        return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
-      }
-    }
-
-    // Rely on the binding for any other value
-    return value as binding.MixedArg;
-  }
-}
-
-function mixedFromBinding(options: TypeOptions, value: binding.MixedArg): unknown {
-  const { realm, getClassHelpers } = options;
-  if (binding.Int64.isInt(value)) {
-    return binding.Int64.intToNum(value);
-  } else if (value instanceof binding.Timestamp) {
-    return value.toDate();
-  } else if (value instanceof binding.Float) {
-    return value.value;
-  } else if (value instanceof binding.ObjLink) {
-    const table = binding.Helpers.getTable(realm.internal, value.tableKey);
-    const linkedObj = table.getObject(value.objKey);
-    const { wrapObject } = getClassHelpers(value.tableKey);
-    return wrapObject(linkedObj);
-  } else if (value instanceof binding.List) {
-    const mixedType = binding.PropertyType.Mixed;
-    const typeHelpers = getTypeHelpers(mixedType, options);
-    return new List(realm, value, createListAccessor({ realm, typeHelpers, itemType: mixedType }), typeHelpers);
-  } else if (value instanceof binding.Dictionary) {
-    const mixedType = binding.PropertyType.Mixed;
-    const typeHelpers = getTypeHelpers(mixedType, options);
-    return new Dictionary(
-      realm,
-      value,
-      createDictionaryAccessor({ realm, typeHelpers, itemType: mixedType }),
-      typeHelpers,
-    );
-  } else {
-    return value;
-  }
-}
-
-function defaultToBinding(value: unknown): binding.MixedArg {
-  return value as binding.MixedArg;
-}
-
-function defaultFromBinding(value: unknown) {
-  return value;
-}
-
-/**
- * Adds a branch to a function, which checks for the argument to be null, in which case it returns early.
- */
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Using `unknown` here breaks type inference in `binding.PropertyType.Object` `toBinding` from for some reason */
-function nullPassthrough<T, R extends any[], F extends (value: unknown, ...rest: R) => unknown>(
-  this: T,
-  fn: F,
-  enabled: boolean,
-): F {
-  if (enabled) {
-    return ((value, ...rest) =>
-      typeof value === "undefined" || value === null ? null : fn.call(this, value, ...rest)) as F;
-  } else {
-    return fn;
-  }
-}
-
-const TYPES_MAPPING: Record<binding.PropertyType, (options: TypeOptions) => TypeHelpers> = {
-  [binding.PropertyType.Int]({ presentation, optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        if (typeof value === "number") {
-          return binding.Int64.numToInt(value);
-        } else if (binding.Int64.isInt(value)) {
-          return value;
-        } else if (value instanceof Counter) {
-          if (presentation !== "counter") {
-            throw new Error(`Counters can only be used when 'counter' is declared in the property schema.`);
-          }
-          return binding.Int64.numToInt(value.value);
-        } else {
-          throw new TypeAssertionError("a number or bigint", value);
-        }
-      }, optional),
-      // TODO: Support returning bigints to end-users
-      fromBinding: nullPassthrough((value) => Number(value), optional),
-    };
-  },
-  [binding.PropertyType.Bool]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.boolean(value);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.String]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.string(value);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Data]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        return toArrayBuffer(value);
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Date]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        if (typeof value === "string") {
-          // TODO: Consider deprecating this undocumented type coercion
-          return binding.Timestamp.fromDate(new Date(value));
-        } else {
-          assert.instanceOf(value, Date);
-          return binding.Timestamp.fromDate(value);
-        }
-      }, optional),
-      fromBinding: nullPassthrough((value) => {
-        assert.instanceOf(value, binding.Timestamp);
-        return value.toDate();
-      }, optional),
-    };
-  },
-  [binding.PropertyType.Float]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.number(value);
-        return new binding.Float(value);
-      }, optional),
-      fromBinding: nullPassthrough((value) => {
-        assert.instanceOf(value, binding.Float);
-        return value.value;
-      }, optional),
-    };
-  },
-  [binding.PropertyType.Double]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.number(value);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Object]({ realm, name, objectType, optional, getClassHelpers }) {
-    assert(objectType);
-    const helpers = getClassHelpers(objectType);
-    const { wrapObject } = helpers;
-    return {
-      toBinding: nullPassthrough((value, options) => {
-        if (
-          value instanceof RealmObject &&
-          value.constructor.name === objectType &&
-          value[REALM].internal.$addr === realm.internal.$addr
-        ) {
-          return value[INTERNAL];
-        } else {
-          // TODO: Consider exposing a way for calling code to disable object creation
-          assert.object(value, name);
-          // Use the update mode if set; otherwise, the object is assumed to be an
-          // unmanaged object that the user wants to create.
-          // TODO: Ideally use `options?.updateMode` instead of `realm.currentUpdateMode`.
-          const createdObject = RealmObject.create(realm, value, realm.currentUpdateMode ?? UpdateMode.Never, {
-            helpers,
-            createObj: options?.createObj,
-          });
-          return createdObject[INTERNAL];
-        }
-      }, optional),
-      fromBinding: nullPassthrough((value) => {
-        if (value instanceof binding.ObjLink) {
-          const table = binding.Helpers.getTable(realm.internal, value.tableKey);
-          const linkedObj = table.getObject(value.objKey);
-          return wrapObject(linkedObj);
-        } else {
-          assert.instanceOf(value, binding.Obj);
-          return wrapObject(value);
-        }
-      }, optional),
-    };
-  },
-  [binding.PropertyType.LinkingObjects]({ objectType, getClassHelpers }) {
-    assert(objectType);
-    const { wrapObject } = getClassHelpers(objectType);
-    return {
-      toBinding: defaultToBinding,
-      fromBinding(value) {
-        assert.instanceOf(value, binding.Obj);
-        return wrapObject(value);
-      },
-    };
-  },
-  [binding.PropertyType.Mixed](options) {
-    return {
-      toBinding: mixedToBinding.bind(null, options.realm.internal),
-      fromBinding: mixedFromBinding.bind(null, options),
-    };
-  },
-  [binding.PropertyType.ObjectId]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.instanceOf(value, BSON.ObjectId);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Decimal]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.instanceOf(value, BSON.Decimal128);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Uuid]({ optional }) {
-    return {
-      toBinding: nullPassthrough((value) => {
-        assert.instanceOf(value, BSON.UUID);
-        return value;
-      }, optional),
-      fromBinding: defaultFromBinding,
-    };
-  },
-  [binding.PropertyType.Array]({ realm, getClassHelpers, name, objectSchemaName }) {
-    assert.string(objectSchemaName, "objectSchemaName");
-    const classHelpers = getClassHelpers(objectSchemaName);
-
-    return {
-      fromBinding(value: unknown) {
-        assert.instanceOf(value, binding.List);
-        const propertyHelpers = classHelpers.properties.get(name);
-        const { listAccessor } = propertyHelpers;
-        assert.object(listAccessor);
-        return new List(realm, value, listAccessor, propertyHelpers);
-      },
-      toBinding() {
-        throw new Error("Not supported");
-      },
-    };
-  },
-  [binding.PropertyType.Set]() {
-    return {
-      fromBinding() {
-        throw new Error("Not yet supported");
-      },
-      toBinding() {
-        throw new Error("Not yet supported");
-      },
-    };
-  },
-  [binding.PropertyType.Dictionary]() {
-    return {
-      fromBinding() {
-        throw new Error("Not supported");
-      },
-      toBinding() {
-        throw new Error("Not supported");
-      },
-    };
-  },
-  [binding.PropertyType.Nullable]() {
-    throw new Error("Not directly mappable");
-  },
-  [binding.PropertyType.Collection]() {
-    throw new Error("Not directly mappable");
-  },
-  [binding.PropertyType.Flags]() {
-    throw new Error("Not directly mappable");
-  },
+const TYPES_MAPPING: Record<MappableTypeHelpers, (options: TypeOptions) => TypeHelpers> = {
+  [binding.PropertyType.Int]: createIntTypeHelpers,
+  [binding.PropertyType.Bool]: createBoolTypeHelpers,
+  [binding.PropertyType.String]: createStringTypeHelpers,
+  [binding.PropertyType.Data]: createDataTypeHelpers,
+  [binding.PropertyType.Date]: createDateTypeHelpers,
+  [binding.PropertyType.Float]: createFloatTypeHelpers,
+  [binding.PropertyType.Double]: createDoubleTypeHelpers,
+  [binding.PropertyType.Object]: createObjectTypeHelpers,
+  [binding.PropertyType.LinkingObjects]: createLinkingObjectsTypeHelpers,
+  [binding.PropertyType.Mixed]: createMixedTypeHelpers,
+  [binding.PropertyType.ObjectId]: createObjectIdTypeHelpers,
+  [binding.PropertyType.Decimal]: createDecimalTypeHelpers,
+  [binding.PropertyType.Uuid]: createUuidTypeHelpers,
+  [binding.PropertyType.Array]: createArrayTypeHelpers,
+  // Unsupported below
+  [binding.PropertyType.Set]: createUnsupportedTypeHelpers,
+  [binding.PropertyType.Dictionary]: createUnsupportedTypeHelpers,
 };
 
 /** @internal */
@@ -444,7 +78,7 @@ export function toItemType(type: binding.PropertyType) {
 }
 
 /** @internal */
-export function getTypeHelpers(type: binding.PropertyType, options: TypeOptions): TypeHelpers {
+export function getTypeHelpers(type: MappableTypeHelpers, options: TypeOptions): TypeHelpers {
   const helpers = TYPES_MAPPING[type];
   assert(helpers, `Unexpected type ${type}`);
   return helpers(options);

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -55,6 +55,10 @@ export * from "./ClassHelpers";
 export * from "./ClassMap";
 /** @internal */
 export * from "./TypeHelpers";
+/** @internal */
+export { mixedToBinding } from "./type-helpers/Mixed";
+/** @internal */
+export { toArrayBuffer } from "./type-helpers/array-buffer";
 
 export * from "./PromiseHandle";
 

--- a/packages/realm/src/internal.ts
+++ b/packages/realm/src/internal.ts
@@ -59,6 +59,8 @@ export * from "./TypeHelpers";
 export { mixedToBinding } from "./type-helpers/Mixed";
 /** @internal */
 export { toArrayBuffer } from "./type-helpers/array-buffer";
+/** @internal */
+export type { TypeHelpers, TypeOptions } from "./type-helpers/types";
 
 export * from "./PromiseHandle";
 

--- a/packages/realm/src/property-accessors/Array.ts
+++ b/packages/realm/src/property-accessors/Array.ts
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import {
+  List,
+  Results,
+  TypeAssertionError,
+  assert,
+  binding,
+  createListAccessor,
+  createResultsAccessor,
+  getTypeHelpers,
+  toItemType,
+} from "../internal";
+import type { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createArrayPropertyAccessor({
+  realm,
+  type,
+  name,
+  columnKey,
+  objectType,
+  embedded,
+  linkOriginPropertyName,
+  getClassHelpers,
+  optional,
+}: PropertyOptions): PropertyAccessor {
+  const realmInternal = realm.internal;
+  const itemType = toItemType(type);
+  const itemHelpers = getTypeHelpers(itemType, {
+    realm,
+    name: `element of ${name}`,
+    optional,
+    getClassHelpers,
+    objectType,
+    objectSchemaName: undefined,
+  });
+
+  if (itemType === binding.PropertyType.LinkingObjects) {
+    // Locate the table of the targeted object
+    assert.string(objectType, "object type");
+    assert(objectType !== "", "Expected a non-empty string");
+    const targetClassHelpers = getClassHelpers(objectType);
+    const {
+      objectSchema: { tableKey, persistedProperties },
+    } = targetClassHelpers;
+    // TODO: Check if we want to match with the `p.name` or `p.publicName` here
+    const targetProperty = persistedProperties.find((p) => p.name === linkOriginPropertyName);
+    assert(targetProperty, `Expected a '${linkOriginPropertyName}' property on ${objectType}`);
+    const tableRef = binding.Helpers.getTable(realmInternal, tableKey);
+    const resultsAccessor = createResultsAccessor({ realm, typeHelpers: itemHelpers, itemType });
+
+    return {
+      get(obj: binding.Obj) {
+        const tableView = obj.getBacklinkView(tableRef, targetProperty.columnKey);
+        const results = binding.Results.fromTableView(realmInternal, tableView);
+        return new Results(realm, results, resultsAccessor, itemHelpers);
+      },
+      set() {
+        throw new Error("Not supported");
+      },
+    };
+  } else {
+    const listAccessor = createListAccessor({ realm, typeHelpers: itemHelpers, itemType, isEmbedded: embedded });
+
+    return {
+      listAccessor,
+      get(obj: binding.Obj) {
+        const internal = binding.List.make(realm.internal, obj, columnKey);
+        assert.instanceOf(internal, binding.List);
+        return new List(realm, internal, listAccessor, itemHelpers);
+      },
+      set(obj, values) {
+        assert.inTransaction(realm);
+        assert.iterable(values);
+
+        const internal = binding.List.make(realm.internal, obj, columnKey);
+        internal.removeAll();
+        let index = 0;
+        try {
+          for (const value of values) {
+            listAccessor.insert(internal, index++, value);
+          }
+        } catch (err) {
+          if (err instanceof TypeAssertionError) {
+            err.rename(`${name}[${index - 1}]`);
+          }
+          throw err;
+        }
+      },
+    };
+  }
+}

--- a/packages/realm/src/property-accessors/Array.ts
+++ b/packages/realm/src/property-accessors/Array.ts
@@ -29,6 +29,7 @@ import {
 } from "../internal";
 import type { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createArrayPropertyAccessor({
   realm,
   type,

--- a/packages/realm/src/property-accessors/Dictionary.ts
+++ b/packages/realm/src/property-accessors/Dictionary.ts
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import {
+  Dictionary,
+  TypeAssertionError,
+  assert,
+  binding,
+  createDictionaryAccessor,
+  getTypeHelpers,
+  toItemType,
+} from "../internal";
+import type { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createDictionaryPropertyAccessor({
+  columnKey,
+  realm,
+  name,
+  type,
+  optional,
+  objectType,
+  getClassHelpers,
+  embedded,
+}: PropertyOptions): PropertyAccessor {
+  const itemType = toItemType(type);
+  const itemHelpers = getTypeHelpers(itemType, {
+    realm,
+    name: `value in ${name}`,
+    getClassHelpers,
+    objectType,
+    optional,
+    objectSchemaName: undefined,
+  });
+  const dictionaryAccessor = createDictionaryAccessor({
+    realm,
+    typeHelpers: itemHelpers,
+    itemType,
+    isEmbedded: embedded,
+  });
+
+  return {
+    get(obj) {
+      const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
+      return new Dictionary(realm, internal, dictionaryAccessor, itemHelpers);
+    },
+    set(obj, value) {
+      assert.inTransaction(realm);
+
+      const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
+      // Clear the dictionary before adding new values
+      internal.removeAll();
+      assert.object(value, `values of ${name}`, { allowArrays: false });
+      for (const [k, v] of Object.entries(value)) {
+        try {
+          dictionaryAccessor.set(internal, k, v);
+        } catch (err) {
+          if (err instanceof TypeAssertionError) {
+            err.rename(`${name}["${k}"]`);
+          }
+          throw err;
+        }
+      }
+    },
+  };
+}

--- a/packages/realm/src/property-accessors/Dictionary.ts
+++ b/packages/realm/src/property-accessors/Dictionary.ts
@@ -27,6 +27,7 @@ import {
 } from "../internal";
 import type { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createDictionaryPropertyAccessor({
   columnKey,
   realm,

--- a/packages/realm/src/property-accessors/Int.ts
+++ b/packages/realm/src/property-accessors/Int.ts
@@ -18,7 +18,6 @@
 
 import { Counter } from "../internal";
 import { createDefaultPropertyAccessor } from "./default";
-
 import type { PropertyAccessor, PropertyOptions } from "./types";
 
 /** @internal */

--- a/packages/realm/src/property-accessors/Int.ts
+++ b/packages/realm/src/property-accessors/Int.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Counter } from "../internal";
+import { createDefaultPropertyAccessor } from "./default";
+
+import type { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createIntPropertyAccessor(options: PropertyOptions): PropertyAccessor {
+  const { realm, columnKey, presentation, optional } = options;
+  const defaultAccessor = createDefaultPropertyAccessor(options);
+
+  if (presentation === "counter") {
+    return {
+      get(obj) {
+        return obj.getAny(columnKey) === null ? null : new Counter(realm, obj, columnKey);
+      },
+      set(obj, value, isCreating) {
+        // We only allow resetting a counter this way (e.g. realmObject.counter = 5)
+        // when it is first created, or when resetting a nullable/optional counter
+        // to `null`, or when a nullable counter was previously `null`.
+        const isAllowed =
+          isCreating || (optional && (value === null || value === undefined || obj.getAny(columnKey) === null));
+
+        if (isAllowed) {
+          defaultAccessor.set(obj, value);
+        } else {
+          throw new Error(
+            "You can only reset a Counter instance when initializing a previously " +
+              "null Counter or resetting a nullable Counter to null. To update the " +
+              "value of the Counter, use its instance methods.",
+          );
+        }
+      },
+    };
+  } else {
+    return defaultAccessor;
+  }
+}

--- a/packages/realm/src/property-accessors/Int.ts
+++ b/packages/realm/src/property-accessors/Int.ts
@@ -21,6 +21,7 @@ import { createDefaultPropertyAccessor } from "./default";
 
 import type { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createIntPropertyAccessor(options: PropertyOptions): PropertyAccessor {
   const { realm, columnKey, presentation, optional } = options;
   const defaultAccessor = createDefaultPropertyAccessor(options);

--- a/packages/realm/src/property-accessors/Mixed.ts
+++ b/packages/realm/src/property-accessors/Mixed.ts
@@ -31,6 +31,7 @@ import {
 import { createDefaultPropertyAccessor } from "./default";
 import type { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createMixedPropertyAccessor(options: PropertyOptions): PropertyAccessor {
   const { realm, columnKey, typeHelpers } = options;
   const { fromBinding, toBinding } = typeHelpers;

--- a/packages/realm/src/property-accessors/Mixed.ts
+++ b/packages/realm/src/property-accessors/Mixed.ts
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import {
+  Dictionary,
+  List,
+  assert,
+  binding,
+  createDictionaryAccessor,
+  createListAccessor,
+  insertIntoDictionaryOfMixed,
+  insertIntoListOfMixed,
+  isJsOrRealmDictionary,
+  isJsOrRealmList,
+} from "../internal";
+import { createDefaultPropertyAccessor } from "./default";
+import type { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createMixedPropertyAccessor(options: PropertyOptions): PropertyAccessor {
+  const { realm, columnKey, typeHelpers } = options;
+  const { fromBinding, toBinding } = typeHelpers;
+  const listAccessor = createListAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
+  const dictionaryAccessor = createDictionaryAccessor({ realm, typeHelpers, itemType: binding.PropertyType.Mixed });
+  const { set: defaultSet } = createDefaultPropertyAccessor(options);
+
+  return {
+    get(obj) {
+      try {
+        const value = obj.getAny(columnKey);
+        switch (value) {
+          case binding.ListSentinel: {
+            const internal = binding.List.make(realm.internal, obj, columnKey);
+            return new List(realm, internal, listAccessor, typeHelpers);
+          }
+          case binding.DictionarySentinel: {
+            const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
+            return new Dictionary(realm, internal, dictionaryAccessor, typeHelpers);
+          }
+          default:
+            return fromBinding(value);
+        }
+      } catch (err) {
+        assert.isValid(obj);
+        throw err;
+      }
+    },
+    set(obj: binding.Obj, value: unknown) {
+      assert.inTransaction(realm);
+
+      if (isJsOrRealmList(value)) {
+        obj.setCollection(columnKey, binding.CollectionType.List);
+        const internal = binding.List.make(realm.internal, obj, columnKey);
+        insertIntoListOfMixed(value, internal, toBinding);
+      } else if (isJsOrRealmDictionary(value)) {
+        obj.setCollection(columnKey, binding.CollectionType.Dictionary);
+        const internal = binding.Dictionary.make(realm.internal, obj, columnKey);
+        insertIntoDictionaryOfMixed(value, internal, toBinding);
+      } else {
+        defaultSet(obj, value);
+      }
+    },
+  };
+}

--- a/packages/realm/src/property-accessors/Object.ts
+++ b/packages/realm/src/property-accessors/Object.ts
@@ -18,6 +18,7 @@
 
 import { assert, binding } from "../internal";
 import { createDefaultPropertyAccessor } from "./default";
+import type { PropertyAccessor, PropertyOptions } from "./types";
 
 function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
   return (obj: binding.Obj, value: unknown) => {
@@ -32,8 +33,6 @@ function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOp
     }
   };
 }
-
-import type { PropertyAccessor, PropertyOptions } from "./types";
 
 /** @internal */
 export function createObjectPropertyAccessor(options: PropertyOptions): PropertyAccessor {

--- a/packages/realm/src/property-accessors/Object.ts
+++ b/packages/realm/src/property-accessors/Object.ts
@@ -19,7 +19,7 @@
 import { assert, binding } from "../internal";
 import { createDefaultPropertyAccessor } from "./default";
 
-export function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
+function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
   return (obj: binding.Obj, value: unknown) => {
     // Asking for the toBinding will create the object and link it to the parent in one operation.
     // Thus, no need to actually set the value on the `obj` unless it's an optional null value.
@@ -35,6 +35,7 @@ export function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: Pro
 
 import type { PropertyAccessor, PropertyHelpers, PropertyOptions } from "./types";
 
+/** @internal */
 export function createObjectPropertyAccessor(options: PropertyOptions): PropertyAccessor {
   const {
     columnKey,

--- a/packages/realm/src/property-accessors/Object.ts
+++ b/packages/realm/src/property-accessors/Object.ts
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding } from "../internal";
+import { createDefaultPropertyAccessor } from "./default";
+
+export function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOptions) {
+  return (obj: binding.Obj, value: unknown) => {
+    // Asking for the toBinding will create the object and link it to the parent in one operation.
+    // Thus, no need to actually set the value on the `obj` unless it's an optional null value.
+    const bindingValue = toBinding(value, { createObj: () => [obj.createAndSetLinkedObject(columnKey), true] });
+    // No need to destructure `optional` and check that it's `true` in this condition before setting
+    // it to null as objects are always optional. The condition is placed after the invocation of
+    // `toBinding()` in order to leave the type conversion responsibility to `toBinding()`.
+    if (bindingValue === null) {
+      obj.setAny(columnKey, bindingValue);
+    }
+  };
+}
+
+import type { PropertyAccessor, PropertyHelpers, PropertyOptions } from "./types";
+
+export function createObjectPropertyAccessor(options: PropertyOptions): PropertyAccessor {
+  const {
+    columnKey,
+    typeHelpers: { fromBinding },
+    embedded,
+  } = options;
+  assert(options.optional, "Objects are always nullable");
+
+  const { set: defaultSet } = createDefaultPropertyAccessor(options);
+
+  return {
+    get(this: PropertyHelpers, obj) {
+      return fromBinding(obj.getLinkedObject(columnKey));
+    },
+    set: embedded ? createEmbeddedSet(options) : defaultSet,
+  };
+}

--- a/packages/realm/src/property-accessors/Object.ts
+++ b/packages/realm/src/property-accessors/Object.ts
@@ -33,7 +33,7 @@ function createEmbeddedSet({ typeHelpers: { toBinding }, columnKey }: PropertyOp
   };
 }
 
-import type { PropertyAccessor, PropertyHelpers, PropertyOptions } from "./types";
+import type { PropertyAccessor, PropertyOptions } from "./types";
 
 /** @internal */
 export function createObjectPropertyAccessor(options: PropertyOptions): PropertyAccessor {
@@ -47,7 +47,7 @@ export function createObjectPropertyAccessor(options: PropertyOptions): Property
   const { set: defaultSet } = createDefaultPropertyAccessor(options);
 
   return {
-    get(this: PropertyHelpers, obj) {
+    get(obj) {
       return fromBinding(obj.getLinkedObject(columnKey));
     },
     set: embedded ? createEmbeddedSet(options) : defaultSet,

--- a/packages/realm/src/property-accessors/Set.ts
+++ b/packages/realm/src/property-accessors/Set.ts
@@ -19,6 +19,7 @@
 import { RealmSet, assert, binding, createSetAccessor, getTypeHelpers, toItemType } from "../internal";
 import { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createSetPropertyAccessor({
   columnKey,
   realm,

--- a/packages/realm/src/property-accessors/Set.ts
+++ b/packages/realm/src/property-accessors/Set.ts
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { RealmSet, assert, binding, createSetAccessor, getTypeHelpers, toItemType } from "../internal";
+import { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createSetPropertyAccessor({
+  columnKey,
+  realm,
+  name,
+  type,
+  optional,
+  objectType,
+  getClassHelpers,
+}: PropertyOptions): PropertyAccessor {
+  const itemType = toItemType(type);
+  const itemHelpers = getTypeHelpers(itemType, {
+    realm,
+    name: `value in ${name}`,
+    getClassHelpers,
+    objectType,
+    optional,
+    objectSchemaName: undefined,
+  });
+  assert.string(objectType);
+  const setAccessor = createSetAccessor({ realm, typeHelpers: itemHelpers, itemType });
+
+  return {
+    get(obj) {
+      const internal = binding.Set.make(realm.internal, obj, columnKey);
+      return new RealmSet(realm, internal, setAccessor, itemHelpers);
+    },
+    set(obj, value) {
+      assert.inTransaction(realm);
+
+      const internal = binding.Set.make(realm.internal, obj, columnKey);
+      // Clear the set before adding new values
+      internal.removeAll();
+      assert.array(value, "values");
+      for (const v of value) {
+        setAccessor.insert(internal, v);
+      }
+    },
+  };
+}

--- a/packages/realm/src/property-accessors/default.ts
+++ b/packages/realm/src/property-accessors/default.ts
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding } from "../internal";
+import { PropertyAccessor, PropertyOptions } from "./types";
+
+export function createDefaultPropertyAccessor({
+  realm,
+  typeHelpers: { fromBinding, toBinding },
+  columnKey,
+}: PropertyOptions): PropertyAccessor {
+  return {
+    get(obj: binding.Obj) {
+      try {
+        return fromBinding(obj.getAny(columnKey));
+      } catch (err) {
+        assert.isValid(obj);
+        throw err;
+      }
+    },
+
+    set(obj: binding.Obj, value: unknown) {
+      assert.inTransaction(realm);
+      try {
+        if (!realm.isInMigration && obj.table.getPrimaryKeyColumn() === columnKey) {
+          throw new Error(`Cannot change value of primary key outside migration function`);
+        }
+        obj.setAny(columnKey, toBinding(value));
+      } catch (err) {
+        assert.isValid(obj);
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/realm/src/property-accessors/default.ts
+++ b/packages/realm/src/property-accessors/default.ts
@@ -34,7 +34,6 @@ export function createDefaultPropertyAccessor({
         throw err;
       }
     },
-
     set(obj: binding.Obj, value: unknown) {
       assert.inTransaction(realm);
       try {

--- a/packages/realm/src/property-accessors/default.ts
+++ b/packages/realm/src/property-accessors/default.ts
@@ -19,6 +19,7 @@
 import { assert, binding } from "../internal";
 import { PropertyAccessor, PropertyOptions } from "./types";
 
+/** @internal */
 export function createDefaultPropertyAccessor({
   realm,
   typeHelpers: { fromBinding, toBinding },

--- a/packages/realm/src/property-accessors/types.ts
+++ b/packages/realm/src/property-accessors/types.ts
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { ClassHelpers, ListAccessor, PresentationPropertyTypeName, Realm, TypeHelpers, binding } from "../internal";
+
+export type PropertyContext = binding.Property & {
+  type: binding.PropertyType;
+  objectSchemaName: string;
+  embedded: boolean;
+  presentation?: PresentationPropertyTypeName;
+  default?: unknown;
+};
+
+/** @internal */
+export type HelperOptions = {
+  realm: Realm;
+  getClassHelpers: (name: string) => ClassHelpers;
+};
+
+export type PropertyOptions = {
+  typeHelpers: TypeHelpers;
+  columnKey: binding.ColKey;
+  optional: boolean;
+  embedded: boolean;
+  presentation?: PresentationPropertyTypeName;
+} & HelperOptions &
+  binding.Property_Relaxed;
+
+export type PropertyAccessor = {
+  get(obj: binding.Obj): unknown;
+  set(obj: binding.Obj, value: unknown, isCreating?: boolean): unknown;
+  listAccessor?: ListAccessor;
+};
+
+/** @internal */
+export type PropertyHelpers = TypeHelpers &
+  PropertyAccessor & {
+    type: binding.PropertyType;
+    columnKey: binding.ColKey;
+    embedded: boolean;
+    default?: unknown;
+    objectType?: string;
+  };

--- a/packages/realm/src/property-accessors/types.ts
+++ b/packages/realm/src/property-accessors/types.ts
@@ -19,6 +19,7 @@
 import { ClassHelpers, ListAccessor, PresentationPropertyTypeName, Realm, binding } from "../internal";
 import type { TypeHelpers } from "../type-helpers/types";
 
+/** @internal */
 export type PropertyContext = binding.Property & {
   type: binding.PropertyType;
   objectSchemaName: string;
@@ -33,6 +34,7 @@ export type HelperOptions = {
   getClassHelpers: (name: string) => ClassHelpers;
 };
 
+/** @internal */
 export type PropertyOptions = {
   typeHelpers: TypeHelpers;
   columnKey: binding.ColKey;
@@ -42,6 +44,7 @@ export type PropertyOptions = {
 } & HelperOptions &
   binding.Property_Relaxed;
 
+/** @internal */
 export type PropertyAccessor = {
   get(obj: binding.Obj): unknown;
   set(obj: binding.Obj, value: unknown, isCreating?: boolean): unknown;

--- a/packages/realm/src/property-accessors/types.ts
+++ b/packages/realm/src/property-accessors/types.ts
@@ -16,7 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { ClassHelpers, ListAccessor, PresentationPropertyTypeName, Realm, TypeHelpers, binding } from "../internal";
+import { ClassHelpers, ListAccessor, PresentationPropertyTypeName, Realm, binding } from "../internal";
+import type { TypeHelpers } from "../type-helpers/types";
 
 export type PropertyContext = binding.Property & {
   type: binding.PropertyType;

--- a/packages/realm/src/type-helpers/Array.ts
+++ b/packages/realm/src/type-helpers/Array.ts
@@ -19,6 +19,7 @@
 import { List, assert, binding } from "../internal";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createArrayTypeHelpers({ realm, getClassHelpers, name, objectSchemaName }: TypeOptions): TypeHelpers {
   assert.string(objectSchemaName, "objectSchemaName");
   const classHelpers = getClassHelpers(objectSchemaName);

--- a/packages/realm/src/type-helpers/Array.ts
+++ b/packages/realm/src/type-helpers/Array.ts
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { List, assert, binding } from "../internal";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createArrayTypeHelpers({ realm, getClassHelpers, name, objectSchemaName }: TypeOptions): TypeHelpers {
+  assert.string(objectSchemaName, "objectSchemaName");
+  const classHelpers = getClassHelpers(objectSchemaName);
+
+  return {
+    fromBinding(value: unknown) {
+      assert.instanceOf(value, binding.List);
+      const propertyHelpers = classHelpers.properties.get(name);
+      const { listAccessor } = propertyHelpers;
+      assert.object(listAccessor);
+      return new List(realm, value, listAccessor, propertyHelpers);
+    },
+    toBinding() {
+      throw new Error("Not supported");
+    },
+  };
+}

--- a/packages/realm/src/type-helpers/Bool.ts
+++ b/packages/realm/src/type-helpers/Bool.ts
@@ -21,6 +21,7 @@ import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import type { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createBoolTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Bool.ts
+++ b/packages/realm/src/type-helpers/Bool.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert } from "../internal";
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import type { TypeHelpers, TypeOptions } from "./types";
+
+export function createBoolTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.boolean(value);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/Data.ts
+++ b/packages/realm/src/type-helpers/Data.ts
@@ -21,6 +21,7 @@ import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 import { toArrayBuffer } from "./array-buffer";
 
+/** @internal */
 export function createDataTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Data.ts
+++ b/packages/realm/src/type-helpers/Data.ts
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+import { toArrayBuffer } from "./array-buffer";
+
+export function createDataTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      return toArrayBuffer(value);
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/Date.ts
+++ b/packages/realm/src/type-helpers/Date.ts
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding } from "../internal";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeOptions } from "./types";
+
+export function createDateTypeHelpers({ optional }: TypeOptions) {
+  return {
+    toBinding: nullPassthrough((value) => {
+      if (typeof value === "string") {
+        // TODO: Consider deprecating this undocumented type coercion
+        return binding.Timestamp.fromDate(new Date(value));
+      } else {
+        assert.instanceOf(value, Date);
+        return binding.Timestamp.fromDate(value);
+      }
+    }, optional),
+    fromBinding: nullPassthrough((value) => {
+      assert.instanceOf(value, binding.Timestamp);
+      return value.toDate();
+    }, optional),
+  };
+}

--- a/packages/realm/src/type-helpers/Date.ts
+++ b/packages/realm/src/type-helpers/Date.ts
@@ -20,6 +20,7 @@ import { assert, binding } from "../internal";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeOptions } from "./types";
 
+/** @internal */
 export function createDateTypeHelpers({ optional }: TypeOptions) {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Decimal.ts
+++ b/packages/realm/src/type-helpers/Decimal.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { BSON, assert } from "../internal";
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createDecimalTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.instanceOf(value, BSON.Decimal128);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/Decimal.ts
+++ b/packages/realm/src/type-helpers/Decimal.ts
@@ -21,6 +21,7 @@ import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createDecimalTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Double.ts
+++ b/packages/realm/src/type-helpers/Double.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert } from "../internal";
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createDoubleTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.number(value);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/Double.ts
+++ b/packages/realm/src/type-helpers/Double.ts
@@ -21,6 +21,7 @@ import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createDoubleTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Float.ts
+++ b/packages/realm/src/type-helpers/Float.ts
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding } from "../internal";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createFloatTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.number(value);
+      return new binding.Float(value);
+    }, optional),
+    fromBinding: nullPassthrough((value) => {
+      assert.instanceOf(value, binding.Float);
+      return value.value;
+    }, optional),
+  };
+}

--- a/packages/realm/src/type-helpers/Float.ts
+++ b/packages/realm/src/type-helpers/Float.ts
@@ -20,6 +20,7 @@ import { assert, binding } from "../internal";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createFloatTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Int.ts
+++ b/packages/realm/src/type-helpers/Int.ts
@@ -20,6 +20,7 @@ import { Counter, TypeAssertionError, binding } from "../internal";
 import { nullPassthrough } from "./null-passthrough";
 import type { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createIntTypeHelpers({ presentation, optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Int.ts
+++ b/packages/realm/src/type-helpers/Int.ts
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { Counter, TypeAssertionError, binding } from "../internal";
+import { nullPassthrough } from "./null-passthrough";
+import type { TypeHelpers, TypeOptions } from "./types";
+
+export function createIntTypeHelpers({ presentation, optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      if (typeof value === "number") {
+        return binding.Int64.numToInt(value);
+      } else if (binding.Int64.isInt(value)) {
+        return value;
+      } else if (value instanceof Counter) {
+        if (presentation !== "counter") {
+          throw new Error(`Counters can only be used when 'counter' is declared in the property schema.`);
+        }
+        return binding.Int64.numToInt(value.value);
+      } else {
+        throw new TypeAssertionError("a number or bigint", value);
+      }
+    }, optional),
+    // TODO: Support returning bigints to end-users
+    fromBinding: nullPassthrough((value) => Number(value), optional),
+  };
+}

--- a/packages/realm/src/type-helpers/LinkingObjects.ts
+++ b/packages/realm/src/type-helpers/LinkingObjects.ts
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding } from "../internal";
+import { defaultToBinding } from "./default";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createLinkingObjectsTypeHelpers({ objectType, getClassHelpers }: TypeOptions): TypeHelpers {
+  assert(objectType);
+  const { wrapObject } = getClassHelpers(objectType);
+  return {
+    toBinding: defaultToBinding,
+    fromBinding(value) {
+      assert.instanceOf(value, binding.Obj);
+      return wrapObject(value);
+    },
+  };
+}

--- a/packages/realm/src/type-helpers/LinkingObjects.ts
+++ b/packages/realm/src/type-helpers/LinkingObjects.ts
@@ -20,6 +20,7 @@ import { assert, binding } from "../internal";
 import { defaultToBinding } from "./default";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createLinkingObjectsTypeHelpers({ objectType, getClassHelpers }: TypeOptions): TypeHelpers {
   assert(objectType);
   const { wrapObject } = getClassHelpers(objectType);

--- a/packages/realm/src/type-helpers/Mixed.ts
+++ b/packages/realm/src/type-helpers/Mixed.ts
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import {
+  Collection,
+  Counter,
+  Dictionary,
+  INTERNAL,
+  List,
+  REALM,
+  RealmObject,
+  RealmSet,
+  assert,
+  binding,
+  boxToBindingGeospatial,
+  circleToBindingGeospatial,
+  createDictionaryAccessor,
+  createListAccessor,
+  getTypeHelpers,
+  isGeoBox,
+  isGeoCircle,
+  isGeoPolygon,
+  polygonToBindingGeospatial,
+} from "../internal";
+import { TYPED_ARRAY_CONSTRUCTORS } from "./array-buffer";
+import { TypeHelpers, TypeOptions } from "./types";
+
+// TODO: Consider testing for expected object instance types and throw something similar to the legacy SDK:
+// "Only Realm instances are supported." (which should probably have been "RealmObject")
+// instead of relying on the binding to throw.
+/**
+ * Convert an SDK value to a Binding value representation.
+ * @param realm The Realm used.
+ * @param value The value to convert.
+ * @param options Options needed.
+ * @param options.isQueryArg Whether the value to convert is a query argument used
+ *  for `OrderedCollection.filtered()`. If so, this will be validated differently.
+ * @returns The `MixedArg` binding representation.
+ * @internal
+ */
+export function mixedToBinding(
+  realm: binding.Realm,
+  value: unknown,
+  { isQueryArg } = { isQueryArg: false },
+): binding.MixedArg {
+  const displayedType = isQueryArg ? "a query argument" : "a Mixed value";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
+    // Fast track pass through for the most commonly used types
+    return value;
+  } else if (value === undefined) {
+    return null;
+  } else if (value instanceof Date) {
+    return binding.Timestamp.fromDate(value);
+  } else if (value instanceof RealmObject) {
+    if (value.objectSchema().embedded) {
+      throw new Error(`Using an embedded object (${value.constructor.name}) as ${displayedType} is not supported.`);
+    }
+    const otherRealm = value[REALM].internal;
+    assert.isSameRealm(realm, otherRealm, "Realm object is from another Realm");
+    return value[INTERNAL];
+  } else if (value instanceof RealmSet || value instanceof Set) {
+    throw new Error(`Using a ${value.constructor.name} as ${displayedType} is not supported.`);
+  } else if (value instanceof Counter) {
+    let errMessage = `Using a Counter as ${displayedType} is not supported.`;
+    errMessage += isQueryArg ? " Use 'Counter.value'." : "";
+    throw new Error(errMessage);
+  } else {
+    if (isQueryArg) {
+      if (value instanceof Collection || Array.isArray(value)) {
+        throw new Error(`Using a ${value.constructor.name} as a query argument is not supported.`);
+      }
+      // Geospatial types can currently only be used when querying and
+      // are not yet supported as standalone data types in the schema.
+      if (typeof value === "object") {
+        if (isGeoCircle(value)) {
+          return circleToBindingGeospatial(value);
+        } else if (isGeoBox(value)) {
+          return boxToBindingGeospatial(value);
+        } else if (isGeoPolygon(value)) {
+          return polygonToBindingGeospatial(value);
+        }
+      }
+    }
+
+    // Convert typed arrays to an `ArrayBuffer`
+    for (const TypedArray of TYPED_ARRAY_CONSTRUCTORS) {
+      if (value instanceof TypedArray) {
+        return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+      }
+    }
+
+    // Rely on the binding for any other value
+    return value as binding.MixedArg;
+  }
+}
+
+function mixedFromBinding(options: TypeOptions, value: binding.MixedArg): unknown {
+  const { realm, getClassHelpers } = options;
+  if (binding.Int64.isInt(value)) {
+    return binding.Int64.intToNum(value);
+  } else if (value instanceof binding.Timestamp) {
+    return value.toDate();
+  } else if (value instanceof binding.Float) {
+    return value.value;
+  } else if (value instanceof binding.ObjLink) {
+    const table = binding.Helpers.getTable(realm.internal, value.tableKey);
+    const linkedObj = table.getObject(value.objKey);
+    const { wrapObject } = getClassHelpers(value.tableKey);
+    return wrapObject(linkedObj);
+  } else if (value instanceof binding.List) {
+    const mixedType = binding.PropertyType.Mixed;
+    const typeHelpers = getTypeHelpers(mixedType, options);
+    return new List(realm, value, createListAccessor({ realm, typeHelpers, itemType: mixedType }), typeHelpers);
+  } else if (value instanceof binding.Dictionary) {
+    const mixedType = binding.PropertyType.Mixed;
+    const typeHelpers = getTypeHelpers(mixedType, options);
+    return new Dictionary(
+      realm,
+      value,
+      createDictionaryAccessor({ realm, typeHelpers, itemType: mixedType }),
+      typeHelpers,
+    );
+  } else {
+    return value;
+  }
+}
+
+export function createMixedTypeHelpers(options: TypeOptions): TypeHelpers {
+  return {
+    toBinding: mixedToBinding.bind(null, options.realm.internal),
+    fromBinding: mixedFromBinding.bind(null, options),
+  };
+}

--- a/packages/realm/src/type-helpers/Mixed.ts
+++ b/packages/realm/src/type-helpers/Mixed.ts
@@ -109,6 +109,7 @@ export function mixedToBinding(
   }
 }
 
+/** @internal */
 function mixedFromBinding(options: TypeOptions, value: binding.MixedArg): unknown {
   const { realm, getClassHelpers } = options;
   if (binding.Int64.isInt(value)) {
@@ -140,6 +141,7 @@ function mixedFromBinding(options: TypeOptions, value: binding.MixedArg): unknow
   }
 }
 
+/** @internal */
 export function createMixedTypeHelpers(options: TypeOptions): TypeHelpers {
   return {
     toBinding: mixedToBinding.bind(null, options.realm.internal),

--- a/packages/realm/src/type-helpers/Object.ts
+++ b/packages/realm/src/type-helpers/Object.ts
@@ -20,6 +20,7 @@ import { INTERNAL, REALM, RealmObject, UpdateMode, assert, binding } from "../in
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createObjectTypeHelpers({
   realm,
   name,

--- a/packages/realm/src/type-helpers/Object.ts
+++ b/packages/realm/src/type-helpers/Object.ts
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { INTERNAL, REALM, RealmObject, UpdateMode, assert, binding } from "../internal";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createObjectTypeHelpers({
+  realm,
+  name,
+  objectType,
+  optional,
+  getClassHelpers,
+}: TypeOptions): TypeHelpers {
+  assert(objectType);
+  const helpers = getClassHelpers(objectType);
+  const { wrapObject } = helpers;
+  return {
+    toBinding: nullPassthrough((value, options) => {
+      if (
+        value instanceof RealmObject &&
+        value.constructor.name === objectType &&
+        value[REALM].internal.$addr === realm.internal.$addr
+      ) {
+        return value[INTERNAL];
+      } else {
+        // TODO: Consider exposing a way for calling code to disable object creation
+        assert.object(value, name);
+        // Use the update mode if set; otherwise, the object is assumed to be an
+        // unmanaged object that the user wants to create.
+        // TODO: Ideally use `options?.updateMode` instead of `realm.currentUpdateMode`.
+        const createdObject = RealmObject.create(realm, value, realm.currentUpdateMode ?? UpdateMode.Never, {
+          helpers,
+          createObj: options?.createObj,
+        });
+        return createdObject[INTERNAL];
+      }
+    }, optional),
+    fromBinding: nullPassthrough((value) => {
+      if (value instanceof binding.ObjLink) {
+        const table = binding.Helpers.getTable(realm.internal, value.tableKey);
+        const linkedObj = table.getObject(value.objKey);
+        return wrapObject(linkedObj);
+      } else {
+        assert.instanceOf(value, binding.Obj);
+        return wrapObject(value);
+      }
+    }, optional),
+  };
+}

--- a/packages/realm/src/type-helpers/ObjectId.ts
+++ b/packages/realm/src/type-helpers/ObjectId.ts
@@ -22,6 +22,7 @@ import { TypeHelpers, TypeOptions } from "./types";
 
 import { BSON, assert } from "../internal";
 
+/** @internal */
 export function createObjectIdTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/ObjectId.ts
+++ b/packages/realm/src/type-helpers/ObjectId.ts
@@ -19,7 +19,6 @@
 import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
-
 import { BSON, assert } from "../internal";
 
 /** @internal */

--- a/packages/realm/src/type-helpers/ObjectId.ts
+++ b/packages/realm/src/type-helpers/ObjectId.ts
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+import { BSON, assert } from "../internal";
+
+export function createObjectIdTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.instanceOf(value, BSON.ObjectId);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/String.ts
+++ b/packages/realm/src/type-helpers/String.ts
@@ -21,6 +21,7 @@ import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createStringTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/String.ts
+++ b/packages/realm/src/type-helpers/String.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert } from "../internal";
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createStringTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.string(value);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/Uuid.ts
+++ b/packages/realm/src/type-helpers/Uuid.ts
@@ -21,6 +21,7 @@ import { defaultFromBinding } from "./default";
 import { nullPassthrough } from "./null-passthrough";
 import { TypeHelpers, TypeOptions } from "./types";
 
+/** @internal */
 export function createUuidTypeHelpers({ optional }: TypeOptions): TypeHelpers {
   return {
     toBinding: nullPassthrough((value) => {

--- a/packages/realm/src/type-helpers/Uuid.ts
+++ b/packages/realm/src/type-helpers/Uuid.ts
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { BSON, assert } from "../internal";
+import { defaultFromBinding } from "./default";
+import { nullPassthrough } from "./null-passthrough";
+import { TypeHelpers, TypeOptions } from "./types";
+
+export function createUuidTypeHelpers({ optional }: TypeOptions): TypeHelpers {
+  return {
+    toBinding: nullPassthrough((value) => {
+      assert.instanceOf(value, BSON.UUID);
+      return value;
+    }, optional),
+    fromBinding: defaultFromBinding,
+  };
+}

--- a/packages/realm/src/type-helpers/array-buffer.ts
+++ b/packages/realm/src/type-helpers/array-buffer.ts
@@ -18,6 +18,7 @@
 
 import { assert, binding, safeGlobalThis } from "../internal";
 
+/** @internal */
 export const TYPED_ARRAY_CONSTRUCTORS = new Set(
   [
     DataView,
@@ -36,6 +37,7 @@ export const TYPED_ARRAY_CONSTRUCTORS = new Set(
   ].filter((ctor) => ctor !== undefined),
 );
 
+/** @internal */
 export function toArrayBuffer(value: unknown, stringToBase64 = true) {
   if (typeof value === "string" && stringToBase64) {
     return binding.Helpers.base64Decode(value);

--- a/packages/realm/src/type-helpers/array-buffer.ts
+++ b/packages/realm/src/type-helpers/array-buffer.ts
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { assert, binding, safeGlobalThis } from "../internal";
+
+export const TYPED_ARRAY_CONSTRUCTORS = new Set(
+  [
+    DataView,
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    // These will not be present on old versions of JSC without BigInt support.
+    safeGlobalThis.BigInt64Array,
+    safeGlobalThis.BigUint64Array,
+  ].filter((ctor) => ctor !== undefined),
+);
+
+export function toArrayBuffer(value: unknown, stringToBase64 = true) {
+  if (typeof value === "string" && stringToBase64) {
+    return binding.Helpers.base64Decode(value);
+  }
+  for (const TypedArray of TYPED_ARRAY_CONSTRUCTORS) {
+    if (value instanceof TypedArray) {
+      return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+    }
+  }
+  assert.instanceOf(value, ArrayBuffer);
+  return value;
+}

--- a/packages/realm/src/type-helpers/default.ts
+++ b/packages/realm/src/type-helpers/default.ts
@@ -18,10 +18,12 @@
 
 import type { binding } from "../internal";
 
+/** @internal */
 export function defaultToBinding(value: unknown): binding.MixedArg {
   return value as binding.MixedArg;
 }
 
+/** @internal */
 export function defaultFromBinding(value: unknown) {
   return value;
 }

--- a/packages/realm/src/type-helpers/default.ts
+++ b/packages/realm/src/type-helpers/default.ts
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import type { binding } from "../internal";
+
+export function defaultToBinding(value: unknown): binding.MixedArg {
+  return value as binding.MixedArg;
+}
+
+export function defaultFromBinding(value: unknown) {
+  return value;
+}

--- a/packages/realm/src/type-helpers/null-passthrough.ts
+++ b/packages/realm/src/type-helpers/null-passthrough.ts
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Adds a branch to a function, which checks for the argument to be null, in which case it returns early.
+ */
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Using `unknown` here breaks type inference in `binding.PropertyType.Object` `toBinding` from for some reason */
+export function nullPassthrough<T, R extends any[], F extends (value: unknown, ...rest: R) => unknown>(
+  this: T,
+  fn: F,
+  enabled: boolean,
+): F {
+  if (enabled) {
+    return ((value, ...rest) =>
+      typeof value === "undefined" || value === null ? null : fn.call(this, value, ...rest)) as F;
+  } else {
+    return fn;
+  }
+}

--- a/packages/realm/src/type-helpers/null-passthrough.ts
+++ b/packages/realm/src/type-helpers/null-passthrough.ts
@@ -18,6 +18,7 @@
 
 /**
  * Adds a branch to a function, which checks for the argument to be null, in which case it returns early.
+ * @internal
  */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Using `unknown` here breaks type inference in `binding.PropertyType.Object` `toBinding` from for some reason */
 export function nullPassthrough<T, R extends any[], F extends (value: unknown, ...rest: R) => unknown>(

--- a/packages/realm/src/type-helpers/types.ts
+++ b/packages/realm/src/type-helpers/types.ts
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import type { ClassHelpers, ObjCreator, PresentationPropertyTypeName, Realm, UpdateMode, binding } from "../internal";
+
+export type TypeHelpers<T = unknown> = {
+  toBinding(
+    value: T,
+    options?: { createObj?: ObjCreator; updateMode?: UpdateMode; isQueryArg?: boolean },
+  ): binding.MixedArg;
+  fromBinding(value: unknown): T;
+};
+
+/** @internal */
+export type TypeOptions = {
+  realm: Realm;
+  name: string;
+  optional: boolean;
+  objectType: string | undefined;
+  objectSchemaName: string | undefined;
+  presentation?: PresentationPropertyTypeName;
+  getClassHelpers(nameOrTableKey: string | binding.TableKey): ClassHelpers;
+};

--- a/packages/realm/src/type-helpers/types.ts
+++ b/packages/realm/src/type-helpers/types.ts
@@ -18,6 +18,7 @@
 
 import type { ClassHelpers, ObjCreator, PresentationPropertyTypeName, Realm, UpdateMode, binding } from "../internal";
 
+/** @internal */
 export type TypeHelpers<T = unknown> = {
   toBinding(
     value: T,


### PR DESCRIPTION
## What, How & Why?

This refactors the type and property helpers into multiple files.

I want to move away from the ["internal-pattern"](https://github.com/realm/realm-js/blob/8a0f7f1b36f01360d2cf1d9ce4210565423e0c12/packages/realm/src/internal.ts#L19-L22) to get rid of the circular reference warnings, which I somewhat started here and I'll have to do a separate (massive) PR later to complete that.

At some point, I think it'll also be nice to move some of the functions introduced in https://github.com/realm/realm-js/pull/6613 into type specific property helpers.