### PR TITLE
Update main package PR workflow to ignore unrelated packages

### DIFF
--- a/.github/workflows/pr-realm-js.yml
+++ b/.github/workflows/pr-realm-js.yml
@@ -8,6 +8,9 @@ on:
       - "**.md"
       - "**.png"
       - "packages/realm-web/**"
+      - "packages/realm-web-integration-tests/**"
+      - "packages/realm-react/**"
+      - "packages/realm-tools/**"
   pull_request:
     # Note that the workflow will still run if paths outside of `paths-ignore` have
     # been modified in the PR, irrespective of an individual commit only modifying
@@ -16,6 +19,9 @@ on:
       - "**.md"
       - "**.png"
       - "packages/realm-web/**"
+      - "packages/realm-web-integration-tests/**"
+      - "packages/realm-react/**"
+      - "packages/realm-tools/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What, How & Why?

I don't see a reason to run the main PR workflow when these packages receive updates.
