### PR TITLE
RJS-2204: Re-enabled client reset tests

### DIFF
--- a/integration-tests/tests/src/hooks/import-app-before.ts
+++ b/integration-tests/tests/src/hooks/import-app-before.ts
@@ -18,45 +18,18 @@
 
 import Realm, { AppConfiguration } from "realm";
 
-import { AppConfig, AppImporter, Credentials } from "@realm/app-importer";
+import { AppConfig } from "@realm/app-importer";
 import { mongodbServiceType } from "../utils/ExtendedAppConfigBuilder";
 import { printWarningBox } from "../utils/print-warning-box";
+import { baasAppImporter } from "../utils/baas-app-importer";
 
 const REALM_LOG_LEVELS = ["all", "trace", "debug", "detail", "info", "warn", "error", "fatal", "off"];
 
-const {
-  syncLogLevel = "warn",
-  baseUrl = "http://localhost:9090",
-  reuseApp = false,
-  username = "unique_user@domain.com",
-  password = "password",
-  publicKey,
-  privateKey,
-  missingServer,
-} = environment;
+const { syncLogLevel = "warn", baseUrl = "http://localhost:9090", missingServer } = environment;
 
 export { baseUrl };
 
 const allowSkippingServerTests = typeof environment.baseUrl === "undefined" && missingServer !== false;
-
-const credentials: Credentials =
-  typeof publicKey === "string" && typeof privateKey === "string"
-    ? {
-        kind: "api-key",
-        publicKey,
-        privateKey,
-      }
-    : {
-        kind: "username-password",
-        username,
-        password,
-      };
-
-const importer = new AppImporter({
-  baseUrl,
-  credentials,
-  reuseApp,
-});
 
 function isConnectionRefused(err: unknown) {
   return (
@@ -105,7 +78,7 @@ export function importAppBefore(
       throw new Error("Unexpected app on context, use only one importAppBefore per test");
     } else {
       try {
-        const { appId } = await importer.importApp(config);
+        const { appId } = await baasAppImporter.importApp(config);
         this.app = new Realm.App({ id: appId, baseUrl, ...sdkConfig });
       } catch (err) {
         if (isConnectionRefused(err) && allowSkippingServerTests) {

--- a/integration-tests/tests/src/utils/baas-admin-api.ts
+++ b/integration-tests/tests/src/utils/baas-admin-api.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2020 Realm Inc.
+// Copyright 2024 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,22 +16,27 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export type { Credentials } from "./AdminApiClient";
-export type { AppImporterOptions } from "./AppImporter";
-export type {
-  AppConfig,
-  AuthProviderConfig,
-  FunctionConfig,
-  ServiceConfig,
-  ServiceRule,
-  SyncConfig,
-  PartitionSyncConfig,
-  PartitionConfig,
-  FlexibleSyncConfig,
-  CustomTokenAuthMetadataField,
-  EmailPasswordAuthConfig,
-} from "./AppConfigBuilder";
+import { AdminApiClient, Credentials } from "@realm/app-importer";
 
-export { AdminApiClient } from "./AdminApiClient";
-export { AppImporter } from "./AppImporter";
-export { AppConfigBuilder } from "./AppConfigBuilder";
+const {
+  baseUrl = "http://localhost:9090",
+  username = "unique_user@domain.com",
+  password = "password",
+  publicKey,
+  privateKey,
+} = environment;
+
+export const credentials: Credentials =
+  typeof publicKey === "string" && typeof privateKey === "string"
+    ? {
+        kind: "api-key",
+        publicKey,
+        privateKey,
+      }
+    : {
+        kind: "username-password",
+        username,
+        password,
+      };
+
+export const baasAdminClient = new AdminApiClient({ baseUrl, credentials });

--- a/integration-tests/tests/src/utils/baas-app-importer.ts
+++ b/integration-tests/tests/src/utils/baas-app-importer.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2020 Realm Inc.
+// Copyright 2024 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,22 +16,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export type { Credentials } from "./AdminApiClient";
-export type { AppImporterOptions } from "./AppImporter";
-export type {
-  AppConfig,
-  AuthProviderConfig,
-  FunctionConfig,
-  ServiceConfig,
-  ServiceRule,
-  SyncConfig,
-  PartitionSyncConfig,
-  PartitionConfig,
-  FlexibleSyncConfig,
-  CustomTokenAuthMetadataField,
-  EmailPasswordAuthConfig,
-} from "./AppConfigBuilder";
+import { AppImporter } from "@realm/app-importer";
 
-export { AdminApiClient } from "./AdminApiClient";
-export { AppImporter } from "./AppImporter";
-export { AppConfigBuilder } from "./AppConfigBuilder";
+import { baasAdminClient } from "./baas-admin-api";
+
+const { reuseApp = false } = environment;
+
+export const baasAppImporter = new AppImporter({
+  client: baasAdminClient,
+  reuseApp,
+});

--- a/packages/realm-app-importer/src/AdminApiClient.ts
+++ b/packages/realm-app-importer/src/AdminApiClient.ts
@@ -348,6 +348,14 @@ export class AdminApiClient {
     });
   }
 
+  public async forceSyncReset(appId: string, fileIdent: number) {
+    await this.fetch({
+      route: ["groups", await this.groupId, "apps", appId, "sync", "force_reset"],
+      method: "PUT",
+      body: { file_ident: fileIdent },
+    });
+  }
+
   public async applyAllowedRequestOrigins(appId: string, origins: string[]) {
     await this.fetch({
       route: ["groups", await this.groupId, "apps", appId, "security", "allowed_request_origins"],

--- a/packages/realm-react/src/__tests__/helpers.ts
+++ b/packages/realm-react/src/__tests__/helpers.ts
@@ -19,7 +19,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { AppConfig, AppImporter, Credentials } from "@realm/app-importer";
+import { AdminApiClient, AppConfig, AppImporter, Credentials } from "@realm/app-importer";
 import { act, waitFor } from "@testing-library/react-native";
 
 const {
@@ -47,25 +47,22 @@ export async function testAuthOperation({
   });
 }
 
-function getCredentials(): Credentials {
-  if (typeof publicKey === "string" && typeof privateKey === "string") {
-    return {
-      kind: "api-key",
-      publicKey,
-      privateKey,
-    };
-  } else {
-    return {
-      kind: "username-password",
-      username,
-      password,
-    };
-  }
-}
-
 const importer = new AppImporter({
-  baseUrl,
-  credentials: getCredentials(),
+  client: new AdminApiClient({
+    baseUrl,
+    credentials:
+      typeof publicKey === "string" && typeof privateKey === "string"
+        ? {
+            kind: "api-key",
+            publicKey,
+            privateKey,
+          }
+        : {
+            kind: "username-password",
+            username,
+            password,
+          },
+  }),
 });
 
 export async function importApp(config: AppConfig): Promise<{ appId: string }> {

--- a/packages/realm-web-integration-tests/harness/import-realm-app.ts
+++ b/packages/realm-web-integration-tests/harness/import-realm-app.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { AppImporter, AppConfigBuilder } from "@realm/app-importer";
+import { AppImporter, AppConfigBuilder, AdminApiClient } from "@realm/app-importer";
 
 const {
   BAAS_BASE_URL = "http://localhost:9090",
@@ -33,12 +33,14 @@ export async function importRealmApp() {
     return { appId: BAAS_APP_ID, baseUrl };
   } else {
     const importer = new AppImporter({
-      baseUrl,
-      credentials: {
-        kind: "username-password",
-        username: BAAS_USERNAME,
-        password: BAAS_PASSWORD,
-      },
+      client: new AdminApiClient({
+        baseUrl,
+        credentials: {
+          kind: "username-password",
+          username: BAAS_USERNAME,
+          password: BAAS_PASSWORD,
+        },
+      }),
     });
     const builder = new AppConfigBuilder("my-test-app")
       .security({ allowed_request_origins: ["http://localhost:8080"] })


### PR DESCRIPTION
## What, How & Why?

Fixes https://github.com/realm/realm-js/issues/5500 by calling the admin API to perform client reset.
This also brings a refactor of the app importer to take the client as an argument, since we want to instantiate and call this outside of the context of importing apps.

Note: This should be rebased once https://github.com/realm/realm-js/pull/6733 merge.
