### PR TITLE
Correct usage of RealmProvider in README.md

### DIFF
--- a/packages/realm-react/README.md
+++ b/packages/realm-react/README.md
@@ -201,7 +201,7 @@ const AppWrapper = () => {
   return (
     <RealmProvider schema={[Item]}>
       <SomeComponent/>
-    <RealmProvider>
+    </RealmProvider>
   )
 }
 


### PR DESCRIPTION
The <RealmProvivider> needs to an closing tag.

## What, How & Why?
Current documentation is showing incorrect use of the RealmProvider.

