### PR TITLE
RJS-2846: Fix path configuration when using sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0). Note: if you have previously used a custom path configuration with your synced Realm, this fix can lead to a re-download of the data in the new Realm that will get opened in the specified path.
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0). Note: if you have been using a custom path configuration with your synced Realm, this fix will lead to a re-download of its data.
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm. ([#6753](https://github.com/realm/realm-js/pull/6753), since v12.8.0)
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0). Note: if you have been using a custom path configuration with your synced Realm, this fix will lead to a re-download of its data.
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0). Note: if you have been using a custom path configuration with your synced Realm, this fix will lead to a re-download of its data in the custom path.
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm.
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6753](https://github.com/realm/realm-js/pull/6753))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0)
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6754](https://github.com/realm/realm-js/issues/6754), since v12.8.0). Note: if you have previously used a custom path configuration with your synced Realm, this fix can lead to a re-download of the data in the new Realm that will get opened in the specified path.
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* `path` option in the Realm configuration not being set when using a synced Realm.
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * None
 
 ### Fixed
-* `path` option in the Realm configuration not being set when using a synced Realm. ([#6753](https://github.com/realm/realm-js/pull/6753))
+* `path` option in the Realm configuration not being set when using a synced Realm. ([#6753](https://github.com/realm/realm-js/pull/6753), since v12.8.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -411,7 +411,7 @@ describe("Flexible sync", function () {
             closeRealm(realm2);
           });
 
-          it("sets the correct path from the configuration", async function () {
+          it("sets custom path from the configuration", async function () {
             const realm = await Realm.open({
               path: "custom_path.realm",
               ...getSuccessConfig(this.user, {}),

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -411,6 +411,15 @@ describe("Flexible sync", function () {
             closeRealm(realm2);
           });
 
+          it("sets the correct path from the configuration", async function () {
+            const realm = await Realm.open({
+              path: "custom_path.realm.realm",
+              ...getSuccessConfig(this.user, {}),
+            });
+
+            expect(realm.path).to.contain("custom_path.realm");
+          });
+
           it("does not update the subscriptions on second open if rerunOnOpen is false", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, { rerunOnOpen: false }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");

--- a/integration-tests/tests/src/tests/sync/flexible.ts
+++ b/integration-tests/tests/src/tests/sync/flexible.ts
@@ -411,15 +411,6 @@ describe("Flexible sync", function () {
             closeRealm(realm2);
           });
 
-          it("sets custom path from the configuration", async function () {
-            const realm = await Realm.open({
-              path: "custom_path.realm",
-              ...getSuccessConfig(this.user, {}),
-            });
-
-            expect(realm.path).to.contain("custom_path.realm");
-          });
-
           it("does not update the subscriptions on second open if rerunOnOpen is false", async function (this: RealmContext) {
             const realm = await testSuccess(this.user, { rerunOnOpen: false }, false);
             if (!realm) throw new Error("Valid realm was not returned from testSuccess");

--- a/integration-tests/tests/src/tests/sync/realm.ts
+++ b/integration-tests/tests/src/tests/sync/realm.ts
@@ -2132,7 +2132,7 @@ describe("Realmtest", () => {
       expect(realm.path).equals(defaultDir + testPath);
       const path = realm.path;
       realm.close();
-      const pathExistAfterInitialization = fs.exists(path);
+      const pathExistAfterInitialization = await fs.exists(path);
       expect(pathExistAfterInitialization).to.be.true;
     });
 
@@ -2145,10 +2145,10 @@ describe("Realmtest", () => {
       const realm = new Realm(config);
       const path = realm.path;
       realm.close();
-      const pathExistBeforeDelete = fs.exists(path);
+      const pathExistBeforeDelete = await fs.exists(path);
       expect(pathExistBeforeDelete).to.be.true;
       Realm.deleteFile(config);
-      const pathExistAfterDelete = fs.exists(path);
+      const pathExistAfterDelete = await fs.exists(path);
       expect(pathExistAfterDelete).to.be.false;
     });
   });

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -385,7 +385,7 @@ export class Realm {
         return Realm.normalizePath(config.path);
       } else {
         const bindingSyncConfig = toBindingSyncConfig(config.sync);
-        return config.sync.user.internal.pathForRealm(bindingSyncConfig, undefined);
+        return config.sync.user.internal.pathForRealm(bindingSyncConfig, config.path);
       }
     } else {
       return Realm.normalizePath(config.path);


### PR DESCRIPTION
## What, How & Why?
A bug was introduced in 12.8.0 where a custom path was being ignored when using a sync configuration. This fixes it and introduces a new test to track it.

This closes https://github.com/realm/realm-js/issues/6754

## ☑️ ToDos
<!-- Add your own todos here -->
* [X] 📝 Changelog entry
* [X]~ 📝 `Compatibility` label is updated or copied from previous entry~
* [ ] ~📝 Update `COMPATIBILITY.md`~
* [X] 🚦 Tests
* [ ]~ 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)~
* [ ] ~📱 Check the React Native/other sample apps work if necessary~
* [ ] ~💥 `Breaking` label has been applied or is not necessary~
