### PR TITLE
RJS-2861: Deprecate AppConfiguration.app and add app instance to App Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Deprecations
 * The callback for `SyncSession.addProgressNotification` taking `transferred` and `transferable` arguments is deprecated and will be removed. See **Enhancements** below for the new callback supporting both Flexible Sync and Partition-Based Sync. ([#6743](https://github.com/realm/realm-js/pull/6743))
+* `AppConfiguration.app` is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used. ([#6785](https://github.com/realm/realm-js/issues/6785))
 
 ### Enhancements
 * Added progress notifications support for Flexible Sync using an `estimate` as the new callback argument. The `estimate` is roughly equivalent to an estimated value of `transferred / transferable` in the deprecated Partition-Based Sync callback. ([#6743](https://github.com/realm/realm-js/pull/6743))

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,13 +1,24 @@
 ## vNext (TBD)
 
-### Deprecations
-* None
-
 ### Enhancements
-* None
+* Added the ability to pass an existing `Realm.App` instance in `AppProvider` with the `app` prop. ([#6785](https://github.com/realm/realm-js/pull/6785))
+```jsx
+import { AppProvider } from "@realm/react";
+
+const app = new Realm.App(...);
+
+function MyApp() {
+  return (
+    <AppProvider app={app}> 
+      ...
+    </AppProvider>
+  );
+}
+```
 
 ### Fixed
 * Fixed listener that was not being removed during unmounting of `useObject` and `useQuery` if the listener was added in a write transaction. ([#6552](https://github.com/realm/realm-js/pull/6552)) Thanks [@bimusiek](https://github.com/bimusiek)!
+* The `app` prop in `AppProvider` meant for `LocalAppConfiguration` was not being used by Atlas Device Sync and has been removed. `app` is now only used to pass an existing `Realm.App` to the provider. ([#6785](https://github.com/realm/realm-js/pull/6785))
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
-* Added the ability to pass an existing `Realm.App` instance in `AppProvider` with the `app` prop. ([#6785](https://github.com/realm/realm-js/pull/6785))
+* Added the ability to pass an existing `Realm.App` instance in `AppProvider` with the `app` prop. ([#6785](https://github.com/realm/realm-js/issues/6785))
 ```jsx
 import { AppProvider } from "@realm/react";
 

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -103,7 +103,7 @@ export function AppProvider({ children, app, ...appWithConfigurationProps }: Dyn
       throw new Error("Cannot use configuration props when using an existing App instance.");
     }
     return <AppProviderWithApp app={app}>{children}</AppProviderWithApp>;
-  } else if (app != null) {
+  } else if (typeof app === "object") {
     throw new Error(
       `The "app" prop is used to use an existing Realm.App instance with an AppProvider. Either remove it or pass a valid Realm.App.`,
     );
@@ -127,9 +127,9 @@ function AppProviderWithApp({ app, children }: React.PropsWithChildren<AppProvid
 function AppProviderWithConfiguration({
   appRef,
   children,
-  ...configurationProps
+  ...config
 }: React.PropsWithChildren<AppProviderWithConfigurationProps>) {
-  const configuration = useRef<Realm.AppConfiguration>(configurationProps);
+  const configRef = useRef<Realm.AppConfiguration>(config);
 
   const [app, setApp] = useState<Realm.App>(() => new Realm.App(configuration.current));
 

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -104,7 +104,7 @@ export function AppProvider({
 }: DynamicAppProviderProps): React.ReactNode {
   if (appInstance != null) {
     if (Object.keys(appWithConfigurationProps).length > 0) {
-      throw new Error("Cannot use configuration props when using an existing App.");
+      throw new Error("Cannot use configuration props when using an existing App instance.");
     }
 
     return <AppProviderWithApp appInstance={appInstance}>{children}</AppProviderWithApp>;

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -104,20 +104,20 @@ export function AppProvider(props: DynamicAppProviderWithConfigurationProps): Re
  * @param app - The {@link Realm.App} for the provider.
  */
 export function AppProvider(props: DynamicAppProviderWithAppProps): React.ReactNode;
-export function AppProvider({ children, app, ...appWithConfigurationProps }: DynamicAppProviderProps): React.ReactNode {
+export function AppProvider({ children, app, ...config }: DynamicAppProviderProps): React.ReactNode {
   if (app instanceof App) {
-    if (Object.keys(appWithConfigurationProps).length > 0) {
+    if (Object.keys(config).length > 0) {
       throw new Error("Cannot use configuration props when using an existing App instance.");
     }
     return <AppProviderWithApp app={app}>{children}</AppProviderWithApp>;
-  } else if (typeof app === "object") {
+  } else if (typeof app !== "undefined") {
     throw new Error(
-      `The "app" prop is used to use an existing Realm.App instance with an AppProvider. Either remove it or pass a valid Realm.App.`,
+      `The "app" prop is used to pass an existing Realm.App instance into an AppProvider. Either remove it or pass a valid Realm.App.`,
     );
   }
 
   return (
-    <AppProviderWithConfiguration {...(appWithConfigurationProps as AppProviderWithConfigurationProps)}>
+    <AppProviderWithConfiguration {...(config as AppProviderWithConfigurationProps)}>
       {children}
     </AppProviderWithConfiguration>
   );

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -78,9 +78,8 @@ type DynamicAppProviderWithConfigurationProps = RestrictivePick<
 >;
 
 /**
- * Props for the AppProvider component. You can either pass an existing app through the `app` prop
- * or props that replicate the configuration that is used to create a Realm.App instance:
- * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
+ * Props for the AppProvider component. You can either pass an existing {@link Realm.App} through the `app` prop
+ * or props that replicate the {@link Realm.AppConfiguration} that is used to create a Realm.App instance.
  */
 type DynamicAppProviderProps = DynamicAppProviderWithAppProps | DynamicAppProviderWithConfigurationProps;
 
@@ -94,7 +93,7 @@ export function AppProvider(props: DynamicAppProviderProps): React.ReactNode;
 /**
  * React component providing a Realm App instance on the context for the
  * sync hooks to use. An `AppProvider` is required for an app to use the hooks.
- * @param appProps - The {@link Realm.AppConfiguration} for App Services, passed as props.
+ * @param props - The {@link Realm.AppConfiguration} for App Services, passed as props.
  * @param appRef - A ref to the app instance, which can be used to access the app instance outside of the React component tree.
  */
 export function AppProvider(props: DynamicAppProviderWithConfigurationProps): React.ReactNode;

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -71,8 +71,8 @@ type DynamicAppProviderWithConfigurationProps = RestrictivePick<
 >;
 
 /**
- * Props for the AppProvider component. These replicate the options which
- * can be used to create a Realm.App instance:
+ * Props for the AppProvider component. You can either pass an existing app through the `appInstance` prop
+ * or props that replicate the configuration that is used to create a Realm.App instance:
  * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
  */
 type DynamicAppProviderProps = DynamicAppProviderWithAppProps | DynamicAppProviderWithConfigurationProps;

--- a/packages/realm-react/src/AppProvider.tsx
+++ b/packages/realm-react/src/AppProvider.tsx
@@ -49,6 +49,7 @@ const AuthOperationProvider: React.FC<AuthOperationProps> = ({ children }) => {
   );
 };
 
+/** Mutually exclusive props for the AppProvider component when using a {@link Realm.AppConfiguration} */
 type AppProviderWithConfigurationProps = Omit<Realm.AppConfiguration, "app"> & {
   /**
    * A ref to the App instance. This is useful if you need to access the App
@@ -58,20 +59,26 @@ type AppProviderWithConfigurationProps = Omit<Realm.AppConfiguration, "app"> & {
   children: React.ReactNode;
 };
 
+/** Props the AppProvider component when using an existing {@link Realm.App} instance */
 type AppProviderWithAppProps = {
   app: Realm.App;
   children: React.ReactNode;
 };
 
+/** Combined props for the AppProvider component, used when defining mutually exclusive props */
 type AppProviderProps = AppProviderWithAppProps & AppProviderWithConfigurationProps;
+
+/** Mutually exclusive props for the AppProvider component when using an existing {@link Realm.App} instance */
 type DynamicAppProviderWithAppProps = RestrictivePick<AppProviderProps, keyof AppProviderWithAppProps>;
+
+/** Mutually exclusive props for the AppProvider component when using a {@link Realm.AppConfiguration} */
 type DynamicAppProviderWithConfigurationProps = RestrictivePick<
   AppProviderProps,
   keyof AppProviderWithConfigurationProps
 >;
 
 /**
- * Props for the AppProvider component. You can either pass an existing app through the `appInstance` prop
+ * Props for the AppProvider component. You can either pass an existing app through the `app` prop
  * or props that replicate the configuration that is used to create a Realm.App instance:
  * https://www.mongodb.com/docs/realm-sdks/js/latest/Realm.App.html#~AppConfiguration
  */
@@ -94,7 +101,7 @@ export function AppProvider(props: DynamicAppProviderWithConfigurationProps): Re
 /**
  * React component providing a Realm App instance on the context for the
  * sync hooks to use. An `AppProvider` is required for an app to use the hooks.
- * @param appInstance - The {@link Realm.App} for the provider.
+ * @param app - The {@link Realm.App} for the provider.
  */
 export function AppProvider(props: DynamicAppProviderWithAppProps): React.ReactNode;
 export function AppProvider({ children, app, ...appWithConfigurationProps }: DynamicAppProviderProps): React.ReactNode {
@@ -131,14 +138,14 @@ function AppProviderWithConfiguration({
 }: React.PropsWithChildren<AppProviderWithConfigurationProps>) {
   const configRef = useRef<Realm.AppConfiguration>(config);
 
-  const [app, setApp] = useState<Realm.App>(() => new Realm.App(configuration.current));
+  const [app, setApp] = useState<Realm.App>(() => new Realm.App(configRef.current));
 
   // Support for a possible change in configuration
-  if (!isEqual(configurationProps, configuration.current)) {
-    configuration.current = configurationProps as Realm.AppConfiguration;
+  if (!isEqual(config, configRef.current)) {
+    configRef.current = config as Realm.AppConfiguration;
 
     try {
-      setApp(new Realm.App(configuration.current));
+      setApp(new Realm.App(configRef.current));
     } catch (err) {
       console.error(err);
     }

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -78,7 +78,7 @@ export type DynamicRealmProviderWithRealmProps = RestrictivePick<RealmProviderPr
 /**
  * Represents properties of a {@link DynamicRealmProvider} where Realm configuration props are set and Realm instance props are disallowed.
  */
-export type DynamicsRealmProviderWithConfigurationProps = RestrictivePick<
+export type DynamicRealmProviderWithConfigurationProps = RestrictivePick<
   RealmProviderProps,
   keyof RealmProviderConfigurationProps
 >;
@@ -88,7 +88,7 @@ export type DynamicsRealmProviderWithConfigurationProps = RestrictivePick<
  * Supports either {@link RealmProviderRealmProps} or {@link RealmProviderConfigurationProps}.
  */
 export type DynamicRealmProvider = React.FC<
-  DynamicRealmProviderWithRealmProps | DynamicsRealmProviderWithConfigurationProps
+  DynamicRealmProviderWithRealmProps | DynamicRealmProviderWithConfigurationProps
 >;
 
 export function createRealmProviderFromRealm(

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -119,7 +119,7 @@ describe("AppProvider", () => {
     it("handle passing an app and changing it", async () => {
       const appInstanceId = "appInstanceId";
       const differentAppInstanceId = "differentAppInstanceId";
-      const appInstance = new Realm.App({
+      const app = new Realm.App({
         id: appInstanceId,
       });
 
@@ -129,7 +129,7 @@ describe("AppProvider", () => {
       };
 
       const App = () => {
-        const [currentApp, setCurrentApp] = useState(appInstance);
+        const [currentApp, setCurrentApp] = useState(app);
         return (
           <>
             <View testID="firstRealmProvider">

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -163,4 +163,15 @@ describe("AppProvider", () => {
       expect(newSchemaNameContainer).toHaveTextContent(differentAppInstanceId);
     });
   });
+
+  it("throws an error when both appInstance and configuration props are provided", () => {
+    expect(() =>
+      render(
+        // @ts-expect-error The appInstance and configuration props should be mutually exclusive
+        <AppProvider appInstance={new Realm.App({ id: "asas" })} id="3">
+          ...
+        </AppProvider>,
+      ),
+    ).toThrow("Cannot use configuration props when using an existing App instance.");
+  });
 });

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -21,6 +21,7 @@ import { Button, Text, View } from "react-native";
 import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/react-native";
 
 import { AppProvider, useApp } from "../AppProvider";
+import { Realm } from "realm";
 
 jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper");
 
@@ -42,72 +43,124 @@ describe("AppProvider", () => {
     );
   });
 
-  it("handle state changes to its configuration", async () => {
-    const AppComponent = () => {
-      const app = useApp();
-      return <Text testID="appId">{app.id}</Text>;
-    };
-    const App = () => {
-      const [id, setId] = useState("someId");
-      return (
-        <>
-          <View testID="firstRealmProvider">
-            <AppProvider id={id}>
-              <AppComponent />
-            </AppProvider>
-          </View>
-          <Button testID="changeId" title="change app id" onPress={() => setId("newId")} />
-        </>
-      );
-    };
-    const { getByTestId } = render(<App />);
-    const schemaNameContainer = await waitFor(() => getByTestId("appId"));
-    const changeSchemaButton = getByTestId("changeId");
+  describe("with an App Configuration", function () {
+    it("handle state changes to its configuration", async () => {
+      const AppComponent = () => {
+        const app = useApp();
+        return <Text testID="appId">{app.id}</Text>;
+      };
+      const App = () => {
+        const [id, setId] = useState("someId");
+        return (
+          <>
+            <View testID="firstRealmProvider">
+              <AppProvider id={id}>
+                <AppComponent />
+              </AppProvider>
+            </View>
+            <Button testID="changeId" title="change app id" onPress={() => setId("newId")} />
+          </>
+        );
+      };
+      const { getByTestId } = render(<App />);
+      const schemaNameContainer = await waitFor(() => getByTestId("appId"));
+      const changeSchemaButton = getByTestId("changeId");
 
-    expect(schemaNameContainer).toHaveTextContent("someId");
+      expect(schemaNameContainer).toHaveTextContent("someId");
 
-    await act(async () => {
-      fireEvent.press(changeSchemaButton);
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await act(async () => {
+        fireEvent.press(changeSchemaButton);
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Changing the realm provider configuration will cause a remount
+      // of the child component.  Therefore it must be retrieved again
+      const newSchemaNameContainer = getByTestId("appId");
+
+      expect(newSchemaNameContainer).toHaveTextContent("newId");
     });
 
-    // Changing the realm provider configuration will cause a remount
-    // of the child component.  Therefore it must be retrieved again
-    const newSchemaNameContainer = getByTestId("appId");
+    it("can access realm through realmRef as a forwarded ref", async () => {
+      const AppComponent = () => {
+        const app = useApp();
+        return <Text testID="appId">{app.id}</Text>;
+      };
+      const App = () => {
+        const [id, setId] = useState("");
+        const appRef = useRef<Realm.App | null>(null);
+        return (
+          <>
+            <View testID="firstRealmProvider">
+              <AppProvider id={"testId"} appRef={appRef}>
+                <AppComponent />
+              </AppProvider>
+            </View>
+            <Button testID="toggleAppRef" title="toggle app ref" onPress={() => setId(appRef?.current?.id ?? "")} />
+            {appRef.current && <Text testID="appIdText">{id}</Text>}
+          </>
+        );
+      };
+      const { getByTestId } = render(<App />);
+      const toggleAppRef = getByTestId("toggleAppRef");
 
-    expect(newSchemaNameContainer).toHaveTextContent("newId");
+      // Wait a tick for the app reference to be set by the provider.  Then force a rerender.
+      await act(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        fireEvent.press(toggleAppRef);
+      });
+
+      const appIdText = await waitFor(() => getByTestId("appIdText"));
+
+      expect(appIdText).toHaveTextContent("testId");
+    });
   });
-  it("can access realm through realmRef as a forwarded ref", async () => {
-    const AppComponent = () => {
-      const app = useApp();
-      return <Text testID="appId">{app.id}</Text>;
-    };
-    const App = () => {
-      const [id, setId] = useState("");
-      const appRef = useRef<Realm.App | null>(null);
-      return (
-        <>
-          <View testID="firstRealmProvider">
-            <AppProvider id={"testId"} appRef={appRef}>
-              <AppComponent />
-            </AppProvider>
-          </View>
-          <Button testID="toggleAppRef" title="toggle app ref" onPress={() => setId(appRef?.current?.id ?? "")} />
-          {appRef.current && <Text testID="appIdText">{id}</Text>}
-        </>
-      );
-    };
-    const { getByTestId } = render(<App />);
-    const toggleAppRef = getByTestId("toggleAppRef");
 
-    // Wait a tick for the app reference to be set by the provider.  Then force a rerender.
-    await act(async () => {
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      fireEvent.press(toggleAppRef);
+  describe("with an App instance", function () {
+    it("handle passing an app and changing it", async () => {
+      const appInstanceId = "appInstanceId";
+      const differentAppInstanceId = "differentAppInstanceId";
+      const appInstance = new Realm.App({
+        id: appInstanceId,
+      });
+
+      const AppComponent = () => {
+        const app = useApp();
+        return <Text testID="appId">{app.id}</Text>;
+      };
+
+      const App = () => {
+        const [currentApp, setCurrentApp] = useState(appInstance);
+        return (
+          <>
+            <View testID="firstRealmProvider">
+              <AppProvider appInstance={currentApp}>
+                <AppComponent />
+              </AppProvider>
+            </View>
+            <Button
+              testID="changeId"
+              title="change app id"
+              onPress={() => setCurrentApp(new Realm.App({ id: differentAppInstanceId }))}
+            />
+          </>
+        );
+      };
+      const { getByTestId } = render(<App />);
+      const schemaNameContainer = await waitFor(() => getByTestId("appId"));
+      const changeSchemaButton = getByTestId("changeId");
+
+      expect(schemaNameContainer).toHaveTextContent(appInstanceId);
+
+      await act(async () => {
+        fireEvent.press(changeSchemaButton);
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Changing the realm provider configuration will cause a remount
+      // of the child component.  Therefore it must be retrieved again
+      const newSchemaNameContainer = getByTestId("appId");
+
+      expect(newSchemaNameContainer).toHaveTextContent(differentAppInstanceId);
     });
-
-    const appIdText = await waitFor(() => getByTestId("appIdText"));
-
-    expect(appIdText).toHaveTextContent("testId");
   });
 });

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -171,7 +171,7 @@ describe("AppProvider", () => {
         <AppProvider app={{ name: "test", version: "3" }}>...</AppProvider>,
       ),
     ).toThrow(
-      `The "app" prop is used to use an existing Realm.App instance with an AppProvider. Either remove it or pass a valid Realm.App.`,
+      `The "app" prop is used to pass an existing Realm.App instance into an AppProvider. Either remove it or pass a valid Realm.App.`,
     );
   });
 

--- a/packages/realm-react/src/__tests__/AppProvider.test.tsx
+++ b/packages/realm-react/src/__tests__/AppProvider.test.tsx
@@ -28,7 +28,7 @@ jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper");
 describe("AppProvider", () => {
   it("returns the configured app with useApp", async () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AppProvider id="someId" app={{ name: "someName", version: "42" }} baseUrl="http://someurl">
+      <AppProvider id="someId" baseUrl="http://someurl">
         {children}
       </AppProvider>
     );
@@ -133,7 +133,7 @@ describe("AppProvider", () => {
         return (
           <>
             <View testID="firstRealmProvider">
-              <AppProvider appInstance={currentApp}>
+              <AppProvider app={currentApp}>
                 <AppComponent />
               </AppProvider>
             </View>
@@ -164,11 +164,22 @@ describe("AppProvider", () => {
     });
   });
 
-  it("throws an error when both appInstance and configuration props are provided", () => {
+  it("throws an error if the app is not a Realm.App", () => {
     expect(() =>
       render(
-        // @ts-expect-error The appInstance and configuration props should be mutually exclusive
-        <AppProvider appInstance={new Realm.App({ id: "asas" })} id="3">
+        // @ts-expect-error The app prop type should be Realm.App
+        <AppProvider app={{ name: "test", version: "3" }}>...</AppProvider>,
+      ),
+    ).toThrow(
+      `The "app" prop is used to use an existing Realm.App instance with an AppProvider. Either remove it or pass a valid Realm.App.`,
+    );
+  });
+
+  it("throws an error when both app and configuration props are provided", () => {
+    expect(() =>
+      render(
+        // @ts-expect-error The app and configuration props should be mutually exclusive
+        <AppProvider app={new Realm.App({ id: "test" })} id="invalid">
           ...
         </AppProvider>,
       ),

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -119,7 +119,7 @@ export type AppConfiguration = {
   baseUrl?: string;
 
   /**
-   * @deprecated LocalAppConfiguration is no longer used by Atlas Device Sync. It will be removed from in future SDK releases.
+   * @deprecated No longer used by Atlas Device Sync. It will be removed from in future SDK releases.
    * This describes the local app, sent to the server when a user authenticates.
    * Specifying this will enable the server to respond differently to specific versions of specific apps.
    * @since v10.0.0
@@ -158,7 +158,7 @@ export type AppConfiguration = {
 };
 
 /**
- * @deprecated LocalAppConfiguration is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.
+ * @deprecated No longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.
  * This describes the local app, sent to the server when a user authenticates.
  */
 export type LocalAppConfiguration = {

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -119,6 +119,7 @@ export type AppConfiguration = {
   baseUrl?: string;
 
   /**
+   * @deprecated LocalAppConfiguration is no longer used by Atlas Device Sync. It will be removed from in future SDK releases.
    * This describes the local app, sent to the server when a user authenticates.
    * Specifying this will enable the server to respond differently to specific versions of specific apps.
    * @since v10.0.0
@@ -157,6 +158,7 @@ export type AppConfiguration = {
 };
 
 /**
+ * @deprecated LocalAppConfiguration is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.
  * This describes the local app, sent to the server when a user authenticates.
  */
 export type LocalAppConfiguration = {
@@ -267,7 +269,7 @@ export class App<
   constructor(configOrId: AppConfiguration | string) {
     const config: AppConfiguration = typeof configOrId === "string" ? { id: configOrId } : configOrId;
     assert.object(config, "config");
-    const { id, baseUrl, timeout, multiplexSessions = true, baseFilePath, metadata, fetch } = config;
+    const { id, baseUrl, timeout, multiplexSessions = true, baseFilePath, metadata, fetch, app } = config;
     assert.string(id, "id");
     if (timeout !== undefined) {
       assert.number(timeout, "timeout");
@@ -284,6 +286,15 @@ export class App<
     }
     if (fetch !== undefined) {
       assert.function(fetch, "fetch");
+    }
+
+    // TODO: Delete this warning once the app field has been removed from the SDK.
+    if (app !== undefined) {
+      internal.defaultLogger({
+        category: "Realm.App",
+        level: "warn",
+        message: `The "app" field in the App.Configuration is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.`,
+      });
     }
 
     fs.ensureDirectoryForFile(fs.joinPaths(baseFilePath || fs.getDefaultDirectoryPath(), "mongodb-realm"));

--- a/packages/realm/src/app-services/App.ts
+++ b/packages/realm/src/app-services/App.ts
@@ -290,11 +290,10 @@ export class App<
 
     // TODO: Delete this warning once the app field has been removed from the SDK.
     if (app !== undefined) {
-      internal.defaultLogger({
-        category: "Realm.App",
-        level: "warn",
-        message: `The "app" field in the App.Configuration is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.`,
-      });
+      // eslint-disable-next-line no-console
+      console.warn(
+        `The "app" field in the App.Configuration is no longer used by Atlas Device Sync. It will be removed in future SDK releases and should not be used.`,
+      );
     }
 
     fs.ensureDirectoryForFile(fs.joinPaths(baseFilePath || fs.getDefaultDirectoryPath(), "mongodb-realm"));


### PR DESCRIPTION
@realm/devdocs 
## What, How & Why?
Allow the client to use an existing `Realm.App` in `@realm/react`. Helps support usecases like #6233 better.

This closes https://github.com/realm/realm-js/issues/6785

## ☑️ ToDos
<!-- Add your own todos here -->
* [X] 📝 Changelog entry
* [X] 📝 `Compatibility` label is updated or copied from previous entry
* [X] 📝 Update `COMPATIBILITY.md`
* [X] 🚦 Tests
* [X] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [X] 📱 Check the React Native/other sample apps work if necessary
* [X] 💥 `Breaking` label has been applied or is not necessary
* [X] 🔔 Mention `@realm/devdocs` if documentation changes are needed
