### PR TITLE
RJS-2870: Remove an unused header from the iOS and unused import from Android binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fixed compiler error when building binding for React Native iOS: "'React-featureflags/react/featureflags/ReactNativeFeatureFlags.h' file not found" ([#6808](https://github.com/realm/realm-js/issues/6808), since v12.12.0)
 
 ### Compatibility
 * React Native >= v0.71.4
@@ -16,9 +15,7 @@
 * File format: generates Realms with format v24 (reads and upgrades file format v10).
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Removed an unused import in the binding for React Native Android. ([#6808](https://github.com/realm/realm-js/issues/6808), since v12.12.0)
 
 ## 12.12.0 (2024-07-23)
 

--- a/packages/realm/binding/android/src/main/java/io/realm/react/RealmReactModule.java
+++ b/packages/realm/binding/android/src/main/java/io/realm/react/RealmReactModule.java
@@ -24,7 +24,6 @@ import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.soloader.SoLoader;

--- a/packages/realm/binding/apple/RealmReactModule.mm
+++ b/packages/realm/binding/apple/RealmReactModule.mm
@@ -21,7 +21,6 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTInvalidating.h>
 #import <ReactCommon/CallInvoker.h>
-#import <React-featureflags/react/featureflags/ReactNativeFeatureFlags.h>
 #import <jsi/jsi.h>
 
 #import <arpa/inet.h>


### PR DESCRIPTION
## What, How & Why?

This closes #6808 by removing an import which is no longer used.
The fix was verified by the original creator of the issue here: https://github.com/realm/realm-js/issues/6808#issuecomment-2248096323

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests (by the original reporter)
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
* [x] 🔔 Mention `@realm/devdocs` if documentation changes are needed
