### PR TITLE
Update expo instructions

### DIFF
--- a/packages/realm/README.md
+++ b/packages/realm/README.md
@@ -134,7 +134,7 @@ If you are using Expo, a common pitfall is not installing the `expo-dev-client` 
 
 - install the `expo-dev-client`:
   ```
-  npm install expo-dev-client
+  npx expo install expo-dev-client
   ```
 - build the dev client for iOS
   ```

--- a/packages/realm/src/platform/react-native/expo-go-detection.ts
+++ b/packages/realm/src/platform/react-native/expo-go-detection.ts
@@ -31,7 +31,7 @@ export class RealmInExpoGoError extends Error {
   constructor() {
     const runCommand = `npx expo run:${Platform.OS}`;
     super(
-      `'realm' was imported from the Expo Go app, but unfortunately Expo Go doesn't contain the native module for the 'realm' package - consider using an Expo development build instead:\n\nnpm install expo-dev-client\n${runCommand}\n\nRead more: https://docs.expo.dev/develop/development-builds/introduction/`,
+      `'realm' was imported from the Expo Go app, but unfortunately Expo Go doesn't contain the native module for the 'realm' package - consider using an Expo development build instead:\n\nnpx expo install expo-dev-client\n${runCommand}\n\nRead more: https://docs.expo.dev/develop/development-builds/introduction/`,
     );
   }
 }

--- a/packages/realm/src/platform/react-native/expo-go-detection.ts
+++ b/packages/realm/src/platform/react-native/expo-go-detection.ts
@@ -31,7 +31,7 @@ export class RealmInExpoGoError extends Error {
   constructor() {
     const runCommand = `npx expo run:${Platform.OS}`;
     super(
-      `'realm' was imported from the Expo Go app, but unfortunately Expo Go doesn't contain the native module for the 'realm' package - consider using an Expo development build instead:\n\nnpx expo install expo-dev-client\n${runCommand}\n\nRead more: https://docs.expo.dev/develop/development-builds/introduction/`,
+      `Expo Go does not contain the native module for the 'realm' package. To use native modules outside of what is packaged in Expo Go, create a development build:\n\nnpx expo install expo-dev-client\n${runCommand}\n\nRead more: https://docs.expo.dev/develop/development-builds/introduction/`,
     );
   }
 }


### PR DESCRIPTION
## What, How & Why?

### 1. use `npx expo install` instead of `npm install`
`npx expo install` will use your configured package manager, `npm install` will use `npm` so won't work if you're using a different package manager

### 2. update expo go instructions
The instructions said "consider using development build" which implies there are other ways to get it to work within Expo Go, which isn't the case. This adds a small tweak to make it clearer what to do next.

