### PR TITLE
Throwing `RealmInExpoGoError` only when native module fails to load

### DIFF
--- a/packages/realm/src/platform/react-native/binding.ts
+++ b/packages/realm/src/platform/react-native/binding.ts
@@ -21,6 +21,7 @@ declare const global: Record<string, unknown>;
 import { NativeModules } from "react-native";
 import { NativeBigInt, PolyfilledBigInt, type binding, injectNativeModule } from "../binding";
 import { assert } from "../../assert";
+import { RealmInExpoGoError, isExpoGo } from "./expo-go-detection";
 
 try {
   const RealmNativeModule = NativeModules.Realm;
@@ -46,7 +47,11 @@ try {
     },
   });
 } catch (err) {
-  throw new Error(
-    "Could not find the Realm binary. Please consult our troubleshooting guide: https://www.mongodb.com/docs/realm-sdks/js/latest/#md:troubleshooting-missing-binary",
-  );
+  if (isExpoGo()) {
+    throw new RealmInExpoGoError();
+  } else {
+    throw new Error(
+      "Could not find the Realm binary. Please consult our troubleshooting guide: https://www.mongodb.com/docs/realm-sdks/js/latest/#md:troubleshooting-missing-binary",
+    );
+  }
 }

--- a/packages/realm/src/platform/react-native/expo-go-detection.ts
+++ b/packages/realm/src/platform/react-native/expo-go-detection.ts
@@ -35,7 +35,3 @@ export class RealmInExpoGoError extends Error {
     );
   }
 }
-
-if (isExpoGo()) {
-  throw new RealmInExpoGoError();
-}


### PR DESCRIPTION
## What, How & Why?

Debugging an app I found that it seems Expo / Metro is running the code in conditions that trigger the `RealmInExpoGoError` exception. I suggest moving the ExpoGo check from a top-level into the `catch` block when loading the native module actually fails.
