### PR TITLE
RJS-2887: Avoid recreating Provider in createDynamicRealmProvider

### DIFF
--- a/packages/realm-react/CHANGELOG.md
+++ b/packages/realm-react/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fixing the `RealmProvider` component when context is created without passing neither a `Realm` instance nor a `Realm.Configuration` to avoid unnecessary recreation of the provider, which was causing "Cannot access realm that has been closed" errors. ([#6842](https://github.com/realm/realm-js/issues/6842), since v0.8.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm-react/src/RealmProvider.tsx
+++ b/packages/realm-react/src/RealmProvider.tsx
@@ -208,17 +208,15 @@ export function createRealmProviderFromConfig(
  * @returns a RealmProvider component that provides context to all context hooks
  */
 export function createDynamicRealmProvider(RealmContext: React.Context<Realm | null>): DynamicRealmProvider {
-  return ({ realm, children, ...configurationProps }) => {
+  const RealmProviderFromConfig = createRealmProviderFromConfig({}, RealmContext);
+  return ({ realm, children, ...config }) => {
     if (realm) {
-      if (Object.keys(configurationProps).length > 0) {
+      if (Object.keys(config).length > 0) {
         throw new Error("Cannot use configuration props when using an existing Realm instance.");
       }
-
-      const RealmProvider = createRealmProviderFromRealm(realm, RealmContext);
-      return <RealmProvider>{children}</RealmProvider>;
+      return <RealmContext.Provider value={realm} children={children} />;
     } else {
-      const RealmProvider = createRealmProviderFromConfig({}, RealmContext);
-      return <RealmProvider {...configurationProps}>{children}</RealmProvider>;
+      return <RealmProviderFromConfig {...config} children={children} />;
     }
   };
 }


### PR DESCRIPTION
## What, How & Why?

This closes #6842 by moving the creation of the `RealmProviderFromConfig` out of the `DynamicRealmProvider` component.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [x] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
* [x] 🔔 Mention `@realm/devdocs` if documentation changes are needed
