### PR TITLE
Update device sdks deprecation link

### DIFF
--- a/packages/realm/README.md
+++ b/packages/realm/README.md
@@ -1,6 +1,6 @@
 > [!WARNING]
 > We announced the deprecation of Atlas Device Sync + Realm SDKs in September 2024. For more information please see:
-> - [SDK Deprecation](https://www.mongodb.com/docs/atlas/device-sdks/device-sdk-deprecation)
+> - [SDK Deprecation](https://www.mongodb.com/docs/atlas/device-sdks/deprecation)
 > - [Device Sync Deprecation](https://www.mongodb.com/docs/atlas/app-services/sync/device-sync-deprecation)
 >
 > For a version of RealmJS without sync features, install from [community on npm](https://www.npmjs.com/package/realm/v/community) or see the `community` git branch.


### PR DESCRIPTION
Current link to SDK Deprecation is broken.