### PR TITLE
fix: cannot read property size of undefined (#6626)

### DIFF
--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -93,7 +93,7 @@ export class Results<T = unknown> extends OrderedCollection<
   }
 
   get length(): number {
-    return this.internal.size();
+    return this.internal?.size();
   }
 
   set length(value: number) {


### PR DESCRIPTION
## What, How & Why?

I fixed the TypeError: Cannot read property 'size' of undefined, which occurred due to attempting to access the size property of an undefined object. I added a check to ensure the object exists before accessing its properties to prevent this error.

This closes #6626

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
