### PR TITLE
RJS-2916: Exclude `libreactnative.so` to prevent duplicate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fix build failure from duplicate libreactnative.so files. I.e. "2 files found with path 'lib/arm64-v8a/libreactnative.so' from inputs" ([#6918](https://github.com/realm/realm-js/issues/6918), since v12.13.2)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/packages/realm/binding/android/build.gradle
+++ b/packages/realm/binding/android/build.gradle
@@ -103,6 +103,7 @@ android {
                 "**/libjsi.so",
                 "**/libreactnativejni.so",
                 "**/libturbomodulejsijni.so",
+                "**/libreactnative.so",
         ]
     }
 }


### PR DESCRIPTION
## What, How & Why?

This closes #6918 by excluding the `libreactnative.so` from our package.
I suspect the issue wasn't caught during the release of v12.13.2 as the other file is provided by a Gradle cache which isn't hot on CI.

## ☑️ ToDos
* [x] 📝 Changelog entry
* [x] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
