### PR TITLE
Add option to exclude Realm file from iCloud backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 * None
 
 ### Enhancements
-* Added option to exclude realm files from iCloud backup ([#4139](https://github.com/realm/realm-js/issues/4139))
+* Added `excludeFromIcloudBackup` option to the `Realm` constructor to exclude the realm files from iCloud backup. ([#4139](https://github.com/realm/realm-js/issues/4139))
+```typescript
+const realm = new Realm({
+  schema: [
+    /* your schema */
+  ],
+  // Set to true to exclude from iCloud backup, false to include, defaults to false
+  excludeFromIcloudBackup: true,
+});
+```
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* None
+* Added option to exclude realm files from iCloud backup ([#4139](https://github.com/realm/realm-js/issues/4139))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -384,9 +384,8 @@ export NVM_DIR="$HOME/.nvm"
 
 ## Testing against real apps
 
-There are a couple of suggested workflows for testing your changes to Realm JS against real apps:
+Here's the suggested workflow for testing your changes to Realm JS against real apps:
 
-- [Guide: Setting up watchman to copy changes from this package to an app](guide-watchman.md)
 - [Guide: Testing your changes against sample apps using a script](guide-testing-with-sample-apps.md)
 
 ## Debugging

--- a/contrib/building.md
+++ b/contrib/building.md
@@ -52,6 +52,7 @@ The following dependencies are required. All except Xcode can be installed by fo
 - [Android NDK 23](https://developer.android.com/ndk/downloads/index.html)
 - [Android CMake](https://developer.android.com/ndk/guides/cmake)
 - [Docker](https://www.docker.com/) is used for testing. You can install it [as a desktop app](https://www.docker.com/products/docker-desktop/) or through Homebrew: `brew install --cask docker`.
+- [Ninja](https://ninja-build.org/) `brew install ninja`
 
 Moreover, in order to avoid introducing false positives in our analytics dataset, it is highly recommended to disable analytics by adding the following to your shell configuration:
 
@@ -83,9 +84,10 @@ brew install cmake
 
 #### Android
 
-First, install OpenJDK:
+First, install OpenJDK and Ninja:
 
 ```sh
+brew install ninja
 brew install --cask temurin
 
 # Check this returns: openjdk version "18.0.1" 2022-04-19

--- a/contrib/guide-testing-exclude-icloud-backup.md
+++ b/contrib/guide-testing-exclude-icloud-backup.md
@@ -1,0 +1,50 @@
+# Guide: Testing Exclude iCloud Backup
+
+Before starting the testing process, you need to configure your Realm database to either include or exclude files from iCloud backup. This is done by setting the `excludeFromIcloudBackup` property in your Realm configuration. Here is an example of how to set this property:
+
+```javascript
+const realmConfig = {
+  schema: [
+    /* your schema */
+  ],
+  path: "default.realm",
+  excludeFromIcloudBackup: true, // Set to true to exclude from iCloud backup, false to include, defaults to false
+};
+
+const realm = new Realm(realmConfig);
+```
+
+Make sure to replace the schema and path with your actual Realm schema and desired file path. Once you have configured this property, you can proceed with the following steps to test if the exclusion from iCloud backup is working correctly.
+
+## Prerequisites
+
+- macOS
+- iOS Simulator
+
+## Testing
+
+To verify if a file has been successfully excluded from iCloud backup, you need to check the file's attributes. We provide an easy script to do so. Ensure you have booted a simulator with an app using Realm. From the root of the project, run:
+
+```sh
+contrib/scripts/check-exclude-icloud-backup.sh <com.your.app.bundle>
+```
+
+If the script doesn't work, you can also check it manually. First, get the path of the Realm files from the simulator's Documents folder by running:
+
+```sh
+open `xcrun simctl get_app_container booted com.your.app.bundleId data`/Documents
+```
+
+This will open a Finder window with the files. Drag and drop each file to the terminal after adding `xattr`:
+
+```sh
+xattr <realm file simulator path>
+```
+
+If this command returns:
+
+```sh
+com.apple.metadata:com_apple_backup_excludeItem
+```
+
+It means the file has been successfully marked as excluded from backup 🎉. If it returns nothing, the file has no attributes and is not excluded from backup.

--- a/contrib/scripts/check-exclude-icloud-backup.sh
+++ b/contrib/scripts/check-exclude-icloud-backup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Check if appbundle parameter is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <com.app.bundle.id>"
+    exit 1
+fi
+
+appbundle=$1
+
+# Check if a simulator is booted
+booted_simulators=$(xcrun simctl list | grep "Booted")
+
+if [ -z "$booted_simulators" ]; then
+    echo "No simulator booted. Please boot a simulator with the React Native app running and re-run the script."
+    exit 1
+fi
+
+# Count the number of booted simulators
+booted_count=$(echo "$booted_simulators" | wc -l)
+
+if [ "$booted_count" -gt 1 ]; then
+    echo "More than one simulator is booted. Please keep only one open and re-run the script."
+    exit 1
+fi
+
+# Extract the name of the booted simulator
+booted_simulator=$(echo "$booted_simulator" | xargs)
+echo -e "Running script on simulator: $booted_simulator\n"
+
+# Get the app container path
+app_container_path=$(xcrun simctl get_app_container booted "$appbundle" data 2>/dev/null)
+
+# Check if the command was successful
+if [ $? -ne 0 ] || [ -z "$app_container_path" ]; then
+    echo "Failed to get app container path for $appbundle"
+    exit 1
+fi
+
+# Append /Documents to the path
+documents_path="$app_container_path/Documents"
+
+# Check if the directory exists
+if [ ! -d "$documents_path" ]; then
+    echo "Documents directory does not exist at $documents_path"
+    exit 1
+fi
+
+# Run xattr on all files in the directory
+for file in "$documents_path"/*; do
+    if [ -e "$file" ]; then
+        filename=$(basename "$file")
+        attrs=$(xattr "$file" 2>/dev/null)
+        if [ -z "$attrs" ]; then
+            echo -e "\033[1;33m$filename:\033[0m no attributes set ❌"
+        else
+            if echo "$attrs" | grep -q "com_apple_backup_excludeItem"; then
+                echo -e "\033[0;32m\033[1m$filename:\033[0m: $attrs\033[0;32m ✅\033[0m"
+            else
+                echo "$filename: $attrs"
+            fi
+        fi
+    fi
+done
+

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -51,6 +51,7 @@ records:
       - initialization_function
       - should_compact_on_launch_function
       - automatically_handle_backlinks_in_migrations
+      - exclude_from_icloud_backup
 
   UserIdentity:
     fields:
@@ -238,6 +239,7 @@ classes:
       - remove_file
       - remove_directory
       - get_cpu_arch
+      - after_realm_open
 
   WeakSyncSession:
     methods:

--- a/packages/realm/bindgen/js_opt_in_spec.yml
+++ b/packages/realm/bindgen/js_opt_in_spec.yml
@@ -51,7 +51,6 @@ records:
       - initialization_function
       - should_compact_on_launch_function
       - automatically_handle_backlinks_in_migrations
-      - exclude_from_icloud_backup
 
   UserIdentity:
     fields:

--- a/packages/realm/bindgen/js_spec.yml
+++ b/packages/realm/bindgen/js_spec.yml
@@ -15,6 +15,7 @@ classes:
       remove_file: '(path: const std::string&)'
       remove_directory: '(path: const std::string&)'
       get_cpu_arch: () -> std::string
+      after_realm_open: '(sharedRealm: std::shared_ptr<Realm>)'
       # print: (const char* fmt, ...) # can't expose varargs directly. Could expose a fixed overload.
 
   WeakSyncSession:

--- a/packages/realm/bindgen/js_spec.yml
+++ b/packages/realm/bindgen/js_spec.yml
@@ -15,7 +15,7 @@ classes:
       remove_file: '(path: const std::string&)'
       remove_directory: '(path: const std::string&)'
       get_cpu_arch: () -> std::string
-      after_realm_open: '(realm: SharedRealm)'
+      after_realm_open: '(realm: SharedRealm, exclude_from_icloud_backup: bool)'
       # print: (const char* fmt, ...) # can't expose varargs directly. Could expose a fixed overload.
 
   WeakSyncSession:

--- a/packages/realm/bindgen/js_spec.yml
+++ b/packages/realm/bindgen/js_spec.yml
@@ -15,7 +15,7 @@ classes:
       remove_file: '(path: const std::string&)'
       remove_directory: '(path: const std::string&)'
       get_cpu_arch: () -> std::string
-      after_realm_open: '(sharedRealm: std::shared_ptr<Realm>)'
+      after_realm_open: '(realm: SharedRealm)'
       # print: (const char* fmt, ...) # can't expose varargs directly. Could expose a fixed overload.
 
   WeakSyncSession:

--- a/packages/realm/binding/android/src/main/cpp/platform.cpp
+++ b/packages/realm/binding/android/src/main/cpp/platform.cpp
@@ -115,6 +115,8 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
+void JsPlatformHelpers::after_realm_open(const std::shared_ptr<Realm>) {}
+
 std::string JsPlatformHelpers::get_cpu_arch()
 {
 #if defined(__arm__)

--- a/packages/realm/binding/android/src/main/cpp/platform.cpp
+++ b/packages/realm/binding/android/src/main/cpp/platform.cpp
@@ -115,7 +115,7 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
-void JsPlatformHelpers::after_realm_open(const std::shared_ptr<Realm>) {}
+void JsPlatformHelpers::after_realm_open(const SharedRealm) {}
 
 std::string JsPlatformHelpers::get_cpu_arch()
 {

--- a/packages/realm/binding/android/src/main/cpp/platform.cpp
+++ b/packages/realm/binding/android/src/main/cpp/platform.cpp
@@ -115,7 +115,7 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
-void JsPlatformHelpers::after_realm_open(const SharedRealm) {}
+void JsPlatformHelpers::after_realm_open(SharedRealm, bool) {}
 
 std::string JsPlatformHelpers::get_cpu_arch()
 {

--- a/packages/realm/binding/apple/platform.mm
+++ b/packages/realm/binding/apple/platform.mm
@@ -18,7 +18,6 @@
 
 #include "../platform.hpp"
 
-#include <memory>
 #include <realm/util/to_string.hpp>
 
 #include <stdarg.h>

--- a/packages/realm/binding/apple/platform.mm
+++ b/packages/realm/binding/apple/platform.mm
@@ -163,10 +163,10 @@ void JsPlatformHelpers::remove_file(const std::string &path)
     }
 }
 
-void JsPlatformHelpers::after_realm_open(const SharedRealm realm) {
+void JsPlatformHelpers::after_realm_open(const SharedRealm realm, bool exclude_from_icloud_backup) {
   const auto path = realm->config().path;
                         
-     if(realm->config().exclude_from_icloud_backup) {
+     if(exclude_from_icloud_backup) {
        RLMAddSkipBackupAttributeToItemAtPath(path);
        RLMAddSkipBackupAttributeToItemAtPath(path +
                                              ".lock");

--- a/packages/realm/binding/apple/platform.mm
+++ b/packages/realm/binding/apple/platform.mm
@@ -163,14 +163,16 @@ void JsPlatformHelpers::remove_file(const std::string &path)
     }
 }
 
-void JsPlatformHelpers::after_realm_open(const std::shared_ptr<Realm> sharedRealm) {
-     if(sharedRealm->config().exclude_from_icloud_backup) {
-       RLMAddSkipBackupAttributeToItemAtPath(sharedRealm->config().path);
-       RLMAddSkipBackupAttributeToItemAtPath(sharedRealm->config().path +
+void JsPlatformHelpers::after_realm_open(const SharedRealm realm) {
+  const auto path = realm->config().path;
+                        
+     if(realm->config().exclude_from_icloud_backup) {
+       RLMAddSkipBackupAttributeToItemAtPath(path);
+       RLMAddSkipBackupAttributeToItemAtPath(path +
                                              ".lock");
-       RLMAddSkipBackupAttributeToItemAtPath(sharedRealm->config().path +
+       RLMAddSkipBackupAttributeToItemAtPath(path +
                                              ".note");
-       RLMAddSkipBackupAttributeToItemAtPath(sharedRealm->config().path +
+       RLMAddSkipBackupAttributeToItemAtPath(path +
                                                 ".management");
      }
 }

--- a/packages/realm/binding/node/platform.cpp
+++ b/packages/realm/binding/node/platform.cpp
@@ -219,7 +219,7 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
-void JsPlatformHelpers::after_realm_open(const std::shared_ptr<Realm>)
+void JsPlatformHelpers::after_realm_open(const SharedRealm)
 {
     // no-op
 }

--- a/packages/realm/binding/node/platform.cpp
+++ b/packages/realm/binding/node/platform.cpp
@@ -219,7 +219,7 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
-void JsPlatformHelpers::after_realm_open(const SharedRealm)
+void JsPlatformHelpers::after_realm_open(SharedRealm, bool)
 {
     // no-op
 }

--- a/packages/realm/binding/node/platform.cpp
+++ b/packages/realm/binding/node/platform.cpp
@@ -219,6 +219,11 @@ void JsPlatformHelpers::print(const char* fmt, ...)
     va_end(vl);
 }
 
+void JsPlatformHelpers::after_realm_open(const std::shared_ptr<Realm>)
+{
+    // no-op
+}
+
 // this should never be called
 std::string JsPlatformHelpers::get_cpu_arch()
 {

--- a/packages/realm/binding/platform.hpp
+++ b/packages/realm/binding/platform.hpp
@@ -57,6 +57,6 @@ public:
     static void print(const char* fmt, ...);
 
     // runs after the realm has been opened
-    static void after_realm_open(const SharedRealm realm);
+    static void after_realm_open(const SharedRealm realm, const bool exclude_from_icloud_backup = false);
 };
 } // namespace realm

--- a/packages/realm/binding/platform.hpp
+++ b/packages/realm/binding/platform.hpp
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <string>
-#include "realm/object-store/shared_realm.hpp"
+#include <realm/object-store/shared_realm.hpp>
 
 namespace realm {
 //
@@ -57,6 +57,6 @@ public:
     static void print(const char* fmt, ...);
 
     // runs after the realm has been opened
-    static void after_realm_open(const std::shared_ptr<Realm> sharedRealm);
+    static void after_realm_open(const SharedRealm realm);
 };
 } // namespace realm

--- a/packages/realm/binding/platform.hpp
+++ b/packages/realm/binding/platform.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <string>
+#include "realm/object-store/shared_realm.hpp"
 
 namespace realm {
 //
@@ -54,5 +55,8 @@ public:
 
     // print something
     static void print(const char* fmt, ...);
+
+    // runs after the realm has been opened
+    static void after_realm_open(const std::shared_ptr<Realm> sharedRealm);
 };
 } // namespace realm

--- a/packages/realm/src/Configuration.ts
+++ b/packages/realm/src/Configuration.ts
@@ -160,6 +160,12 @@ export type BaseConfiguration = {
    */
   onFirstOpen?: (realm: Realm) => void;
   migrationOptions?: MigrationOptions;
+  /**
+   * Specifies if this Realm should be excluded from iCloud backup.
+   * @default false
+   * @since 12.13.3
+   */
+  excludeFromIcloudBackup?: boolean;
 };
 
 export type ConfigurationWithSync = BaseConfiguration & {

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -423,13 +423,14 @@ export class Realm {
     const normalizedSchema = config.schema && normalizeRealmSchema(config.schema);
     const schemaExtras = Realm.extractRealmSchemaExtras(normalizedSchema || []);
     const path = Realm.determinePath(config);
-    const { fifoFilesFallbackPath, shouldCompact, inMemory } = config;
+    const { fifoFilesFallbackPath, shouldCompact, inMemory, excludeFromIcloudBackup } = config;
     const bindingSchema = normalizedSchema && toBindingSchema(normalizedSchema);
     return {
       schemaExtras,
       bindingConfig: {
         path,
         cache: true,
+        excludeFromIcloudBackup,
         fifoFilesFallbackPath,
         schema: bindingSchema,
         inMemory: inMemory === true,
@@ -578,6 +579,8 @@ export class Realm {
       this.internal = internal;
       this.schemaExtras = schemaExtras || {};
     }
+
+    binding.JsPlatformHelpers.afterRealmOpen(this.internal);
 
     Object.defineProperty(this, "classes", {
       enumerable: false,

--- a/packages/realm/src/Realm.ts
+++ b/packages/realm/src/Realm.ts
@@ -423,14 +423,13 @@ export class Realm {
     const normalizedSchema = config.schema && normalizeRealmSchema(config.schema);
     const schemaExtras = Realm.extractRealmSchemaExtras(normalizedSchema || []);
     const path = Realm.determinePath(config);
-    const { fifoFilesFallbackPath, shouldCompact, inMemory, excludeFromIcloudBackup } = config;
+    const { fifoFilesFallbackPath, shouldCompact, inMemory } = config;
     const bindingSchema = normalizedSchema && toBindingSchema(normalizedSchema);
     return {
       schemaExtras,
       bindingConfig: {
         path,
         cache: true,
-        excludeFromIcloudBackup,
         fifoFilesFallbackPath,
         schema: bindingSchema,
         inMemory: inMemory === true,
@@ -580,7 +579,7 @@ export class Realm {
       this.schemaExtras = schemaExtras || {};
     }
 
-    binding.JsPlatformHelpers.afterRealmOpen(this.internal);
+    binding.JsPlatformHelpers.afterRealmOpen(this.internal, config.excludeFromIcloudBackup ?? false);
 
     Object.defineProperty(this, "classes", {
       enumerable: false,


### PR DESCRIPTION
## What, How & Why?
This PR adds a flag on Realm Config to exclude realm files from iCloud backup and also removes a reference from a guide that has been deleted.

This closes #4139

## Draft discussion
@kraenhansen I'm starting this as a draft to make sure I'm on the right path, and to align some things:

1.  In order to add this flag, some changes are required on @realm/core, to basically add `exclude_from_icloud_backup` on `spec.yml` and `shared_realm.hpp`, how is that coordinated ?

2.  You mentioned testing might be tricky for this one, it's a bit concerning if it's too difficult because I might not have the bandwidth to do it, but I can give it a try if there are some really similar examples.

3. This implementation is enough to ENABLE excluding from backup, but it cannot be DISABLED once a realm file has been set with  `excludedFromBackup`,  since we are just checking for `true` on the flag and then setting the `NSURLIsExcludedFromBackupKey` key, there's no check to remove this key when the flag is false again. Which means that, if a realm file has been created with `excludeFromIcloudBackup=false` and then set to `excludeFromIcloudBackup=true` the file will be correctly excluded, but if the same file if set again to `excludeFromIcloudBackup=false` it will remain excluded. I see two ways to handle this:   

 - 1. Stick with this implementation and explain the behavior via docs;
 - 2. Always check flag status and update files accordingly; 

- Particularly I don't think there's much usage of setting this flag dynamically, so i'd probably go with the first option since realm does provide an easy way to copy a file with different configs if needed, although the second one is more flexible, it might take longer to be done as I believe I'd need to always be checking if the files already have the excludedFromBackup key set. 

4. About the .md file on how to test this fix,  where would that live?

## Testing the fix
Generate the build files and test it on a sample react-native app on an IOS simulator, adding `excludeFromIcloudBackup: true` to the Realm configuration. 

To validate if the file has the exclude backup attribute, you need to check the files attributes with `xattr` on your terminal, in order to do so you need the path of realm files from the simulator Documents' folder, you can easily get that first by running:
```shell
open `xcrun simctl get_app_container booted com.your.app.bundleId data`/Documents
```
This will open a Finder window with the files, you can just drag and drop it to the terminal after adding `xattr`
 ```shell
 xattr [realm file simulator path]
 ```
 if this command returns:
 ```shell
 com.apple.metadata:com_apple_backup_excludeItem
 ```
It means the file has been successfully marked as excluded from backup 🎉 
if it returns nothing, it means the file has no attributes therefore is not excluded from backup. 

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [x] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed



