### PR TITLE
Refactor Android filesystem platform helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ const realm = new Realm({
 * File format: generates Realms with format v24 (reads and upgrades file format v10).
 
 ### Internal
-<!-- * Either mention core version or upgrade -->
-<!-- * Using Realm Core vX.Y.Z -->
-<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+* Refactored Android filesystem platform helpers. ([#5296](https://github.com/realm/realm-js/issues/5296) and [realm/realm-js-private#507](https://github.com/realm/realm-js-private/issues/507))
 
 ## 12.13.2 (2024-10-30)
 


### PR DESCRIPTION
## What, How & Why?

This closes #5296 using the `std::filesystem` API as a pre-requisite for merging https://github.com/realm/realm-js/pull/6927 (as that needs the `ensure_directory_exists_for_file` to get tests passing).

## ☑️ ToDos
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
