### PR TITLE
Nested unmanaged types

### DIFF
--- a/packages/realm/package.json
+++ b/packages/realm/package.json
@@ -73,7 +73,7 @@
   ],
   "scripts": {
     "test": "wireit",
-    "test:types": "tsc --project type-tests/tsconfig.json",
+    "test:types": "wireit",
     "lint": "eslint --ext .js,.mjs,.ts .",
     "prebuild": "tsx ./src/scripts/build/cli.ts",
     "prebuild-apple": "wireit",
@@ -101,6 +101,12 @@
       "env": {
         "TSX_TSCONFIG_PATH": "tsconfig.tests.json"
       }
+    },
+    "test:types": {
+      "command": "tsc --project type-tests/tsconfig.json",
+      "dependencies": [
+        "build:ts"
+      ]
     },
     "prebuild-apple": {
       "command": "tsx ./src/scripts/build/cli.ts build-apple",

--- a/packages/realm/type-tests/nested-unmanaged-tests.ts
+++ b/packages/realm/type-tests/nested-unmanaged-tests.ts
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+/* eslint-disable @typescript-eslint/no-unused-vars -- We're just testing types */
+
+// This file checks that the Unmanaged type re-mappings work correctly for Realm types, especially when there are nested classes
+
+import Realm from "realm";
+
+class RealmClassWithRequiredParams extends Realm.Object<
+  RealmClassWithRequiredParams,
+  "aMandatoryString" | "anOptionalString"
+> {
+  public aMandatoryString!: Realm.Types.String;
+  public anOptionalString?: Realm.Types.String;
+
+  static schema: Realm.ObjectSchema = {
+    name: "RealmClassWithRequiredParams",
+    properties: {
+      aMandatoryString: "string",
+      anOptionalString: "string?",
+    },
+  };
+
+  public someFunction() {
+    return 1;
+  }
+}
+
+class RealmClassWithoutRequiredParams extends Realm.Object<RealmClassWithoutRequiredParams> {
+  public aMandatoryString!: Realm.Types.String;
+  public anOptionalString?: Realm.Types.String;
+
+  static schema: Realm.ObjectSchema = {
+    name: "RealmClassWithoutRequiredParams",
+    properties: {
+      aMandatoryString: "string",
+      anOptionalString: "string?",
+    },
+  };
+
+  public someFunction() {
+    return 1;
+  }
+}
+
+const realm = new Realm({ schema: [RealmClassWithRequiredParams, RealmClassWithoutRequiredParams] });
+
+// @ts-expect-error - a String shouldn't be accepted as 'values'
+new RealmClassWithRequiredParams(realm, "this shouldn't be accepted");
+
+// FIXME - this doesn't error and it should
+// @xxxts-expect-error - a String shouldn't be accepted as 'values'
+new RealmClassWithoutRequiredParams(realm, "this shouldn't be accepted");
+
+realm.write(() => {
+  // === Realm.Object classes ===
+  // @ts-expect-error - Empty object not allowed due to being required params
+  realm.create(RealmClassWithRequiredParams, new RealmClassWithRequiredParams(realm, {}));
+
+  realm.create(
+    RealmClassWithRequiredParams,
+    new RealmClassWithRequiredParams(realm, {
+      aMandatoryString: "string",
+      // anOptionalString is a required param, but it's of type "string?" so doesn't need to be specified
+    }),
+  );
+
+  realm.create(RealmClassWithoutRequiredParams, new RealmClassWithoutRequiredParams(realm, {}));
+
+  // === Unmanaged objects ===
+  // FIXME - Should this be erroring? The class has required types so shouldn't they be automatically required in the Unmanaged version too? Is this possible
+  // @xxxts-expect-error - Empty object not allowed due to being required params
+  realm.create(RealmClassWithRequiredParams, {});
+
+  realm.create(RealmClassWithRequiredParams, {
+    aMandatoryString: "string",
+    // anOptionalString is a required param, but it's of type "string?" so doesn't need to be specified
+  });
+
+  realm.create(RealmClassWithoutRequiredParams, {});
+});
+
+// Shouldn't be expecting someFunction(), keys(), entries(), etc
+const realmObjectPropertiesOmitted1: Realm.Unmanaged<RealmClassWithRequiredParams> = {};
+
+const realmObjectPropertiesOmitted2: Realm.Unmanaged<
+  RealmClassWithRequiredParams,
+  "aMandatoryString" | "anOptionalString"
+> = {
+  aMandatoryString: "string",
+};

--- a/packages/realm/type-tests/tsconfig.json
+++ b/packages/realm/type-tests/tsconfig.json
@@ -1,21 +1,14 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.public-types-check.json",
   "compilerOptions": {
-    "noEmit": true,
-    "noResolve": true,
     "esModuleInterop": true,
-    "lib": [
-      "ES2022",
-    ],
-    "baseUrl": ".",
     "paths": {
-      "realm": ["../../.."],
-      "next-realm": [".."],
+      "realm": [
+        "../dist/public-types"
+      ]
     }
   },
-  "exclude": [],
   "include": [
-    "../src/**/*.ts",
-    "type-tests.ts"
+    "*.ts"
   ]
 }

--- a/packages/realm/type-tests/type-tests.ts
+++ b/packages/realm/type-tests/type-tests.ts
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars -- We're just testing types */
 
-import { Realm as Realm2 } from "../src/index";
+import { Realm as Realm2 } from "realm";
 
 const realm = new Realm();
 const realm2: Realm = new Realm();


### PR DESCRIPTION
## What, How & Why?
Ensures `Unmanaged` works when a `Realm.Object` contains other `Realm.Objects` (or Lists, etc of them).

This closes #6037

## ☑️ ToDos
* [ ] 👨‍💻 Expand checks to existing things that already work; List, Dictionary, Set & Counter
* [ ] ❓ Why did the Counter PR add `ExtractPropertyNamesOfTypeExcludingNullability` instead of using `ExtractPropertyNamesOfType`?
* [ ] 👨‍💻 Expand checks to include things that don't currently work; nested Object, List<Object>, etc so tests fail
* [ ] 👨‍💻 Update Unmanaged so that it supports the new things and tests pass again
* [ ] ❓ Should `type:tests` be run as part of a higher level `build` or `test`?
* [ ] ❗ String still accepted as `values`, matches `Unmanaged<DefaultObject, never>`?
* [ ] ❓ If a Realm.Object has required types shouldn't they be automatically required in the Unmanaged version during `realm.create()` too? Is this possible or will there be a circular type reference?
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
