### PR TITLE
fix(realm/Results): provide fallback condition

### DIFF
--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -93,7 +93,7 @@ export class Results<T = unknown> extends OrderedCollection<
   }
 
   get length() {
-    return this.internal ? this.internal.size() : 0;
+    return this.internal?.size() ?? 0;
   }
 
   set length(value: number) {

--- a/packages/realm/src/Results.ts
+++ b/packages/realm/src/Results.ts
@@ -92,8 +92,8 @@ export class Results<T = unknown> extends OrderedCollection<
     throw new Error("Modifying a Results collection is not supported.");
   }
 
-  get length(): number {
-    return this.internal.size();
+  get length() {
+    return this.internal ? this.internal.size() : 0;
   }
 
   set length(value: number) {


### PR DESCRIPTION
## What, How & Why?
Small change in the getter `length` from Results' class.
This solves an issue that causes an app crash when upgrading from react-native: 0.71.2, realm: 11.9.0 and @realm/react: 0.4.3 to the corresponding latest versions.
The issue is solved by providing a fallback condition in the getter (i.e., when `this.internal` is not defined).


This closes #6954 
