### PR TITLE
Adds failing test case for issue #6889 + fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * None
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None
+* Fix setting `List` values from themselves (either through assignment or the `Realm#create` method). Before this fix, the list would be emptied before being iterated, resulting in elements being removed from the list. ([#6977](https://github.com/realm/realm-js/pull/6977), since v12.12.0)
 
 ### Compatibility
 * React Native >= v0.71.4

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -634,6 +634,45 @@ describe("Realm.Object", () => {
         expect(persons.length).equals(1);
       });
 
+      describe("with collection", () => {
+        it("can be created, fetched, updated and refetched without affecting collection", function (this: Mocha.Context &
+          RealmContext) {
+          const _id = new Realm.BSON.ObjectId();
+
+          const friend = {
+            age: 18,
+            name: "Friend's Name",
+            _id: new Realm.BSON.ObjectId(),
+          };
+
+          this.realm.write(() => {
+            this.realm.create(
+              PersonWithId,
+              {
+                _id,
+                name: "John Doe",
+                age: 42,
+                friends: [friend],
+              },
+              UpdateMode.All,
+            );
+          });
+
+          const john = this.realm.objectForPrimaryKey(PersonWithId, _id);
+          if (!john) throw new Error("Object not found");
+
+          this.realm.write(() => {
+            this.realm.create(PersonWithId, john, UpdateMode.All);
+          });
+
+          const johnAfterUpdate = this.realm.objectForPrimaryKey(PersonWithId, _id);
+          if (!johnAfterUpdate) throw new Error("Object not found");
+
+          expect(john.friends.length).equals(1);
+          expect(johnAfterUpdate.friends.length).equals(1);
+        });
+      });
+
       describe("applying 'UpdateMode' recursively", () => {
         let aliceId: Realm.BSON.ObjectId;
         let bobId: Realm.BSON.ObjectId;

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -637,36 +637,27 @@ describe("Realm.Object", () => {
       describe("with collection", () => {
         it("can be created, fetched, updated and refetched without affecting collection", function (this: Mocha.Context &
           RealmContext) {
-          const _id = new Realm.BSON.ObjectId();
-
-          const friend = {
-            age: 18,
-            name: "Friend's Name",
-            _id: new Realm.BSON.ObjectId(),
-          };
-
-          this.realm.write(() => {
+          const john = this.realm.write(() =>
             this.realm.create(
               PersonWithId,
               {
-                _id,
+                _id: new Realm.BSON.ObjectId(),
                 name: "John Doe",
                 age: 42,
-                friends: [friend],
+                friends: [
+                  {
+                    age: 18,
+                    name: "Friend's Name",
+                    _id: new Realm.BSON.ObjectId(),
+                  },
+                ],
               },
               UpdateMode.All,
-            );
-          });
+            ),
+          );
 
-          const john = this.realm.objectForPrimaryKey(PersonWithId, _id);
-          if (!john) throw new Error("Object not found");
-
-          this.realm.write(() => {
-            this.realm.create(PersonWithId, john, UpdateMode.All);
-          });
-
-          const johnAfterUpdate = this.realm.objectForPrimaryKey(PersonWithId, _id);
-          if (!johnAfterUpdate) throw new Error("Object not found");
+          // Update john from itself
+          const johnAfterUpdate = this.realm.write(() => this.realm.create(PersonWithId, john, UpdateMode.All));
 
           expect(john.friends.length).equals(1);
           expect(johnAfterUpdate.friends.length).equals(1);

--- a/integration-tests/tests/src/tests/objects.ts
+++ b/integration-tests/tests/src/tests/objects.ts
@@ -638,22 +638,18 @@ describe("Realm.Object", () => {
         it("can be created, fetched, updated and refetched without affecting collection", function (this: Mocha.Context &
           RealmContext) {
           const john = this.realm.write(() =>
-            this.realm.create(
-              PersonWithId,
-              {
-                _id: new Realm.BSON.ObjectId(),
-                name: "John Doe",
-                age: 42,
-                friends: [
-                  {
-                    age: 18,
-                    name: "Friend's Name",
-                    _id: new Realm.BSON.ObjectId(),
-                  },
-                ],
-              },
-              UpdateMode.All,
-            ),
+            this.realm.create(PersonWithId, {
+              _id: new Realm.BSON.ObjectId(),
+              name: "John Doe",
+              age: 42,
+              friends: [
+                {
+                  _id: new Realm.BSON.ObjectId(),
+                  name: "Friend's Name",
+                  age: 18,
+                },
+              ],
+            }),
           );
 
           // Update john from itself

--- a/packages/realm/src/property-accessors/Array.ts
+++ b/packages/realm/src/property-accessors/Array.ts
@@ -87,11 +87,12 @@ export function createArrayPropertyAccessor({
         assert.inTransaction(realm);
         assert.iterable(values);
 
+        const valuesCopiedRef = Array.from(values);
         const internal = binding.List.make(realm.internal, obj, columnKey);
         internal.removeAll();
         let index = 0;
         try {
-          for (const value of values) {
+          for (const value of valuesCopiedRef) {
             listAccessor.insert(internal, index++, value);
           }
         } catch (err) {

--- a/packages/realm/src/property-accessors/Array.ts
+++ b/packages/realm/src/property-accessors/Array.ts
@@ -87,12 +87,13 @@ export function createArrayPropertyAccessor({
         assert.inTransaction(realm);
         assert.iterable(values);
 
-        const valuesCopiedRef = Array.from(values);
+        // Taking a snapshot in case we're iterating the list we're mutating
+        const valuesSnapshot = values instanceof List ? values.snapshot() : values;
         const internal = binding.List.make(realm.internal, obj, columnKey);
         internal.removeAll();
         let index = 0;
         try {
-          for (const value of valuesCopiedRef) {
+          for (const value of valuesSnapshot) {
             listAccessor.insert(internal, index++, value);
           }
         } catch (err) {


### PR DESCRIPTION
#6889 issue, failing test ticket

If you remove lines 664-666, (the part with updating the managed object):
```
this.realm.write(() => {
    this.realm.create(PersonWithId, john, UpdateMode.All);
});
```

It works well. So the problem is when you update a managed object, it somehow loses the collection.

Update: Pushed a [commit](https://github.com/realm/realm-js/pull/6977/commits/625c997a1b3f1623533689fa373af2b0eae7ea4a) that fixes the issue.