### PR TITLE
Support 16KB page size on Android 15+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* 16KB page size support for Android 15+ ([#7019](https://github.com/realm/realm-js/pull/7019)).
+* 16KB page size support for Android 15+ ([#7019](https://github.com/realm/realm-js/pull/7019)). If you are using Android Gradle Plugin (AGP) 8.5 or lower, you will need to [enable legacy packaging](https://developer.android.com/guide/practices/page-sizes#update-packaging). 
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Enhancements
-* None
+* 16KB page size support for Android 15+ ([#7019](https://github.com/realm/realm-js/pull/7019)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/packages/realm/binding/android/CMakeLists.txt
+++ b/packages/realm/binding/android/CMakeLists.txt
@@ -28,6 +28,7 @@ set_target_properties(realm-js-android-binding PROPERTIES
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -Oz")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 
 target_link_options(realm-js-android-binding PUBLIC -fvisibility=hidden)
 


### PR DESCRIPTION
## What, How & Why?

Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

This PR ensures `librealm.so` is 16KB aligned when built (*Note:* [If you're on an AGP version less than 8.5.1 you will also need extra config in your app's build.gradle](https://developer.android.com/guide/practices/page-sizes#agp_version_85_or_lower))

This is based on the changes done to realm-kotlin here: https://github.com/realm/realm-kotlin/pull/1834 It doesn't change the build.gradle because I _think_ that's only going to have an affect if you do it in your app/build.gradle. I might be wrong?

This closes #7015
This closes #7008

For reviewers (@kraenhansen?) please note I've not been able to work out how to get the realm-js Android app tests working successfully so I've not tested it in this repo directly. I've been making the equivalent change in an RN app with realm in it's node_modules via `patch-package`.

I've used [`check_elf_alignment.sh`](https://developer.android.com/guide/practices/page-sizes#alignment-use-script) to ensure the produced 64bit `librealm.so` file is aligned.

I've exercised basic functionality of Realm in both a 16KB page size and 4KB page size Android emulator following [these instructions](https://developer.android.com/guide/practices/page-sizes#16kb-emulator).

I don't _think_ this is a breaking change as far as builds are concerned. Edit: that might not be true? This works fine on a 0.79.5 app but an older 0.74.6 one needed the [legacy packaging option](https://developer.android.com/guide/practices/page-sizes#agp_version_85_or_lower) to still build correctly.

## ☑️ ToDos
<!-- Add your own todos here -->
* [x] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
