### PR TITLE
Upgrade GHA workflows to use Node v22

### DIFF
--- a/.github/workflows/package-unit-tests.yml
+++ b/.github/workflows/package-unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       # ninja-build is used by default if available and results in faster build times
       - name: Install ninja

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20.11.1
+          node-version: 22
           cache: npm
 
       - name: Setup Wireit cache

--- a/.github/workflows/pr-linting.yml
+++ b/.github/workflows/pr-linting.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: "recursive"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install root package dependencies
         run: npm ci
       - name: Check types

--- a/.github/workflows/pr-realm-web.yml
+++ b/.github/workflows/pr-realm-web.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       # Install the root package
       - run: npm ci

--- a/.github/workflows/prepare-templates-release.yml
+++ b/.github/workflows/prepare-templates-release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -49,7 +49,7 @@ jobs:
           submodules: "recursive"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       # Install the root package (--ignore-scripts to avoid downloading or building the native module)
       - name: Install root package dependencies

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Setup node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/packages/realm-common/rollup.config.mjs
+++ b/packages/realm-common/rollup.config.mjs
@@ -21,7 +21,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import dts from "rollup-plugin-dts";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 export default [
   {

--- a/packages/realm-react/rollup.config.js
+++ b/packages/realm-react/rollup.config.js
@@ -20,7 +20,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 export default [
   {

--- a/packages/realm-web/rollup.config.mjs
+++ b/packages/realm-web/rollup.config.mjs
@@ -22,7 +22,7 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import replace from "@rollup/plugin-replace";
 import dts from "rollup-plugin-dts";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 const replacer = replace({
   __SDK_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## What, How & Why?

This updates Node version to v22 across workflows.

## ☑️ ToDos
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed
